### PR TITLE
Prompt scouts to link existing subquestions

### DIFF
--- a/prompts/scout.md
+++ b/prompts/scout.md
@@ -19,6 +19,12 @@ Produce **up to 3 new considerations**, prioritising importance and novelty. Do 
 
 For each consideration, create the claim and link it to the question.
 
+## Linking Existing Questions
+
+Check the workspace map for questions elsewhere in the workspace that are directly relevant to the question you're scouting. If an existing question would serve as a useful sub-question — i.e. answering it would materially inform the current question — link it with `link_child_question`. This makes existing research visible to prioritization and prevents duplicate investigation.
+
+Only link questions that are genuinely useful decompositions, not merely topically related.
+
 ## Hypothesis Questions
 
 When you have a compelling candidate answer or paradigm — not just a piece of evidence, but a specific view that, if true, would substantially shape the response to the question — propose a hypothesis. This is worth doing when the view is likely correct, or when engaging with it seriously might yield useful insights: clarifying why it fails, surfacing adjacent territory, or extracting the partial truth inside an otherwise wrong answer.


### PR DESCRIPTION
## Summary
- Adds a section to the scout prompt instructing it to check the workspace map for existing questions that would serve as useful subquestions of the target, and link them with `link_child_question`
- This makes existing research in other subtrees visible to prioritization, preventing duplicate investigation
- Prompt-only change — scouts already had access to `LINK_CHILD_QUESTION` and the workspace map

## Test plan
- [x] Ran a new question ("What are the key physical bottlenecks limiting AI-driven economic growth?") that overlaps with existing research
- [x] Scout successfully linked existing subquestion `5a45425e` ("How effectively can AI accelerate physical infrastructure buildout...") from another question's subtree
- [x] Also linked an existing claim as a consideration and created a `related` link to the parent GDP question

🤖 Generated with [Claude Code](https://claude.com/claude-code)