### PR TITLE
Clarify budget consumption in prioritization dispatch

### DIFF
--- a/prompts/prioritization.md
+++ b/prompts/prioritization.md
@@ -6,6 +6,15 @@ You are performing a **Prioritization** call. You are managing research strategy
 
 You are **not** doing object-level research yourself. You are deciding what to dispatch. Your total dispatched budget must not exceed your allocated budget.
 
+## Budget Accounting
+
+Each dispatch type has a concrete budget cost:
+- **Scout:** each round costs 1 budget. A scout with `max_rounds: N` can cost up to N budget (it may stop early via `fruit_threshold`, but you must budget for the worst case).
+- **Assess:** costs exactly 1 budget.
+- **Sub-prioritization:** costs exactly the budget you assign to it.
+
+When planning dispatches, add up the **worst-case** costs and ensure the total does not exceed your allocated budget. For example, with budget 3 you could dispatch one scout (`max_rounds: 2`) plus one assess (total worst case: 3), but not a scout with `max_rounds: 3` plus an assess (worst case: 4).
+
 ## Decision Principles
 
 - **Scout before assessing.** A question needs at least 2–3 considerations before assessment adds much value.
@@ -26,7 +35,7 @@ The fruit scale runs 0–10:
 - **1–2** close to exhausted, only marginal additions expected
 - **0** nothing more to add right now
 
-Guidance by question priority:
+Guidance by question priority (assuming sufficient budget — always cap `max_rounds` at available budget):
 - **High priority:** `fruit_threshold: 3, max_rounds: 8` — squeeze hard, high failsafe
 - **Medium priority:** `fruit_threshold: 4, max_rounds: 5` — standard defaults
 - **Low priority:** `fruit_threshold: 5, max_rounds: 4` — stop earlier, tighter cap

--- a/src/differential/calls/dispatches.py
+++ b/src/differential/calls/dispatches.py
@@ -46,8 +46,9 @@ DISPATCH_DEFS: dict[CallType, DispatchDef] = {
         name="dispatch_scout",
         description=(
             'Dispatch scout rounds for a question. Finds missing considerations. '
-            'Costs up to max_rounds calls, stops early when fruit falls below '
-            'fruit_threshold.'
+            'Each round consumes 1 unit of budget. Runs up to max_rounds rounds, '
+            'stopping early when remaining fruit falls below fruit_threshold. '
+            'Budget cost: between 1 and max_rounds (inclusive).'
         ),
         schema=ScoutDispatchPayload,
     ),
@@ -55,7 +56,8 @@ DISPATCH_DEFS: dict[CallType, DispatchDef] = {
         call_type=CallType.ASSESS,
         name="dispatch_assess",
         description=(
-            'Dispatch an assessment for a question. Renders a judgement. Costs 1 call.'
+            'Dispatch an assessment for a question. Renders a judgement. '
+            'Budget cost: exactly 1.'
         ),
         schema=AssessDispatchPayload,
     ),
@@ -64,7 +66,7 @@ DISPATCH_DEFS: dict[CallType, DispatchDef] = {
         name="dispatch_prioritization",
         description=(
             'Dispatch a sub-prioritization for a question. Delegates structured '
-            'investigation. Costs the budget you assign.'
+            'investigation. Budget cost: exactly the budget you assign.'
         ),
         schema=PrioritizationDispatchPayload,
     ),

--- a/src/differential/models.py
+++ b/src/differential/models.py
@@ -99,7 +99,7 @@ class ScoutDispatchPayload(BaseDispatchPayload):
     fruit_threshold: int = Field(
         4, description='Remaining fruit threshold for stopping'
     )
-    max_rounds: int = Field(5, description='Maximum scouting rounds')
+    max_rounds: int = Field(5, description='Maximum scouting rounds (each round costs 1 budget)')
 
 
 class AssessDispatchPayload(BaseDispatchPayload):


### PR DESCRIPTION
## Summary
- Added a "Budget Accounting" section to the prioritization prompt explaining the exact cost of each dispatch type (scout rounds = 1 each, assess = 1, sub-prioritization = assigned budget) and requiring worst-case budgeting
- Updated dispatch tool descriptions to use consistent `Budget cost:` format so the LLM sees costs in the tool schema itself
- Updated `max_rounds` field description to note each round costs 1 budget

## Motivation
The prioritization LLM didn't realize each scout round costs 1 budget unit. With budget=2, it would dispatch a scout with `max_rounds: 5` — the orchestrator's hard cap prevented overspend, but the model wasted all budget on scouting with none left for assessment. After this change, the same scenario correctly produces scout (`max_rounds: 1`) + assess (worst-case total: 2).

## Test plan
- [x] `uv run pytest` — 29 tests pass
- [x] Manual test: budget=1 simple question → scout with `max_rounds: 1`, uses 1/1
- [x] Manual test: budget=2 complex question → scout (`max_rounds: 1`) + assess, uses 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)