### PR TITLE
Include child question judgements in working context

### DIFF
--- a/src/differential/context.py
+++ b/src/differential/context.py
@@ -106,6 +106,20 @@ def build_context_for_question(
                 parts.append(format_page(j))
                 parts.append("")
 
+        children = db.get_child_questions(question_id)
+        child_judgements = []
+        for child in children:
+            for j in db.get_judgements_for_question(child.id):
+                child_judgements.append((child, j))
+        if child_judgements:
+            parts.append("## Sub-question Judgements")
+            parts.append("")
+            for child, j in child_judgements:
+                loaded_ids.append(j.id)
+                parts.append(f"*On sub-question: {child.summary} (`{child.id}`)*")
+                parts.append(format_page(j))
+                parts.append("")
+
     return "\n".join(parts), loaded_ids
 
 


### PR DESCRIPTION
## Summary
- When building working context for a question, child question judgements were not included — only the target question's own considerations and judgements were surfaced
- Now adds a "Sub-question Judgements" section with full judgement content, attributed to the source sub-question
- This means assess calls (and scouts) automatically see conclusions already reached on subquestions without needing to `load_page` them

## Test plan
- [x] All 24 tests pass
- [x] Verified context building against local DB (no child judgements exist yet, but code path is exercised without error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)