### PR TITLE
Add project workspaces with --workspace flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -262,12 +262,13 @@ def cmd_summary(question_id: str, db: DB) -> None:
     print(f"\n---\nSummary saved to: {path}")
 
 
-def cmd_list(db: DB) -> None:
+def cmd_list(db: DB, workspace_name: str) -> None:
     questions = db.get_root_questions()
     if not questions:
-        print("No questions in workspace yet.")
+        print(f"No questions in workspace '{workspace_name}'.")
         return
 
+    print(f"\nWorkspace: {workspace_name}")
     print(f"\n{'ID':38}  {'Cons':>4}  {'Judg':>4}  Question")
     print("-" * 100)
     for q in questions:
@@ -278,6 +279,17 @@ def cmd_list(db: DB) -> None:
         )
     print("\nTo continue investigating a question:")
     print("  python main.py --continue QUESTION_ID --budget N")
+
+
+def cmd_list_workspaces(db: DB) -> None:
+    projects = db.list_projects()
+    if not projects:
+        print("No workspaces yet.")
+        return
+    print(f"\n{'Name':20}  {'Created':20}  ID")
+    print("-" * 80)
+    for p in projects:
+        print(f"{p.name:20}  {p.created_at.strftime('%Y-%m-%d %H:%M'):20}  {p.id}")
 
 
 def cmd_new(
@@ -428,6 +440,18 @@ def main():
         help="Disable execution tracing for this run",
     )
     parser.add_argument(
+        "--workspace",
+        dest="workspace_name",
+        default="default",
+        help="Project workspace name (default: 'default'). Auto-created on first use.",
+    )
+    parser.add_argument(
+        "--list-workspaces",
+        dest="list_workspaces",
+        action="store_true",
+        help="List all project workspaces",
+    )
+    parser.add_argument(
         "--prod-db",
         dest="prod_db",
         action="store_true",
@@ -442,8 +466,15 @@ def main():
 
     db = DB(run_id=str(uuid.uuid4()), prod=args.prod_db)
 
+    if args.list_workspaces:
+        cmd_list_workspaces(db)
+        return
+
+    project = db.get_or_create_project(args.workspace_name)
+    db.project_id = project.id
+
     if args.list:
-        cmd_list(db)
+        cmd_list(db, args.workspace_name)
         return
     elif args.trace_id:
         cmd_trace(args.trace_id, db)

--- a/src/differential/database.py
+++ b/src/differential/database.py
@@ -21,6 +21,7 @@ from differential.models import (
     PageLayer,
     PageLink,
     PageType,
+    Project,
     Workspace,
 )
 
@@ -61,6 +62,7 @@ def _row_to_page(row: dict[str, Any]) -> Page:
         workspace=Workspace(row["workspace"]),
         content=row["content"],
         summary=row["summary"],
+        project_id=row.get("project_id") or "",
         epistemic_status=row["epistemic_status"],
         epistemic_type=row["epistemic_type"] or "",
         provenance_model=row["provenance_model"] or "",
@@ -93,6 +95,7 @@ def _row_to_call(row: dict[str, Any]) -> Call:
         id=row["id"],
         call_type=CallType(row["call_type"]),
         workspace=Workspace(row["workspace"]),
+        project_id=row.get("project_id") or "",
         status=CallStatus(row["status"]),
         parent_call_id=row["parent_call_id"],
         scope_page_id=row["scope_page_id"],
@@ -114,13 +117,55 @@ class DB:
         run_id: str,
         client: Client | None = None,
         prod: bool = False,
+        project_id: str = "",
     ):
         self.run_id = run_id
         self.client = client or _make_client(prod=prod)
+        self.project_id = project_id
+
+    def get_or_create_project(self, name: str) -> Project:
+        rows = _rows(
+            self.client.table("projects").select("*").eq("name", name).execute()
+        )
+        if rows:
+            row = rows[0]
+            return Project(
+                id=row["id"],
+                name=row["name"],
+                created_at=datetime.fromisoformat(row["created_at"]),
+            )
+        row = _rows(
+            self.client.table("projects")
+            .insert({"name": name})
+            .execute()
+        )[0]
+        return Project(
+            id=row["id"],
+            name=row["name"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+    def list_projects(self) -> list[Project]:
+        rows = _rows(
+            self.client.table("projects")
+            .select("*")
+            .order("created_at")
+            .execute()
+        )
+        return [
+            Project(
+                id=r["id"],
+                name=r["name"],
+                created_at=datetime.fromisoformat(r["created_at"]),
+            )
+            for r in rows
+        ]
 
     # --- Pages ---
 
     def save_page(self, page: Page) -> None:
+        if not page.project_id:
+            page.project_id = self.project_id
         self.client.table("pages").upsert(
             {
                 "id": page.id,
@@ -129,6 +174,7 @@ class DB:
                 "workspace": page.workspace.value,
                 "content": page.content,
                 "summary": page.summary,
+                "project_id": page.project_id,
                 "epistemic_status": page.epistemic_status,
                 "epistemic_type": page.epistemic_type,
                 "provenance_model": page.provenance_model,
@@ -189,6 +235,8 @@ class DB:
         active_only: bool = True,
     ) -> list[Page]:
         query = self.client.table("pages").select("*")
+        if self.project_id:
+            query = query.eq("project_id", self.project_id)
         if workspace:
             query = query.eq("workspace", workspace.value)
         if page_type:
@@ -304,11 +352,14 @@ class DB:
         return call
 
     def save_call(self, call: Call) -> None:
+        if not call.project_id:
+            call.project_id = self.project_id
         self.client.table("calls").upsert(
             {
                 "id": call.id,
                 "call_type": call.call_type.value,
                 "workspace": call.workspace.value,
+                "project_id": call.project_id,
                 "status": call.status.value,
                 "parent_call_id": call.parent_call_id,
                 "scope_page_id": call.scope_page_id,
@@ -426,7 +477,10 @@ class DB:
     def get_ingest_history(self) -> dict[str, list[str]]:
         """Return {source_id: [question_id, ...]} based on considerations
         created by ingest calls."""
-        rows = _rows(self.client.rpc("get_ingest_history").execute())
+        params: dict[str, Any] = {}
+        if self.project_id:
+            params["pid"] = self.project_id
+        rows = _rows(self.client.rpc("get_ingest_history", params).execute())
         out: dict[str, list[str]] = {}
         for row in rows:
             out.setdefault(row["source_id"], []).append(row["question_id"])
@@ -532,11 +586,11 @@ class DB:
         workspace: Workspace = Workspace.RESEARCH,
     ) -> list[Page]:
         """Return questions that have no parent (top-level questions)."""
+        params: dict[str, Any] = {"ws": workspace.value}
+        if self.project_id:
+            params["pid"] = self.project_id
         rows = _rows(
-            self.client.rpc(
-                "get_root_questions",
-                {"ws": workspace.value},
-            ).execute()
+            self.client.rpc("get_root_questions", params).execute()
         )
         return [_row_to_page(r) for r in rows]
 
@@ -558,8 +612,12 @@ class DB:
             "judgements": cast(int, judgements_result.data or 0),
         }
 
-    def delete_run_data(self) -> None:
+    def delete_run_data(self, delete_project: bool = False) -> None:
         """Delete all data for this run_id. Used by test teardown."""
         for table in ["page_flags", "page_ratings", "page_links", "calls", "pages"]:
             self.client.table(table).delete().eq("run_id", self.run_id).execute()
         self.client.table("budget").delete().eq("run_id", self.run_id).execute()
+        if delete_project and self.project_id:
+            self.client.table("projects").delete().eq(
+                "id", self.project_id
+            ).execute()

--- a/src/differential/models.py
+++ b/src/differential/models.py
@@ -5,7 +5,6 @@ Data models for the research workspace.
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Optional
 import uuid
 
 from pydantic import BaseModel, Field
@@ -125,6 +124,13 @@ class Dispatch:
 
 
 @dataclass
+class Project:
+    name: str
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass
 class Page:
     page_type: PageType
     layer: PageLayer
@@ -132,13 +138,14 @@ class Page:
     content: str
     summary: str
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    project_id: str = ""
     epistemic_status: float = 2.5  # 0-5 subjective confidence
     epistemic_type: str = ""  # description of uncertainty type
     provenance_model: str = ""
     provenance_call_type: str = ""
     provenance_call_id: str = ""
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-    superseded_by: Optional[str] = None
+    superseded_by: str | None = None
     is_superseded: bool = False
     extra: dict = field(default_factory=dict)
 
@@ -152,7 +159,7 @@ class PageLink:
     to_page_id: str
     link_type: LinkType
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    direction: Optional[ConsiderationDirection] = None  # for CONSIDERATION links
+    direction: ConsiderationDirection | None = None  # for CONSIDERATION links
     strength: float = 2.5  # 0-5
     reasoning: str = ""
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
@@ -163,13 +170,14 @@ class Call:
     call_type: CallType
     workspace: Workspace
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    project_id: str = ""
     status: CallStatus = CallStatus.PENDING
-    parent_call_id: Optional[str] = None
-    scope_page_id: Optional[str] = None  # question/consideration this call is about
-    budget_allocated: Optional[int] = None
+    parent_call_id: str | None = None
+    scope_page_id: str | None = None  # question/consideration this call is about
+    budget_allocated: int | None = None
     budget_used: int = 0
     context_page_ids: list = field(default_factory=list)
     result_summary: str = ""
     review_json: dict = field(default_factory=dict)
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
-    completed_at: Optional[datetime] = None
+    completed_at: datetime | None = None

--- a/supabase/migrations/20260310000000_add_projects.sql
+++ b/supabase/migrations/20260310000000_add_projects.sql
@@ -1,0 +1,52 @@
+-- Create projects table
+CREATE TABLE projects (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Seed default project
+INSERT INTO projects (name) VALUES ('default');
+
+-- Add project_id to pages and calls
+ALTER TABLE pages ADD COLUMN project_id UUID REFERENCES projects(id);
+ALTER TABLE calls ADD COLUMN project_id UUID REFERENCES projects(id);
+
+-- Backfill existing rows to 'default' project
+UPDATE pages SET project_id = (SELECT id FROM projects WHERE name = 'default');
+UPDATE calls SET project_id = (SELECT id FROM projects WHERE name = 'default');
+
+-- Make NOT NULL after backfill
+ALTER TABLE pages ALTER COLUMN project_id SET NOT NULL;
+ALTER TABLE calls ALTER COLUMN project_id SET NOT NULL;
+
+-- Index
+CREATE INDEX idx_pages_project ON pages(project_id);
+CREATE INDEX idx_calls_project ON calls(project_id);
+
+-- Update get_root_questions to filter by project_id
+CREATE OR REPLACE FUNCTION get_root_questions(ws TEXT, pid UUID DEFAULT NULL)
+RETURNS SETOF pages
+LANGUAGE sql STABLE AS $$
+    SELECT p.* FROM pages p
+    WHERE p.page_type = 'question'
+      AND p.workspace = ws
+      AND p.is_superseded = FALSE
+      AND (pid IS NULL OR p.project_id = pid)
+      AND p.id NOT IN (
+          SELECT to_page_id FROM page_links WHERE link_type = 'child_question'
+      )
+    ORDER BY p.created_at DESC;
+$$;
+
+-- Update get_ingest_history to filter by project_id
+CREATE OR REPLACE FUNCTION get_ingest_history(pid UUID DEFAULT NULL)
+RETURNS TABLE(source_id TEXT, question_id TEXT)
+LANGUAGE sql STABLE AS $$
+    SELECT DISTINCT c.scope_page_id AS source_id, pl.to_page_id AS question_id
+    FROM calls c
+    JOIN pages p ON p.provenance_call_id = c.id
+    JOIN page_links pl ON pl.from_page_id = p.id AND pl.link_type = 'consideration'
+    WHERE c.call_type = 'ingest' AND c.status = 'complete'
+      AND (pid IS NULL OR c.project_id = pid);
+$$;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,21 @@ from differential.models import (
 )
 
 
+def pytest_addoption(parser):
+    parser.addoption("--llm", action="store_true", default=False, help="Run tests that call the real LLM API")
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "llm: tests that call the real LLM API")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--llm"):
+        return
+    skip_llm = pytest.mark.skip(reason="needs --llm flag to run")
+    for item in items:
+        if "llm" in item.keywords:
+            item.add_marker(skip_llm)
 
 
 @pytest.fixture
@@ -31,6 +44,8 @@ def tmp_db():
     """Create a DB with a unique run_id for test isolation."""
     run_id = str(uuid.uuid4())
     db = DB(run_id=run_id)
+    project = db.get_or_create_project("default")
+    db.project_id = project.id
     db.init_budget(100)
     yield db
     db.delete_run_data()

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -1,0 +1,190 @@
+"""Test that project workspaces are properly isolated."""
+
+import uuid
+
+from differential.context import build_call_context, build_prioritization_context
+from differential.database import DB
+from differential.models import (
+    ConsiderationDirection,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from differential.workspace_map import build_workspace_map
+
+
+def _make_db(project_name: str) -> DB:
+    db = DB(run_id=str(uuid.uuid4()))
+    project = db.get_or_create_project(project_name)
+    db.project_id = project.id
+    return db
+
+
+def _make_question(db: DB, text: str) -> Page:
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=text,
+        summary=text[:120],
+    )
+    db.save_page(page)
+    return page
+
+
+def _make_claim(db: DB, text: str) -> Page:
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=text,
+        summary=text[:120],
+        epistemic_status=4.5,
+        epistemic_type="well-established",
+    )
+    db.save_page(page)
+    return page
+
+
+def _link_consideration(
+    db: DB, claim: Page, question: Page, direction: ConsiderationDirection
+) -> None:
+    db.save_link(
+        PageLink(
+            from_page_id=claim.id,
+            to_page_id=question.id,
+            link_type=LinkType.CONSIDERATION,
+            direction=direction,
+            strength=4.0,
+            reasoning="test link",
+        )
+    )
+
+
+def _make_source(db: DB, name: str) -> Page:
+    page = Page(
+        page_type=PageType.SOURCE,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Content of {name}",
+        summary=f"Source: {name}",
+        extra={"filename": name, "char_count": 100},
+    )
+    db.save_page(page)
+    return page
+
+
+class TestWorkspaceIsolation:
+    """Pages and calls in one project must not leak into another project's views."""
+
+    def setup_method(self):
+        self.db_alpha = _make_db(f"alpha-{uuid.uuid4().hex[:8]}")
+        self.db_beta = _make_db(f"beta-{uuid.uuid4().hex[:8]}")
+
+        self.q_alpha = _make_question(self.db_alpha, "What colour is the sky?")
+        self.claim_alpha = _make_claim(
+            self.db_alpha, "The sky is blue due to Rayleigh scattering"
+        )
+        _link_consideration(
+            self.db_alpha,
+            self.claim_alpha,
+            self.q_alpha,
+            ConsiderationDirection.SUPPORTS,
+        )
+        self.source_alpha = _make_source(self.db_alpha, "sky-paper.pdf")
+
+        self.q_beta = _make_question(self.db_beta, "Why is the ocean salty?")
+        self.claim_beta = _make_claim(
+            self.db_beta, "Rivers carry dissolved salts into the ocean"
+        )
+        _link_consideration(
+            self.db_beta,
+            self.claim_beta,
+            self.q_beta,
+            ConsiderationDirection.SUPPORTS,
+        )
+
+    def teardown_method(self):
+        self.db_alpha.delete_run_data(delete_project=True)
+        self.db_beta.delete_run_data(delete_project=True)
+
+    def test_root_questions_isolated(self):
+        alpha_qs = self.db_alpha.get_root_questions()
+        beta_qs = self.db_beta.get_root_questions()
+
+        alpha_ids = {q.id for q in alpha_qs}
+        beta_ids = {q.id for q in beta_qs}
+
+        assert self.q_alpha.id in alpha_ids
+        assert self.q_beta.id not in alpha_ids
+        assert self.q_beta.id in beta_ids
+        assert self.q_alpha.id not in beta_ids
+
+    def test_get_pages_isolated(self):
+        alpha_pages = self.db_alpha.get_pages()
+        beta_pages = self.db_beta.get_pages()
+
+        alpha_ids = {p.id for p in alpha_pages}
+        beta_ids = {p.id for p in beta_pages}
+
+        assert self.claim_alpha.id in alpha_ids
+        assert self.claim_alpha.id not in beta_ids
+        assert self.claim_beta.id in beta_ids
+        assert self.claim_beta.id not in alpha_ids
+
+    def test_sources_isolated(self):
+        alpha_sources = self.db_alpha.get_pages(page_type=PageType.SOURCE)
+        beta_sources = self.db_beta.get_pages(page_type=PageType.SOURCE)
+
+        assert any(s.id == self.source_alpha.id for s in alpha_sources)
+        assert not any(s.id == self.source_alpha.id for s in beta_sources)
+
+    def test_workspace_map_isolated(self):
+        map_alpha, ids_alpha = build_workspace_map(self.db_alpha)
+        map_beta, ids_beta = build_workspace_map(self.db_beta)
+
+        assert self.q_alpha.id[:8] in ids_alpha
+        assert self.q_alpha.id[:8] not in ids_beta
+        assert self.q_beta.id[:8] in ids_beta
+        assert self.q_beta.id[:8] not in ids_alpha
+
+        assert "Rayleigh" in map_alpha
+        assert "Rayleigh" not in map_beta
+        assert "salty" in map_beta
+        assert "salty" not in map_alpha
+
+    def test_call_context_isolated(self):
+        ctx_alpha, _, _ = build_call_context(self.q_alpha.id, self.db_alpha)
+        ctx_beta, _, _ = build_call_context(self.q_beta.id, self.db_beta)
+
+        assert "Rayleigh" in ctx_alpha
+        assert "salty" not in ctx_alpha
+        assert "salty" in ctx_beta
+        assert "Rayleigh" not in ctx_beta
+
+    def test_prioritization_context_isolated(self):
+        ctx_alpha, _ = build_prioritization_context(
+            self.db_alpha, self.q_alpha.id
+        )
+        ctx_beta, _ = build_prioritization_context(
+            self.db_beta, self.q_beta.id
+        )
+
+        assert "sky" in ctx_alpha.lower()
+        assert "ocean" not in ctx_alpha.lower()
+        assert "ocean" in ctx_beta.lower()
+        assert "sky" not in ctx_beta.lower()
+
+    def test_source_in_prioritization_context_isolated(self):
+        ctx_alpha, _ = build_prioritization_context(
+            self.db_alpha, self.q_alpha.id
+        )
+        ctx_beta, _ = build_prioritization_context(
+            self.db_beta, self.q_beta.id
+        )
+
+        assert "sky-paper.pdf" in ctx_alpha
+        assert "sky-paper.pdf" not in ctx_beta


### PR DESCRIPTION
## Summary
- New `projects` table + `project_id` FK on `pages` and `calls` to scope all research into isolated workspaces
- `--workspace <name>` CLI flag (default: `'default'`), auto-creates on first use
- `--list-workspaces` to show all projects
- Root questions, pages, sources, workspace map, and prioritization context all filter by active project
- LLM-dependent tests now skip by default; pass `--llm` to pytest to include them

## Test plan
- [x] `uv run pytest` — 20 passed, 9 skipped (LLM tests)
- [x] 7 new workspace isolation tests verify queries don't leak between projects
- [x] Manual: `--list`, `--workspace test --add-question`, `--list-workspaces` all work correctly
- [x] Migration applies cleanly on local Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)