### PR TITLE
Add comprehensive logging and remove print statements

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ Set ANTHROPIC_API_KEY in your environment before running.
 """
 
 import argparse
+import logging
 import sys
 import uuid
 from pathlib import Path
@@ -26,6 +27,8 @@ from differential.mapper import generate_map
 from differential.summary import generate_summary, save_summary
 from differential import tracer
 from differential.tracer import generate_trace
+
+log = logging.getLogger(__name__)
 
 PAGES_DIR = Path(__file__).parent / "pages"
 
@@ -131,6 +134,7 @@ def _generate_source_summary(content: str, filename: str) -> str:
             max_tokens=256,
         ).strip()
     except Exception as e:
+        log.error("Source summary generation failed: %s", e, exc_info=True)
         print(f"  [ingest] Summary generation failed ({e}) — using filename.")
         return filename
 
@@ -144,6 +148,7 @@ def _create_source_page(filepath: str, db: DB) -> Page | None:
     try:
         content = _read_file_content(path)
     except Exception as e:
+        log.error("Failed to read file %s: %s", filepath, e, exc_info=True)
         print(f"Error reading {filepath}: {e}")
         return None
 
@@ -457,7 +462,36 @@ def main():
         action="store_true",
         help="Use production Supabase (requires SUPABASE_PROD_URL and SUPABASE_PROD_KEY)",
     )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable info-level logging to stderr",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug-level logging to stderr (very verbose)",
+    )
     args = parser.parse_args()
+
+    if args.debug:
+        log_level = logging.DEBUG
+    elif args.verbose:
+        log_level = logging.INFO
+    else:
+        log_level = logging.WARNING
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+        stream=sys.stderr,
+    )
+    # Suppress noisy third-party loggers unless --debug
+    if not args.debug:
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
+        logging.getLogger("supabase").setLevel(logging.WARNING)
+        logging.getLogger("hpack").setLevel(logging.WARNING)
 
     if args.no_trace:
         tracer.TRACING_ENABLED = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,11 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "anthropic>=0.84.0",
+    "fastapi>=0.135.1",
     "pydantic>=2.0",
     "python-dotenv>=1.2.2",
     "supabase>=2.0.0",
+    "uvicorn[standard]>=0.41.0",
 ]
 
 [project.optional-dependencies]

--- a/src/differential/calls/assess.py
+++ b/src/differential/calls/assess.py
@@ -1,12 +1,14 @@
 """Assess call: synthesise considerations and render a judgement."""
 
+import logging
+
 from differential.calls.common import (
     RunCallResult,
     complete_call,
     extract_loaded_page_ids,
     format_moves_for_review,
+    log_page_ratings,
     moves_to_trace_data,
-    print_page_ratings,
     run_call,
     run_closing_review,
 )
@@ -14,6 +16,8 @@ from differential.context import build_call_context
 from differential.database import DB
 from differential.models import Call, CallStatus, CallType
 from differential.tracer import CallTrace
+
+log = logging.getLogger(__name__)
 
 
 def run_assess(
@@ -26,7 +30,7 @@ def run_assess(
     Returns (run_call_result, review_dict).
     """
     trace = CallTrace(call.id, db)
-    print(f"\n[ASSESS] {call.id[:8]} — {db.page_label(question_id)}")
+    log.info("Assess starting: call=%s, question=%s", call.id[:8], question_id[:8])
 
     preloaded = call.context_page_ids or []
     context_text, _, working_page_ids = build_call_context(
@@ -65,11 +69,12 @@ def run_assess(
     review_context = format_moves_for_review(result.moves)
     review = run_closing_review(call, review_context, context_text, all_loaded_ids, db)
     if review:
-        print(
-            f"  [review] confidence={review.get('confidence_in_output', '?')}, "
-            f"self_assessment={review.get('self_assessment', '')[:80]}"
+        log.info(
+            "Assess review: confidence=%s, self_assessment=%s",
+            review.get("confidence_in_output", "?"),
+            review.get("self_assessment", "")[:80],
         )
-        print_page_ratings(review, db)
+        log_page_ratings(review, db)
         trace.record(
             "review_complete",
             {
@@ -79,6 +84,10 @@ def run_assess(
         )
 
     call.review_json = review or {}
+    log.info(
+        "Assess complete: call=%s, pages_created=%d",
+        call.id[:8], len(result.created_page_ids),
+    )
     complete_call(
         call,
         db,

--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -30,6 +31,8 @@ from differential.calls.dispatches import DISPATCH_DEFS
 from differential.moves.base import MoveState
 from differential.moves.load_page import LoadPagePayload
 from differential.moves.registry import MOVES
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from differential.tracer import CallTrace
@@ -107,6 +110,7 @@ def _run_phase1(
     db: DB,
 ) -> list[str]:
     """Preliminary page loading. Returns resolved full page IDs. Free."""
+    log.debug("Phase 1 starting: context_len=%d", len(context_text))
     try:
         load_tool = MOVES[MoveType.LOAD_PAGE].bind(state)
         phase1_msg = build_user_message(context_text, PHASE1_TASK)
@@ -126,12 +130,12 @@ def _run_phase1(
                     loaded_ids.append(full_id)
         if loaded_ids:
             labels = [db.page_label(pid) for pid in loaded_ids]
-            print(f"  [phase1] Loaded pages: {', '.join(labels)}")
+            log.info("Phase 1 loaded %d pages: %s", len(loaded_ids), labels)
+        else:
+            log.debug("Phase 1 completed with no pages loaded")
         return loaded_ids
     except Exception as e:
-        status = getattr(e, "status_code", None)
-        reason = f"HTTP {status}" if status else type(e).__name__
-        print(f"  [phase1] Preliminary loading skipped ({reason}) — continuing.")
+        log.warning("Phase 1 skipped due to error: %s", e, exc_info=True)
         return []
 
 
@@ -155,6 +159,12 @@ def run_call(
     when the LLM calls them. Returns a RunCallResult with created page IDs,
     dispatches, and the raw agent result.
     """
+
+    log.info(
+        "run_call: type=%s, call=%s, scope=%s",
+        call_type.value, call.id[:8],
+        call.scope_page_id[:8] if call.scope_page_id else None,
+    )
 
     if available_moves is None:
         available_moves = list(MoveType)
@@ -184,6 +194,11 @@ def run_call(
         max_rounds=max_rounds,
     )
 
+    log.info(
+        "run_call complete: type=%s, pages_created=%d, dispatches=%d, moves=%d",
+        call_type.value, len(state.created_page_ids),
+        len(state.dispatches), len(state.moves),
+    )
     return RunCallResult(
         created_page_ids=state.created_page_ids,
         dispatches=state.dispatches,
@@ -229,7 +244,7 @@ REVIEW_SYSTEM_PROMPT = (
 )
 
 
-def print_page_ratings(review: dict, db: DB) -> None:
+def log_page_ratings(review: dict, db: DB) -> None:
     ratings = review.get("page_ratings", [])
     if not ratings:
         return
@@ -241,7 +256,7 @@ def print_page_ratings(review: dict, db: DB) -> None:
         score = r.get("score", "?")
         note = r.get("note", "")
         label = score_labels.get(score, str(score))
-        print(f"  [page] {page_label} [{label}]: {note}")
+        log.info("Page rating: %s [%s]: %s", page_label, label, note)
 
 
 def complete_call(
@@ -287,6 +302,10 @@ def run_closing_review(
         f"{page_rating_note}"
     )
 
+    log.debug(
+        "Closing review starting: call=%s, type=%s, loaded_pages=%d",
+        call.id[:8], call.call_type.value, len(loaded_page_ids or []),
+    )
     try:
         user_message = build_user_message(context_text, review_task)
         review = structured_call(
@@ -295,17 +314,26 @@ def run_closing_review(
             response_model=ReviewResponse,
             max_tokens=2048,
         )
-        if review and db:
-            for r in review.get("page_ratings", []):
-                pid = db.resolve_page_id(r.get("page_id", ""))
-                score = r.get("score")
-                if pid and isinstance(score, int):
-                    db.save_page_rating(pid, call.id, score, r.get("note", ""))
+        if review:
+            log.info(
+                "Closing review complete: call=%s, fruit=%s, confidence=%s",
+                call.id[:8],
+                review.get("remaining_fruit"),
+                review.get("confidence_in_output"),
+            )
+            if db:
+                for r in review.get("page_ratings", []):
+                    pid = db.resolve_page_id(r.get("page_id", ""))
+                    score = r.get("score")
+                    if pid and isinstance(score, int):
+                        db.save_page_rating(pid, call.id, score, r.get("note", ""))
+        else:
+            log.warning("Closing review returned None for call=%s", call.id[:8])
         return review
     except Exception as e:
-        status = getattr(e, "status_code", None)
-        reason = f"HTTP {status}" if status else type(e).__name__
-        print(f"  [review] Closing review skipped ({reason}) — continuing.")
+        log.error(
+            "Closing review failed for call=%s: %s", call.id[:8], e, exc_info=True,
+        )
         return None
 
 

--- a/src/differential/calls/dispatches.py
+++ b/src/differential/calls/dispatches.py
@@ -1,5 +1,6 @@
 """Dispatch definitions: tool schemas and registry for prioritization dispatches."""
 
+import logging
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -13,6 +14,8 @@ from differential.models import (
     ScoutDispatchPayload,
 )
 from differential.moves.base import MoveState
+
+log = logging.getLogger(__name__)
 
 S = TypeVar("S", bound=BaseDispatchPayload)
 
@@ -51,6 +54,10 @@ class DispatchDef(Generic[S]):
                     resolved not in subtree_ids
                     and resolved not in state.created_page_ids
                 ):
+                    log.warning(
+                        "Dispatch rejected: question %s outside scope subtree",
+                        raw_qid,
+                    )
                     return (
                         f"Question {raw_qid} is outside the scope subtree and was not "
                         "created during this call. You can only dispatch on the scope "
@@ -59,6 +66,10 @@ class DispatchDef(Generic[S]):
 
             state.dispatches.append(
                 Dispatch(call_type=self.call_type, payload=validated)
+            )
+            log.debug(
+                "Dispatch recorded: type=%s, question=%s",
+                self.call_type.value, inp.get("question_id", "?")[:8],
             )
             return "Dispatch recorded."
 

--- a/src/differential/calls/ingest.py
+++ b/src/differential/calls/ingest.py
@@ -1,12 +1,14 @@
 """Ingest call: extract considerations from a source document."""
 
+import logging
+
 from differential.calls.common import (
     RunCallResult,
     complete_call,
     extract_loaded_page_ids,
     format_moves_for_review,
+    log_page_ratings,
     moves_to_trace_data,
-    print_page_ratings,
     run_call,
     run_closing_review,
 )
@@ -14,6 +16,8 @@ from differential.context import build_call_context
 from differential.database import DB
 from differential.models import Call, CallStatus, CallType, Page
 from differential.tracer import CallTrace
+
+log = logging.getLogger(__name__)
 
 
 def run_ingest(
@@ -29,9 +33,9 @@ def run_ingest(
     trace = CallTrace(call.id, db)
     extra = source_page.extra or {}
     filename = extra.get("filename", source_page.id[:8])
-
-    print(
-        f"\n[INGEST] {call.id[:8]} — source '{filename}' -> {db.page_label(question_id)}"
+    log.info(
+        "Ingest starting: call=%s, source=%s (%s), question=%s",
+        call.id[:8], source_page.id[:8], filename, question_id[:8],
     )
 
     preloaded = call.context_page_ids or []
@@ -78,11 +82,12 @@ def run_ingest(
     review_context = format_moves_for_review(result.moves)
     review = run_closing_review(call, review_context, context_text, all_loaded_ids, db)
     if review:
-        print(
-            f"  [review] confidence={review.get('confidence_in_output', '?')}, "
-            f"remaining_fruit={review.get('remaining_fruit', '?')}"
+        log.info(
+            "Ingest review: confidence=%s, remaining_fruit=%s",
+            review.get("confidence_in_output", "?"),
+            review.get("remaining_fruit", "?"),
         )
-        print_page_ratings(review, db)
+        log_page_ratings(review, db)
         trace.record(
             "review_complete",
             {
@@ -92,6 +97,10 @@ def run_ingest(
         )
 
     call.review_json = review or {}
+    log.info(
+        "Ingest complete: call=%s, pages_created=%d, source=%s",
+        call.id[:8], len(result.created_page_ids), filename,
+    )
     complete_call(
         call,
         db,

--- a/src/differential/calls/prioritization.py
+++ b/src/differential/calls/prioritization.py
@@ -1,10 +1,14 @@
 """Prioritization call: plan budget allocation across questions."""
 
+import logging
+
 from differential.calls.common import complete_call, moves_to_trace_data, run_call
 from differential.context import build_prioritization_context, collect_subtree_ids
 from differential.database import DB
 from differential.models import Call, CallType, MoveType
 from differential.tracer import CallTrace
+
+log = logging.getLogger(__name__)
 
 
 def run_prioritization(
@@ -18,10 +22,10 @@ def run_prioritization(
     Returns a summary dict including the list of dispatches and trace.
     """
     trace = CallTrace(call.id, db)
-    print(
-        f"\n[PRIORITIZATION] {call.id[:8]} — {db.page_label(scope_question_id)} — budget {budget}"
+    log.info(
+        "Prioritization starting: call=%s, question=%s, budget=%d",
+        call.id[:8], scope_question_id[:8], budget,
     )
-
     context_text, short_id_map = build_prioritization_context(
         db, scope_question_id=scope_question_id
     )
@@ -70,6 +74,10 @@ def run_prioritization(
         "trace": trace,
     }
 
+    log.info(
+        "Prioritization complete: call=%s, dispatches=%d, moves=%d",
+        call.id[:8], len(result.dispatches), len(result.moves),
+    )
     complete_call(
         call,
         db,

--- a/src/differential/calls/scout.py
+++ b/src/differential/calls/scout.py
@@ -1,12 +1,14 @@
 """Scout call: find missing considerations on a question."""
 
+import logging
+
 from differential.calls.common import (
     RunCallResult,
     complete_call,
     extract_loaded_page_ids,
     format_moves_for_review,
+    log_page_ratings,
     moves_to_trace_data,
-    print_page_ratings,
     run_call,
     run_closing_review,
 )
@@ -14,6 +16,8 @@ from differential.context import build_call_context
 from differential.database import DB
 from differential.models import Call, CallStatus, CallType
 from differential.tracer import CallTrace
+
+log = logging.getLogger(__name__)
 
 
 def run_scout(
@@ -26,7 +30,7 @@ def run_scout(
     Returns (run_call_result, review_dict).
     """
     trace = CallTrace(call.id, db)
-    print(f"\n[SCOUT] {call.id[:8]} — {db.page_label(question_id)}")
+    log.info("Scout starting: call=%s, question=%s", call.id[:8], question_id[:8])
 
     preloaded = call.context_page_ids or []
     context_text, _, working_page_ids = build_call_context(
@@ -64,11 +68,11 @@ def run_scout(
     remaining_fruit = 5
     if review:
         remaining_fruit = review.get("remaining_fruit", 5)
-        print(
-            f"  [review] remaining_fruit={remaining_fruit}, "
-            f"confidence={review.get('confidence_in_output', '?')}"
+        log.info(
+            "Scout review: remaining_fruit=%d, confidence=%s",
+            remaining_fruit, review.get("confidence_in_output", "?"),
         )
-        print_page_ratings(review, db)
+        log_page_ratings(review, db)
         trace.record(
             "review_complete",
             {
@@ -78,6 +82,10 @@ def run_scout(
         )
 
     call.review_json = review or {}
+    log.info(
+        "Scout complete: call=%s, pages_created=%d, fruit=%d",
+        call.id[:8], len(result.created_page_ids), remaining_fruit,
+    )
     complete_call(
         call,
         db,

--- a/src/differential/chat.py
+++ b/src/differential/chat.py
@@ -4,6 +4,7 @@ Reads from the workspace; can add questions for investigation via slash commands
 """
 
 import json
+import logging
 import os
 import re
 from pathlib import Path
@@ -13,6 +14,8 @@ from differential.llm import text_call
 from differential.models import Page, PageLayer, PageLink, PageType, LinkType, Workspace
 from differential.orchestrator import Orchestrator
 from differential.summary import build_research_tree
+
+log = logging.getLogger(__name__)
 
 PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
 DEFAULT_INVESTIGATE_BUDGET = 3
@@ -210,6 +213,7 @@ def run_chat(question_id: str, db: DB) -> None:
                 max_tokens=1024,
             )
         except Exception as e:
+            log.error("Chat LLM call failed: %s", e, exc_info=True)
             print(dim(f"\n[chat] Error: {e}"))
             history.pop()
             continue

--- a/src/differential/context.py
+++ b/src/differential/context.py
@@ -2,11 +2,14 @@
 Build context text from workspace pages for injection into LLM prompts.
 """
 
+import logging
 from typing import Optional
 
 from differential.database import DB
 from differential.models import Page, PageType, Workspace
 from differential.workspace_map import build_workspace_map
+
+log = logging.getLogger(__name__)
 
 
 def collect_subtree_ids(question_id: str, db: DB) -> set[str]:
@@ -179,6 +182,7 @@ def build_call_context(
     part of the question's working context (question itself, considerations,
     judgements).
     """
+    log.debug("build_call_context: question=%s", question_id[:8])
     map_text, short_id_map = build_workspace_map(db)
     working_context, working_page_ids = build_context_for_question(question_id, db)
 
@@ -198,7 +202,12 @@ def build_call_context(
                 parts += ["", "---", "", f"## Pre-loaded Page: `{pid[:8]}`", ""]
                 parts.append(format_page(page, db=db))
 
-    return "\n".join(parts), short_id_map, working_page_ids
+    context_text = "\n".join(parts)
+    log.debug(
+        "build_call_context complete: %d chars, %d working pages, %d extra pages",
+        len(context_text), len(working_page_ids), len(extra_page_ids or []),
+    )
+    return context_text, short_id_map, working_page_ids
 
 
 def build_prioritization_context(

--- a/src/differential/database.py
+++ b/src/differential/database.py
@@ -2,6 +2,7 @@
 Supabase database layer for the research workspace.
 """
 
+import logging
 import os
 import uuid
 from datetime import datetime, timezone
@@ -27,6 +28,8 @@ from differential.models import (
 
 # Supabase SDK types APIResponse.data as JSON | None, but table queries
 # always return list[dict]. We cast to this alias for clarity.
+log = logging.getLogger(__name__)
+
 _Rows = list[dict[str, Any]]
 
 
@@ -164,6 +167,10 @@ class DB:
     # --- Pages ---
 
     def save_page(self, page: Page) -> None:
+        log.debug(
+            "save_page: id=%s, type=%s, summary=%s",
+            page.id[:8], page.page_type.value, page.summary[:60],
+        )
         if not page.project_id:
             page.project_id = self.project_id
         self.client.table("pages").upsert(
@@ -196,12 +203,14 @@ class DB:
         """Resolve a page ID to a full UUID. Handles both full UUIDs and
         8-char short IDs. Returns the full UUID if found, or None."""
         if not page_id:
+            log.debug("resolve_page_id: empty page_id")
             return None
         # Try exact match first
         rows = _rows(
             self.client.table("pages").select("id").eq("id", page_id).execute()
         )
         if rows:
+            log.debug("resolve_page_id: exact match for %s", page_id[:8])
             return rows[0]["id"]
         # Try prefix match for short IDs
         if len(page_id) <= 8:
@@ -212,13 +221,19 @@ class DB:
                 .execute()
             )
             if len(rows) == 1:
+                log.debug(
+                    "resolve_page_id: prefix match %s -> %s",
+                    page_id, rows[0]["id"][:8],
+                )
                 return rows[0]["id"]
             if len(rows) > 1:
-                print(
-                    f"  [db] Ambiguous short ID '{page_id}' matches "
-                    f"{len(rows)} pages — skipping."
+                log.warning(
+                    "Ambiguous short ID '%s' matches %d pages", page_id, len(rows),
                 )
+            else:
+                log.debug("resolve_page_id: no prefix match for %s", page_id)
             return None
+        log.debug("resolve_page_id: no match for %s", page_id[:8])
         return None
 
     def page_label(self, page_id: str) -> str:
@@ -259,6 +274,10 @@ class DB:
     # --- Links ---
 
     def save_link(self, link: PageLink) -> None:
+        log.debug(
+            "save_link: %s -> %s, type=%s",
+            link.from_page_id[:8], link.to_page_id[:8], link.link_type.value,
+        )
         self.client.table("page_links").upsert(
             {
                 "id": link.id,
@@ -339,6 +358,13 @@ class DB:
         workspace: Workspace = Workspace.RESEARCH,
         context_page_ids: list | None = None,
     ) -> Call:
+        log.debug(
+            "create_call: type=%s, scope=%s, parent=%s, budget=%s",
+            call_type.value,
+            scope_page_id[:8] if scope_page_id else None,
+            parent_call_id[:8] if parent_call_id else None,
+            budget_allocated,
+        )
         call = Call(
             call_type=call_type,
             workspace=workspace,
@@ -438,7 +464,9 @@ class DB:
             "consume_budget",
             {"rid": self.run_id, "amount": amount},
         ).execute()
-        return cast(bool, result.data)
+        ok = cast(bool, result.data)
+        log.debug("consume_budget: amount=%d, success=%s", amount, ok)
+        return ok
 
     def add_budget(self, amount: int) -> None:
         """Add more calls to the existing budget (for continue runs)."""

--- a/src/differential/llm.py
+++ b/src/differential/llm.py
@@ -7,6 +7,7 @@ Exports three calling modes:
   - text_call: plain text call
 """
 
+import logging
 import os
 import time
 from collections.abc import Callable
@@ -23,6 +24,8 @@ MODEL = (
     if os.environ.get("DIFFERENTIAL_TEST_MODE")
     else "claude-opus-4-6"
 )
+
+log = logging.getLogger(__name__)
 
 MAX_API_RETRIES = 4
 
@@ -93,9 +96,22 @@ def _call_api(
     if tools:
         kwargs["tools"] = tools
 
+    n_tools = len(tools) if tools else 0
+    log.debug(
+        "API call: model=%s, max_tokens=%d, tools=%d, system_prompt_len=%d, messages=%d",
+        MODEL, max_tokens, n_tools, len(system_prompt), len(messages),
+    )
+
     for attempt in range(MAX_API_RETRIES):
         try:
-            return client.messages.create(**kwargs)
+            response = client.messages.create(**kwargs)
+            log.debug(
+                "API response: stop_reason=%s, usage=%d/%d tokens",
+                response.stop_reason,
+                response.usage.input_tokens,
+                response.usage.output_tokens,
+            )
+            return response
         except Exception as e:
             status = getattr(e, "status_code", None)
             name = type(e).__name__.lower()
@@ -107,12 +123,13 @@ def _call_api(
                 or "overloaded" in str(e).lower()
             )
             if not retryable or attempt == MAX_API_RETRIES - 1:
+                log.error("API call failed (non-retryable): %s", e, exc_info=True)
                 raise
             wait = 2**attempt
             label = f"HTTP {status}" if status else name
-            print(
-                f"  [llm] API temporarily unavailable ({label}), "
-                f"retrying in {wait}s... (attempt {attempt + 1}/{MAX_API_RETRIES})"
+            log.warning(
+                "API temporarily unavailable (%s), retrying in %ds (attempt %d/%d)",
+                label, wait, attempt + 1, MAX_API_RETRIES,
             )
             time.sleep(wait)
 
@@ -153,11 +170,19 @@ def agent_loop(
     ]
     tool_fns = {t.name: t.fn for t in tools}
 
+    tool_names = [t.name for t in tools]
+    log.debug(
+        "agent_loop starting: max_rounds=%d, max_tokens=%d, tools=%s",
+        max_rounds, max_tokens, tool_names,
+    )
+
     messages: list[dict] = [{"role": "user", "content": user_message}]
     text_parts: list[str] = []
     all_tool_calls: list[ToolCall] = []
+    round_num = 0
 
     for round_num in range(max_rounds + 1):
+        log.debug("agent_loop round %d/%d", round_num + 1, max_rounds)
         response = _call_api(
             client,
             system_prompt,
@@ -175,7 +200,16 @@ def agent_loop(
                 tool_uses.append(block)
 
         if response.stop_reason == "end_turn" or not tool_uses:
+            log.debug(
+                "agent_loop ending: stop_reason=%s, tool_uses=%d, rounds_used=%d",
+                response.stop_reason, len(tool_uses), round_num + 1,
+            )
             break
+
+        log.debug(
+            "agent_loop round %d: %d tool call(s): %s",
+            round_num + 1, len(tool_uses), [tu.name for tu in tool_uses],
+        )
 
         # Call each tool and build tool_result messages
         tool_results: list[dict] = []
@@ -183,6 +217,7 @@ def agent_loop(
             fn = tool_fns.get(tu.name)
             if fn is None:
                 result_str = f"Unknown tool: {tu.name}"
+                log.warning("Unknown tool called by LLM: %s", tu.name)
                 tool_results.append(
                     {
                         "type": "tool_result",
@@ -195,6 +230,9 @@ def agent_loop(
                 try:
                     result_str = fn(tu.input)
                 except Exception as e:
+                    log.error(
+                        "Tool %s raised an exception: %s", tu.name, e, exc_info=True,
+                    )
                     result_str = f"Error: {e}"
                     tool_results.append(
                         {
@@ -205,6 +243,10 @@ def agent_loop(
                         }
                     )
                 else:
+                    log.debug(
+                        "Tool %s returned: %s",
+                        tu.name, result_str[:200] if result_str else "(empty)",
+                    )
                     tool_results.append(
                         {
                             "type": "tool_result",
@@ -235,6 +277,10 @@ def agent_loop(
         messages.append({"role": "assistant", "content": response.content})
         messages.append({"role": "user", "content": tool_results + [budget_note]})
 
+    log.info(
+        "agent_loop complete: %d rounds, %d tool calls, %d text chars",
+        round_num + 1, len(all_tool_calls), sum(len(t) for t in text_parts),
+    )
     return AgentResult(
         text="\n".join(text_parts),
         tool_calls=all_tool_calls,
@@ -261,10 +307,13 @@ def text_call(
         if messages is not None
         else [{"role": "user", "content": user_message}]
     )
+    log.debug("text_call: max_tokens=%d, messages=%d", max_tokens, len(msg_list))
     response = _call_api(client, system_prompt, msg_list, max_tokens=max_tokens)
     for block in response.content:
         if isinstance(block, TextBlock):
+            log.debug("text_call returned %d chars", len(block.text))
             return block.text
+    log.debug("text_call returned empty response")
     return ""
 
 
@@ -286,6 +335,10 @@ def structured_call(
     client = anthropic.Anthropic(api_key=api_key)
 
     messages: list[MessageParam] = [{"role": "user", "content": user_message}]
+    log.debug(
+        "structured_call: model=%s, response_model=%s, max_tokens=%d",
+        MODEL, response_model.__name__, max_tokens,
+    )
 
     for attempt in range(MAX_API_RETRIES):
         try:
@@ -297,11 +350,16 @@ def structured_call(
                 output_format=response_model,
             )
             if response.parsed_output is not None:
+                log.debug(
+                    "structured_call success: %s, usage=%d/%d tokens",
+                    response_model.__name__,
+                    response.usage.input_tokens,
+                    response.usage.output_tokens,
+                )
                 return response.parsed_output.model_dump()
-            print(
-                f"  [llm] Structured output was empty "
-                f"(stop_reason={response.stop_reason}, "
-                f"usage={response.usage.output_tokens}/{max_tokens} tokens)"
+            log.warning(
+                "Structured output was empty (stop_reason=%s, usage=%d/%d tokens)",
+                response.stop_reason, response.usage.output_tokens, max_tokens,
             )
             return None
         except Exception as e:
@@ -315,12 +373,16 @@ def structured_call(
                 or "overloaded" in str(e).lower()
             )
             if not retryable or attempt == MAX_API_RETRIES - 1:
+                log.error(
+                    "structured_call failed (non-retryable): %s", e, exc_info=True,
+                )
                 raise
             wait = 2**attempt
             label = f"HTTP {status}" if status else name
-            print(
-                f"  [llm] API temporarily unavailable ({label}), "
-                f"retrying in {wait}s... (attempt {attempt + 1}/{MAX_API_RETRIES})"
+            log.warning(
+                "structured_call: API temporarily unavailable (%s), "
+                "retrying in %ds (attempt %d/%d)",
+                label, wait, attempt + 1, MAX_API_RETRIES,
             )
             time.sleep(wait)
 

--- a/src/differential/moves/base.py
+++ b/src/differential/moves/base.py
@@ -1,5 +1,6 @@
 """Base types and shared helpers for moves."""
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,6 +21,8 @@ from differential.models import (
     PageType,
     Workspace,
 )
+
+log = logging.getLogger(__name__)
 
 S = TypeVar("S", bound=BaseModel)
 
@@ -72,10 +75,11 @@ class MoveDef(Generic[S]):
         from differential.llm import Tool
 
         def fn(inp: dict) -> str:
+            log.debug("Move %s called with input keys: %s", self.name, list(inp.keys()))
             try:
                 validated = self.schema(**inp)
             except Exception as e:
-                print(f"  [validation] {self.name} failed: {e}")
+                log.error("Move %s validation failed: %s", self.name, e, exc_info=True)
                 raise
             if state.last_created_id:
                 validated = _resolve_last_created(validated, state.last_created_id)
@@ -84,6 +88,11 @@ class MoveDef(Generic[S]):
             if result.created_page_id:
                 state.created_page_ids.append(result.created_page_id)
                 state.last_created_id = result.created_page_id
+                log.debug(
+                    "Move %s created page: %s",
+                    self.name, result.created_page_id[:8],
+                )
+            log.debug("Move %s result: %s", self.name, result.message[:100])
             return result.message
 
         return Tool(
@@ -227,7 +236,10 @@ def create_page(
 
     db.save_page(page)
     write_page_file(page)
-    print(f"  [+] {page_type.value}: {page.summary[:70]} [{page.id[:8]}]")
+    log.info(
+        "Page created: type=%s, id=%s, summary=%s",
+        page_type.value, page.id[:8], page.summary[:70],
+    )
 
     message = (
         f"Created [{page.id[:8]}]: {payload.summary}"
@@ -248,9 +260,9 @@ def link_pages(
     from_id = db.resolve_page_id(from_id)
     to_id = db.resolve_page_id(to_id)
     if not from_id or not to_id:
-        print(
-            f"  [executor] {link_type.value} link skipped — "
-            "one or both page IDs not found"
+        log.warning(
+            "Link %s skipped: from_id=%s, to_id=%s — one or both not found",
+            link_type.value, from_id, to_id,
         )
         return MoveResult("Link skipped — page IDs not found.")
 
@@ -261,7 +273,8 @@ def link_pages(
         reasoning=reasoning,
     )
     db.save_link(link)
-    print(
-        f"  [~] {link_type.value}: {db.page_label(from_id)} -> {db.page_label(to_id)}"
+    log.info(
+        "Link created: %s %s -> %s",
+        link_type.value, from_id[:8], to_id[:8],
     )
     return MoveResult("Done.")

--- a/src/differential/moves/flag_funniness.py
+++ b/src/differential/moves/flag_funniness.py
@@ -1,10 +1,14 @@
 """FLAG_FUNNINESS move: flag something that seems off about a page."""
 
+import logging
+
 from pydantic import BaseModel, Field
 
 from differential.database import DB
 from differential.models import Call, MoveType
 from differential.moves.base import MoveDef, MoveResult
+
+log = logging.getLogger(__name__)
 
 
 class FlagFunninessPayload(BaseModel):
@@ -15,7 +19,7 @@ class FlagFunninessPayload(BaseModel):
 def execute(payload: FlagFunninessPayload, call: Call, db: DB) -> MoveResult:
     page_id = db.resolve_page_id(payload.page_id)
     db.save_page_flag("funniness", call_id=call.id, note=payload.note, page_id=page_id)
-    print(f"  [flag] Funniness flagged: {payload.note}")
+    log.info("Funniness flagged: page=%s, note=%s", payload.page_id, payload.note[:80])
     return MoveResult("Done.")
 
 

--- a/src/differential/moves/link_consideration.py
+++ b/src/differential/moves/link_consideration.py
@@ -1,5 +1,7 @@
 """LINK_CONSIDERATION move: link a claim to a question as a consideration."""
 
+import logging
+
 from pydantic import BaseModel, Field
 
 from differential.database import DB
@@ -11,6 +13,8 @@ from differential.models import (
     PageLink,
 )
 from differential.moves.base import MoveDef, MoveResult
+
+log = logging.getLogger(__name__)
 
 
 class LinkConsiderationPayload(BaseModel):
@@ -30,8 +34,9 @@ def execute(payload: LinkConsiderationPayload, call: Call, db: DB) -> MoveResult
     claim_id = db.resolve_page_id(payload.claim_id)
     question_id = db.resolve_page_id(payload.question_id)
     if not claim_id or not question_id:
-        print(
-            "  [executor] LINK_CONSIDERATION skipped — one or both page IDs not found"
+        log.warning(
+            "LINK_CONSIDERATION skipped: claim_id=%s, question_id=%s",
+            claim_id, question_id,
         )
         return MoveResult("Link skipped — page IDs not found.")
 
@@ -39,6 +44,9 @@ def execute(payload: LinkConsiderationPayload, call: Call, db: DB) -> MoveResult
     try:
         direction = ConsiderationDirection(direction_str)
     except ValueError:
+        log.debug(
+            "Invalid direction '%s' defaulting to neutral", direction_str,
+        )
         direction = ConsiderationDirection.NEUTRAL
 
     link = PageLink(
@@ -50,9 +58,9 @@ def execute(payload: LinkConsiderationPayload, call: Call, db: DB) -> MoveResult
         reasoning=payload.reasoning,
     )
     db.save_link(link)
-    print(
-        f"  [~] Consideration: {db.page_label(claim_id)} -> "
-        f"{db.page_label(question_id)} ({direction_str})"
+    log.info(
+        "Consideration linked: %s -> %s (%s)",
+        claim_id[:8], question_id[:8], direction_str,
     )
     return MoveResult("Done.")
 

--- a/src/differential/moves/load_page.py
+++ b/src/differential/moves/load_page.py
@@ -1,11 +1,15 @@
 """LOAD_PAGE move: request the full content of a page."""
 
+import logging
+
 from pydantic import BaseModel, Field
 
 from differential.context import format_page
 from differential.database import DB
 from differential.models import Call, MoveType
 from differential.moves.base import MoveDef, MoveResult
+
+log = logging.getLogger(__name__)
 
 
 class LoadPagePayload(BaseModel):
@@ -16,11 +20,16 @@ def execute(payload: LoadPagePayload, call: Call, db: DB) -> MoveResult:
     page_id = payload.page_id.strip()
     full_id = db.resolve_page_id(page_id)
     if not full_id:
+        log.debug("load_page: page '%s' not found", page_id)
         return MoveResult(f"Page '{page_id}' not found.")
     page = db.get_page(full_id)
     if not page:
+        log.debug("load_page: page '%s' resolved but not loadable", page_id)
         return MoveResult(f"Page '{page_id}' not found.")
-    print(f"  [load] {db.page_label(full_id)}")
+    log.debug(
+        "load_page: loaded %s (%s, %d chars)",
+        full_id[:8], page.page_type.value, len(page.content),
+    )
     return MoveResult(format_page(page, db=db))
 
 

--- a/src/differential/moves/propose_hypothesis.py
+++ b/src/differential/moves/propose_hypothesis.py
@@ -1,5 +1,7 @@
 """PROPOSE_HYPOTHESIS move: create a hypothesis claim and investigation question."""
 
+import logging
+
 from pydantic import BaseModel, Field
 
 from differential.database import DB
@@ -16,6 +18,8 @@ from differential.models import (
 )
 from differential.moves.base import MoveDef, MoveResult, write_page_file
 
+log = logging.getLogger(__name__)
+
 
 class ProposeHypothesisPayload(BaseModel):
     parent_question_id: str = Field(description="Full UUID of the parent question")
@@ -31,14 +35,14 @@ class ProposeHypothesisPayload(BaseModel):
 def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult:
     parent_id = db.resolve_page_id(payload.parent_question_id)
     if not parent_id:
-        print(
-            "  [executor] PROPOSE_HYPOTHESIS: parent_question_id not found: "
-            f"{payload.parent_question_id}"
+        log.warning(
+            "PROPOSE_HYPOTHESIS: parent_question_id not found: %s",
+            payload.parent_question_id,
         )
         return MoveResult("Hypothesis skipped — parent question not found.")
 
     if not payload.hypothesis.strip():
-        print("  [executor] PROPOSE_HYPOTHESIS: missing hypothesis text")
+        log.warning("PROPOSE_HYPOTHESIS: missing hypothesis text")
         return MoveResult("Hypothesis skipped — missing hypothesis text.")
 
     # 1. Create the claim
@@ -61,12 +65,13 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
     )
     db.save_page(claim)
     write_page_file(claim)
-    print(f"  [+] hypothesis claim: {db.page_label(claim.id)}")
+    log.info("Hypothesis claim created: %s", db.page_label(claim.id))
 
     direction_str = payload.direction.lower()
     try:
         direction = ConsiderationDirection(direction_str)
     except ValueError:
+        log.debug("Invalid direction '%s' defaulting to neutral", direction_str)
         direction = ConsiderationDirection.NEUTRAL
 
     db.save_link(
@@ -79,9 +84,9 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
             reasoning=payload.reasoning,
         )
     )
-    print(
-        f"  [~] Consideration: {db.page_label(claim.id)} -> "
-        f"{db.page_label(parent_id)} ({direction_str})"
+    log.info(
+        "Consideration linked: %s -> %s (%s)",
+        claim.id[:8], parent_id[:8], direction_str,
     )
 
     # 2. Create the hypothesis question
@@ -101,7 +106,7 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
     )
     db.save_page(question)
     write_page_file(question)
-    print(f"  [+] hypothesis question: {db.page_label(question.id)}")
+    log.info("Hypothesis question created: %s", db.page_label(question.id))
 
     db.save_link(
         PageLink(
@@ -111,9 +116,9 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
             reasoning=f"Hypothesis: {payload.hypothesis[:80]}",
         )
     )
-    print(
-        f"  [~] child_question: {db.page_label(parent_id)} -> "
-        f"{db.page_label(question.id)}"
+    log.info(
+        "Child question linked: %s -> %s",
+        parent_id[:8], question.id[:8],
     )
 
     return MoveResult(

--- a/src/differential/moves/report_duplicate.py
+++ b/src/differential/moves/report_duplicate.py
@@ -1,10 +1,14 @@
 """REPORT_DUPLICATE move: flag two pages as duplicates."""
 
+import logging
+
 from pydantic import BaseModel, Field
 
 from differential.database import DB
 from differential.models import Call, MoveType
 from differential.moves.base import MoveDef, MoveResult
+
+log = logging.getLogger(__name__)
 
 
 class ReportDuplicatePayload(BaseModel):
@@ -16,7 +20,9 @@ def execute(payload: ReportDuplicatePayload, call: Call, db: DB) -> MoveResult:
     pid_a = db.resolve_page_id(payload.page_id_a)
     pid_b = db.resolve_page_id(payload.page_id_b)
     db.save_page_flag("duplicate", call_id=call.id, page_id_a=pid_a, page_id_b=pid_b)
-    print(f"  [flag] Duplicate reported: {payload.page_id_a} <-> {payload.page_id_b}")
+    log.info(
+        "Duplicate reported: %s <-> %s", payload.page_id_a, payload.page_id_b,
+    )
     return MoveResult("Done.")
 
 

--- a/src/differential/moves/supersede_page.py
+++ b/src/differential/moves/supersede_page.py
@@ -1,10 +1,14 @@
 """SUPERSEDE_PAGE move: replace an existing page with an improved version."""
 
+import logging
+
 from pydantic import Field
 
 from differential.database import DB
 from differential.models import Call, MoveType
 from differential.moves.base import CreatePagePayload, MoveDef, MoveResult, create_page
+
+log = logging.getLogger(__name__)
 
 
 class SupersedePagePayload(CreatePagePayload):
@@ -14,20 +18,17 @@ class SupersedePagePayload(CreatePagePayload):
 def execute(payload: SupersedePagePayload, call: Call, db: DB) -> MoveResult:
     old_id = db.resolve_page_id(payload.old_page_id)
     if not old_id:
-        print(f"  [executor] SUPERSEDE_PAGE: page {payload.old_page_id} not found")
+        log.warning("SUPERSEDE_PAGE: page %s not found", payload.old_page_id)
         return MoveResult(f"Supersede skipped — page {payload.old_page_id} not found.")
 
     old_page = db.get_page(old_id)
     if not old_page:
-        print(f"  [executor] SUPERSEDE_PAGE: page {old_id} not found")
+        log.warning("SUPERSEDE_PAGE: page %s resolved but not loadable", old_id[:8])
         return MoveResult(f"Supersede skipped — page {old_id} not found.")
 
     result = create_page(payload, call, db, old_page.page_type, old_page.layer)
     db.supersede_page(old_id, result.created_page_id)
-    print(
-        f"  [~] Superseded {db.page_label(old_id)} -> "
-        f"{db.page_label(result.created_page_id)}"
-    )
+    log.info("Superseded %s -> %s", old_id[:8], result.created_page_id[:8])
     return result
 
 

--- a/src/differential/orchestrator.py
+++ b/src/differential/orchestrator.py
@@ -3,6 +3,7 @@ Orchestrator: drives the research workflow using the prioritization system.
 Budget is tracked here; prioritization and review calls are free.
 """
 
+import logging
 from typing import Optional
 
 from differential.calls import run_assess, run_ingest, run_prioritization, run_scout
@@ -18,6 +19,8 @@ from differential.models import (
 from differential.tracer import CallTrace
 
 
+log = logging.getLogger(__name__)
+
 DEFAULT_FRUIT_THRESHOLD = 4
 DEFAULT_MAX_ROUNDS = 5
 DEFAULT_INGEST_FRUIT_THRESHOLD = 5
@@ -29,7 +32,7 @@ def _consume_budget(db: DB) -> bool:
     ok = db.consume_budget(1)
     if not ok:
         remaining = db.budget_remaining()
-        print(f"\n[budget] Budget exhausted (remaining: {remaining}). Stopping.")
+        log.info("Budget exhausted (remaining: %d)", remaining)
     return ok
 
 
@@ -46,6 +49,10 @@ def scout_until_done(
     is reached. Returns (rounds_made, list_of_call_ids).
     fruit_threshold is the primary stopping condition; max_rounds is a failsafe.
     """
+    log.info(
+        "scout_until_done: question=%s, max_rounds=%d, fruit_threshold=%d",
+        question_id[:8], max_rounds, fruit_threshold,
+    )
     rounds = 0
     call_ids: list[str] = []
     for i in range(max_rounds):
@@ -63,15 +70,19 @@ def scout_until_done(
         rounds += 1
 
         remaining_fruit = review.get("remaining_fruit", 5) if review else 5
-        print(
-            f"  [orchestrator] Scout round {i + 1}/{max_rounds}, "
-            f"remaining_fruit={remaining_fruit} (threshold={fruit_threshold})"
+        log.info(
+            "Scout round %d/%d: remaining_fruit=%d (threshold=%d)",
+            i + 1, max_rounds, remaining_fruit, fruit_threshold,
         )
 
         if remaining_fruit <= fruit_threshold:
-            print("  [orchestrator] Fruit below threshold, stopping scout.")
+            log.info(
+                "Scout fruit (%d) below threshold (%d), stopping",
+                remaining_fruit, fruit_threshold,
+            )
             break
 
+    log.info("scout_until_done finished: %d rounds, %d calls", rounds, len(call_ids))
     return rounds, call_ids
 
 
@@ -89,6 +100,10 @@ def ingest_until_done(
     fruit_threshold is the primary stopping condition; max_rounds is a failsafe.
     Each round sees previously extracted claims via the question's working context.
     """
+    log.info(
+        "ingest_until_done: source=%s, question=%s, max_rounds=%d",
+        source_page.id[:8], question_id[:8], max_rounds,
+    )
     rounds = 0
     for i in range(max_rounds):
         if not _consume_budget(db):
@@ -103,15 +118,19 @@ def ingest_until_done(
         rounds += 1
 
         remaining_fruit = review.get("remaining_fruit", 5) if review else 5
-        print(
-            f"  [orchestrator] Ingest round {i + 1}/{max_rounds}, "
-            f"remaining_fruit={remaining_fruit} (threshold={fruit_threshold})"
+        log.info(
+            "Ingest round %d/%d: remaining_fruit=%d (threshold=%d)",
+            i + 1, max_rounds, remaining_fruit, fruit_threshold,
         )
 
         if remaining_fruit <= fruit_threshold:
-            print("  [orchestrator] Fruit below threshold, stopping ingest.")
+            log.info(
+                "Ingest fruit (%d) below threshold (%d), stopping",
+                remaining_fruit, fruit_threshold,
+            )
             break
 
+    log.info("ingest_until_done finished: %d rounds", rounds)
     return rounds
 
 
@@ -122,6 +141,7 @@ def assess_question(
     context_page_ids: list | None = None,
 ) -> str | None:
     """Run one Assess call on a question. Returns call ID, or None if no budget."""
+    log.info("assess_question: question=%s", question_id[:8])
     if not _consume_budget(db):
         return None
 
@@ -151,19 +171,18 @@ class Orchestrator:
         - Runs a Prioritization call to plan the budget allocation
         - Executes the plan (Scout, Assess, sub-Prioritization)
         """
-        indent = "  " * depth
         remaining = self.db.budget_remaining()
         actual_budget = min(budget, remaining)
+        log.info(
+            "investigate_question: question=%s, budget=%d, actual=%d, depth=%d",
+            question_id[:8], budget, actual_budget, depth,
+        )
 
         if actual_budget <= 0:
-            print(
-                f"{indent}[orchestrator] No budget remaining, skipping {self.db.page_label(question_id)}"
+            log.info(
+                "No budget remaining, skipping question=%s", question_id[:8],
             )
             return
-
-        print(
-            f"\n{indent}=== Investigating {self.db.page_label(question_id)} | budget={actual_budget} ==="
-        )
 
         # Run a prioritization call (free) to get a plan
         p_call = self.db.create_call(
@@ -182,12 +201,16 @@ class Orchestrator:
         )
 
         dispatches = plan.get("dispatches", [])
+        log.debug(
+            "Prioritization produced %d dispatches for question=%s",
+            len(dispatches), question_id[:8],
+        )
         p_trace: CallTrace | None = plan.get("trace")
 
         if not dispatches:
-            # Prioritization produced no plan — fall back to simple scout+assess
-            print(
-                f"{indent}[orchestrator] No dispatches from prioritization, running default scout+assess"
+            log.info(
+                "No dispatches from prioritization, running default scout+assess "
+                "for question=%s", question_id[:8],
             )
             scout_until_done(question_id, self.db, parent_call_id=p_call.id)
             assess_question(question_id, self.db, parent_call_id=p_call.id)
@@ -203,9 +226,9 @@ class Orchestrator:
 
             resolved = self.db.resolve_page_id(p.question_id)
             if not resolved:
-                print(
-                    f"{indent}  [orchestrator] Skipping dispatch — question ID not found: {p.question_id[:8]}. "
-                    "Falling back to scope question."
+                log.warning(
+                    "Dispatch question ID not found: %s, falling back to scope",
+                    p.question_id[:8],
                 )
                 resolved = question_id
 
@@ -213,9 +236,9 @@ class Orchestrator:
             child_call_id: str | None = None
 
             if isinstance(p, ScoutDispatchPayload):
-                print(
-                    f"{indent}  -> Dispatch: scout on {d_label} "
-                    f"(fruit_threshold={p.fruit_threshold}, max_rounds={p.max_rounds}) — {p.reason}"
+                log.info(
+                    "Dispatch: scout on %s (fruit_threshold=%d, max_rounds=%d) — %s",
+                    d_label, p.fruit_threshold, p.max_rounds, p.reason,
                 )
                 spent, child_ids = scout_until_done(
                     resolved,
@@ -229,7 +252,7 @@ class Orchestrator:
                 child_call_id = child_ids[0] if child_ids else None
 
             elif isinstance(p, AssessDispatchPayload):
-                print(f"{indent}  -> Dispatch: assess on {d_label} — {p.reason}")
+                log.info("Dispatch: assess on %s — %s", d_label, p.reason)
                 child_call_id = assess_question(
                     resolved,
                     self.db,
@@ -240,9 +263,9 @@ class Orchestrator:
                     budget_spent += 1
 
             elif isinstance(p, PrioritizationDispatchPayload):
-                print(
-                    f"{indent}  -> Dispatch: prioritization on {d_label} "
-                    f"(budget={p.budget}) — {p.reason}"
+                log.info(
+                    "Dispatch: prioritization on %s (budget=%d) — %s",
+                    d_label, p.budget, p.reason,
                 )
                 self.investigate_question(
                     question_id=resolved,
@@ -268,10 +291,10 @@ class Orchestrator:
     def run(self, root_question_id: str) -> None:
         """Entry point. Investigate the root question with the full budget."""
         total, used = self.db.get_budget()
-        print(f"\n{'=' * 60}")
-        print(f"Starting research on {self.db.page_label(root_question_id)}")
-        print(f"Total budget: {total} research calls")
-        print(f"{'=' * 60}\n")
+        log.info(
+            "Orchestrator.run starting: root_question=%s, budget=%d",
+            root_question_id[:8], total,
+        )
 
         self.investigate_question(
             question_id=root_question_id,
@@ -279,6 +302,4 @@ class Orchestrator:
         )
 
         total, used = self.db.get_budget()
-        print(f"\n{'=' * 60}")
-        print(f"Research complete. Budget used: {used}/{total}")
-        print(f"{'=' * 60}\n")
+        log.info("Orchestrator.run complete: budget used %d/%d", used, total)

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -267,9 +276,11 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "fastapi" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "supabase" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.optional-dependencies]
@@ -288,10 +299,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.84.0" },
+    { name = "fastapi", specifier = ">=0.135.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pypdf", marker = "extra == 'pdf'", specifier = ">=6.7.5" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "supabase", specifier = ">=2.0.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
 provides-extras = ["pdf"]
 
@@ -319,6 +332,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
 ]
 
 [[package]]
@@ -372,6 +401,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
 ]
 
 [[package]]
@@ -1088,6 +1146,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "realtime"
 version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1170,6 +1274,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]
@@ -1292,6 +1409,132 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add structured Python `logging` throughout the codebase (all modules get per-module loggers via `logging.getLogger(__name__)`)
- Add `-v`/`--verbose` (INFO) and `--debug` (DEBUG) CLI flags to control log verbosity, outputting to stderr
- Replace all internal print statements with appropriate log calls (DEBUG for function internals, INFO for operation milestones, WARNING for fallbacks, ERROR with `exc_info=True` for swallowed exceptions)
- Suppress noisy third-party loggers (httpx, httpcore, supabase, hpack) at WARNING level unless `--debug` is used

## Test plan
- [x] All 27 tests pass
- [ ] Run with `-v` and verify INFO-level output on stderr
- [ ] Run with `--debug` and verify detailed DEBUG output
- [ ] Run without flags and verify only WARNING+ output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)