### PR TITLE
Typed dispatch payloads with per-call-type models

### DIFF
--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -22,11 +22,11 @@ from differential.models import (
     Call,
     CallStatus,
     CallType,
-    DISPATCHABLE_CALL_TYPES,
     Dispatch,
     Move,
     MoveType,
 )
+from differential.calls.dispatches import DISPATCH_DEFS
 from differential.moves.base import MoveState
 from differential.moves.load_page import LoadPagePayload
 from differential.moves.registry import MOVES
@@ -35,47 +35,12 @@ if TYPE_CHECKING:
     from differential.tracer import CallTrace
 
 
-class DispatchPayload(BaseModel):
-    call_type: str = Field(
-        description=(
-            'Type of call to dispatch: "scout", "assess", or "prioritization"'
-        )
-    )
-    question_id: str = Field(description="Page ID of the question to investigate")
-    reason: str = Field("", description="Why this dispatch is a good use of budget")
-    budget: int | None = Field(
-        None, description="Budget to allocate (prioritization dispatches only)"
-    )
-    fruit_threshold: int | None = Field(
-        None, description="Remaining fruit threshold for stopping (scout dispatches only)"
-    )
-    max_rounds: int | None = Field(
-        None, description="Maximum scouting rounds (scout dispatches only)"
-    )
-    context_page_ids: list[str] = Field(
-        default_factory=list,
-        description=(
-            "Optional full UUIDs of pages to pre-load into the dispatched call. "
-            "Use when you know a specific source document or consideration from "
-            "another question will be directly relevant. Use full UUIDs, not short IDs."
-        ),
-    )
-
-
 PHASE1_TASK = (
     "Review the workspace map above and decide if you need the full content of any "
     "pages before starting your main task. Use load_page for any pages you want to "
     "read. Write brief planning notes about your approach."
 )
 
-
-DISPATCH_TOOL_DESCRIPTION = (
-    "Dispatch a research call for a question. Available call types: "
-    "scout (find missing considerations; costs up to max_rounds calls, "
-    "stops early when fruit falls below fruit_threshold), "
-    "assess (render a judgement; costs 1 call), "
-    "prioritization (delegate structured investigation; costs the sub-budget you assign)."
-)
 
 
 class PageRating(BaseModel):
@@ -121,27 +86,6 @@ class RunCallResult:
     phase1_page_ids: list[str] = field(default_factory=list)
     agent_result: AgentResult = field(default_factory=AgentResult)
 
-
-def _make_dispatch_tool(state: MoveState) -> Tool:
-    """Create a Tool that records a dispatch instruction."""
-
-    def fn(inp: dict) -> str:
-        call_type_str = inp.get("call_type", "")
-        try:
-            ct = CallType(call_type_str)
-        except ValueError:
-            return f"Unknown dispatch type: {call_type_str}"
-        if ct not in DISPATCHABLE_CALL_TYPES:
-            return f"Non-dispatchable call type: {call_type_str}"
-        state.dispatches.append(Dispatch(call_type=ct, payload=inp))
-        return "Dispatch recorded."
-
-    return Tool(
-        name="dispatch",
-        description=DISPATCH_TOOL_DESCRIPTION,
-        input_schema=DispatchPayload.model_json_schema(),
-        fn=fn,
-    )
 
 
 def _format_loaded_pages(page_ids: list[str], db: DB) -> str:
@@ -220,7 +164,8 @@ def run_call(
 
     tools = [MOVES[mt].bind(state) for mt in available_moves]
     if call_type == CallType.PRIORITIZATION:
-        tools.append(_make_dispatch_tool(state))
+        for ddef in DISPATCH_DEFS.values():
+            tools.append(ddef.bind(state))
 
     user_message = build_user_message(context_text, task_description)
 

--- a/src/differential/calls/dispatches.py
+++ b/src/differential/calls/dispatches.py
@@ -1,0 +1,71 @@
+"""Dispatch definitions: tool schemas and registry for prioritization dispatches."""
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from differential.llm import Tool
+from differential.models import (
+    AssessDispatchPayload,
+    BaseDispatchPayload,
+    CallType,
+    Dispatch,
+    PrioritizationDispatchPayload,
+    ScoutDispatchPayload,
+)
+from differential.moves.base import MoveState
+
+S = TypeVar("S", bound=BaseDispatchPayload)
+
+
+@dataclass
+class DispatchDef(Generic[S]):
+    """Definition of a dispatch type: its identity, tool schema, and call type."""
+    call_type: CallType
+    name: str
+    description: str
+    schema: type[S]
+
+    def bind(self, state: MoveState) -> Tool:
+        """Return a Tool bound to a call's mutable state."""
+        def fn(inp: dict) -> str:
+            validated = self.schema(**inp)
+            state.dispatches.append(Dispatch(call_type=self.call_type, payload=validated))
+            return "Dispatch recorded."
+
+        return Tool(
+            name=self.name,
+            description=self.description,
+            input_schema=self.schema.model_json_schema(),
+            fn=fn,
+        )
+
+
+DISPATCH_DEFS: dict[CallType, DispatchDef] = {
+    CallType.SCOUT: DispatchDef(
+        call_type=CallType.SCOUT,
+        name="dispatch_scout",
+        description=(
+            'Dispatch scout rounds for a question. Finds missing considerations. '
+            'Costs up to max_rounds calls, stops early when fruit falls below '
+            'fruit_threshold.'
+        ),
+        schema=ScoutDispatchPayload,
+    ),
+    CallType.ASSESS: DispatchDef(
+        call_type=CallType.ASSESS,
+        name="dispatch_assess",
+        description=(
+            'Dispatch an assessment for a question. Renders a judgement. Costs 1 call.'
+        ),
+        schema=AssessDispatchPayload,
+    ),
+    CallType.PRIORITIZATION: DispatchDef(
+        call_type=CallType.PRIORITIZATION,
+        name="dispatch_prioritization",
+        description=(
+            'Dispatch a sub-prioritization for a question. Delegates structured '
+            'investigation. Costs the budget you assign.'
+        ),
+        schema=PrioritizationDispatchPayload,
+    ),
+}

--- a/src/differential/calls/prioritization.py
+++ b/src/differential/calls/prioritization.py
@@ -29,7 +29,7 @@ def run_prioritization(
         f"You have a budget of **{budget} research calls** to allocate on this question.\n\n"
         f"Scope question ID: `{scope_question_id}`\n\n"
         "Review the current state of the workspace above and decide how to spend the budget. "
-        "Use the dispatch tool to allocate calls."
+        "Use the dispatch tools to allocate calls."
     )
 
     result = run_call(CallType.PRIORITIZATION, task, context_text, call, db)
@@ -38,9 +38,7 @@ def run_prioritization(
         "dispatches": [
             {
                 "call_type": d.call_type.value,
-                "question_id": d.payload.get("question_id", ""),
-                "budget": d.payload.get("budget", 1),
-                "reason": d.payload.get("reason", ""),
+                **d.payload.model_dump(exclude_defaults=True),
             }
             for d in result.dispatches
         ],

--- a/src/differential/models.py
+++ b/src/differential/models.py
@@ -5,10 +5,10 @@ Data models for the research workspace.
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any, Optional
+from typing import Optional
 import uuid
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class PageType(str, Enum):
@@ -83,6 +83,33 @@ class ConsiderationDirection(str, Enum):
     NEUTRAL = "neutral"
 
 
+class BaseDispatchPayload(BaseModel):
+    question_id: str = Field(description='Page ID of the question to investigate')
+    reason: str = Field('', description='Why this dispatch is a good use of budget')
+    context_page_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            'Optional full UUIDs of pages to pre-load into the dispatched call. '
+            'Use full UUIDs, not short IDs.'
+        ),
+    )
+
+
+class ScoutDispatchPayload(BaseDispatchPayload):
+    fruit_threshold: int = Field(
+        4, description='Remaining fruit threshold for stopping'
+    )
+    max_rounds: int = Field(5, description='Maximum scouting rounds')
+
+
+class AssessDispatchPayload(BaseDispatchPayload):
+    pass
+
+
+class PrioritizationDispatchPayload(BaseDispatchPayload):
+    budget: int = Field(description='Budget to allocate for the sub-investigation')
+
+
 @dataclass
 class Move:
     move_type: MoveType
@@ -92,7 +119,7 @@ class Move:
 @dataclass
 class Dispatch:
     call_type: CallType
-    payload: dict[str, Any]
+    payload: BaseDispatchPayload
 
 
 @dataclass

--- a/src/differential/orchestrator.py
+++ b/src/differential/orchestrator.py
@@ -7,7 +7,14 @@ from typing import Optional
 
 from differential.calls import run_assess, run_ingest, run_prioritization, run_scout
 from differential.database import DB
-from differential.models import CallType, Page, Workspace
+from differential.models import (
+    AssessDispatchPayload,
+    CallType,
+    Page,
+    PrioritizationDispatchPayload,
+    ScoutDispatchPayload,
+    Workspace,
+)
 from differential.tracer import CallTrace
 
 
@@ -192,75 +199,66 @@ class Orchestrator:
             if budget_spent >= actual_budget or self.db.budget_remaining() <= 0:
                 break
 
-            d_type = dispatch.call_type
             p = dispatch.payload
-            d_question_id = p.get("question_id", question_id)
-            d_budget = int(p.get("budget", 1))
-            d_reason = p.get("reason", "")
-            d_context_ids = p.get("context_page_ids", [])
-            d_fruit_threshold = int(p.get("fruit_threshold", DEFAULT_FRUIT_THRESHOLD))
-            d_max_rounds = int(p.get("max_rounds", DEFAULT_MAX_ROUNDS))
 
-            # Resolve short IDs and validate that the question exists
-            resolved = self.db.resolve_page_id(d_question_id)
+            resolved = self.db.resolve_page_id(p.question_id)
             if not resolved:
                 print(
-                    f"{indent}  [orchestrator] Skipping dispatch — question ID not found: {d_question_id[:8]}. "
-                    "Falling back to scope question."
+                    f"{indent}  [orchestrator] Skipping dispatch — question ID not found: {p.question_id[:8]}. "
+                    'Falling back to scope question.'
                 )
-                d_question_id = question_id
-            else:
-                d_question_id = resolved
+                resolved = question_id
 
-            d_label = self.db.page_label(d_question_id)
-            if d_type == CallType.SCOUT:
-                print(
-                    f"{indent}  -> Dispatch: scout on {d_label} "
-                    f"(fruit_threshold={d_fruit_threshold}, max_rounds={d_max_rounds}) — {d_reason}"
-                )
-            else:
-                print(
-                    f"{indent}  -> Dispatch: {d_type} on {d_label} (budget={d_budget}) — {d_reason}"
-                )
-
+            d_label = self.db.page_label(resolved)
             child_call_id: str | None = None
 
-            if d_type is CallType.SCOUT:
+            if isinstance(p, ScoutDispatchPayload):
+                print(
+                    f"{indent}  -> Dispatch: scout on {d_label} "
+                    f"(fruit_threshold={p.fruit_threshold}, max_rounds={p.max_rounds}) — {p.reason}"
+                )
                 spent, child_ids = scout_until_done(
-                    d_question_id,
+                    resolved,
                     self.db,
-                    max_rounds=d_max_rounds,
-                    fruit_threshold=d_fruit_threshold,
+                    max_rounds=p.max_rounds,
+                    fruit_threshold=p.fruit_threshold,
                     parent_call_id=p_call.id,
-                    context_page_ids=d_context_ids,
+                    context_page_ids=p.context_page_ids,
                 )
                 budget_spent += spent
                 child_call_id = child_ids[0] if child_ids else None
 
-            elif d_type is CallType.ASSESS:
+            elif isinstance(p, AssessDispatchPayload):
+                print(
+                    f"{indent}  -> Dispatch: assess on {d_label} — {p.reason}"
+                )
                 child_call_id = assess_question(
-                    d_question_id,
+                    resolved,
                     self.db,
                     parent_call_id=p_call.id,
-                    context_page_ids=d_context_ids,
+                    context_page_ids=p.context_page_ids,
                 )
                 if child_call_id:
                     budget_spent += 1
 
-            elif d_type is CallType.PRIORITIZATION:
+            elif isinstance(p, PrioritizationDispatchPayload):
+                print(
+                    f"{indent}  -> Dispatch: prioritization on {d_label} "
+                    f"(budget={p.budget}) — {p.reason}"
+                )
                 self.investigate_question(
-                    question_id=d_question_id,
-                    budget=d_budget,
+                    question_id=resolved,
+                    budget=p.budget,
                     parent_call_id=p_call.id,
                     depth=depth + 1,
                 )
-                budget_spent += d_budget
+                budget_spent += p.budget
 
             if p_trace:
                 trace_data: dict = {
                     "index": i,
-                    "child_call_type": d_type.value,
-                    "question_id": d_question_id,
+                    "child_call_type": dispatch.call_type.value,
+                    "question_id": resolved,
                 }
                 if child_call_id:
                     trace_data["child_call_id"] = child_call_id

--- a/tests/test_dispatch_types.py
+++ b/tests/test_dispatch_types.py
@@ -1,7 +1,14 @@
 """Tests for dispatch type validation."""
 
-from differential.models import DISPATCHABLE_CALL_TYPES, CallType, Dispatch
-from differential.calls.common import DispatchPayload
+from differential.calls.dispatches import DISPATCH_DEFS
+from differential.models import (
+    AssessDispatchPayload,
+    CallType,
+    Dispatch,
+    DISPATCHABLE_CALL_TYPES,
+    PrioritizationDispatchPayload,
+    ScoutDispatchPayload,
+)
 
 
 def test_dispatchable_types_include_expected():
@@ -14,16 +21,35 @@ def test_ingest_not_dispatchable():
     assert CallType.INGEST not in DISPATCHABLE_CALL_TYPES
 
 
-def test_dispatch_holds_call_type_and_payload():
-    d = Dispatch(
-        call_type=CallType.SCOUT,
-        payload={"question_id": "abc", "reason": "test"},
-    )
+def test_dispatch_defs_match_dispatchable_types():
+    assert set(DISPATCH_DEFS.keys()) == DISPATCHABLE_CALL_TYPES
+
+
+def test_dispatch_holds_typed_payload():
+    payload = ScoutDispatchPayload(question_id="abc", reason="test")
+    d = Dispatch(call_type=CallType.SCOUT, payload=payload)
     assert d.call_type is CallType.SCOUT
-    assert d.payload["question_id"] == "abc"
+    assert d.payload.question_id == "abc"
 
 
-def test_dispatch_payload_schema_has_required_fields():
-    schema = DispatchPayload.model_json_schema()
-    assert "call_type" in schema["properties"]
-    assert "question_id" in schema["properties"]
+def test_scout_payload_has_defaults():
+    p = ScoutDispatchPayload(question_id="abc")
+    assert p.fruit_threshold == 4
+    assert p.max_rounds == 5
+
+
+def test_assess_payload_has_no_extras():
+    p = AssessDispatchPayload(question_id="abc")
+    assert p.question_id == "abc"
+    assert p.reason == ""
+
+
+def test_prioritization_payload_requires_budget():
+    p = PrioritizationDispatchPayload(question_id="abc", budget=10)
+    assert p.budget == 10
+
+
+def test_each_dispatch_def_schema_has_question_id():
+    for ddef in DISPATCH_DEFS.values():
+        schema = ddef.schema.model_json_schema()
+        assert "question_id" in schema["properties"]

--- a/tests/test_investigate.py
+++ b/tests/test_investigate.py
@@ -1,0 +1,18 @@
+"""Test for the orchestrator's investigate_question."""
+
+import pytest
+
+from differential.orchestrator import Orchestrator
+
+
+@pytest.mark.llm
+def test_investigate_question_creates_pages(tmp_db, question_page):
+    """Budget-1 investigation should produce at least one new page."""
+    tmp_db.init_budget(1)
+    orch = Orchestrator(tmp_db)
+    orch.investigate_question(question_page.id, budget=1)
+
+    rows = tmp_db.client.table("pages").select("id").eq("run_id", tmp_db.run_id).execute()
+    page_ids = [r["id"] for r in rows.data]
+    new_ids = [pid for pid in page_ids if pid != question_page.id]
+    assert len(new_ids) >= 1, f"Expected new pages, only found the original question"


### PR DESCRIPTION
## Summary
- Replace the single flat `DispatchPayload` with typed per-call-type models (`ScoutDispatchPayload`, `AssessDispatchPayload`, `PrioritizationDispatchPayload`) in `models.py`
- Add `DispatchDef` class and `DISPATCH_DEFS` registry in new `calls/dispatches.py`, mirroring the `MoveDef`/`MOVES` pattern
- Rewrite orchestrator dispatch loop to use `isinstance` checks with typed attribute access instead of `dict.get()` calls and `int()` coercions
- Add `test_investigate.py` with a budget-1 LLM integration test for `investigate_question`

## Test plan
- [x] All 29 existing + new tests pass
- [x] LLM integration test confirms end-to-end investigation creates pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)