### PR TITLE
Async codebase + concurrent batch mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ uv run python main.py --trace QUESTION_ID
 Tests: `uv run pytest`. Optional dependency: `pypdf` for PDF ingestion (`uv sync --extra pdf`).
 
 **Database:** Runs against local Supabase by default (`supabase start`). Pass `--prod-db` to any command to target production. Production requires `SUPABASE_PROD_URL` and `SUPABASE_PROD_KEY` (service_role) in `.env`. Migrations live in `supabase/migrations/` and are pushed to prod with `supabase db push`.
+Always use the supabase cli to create new migrations: `supabase migration new`.
 
 ## Architecture
 
@@ -77,6 +78,7 @@ Each call ends with a closing review that produces `remaining_fruit` (0-10 scale
 
 - **NEVER pass `--prod-db` when running `main.py` unless the user explicitly asks you to.** The production database contains real research data. Default to the local database for all testing, development, and exploratory runs.
 - **Never run `supabase db reset`** — this wipes the database and is destructive. To apply pending migrations, use `supabase migration up` instead. If you find yourself wanting to reset the database, stop and ask the user first.
+- Always scope your test runs to a temp/scratch workspace, e.g. `uv run main.py "Is the sky blue?" --workspace skyblue-scratch`
 
 - Epistemic status is a 0-5 float (subjective confidence), always paired with an epistemic_type string
 - Consideration strength is 0-5 (relevance to question)

--- a/README.md
+++ b/README.md
@@ -88,9 +88,33 @@ uv run python main.py --trace QUESTION_ID
 # Or trace a specific call:
 uv run python main.py --trace CALL_ID
 
+# Batch mode: investigate multiple questions concurrently
+uv run python main.py --batch questions.json
+
 # Any command can target the production database
 uv run python main.py --prod-db --list
 ```
+
+### Batch mode
+
+The `--batch` flag accepts a JSON file containing an array of questions to investigate concurrently. Each question runs with its own budget in parallel via `asyncio.gather`.
+
+```json
+[
+  {"question": "What causes coral reef bleaching?", "budget": 10},
+  {"question": "How does sleep deprivation affect cognition?", "budget": 5},
+  {"continue": "323d2d09-3463-434d-8541-68df5aaaa148", "budget": 10}
+]
+```
+
+Each entry supports:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `question` | One of `question` or `continue` | New question to investigate |
+| `continue` | One of `question` or `continue` | ID of an existing question to continue |
+| `budget` | No (default: 10) | Research call budget for this entry |
+| `ingest` | No | List of file paths to ingest (only with `question`) |
 
 ### Execution traces
 

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ Set ANTHROPIC_API_KEY in your environment before running.
 """
 
 import argparse
+import asyncio
+import json
 import sys
 import uuid
 from pathlib import Path
@@ -30,7 +32,7 @@ from differential.tracer import generate_trace
 PAGES_DIR = Path(__file__).parent / "pages"
 
 
-def create_root_question(question_text: str, db: DB) -> str:
+async def create_root_question(question_text: str, db: DB) -> str:
     page = Page(
         page_type=PageType.QUESTION,
         layer=PageLayer.SQUIDGY,
@@ -44,11 +46,11 @@ def create_root_question(question_text: str, db: DB) -> str:
         provenance_call_id="init",
         extra={"status": "open"},
     )
-    db.save_page(page)
+    await db.save_page(page)
     return page.id
 
 
-def cmd_add_question(
+async def cmd_add_question(
     question_text: str, parent_id: str | None, budget: int | None, db: DB
 ) -> None:
     page = Page(
@@ -64,10 +66,10 @@ def cmd_add_question(
         provenance_call_id="manual",
         extra={"status": "open"},
     )
-    db.save_page(page)
+    await db.save_page(page)
 
     if parent_id:
-        parent = db.get_page(parent_id)
+        parent = await db.get_page(parent_id)
         if not parent:
             print(
                 f"Warning: parent '{parent_id}' not found — question created without parent link."
@@ -79,7 +81,7 @@ def cmd_add_question(
                 link_type=LinkType.CHILD_QUESTION,
                 reasoning="Manually added sub-question",
             )
-            db.save_link(link)
+            await db.save_link(link)
             print(f"\nAdded as sub-question of: {parent.summary[:70]}")
 
     print(f"\nQuestion added: {page.id}")
@@ -90,9 +92,9 @@ def cmd_add_question(
         print(
             f"Budget:         {effective_budget} research call{'s' if effective_budget != 1 else ''}\n"
         )
-        db.init_budget(effective_budget)
-        Orchestrator(db).run(page.id)
-        _print_summary(db)
+        await db.init_budget(effective_budget)
+        await Orchestrator(db).run(page.id)
+        await _print_summary(db)
     else:
         print("\nTo investigate it later:")
         print(f"  python main.py --continue {page.id} --budget N")
@@ -135,7 +137,7 @@ def _generate_source_summary(content: str, filename: str) -> str:
         return filename
 
 
-def _create_source_page(filepath: str, db: DB) -> Page | None:
+async def _create_source_page(filepath: str, db: DB) -> Page | None:
     """Read a file and create a Source page. Returns the page, or None on error."""
     path = Path(filepath)
     if not path.exists():
@@ -162,32 +164,32 @@ def _create_source_page(filepath: str, db: DB) -> Page | None:
         provenance_call_id="manual",
         extra={"filename": path.name, "char_count": len(content)},
     )
-    db.save_page(page)
+    await db.save_page(page)
     print(f"\nSource created: {page.id}")
     print(f"File:           {path.name} ({len(content):,} chars)")
     print(f"Summary:        {summary[:120]}{'…' if len(summary) > 120 else ''}")
     return page
 
 
-def _run_ingest_calls(source_pages: list[Page], question_id: str, db: DB) -> int:
+async def _run_ingest_calls(source_pages: list[Page], question_id: str, db: DB) -> int:
     """Run ingest extraction calls for each source against a question. Returns calls made."""
     made = 0
     for source_page in source_pages:
-        if not db.budget_remaining():
+        if not await db.budget_remaining():
             print("  Budget exhausted — skipping remaining ingest extractions.")
             break
-        rounds = ingest_until_done(source_page, question_id, db)
+        rounds = await ingest_until_done(source_page, question_id, db)
         made += rounds
     return made
 
 
-def cmd_ingest(
+async def cmd_ingest(
     ingest_files: list[str], for_question_id: str | None, budget: int | None, db: DB
 ) -> None:
     # Create source pages first (always free)
     source_pages = []
     for filepath in ingest_files:
-        page = _create_source_page(filepath, db)
+        page = await _create_source_page(filepath, db)
         if page:
             source_pages.append(page)
 
@@ -203,7 +205,7 @@ def cmd_ingest(
         )
         return
 
-    question = db.get_page(for_question_id)
+    question = await db.get_page(for_question_id)
     if not question:
         print(
             f"Error: question '{for_question_id}' not found. Run --list to see existing questions."
@@ -217,35 +219,35 @@ def cmd_ingest(
 
     print(f"\nExtracting considerations for: {question.summary[:80]}")
     print(f"Budget: {effective_budget} call{'s' if effective_budget != 1 else ''}\n")
-    db.init_budget(effective_budget)
-    made = _run_ingest_calls(source_pages, for_question_id, db)
-    total, used = db.get_budget()
+    await db.init_budget(effective_budget)
+    made = await _run_ingest_calls(source_pages, for_question_id, db)
+    total, used = await db.get_budget()
     print(f"\nIngest complete. {made} extraction call{'s' if made != 1 else ''} made.")
     print(f"Budget used: {used}/{total}")
     print("\nRun --map or --chat to explore the results.")
 
 
-def cmd_map(question_id: str, db: DB) -> None:
-    question = db.get_page(question_id)
+async def cmd_map(question_id: str, db: DB) -> None:
+    question = await db.get_page(question_id)
     if not question:
         print(
             f"Error: question '{question_id}' not found. Run --list to see existing questions."
         )
         sys.exit(1)
     print(f"\nGenerating map for: {question.summary[:80]}")
-    path = generate_map(question_id, db)
+    path = await generate_map(question_id, db)
     print(f"Map saved to: {path}")
     print("Open that file in your browser to view it.")
 
 
-def cmd_trace(trace_id: str, db: DB) -> None:
-    path = generate_trace(trace_id, db)
+async def cmd_trace(trace_id: str, db: DB) -> None:
+    path = await generate_trace(trace_id, db)
     print(f"Trace saved to: {path}")
     print("Open that file in your browser to view it.")
 
 
-def cmd_summary(question_id: str, db: DB) -> None:
-    question = db.get_page(question_id)
+async def cmd_summary(question_id: str, db: DB) -> None:
+    question = await db.get_page(question_id)
     if not question:
         print(
             f"Error: question '{question_id}' not found. Run --list to see existing questions."
@@ -255,15 +257,15 @@ def cmd_summary(question_id: str, db: DB) -> None:
     print(f"\nGenerating summary for: {question.summary[:80]}")
     print("(This will use one LLM call but does not count against research budget)\n")
 
-    summary_text = generate_summary(question_id, db)
+    summary_text = await generate_summary(question_id, db)
     path = save_summary(summary_text, question.summary)
 
     print(summary_text)
     print(f"\n---\nSummary saved to: {path}")
 
 
-def cmd_list(db: DB, workspace_name: str) -> None:
-    questions = db.get_root_questions()
+async def cmd_list(db: DB, workspace_name: str) -> None:
+    questions = await db.get_root_questions()
     if not questions:
         print(f"No questions in workspace '{workspace_name}'.")
         return
@@ -272,7 +274,7 @@ def cmd_list(db: DB, workspace_name: str) -> None:
     print(f"\n{'ID':38}  {'Cons':>4}  {'Judg':>4}  Question")
     print("-" * 100)
     for q in questions:
-        counts = db.count_pages_for_question(q.id)
+        counts = await db.count_pages_for_question(q.id)
         truncated = q.summary[:55] + "…" if len(q.summary) > 55 else q.summary
         print(
             f"{q.id}  {counts['considerations']:>4}  {counts['judgements']:>4}  {truncated}"
@@ -281,8 +283,8 @@ def cmd_list(db: DB, workspace_name: str) -> None:
     print("  python main.py --continue QUESTION_ID --budget N")
 
 
-def cmd_list_workspaces(db: DB) -> None:
-    projects = db.list_projects()
+async def cmd_list_workspaces(db: DB) -> None:
+    projects = await db.list_projects()
     if not projects:
         print("No workspaces yet.")
         return
@@ -292,15 +294,15 @@ def cmd_list_workspaces(db: DB) -> None:
         print(f"{p.name:20}  {p.created_at.strftime('%Y-%m-%d %H:%M'):20}  {p.id}")
 
 
-def cmd_new(
+async def cmd_new(
     question_text: str,
     budget: int | None,
     db: DB,
     ingest_files: list[str] | None = None,
 ) -> None:
     budget = budget if budget is not None else 10
-    db.init_budget(budget)
-    question_id = create_root_question(question_text, db)
+    await db.init_budget(budget)
+    question_id = await create_root_question(question_text, db)
 
     print(f"\nNew question: {question_id}")
     print(f"Question:     {question_text}")
@@ -309,20 +311,91 @@ def cmd_new(
     if ingest_files:
         source_pages = []
         for filepath in ingest_files:
-            page = _create_source_page(filepath, db)
+            page = await _create_source_page(filepath, db)
             if page:
                 source_pages.append(page)
         if source_pages:
             print(f"\nIngesting {len(source_pages)} source file(s)...")
-            _run_ingest_calls(source_pages, question_id, db)
+            await _run_ingest_calls(source_pages, question_id, db)
 
-    Orchestrator(db).run(question_id)
-    _print_summary(db)
+    await Orchestrator(db).run(question_id)
+    await _print_summary(db)
 
 
-def cmd_continue(question_id: str, additional_budget: int | None, db: DB) -> None:
+def _batch_label(entry: dict) -> str:
+    if "continue" in entry:
+        return f"continue {entry['continue'][:8]}..."
+    return entry["question"][:70]
+
+
+async def _run_one_batch_entry(
+    entry: dict, index: int, total: int, template_db: DB
+) -> None:
+    """Run a single batch entry with its own run_id for budget isolation."""
+    budget = entry.get("budget", 10)
+    label = _batch_label(entry)
+
+    db = await DB.create(
+        run_id=str(uuid.uuid4()),
+        client=template_db.client,
+        project_id=template_db.project_id,
+    )
+
+    print(f"\n[{index + 1}/{total}] Starting: {label} (budget={budget})")
+
+    if "continue" in entry:
+        await cmd_continue(entry["continue"], budget, db)
+    else:
+        await cmd_new(entry["question"], budget, db, ingest_files=entry.get("ingest"))
+
+    print(f"\n[{index + 1}/{total}] Done: {label}")
+
+
+async def cmd_batch(batch_file: str, db: DB) -> None:
+    path = Path(batch_file)
+    if not path.exists():
+        print(f"Error: file not found: {batch_file}")
+        sys.exit(1)
+
+    try:
+        entries = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error reading batch file: {e}")
+        sys.exit(1)
+
+    if not isinstance(entries, list) or not entries:
+        print("Error: batch file must contain a non-empty JSON array.")
+        sys.exit(1)
+
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            print(f"Error: entry {i} must be a JSON object.")
+            sys.exit(1)
+        if "question" not in entry and "continue" not in entry:
+            print(f"Error: entry {i} must have a 'question' or 'continue' field.")
+            sys.exit(1)
+
+    total_budget = sum(e.get("budget", 10) for e in entries)
+    new_count = sum(1 for e in entries if "question" in e)
+    cont_count = sum(1 for e in entries if "continue" in e)
+    parts = []
+    if new_count:
+        parts.append(f"{new_count} new")
+    if cont_count:
+        parts.append(f"{cont_count} continue")
+    print(f"\nBatch: {' + '.join(parts)}, total budget {total_budget}")
+    print("Running concurrently...\n")
+
+    tasks = [
+        _run_one_batch_entry(entry, i, len(entries), db)
+        for i, entry in enumerate(entries)
+    ]
+    await asyncio.gather(*tasks)
+
+
+async def cmd_continue(question_id: str, additional_budget: int | None, db: DB) -> None:
     additional_budget = additional_budget if additional_budget is not None else 10
-    question = db.get_page(question_id)
+    question = await db.get_page(question_id)
     if not question:
         print(
             f"Error: question '{question_id}' not found. Run --list to see existing questions."
@@ -334,8 +407,8 @@ def cmd_continue(question_id: str, additional_budget: int | None, db: DB) -> Non
         )
         sys.exit(1)
 
-    counts = db.count_pages_for_question(question_id)
-    db.init_budget(additional_budget)
+    counts = await db.count_pages_for_question(question_id)
+    await db.init_budget(additional_budget)
 
     print(f"\nContinuing investigation of: {question.summary[:80]}")
     print(f"Question ID:  {question_id}")
@@ -344,18 +417,18 @@ def cmd_continue(question_id: str, additional_budget: int | None, db: DB) -> Non
     )
     print(f"Budget:       {additional_budget} research calls")
 
-    Orchestrator(db).run(question_id)
-    _print_summary(db)
+    await Orchestrator(db).run(question_id)
+    await _print_summary(db)
 
 
-def _print_summary(db: DB) -> None:
-    total, used = db.get_budget()
+async def _print_summary(db: DB) -> None:
+    total, used = await db.get_budget()
     print(f"\nPages written to: {PAGES_DIR}")
     print(f"Budget used:      {used}/{total} calls")
     print("\nRun --list to see all questions.")
 
 
-def main():
+async def async_main():
     parser = argparse.ArgumentParser(
         description="Research workspace.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -452,6 +525,13 @@ def main():
         help="List all project workspaces",
     )
     parser.add_argument(
+        "--batch",
+        dest="batch_file",
+        metavar="FILE",
+        help="JSON file with a list of questions to investigate: "
+        '[{"question": "...", "budget": 10}, ...]',
+    )
+    parser.add_argument(
         "--prod-db",
         dest="prod_db",
         action="store_true",
@@ -464,36 +544,42 @@ def main():
 
     PAGES_DIR.mkdir(parents=True, exist_ok=True)
 
-    db = DB(run_id=str(uuid.uuid4()), prod=args.prod_db)
+    db = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod_db)
 
     if args.list_workspaces:
-        cmd_list_workspaces(db)
+        await cmd_list_workspaces(db)
         return
 
-    project = db.get_or_create_project(args.workspace_name)
+    project = await db.get_or_create_project(args.workspace_name)
     db.project_id = project.id
 
     if args.list:
-        cmd_list(db, args.workspace_name)
+        await cmd_list(db, args.workspace_name)
         return
     elif args.trace_id:
-        cmd_trace(args.trace_id, db)
+        await cmd_trace(args.trace_id, db)
     elif args.chat_id:
-        run_chat(args.chat_id, db)
+        await run_chat(args.chat_id, db)
     elif args.add_question:
-        cmd_add_question(args.add_question, args.parent_id, args.budget, db)
+        await cmd_add_question(args.add_question, args.parent_id, args.budget, db)
     elif args.map_id:
-        cmd_map(args.map_id, db)
+        await cmd_map(args.map_id, db)
     elif args.summary_id:
-        cmd_summary(args.summary_id, db)
+        await cmd_summary(args.summary_id, db)
     elif args.continue_id:
-        cmd_continue(args.continue_id, args.budget, db)
+        await cmd_continue(args.continue_id, args.budget, db)
+    elif args.batch_file:
+        await cmd_batch(args.batch_file, db)
     elif args.ingest_files and not args.question:
-        cmd_ingest(args.ingest_files, args.for_question_id, args.budget, db)
+        await cmd_ingest(args.ingest_files, args.for_question_id, args.budget, db)
     elif args.question:
-        cmd_new(args.question, args.budget, db, ingest_files=args.ingest_files)
+        await cmd_new(args.question, args.budget, db, ingest_files=args.ingest_files)
     else:
         parser.print_help()
+
+
+def main():
+    asyncio.run(async_main())
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,9 @@ dev = [
     "ruff>=0.15.5",
     "pytest>=8.0",
     "pytest-mock>=3.15.1",
+    "pytest-asyncio>=0.25.0",
     "pyright>=1.1.408",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/differential/calls/assess.py
+++ b/src/differential/calls/assess.py
@@ -16,7 +16,7 @@ from differential.models import Call, CallStatus, CallType
 from differential.tracer import CallTrace
 
 
-def run_assess(
+async def run_assess(
     question_id: str,
     call: Call,
     db: DB,
@@ -26,10 +26,10 @@ def run_assess(
     Returns (run_call_result, review_dict).
     """
     trace = CallTrace(call.id, db)
-    print(f"\n[ASSESS] {call.id[:8]} — {db.page_label(question_id)}")
+    print(f"\n[ASSESS] {call.id[:8]} — {await db.page_label(question_id)}")
 
     preloaded = call.context_page_ids or []
-    context_text, _, working_page_ids = build_call_context(
+    context_text, _, working_page_ids = await build_call_context(
         question_id, db, extra_page_ids=preloaded
     )
     trace.record(
@@ -48,11 +48,11 @@ def run_assess(
         "Even if uncertain, commit to a position."
     )
 
-    db.update_call_status(call.id, CallStatus.RUNNING)
-    result = run_call(CallType.ASSESS, task, context_text, call, db)
+    await db.update_call_status(call.id, CallStatus.RUNNING)
+    result = await run_call(CallType.ASSESS, task, context_text, call, db)
     if result.phase1_page_ids:
         trace.record("phase1_loaded", {"page_ids": result.phase1_page_ids})
-    phase2_loaded = extract_loaded_page_ids(result, db)
+    phase2_loaded = await extract_loaded_page_ids(result, db)
     if phase2_loaded:
         trace.record("phase2_loaded", {"page_ids": phase2_loaded})
     trace.record(
@@ -63,13 +63,13 @@ def run_assess(
         dict.fromkeys(preloaded + result.phase1_page_ids + phase2_loaded)
     )
     review_context = format_moves_for_review(result.moves)
-    review = run_closing_review(call, review_context, context_text, all_loaded_ids, db)
+    review = await run_closing_review(call, review_context, context_text, all_loaded_ids, db)
     if review:
         print(
             f"  [review] confidence={review.get('confidence_in_output', '?')}, "
             f"self_assessment={review.get('self_assessment', '')[:80]}"
         )
-        print_page_ratings(review, db)
+        await print_page_ratings(review, db)
         trace.record(
             "review_complete",
             {
@@ -79,7 +79,7 @@ def run_assess(
         )
 
     call.review_json = review or {}
-    complete_call(
+    await complete_call(
         call,
         db,
         f"Assess complete. Created {len(result.created_page_ids)} pages.",

--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -90,17 +90,17 @@ class RunCallResult:
     agent_result: AgentResult = field(default_factory=AgentResult)
 
 
-def _format_loaded_pages(page_ids: list[str], db: DB) -> str:
+async def _format_loaded_pages(page_ids: list[str], db: DB) -> str:
     """Format loaded pages as context text for phase 2."""
     parts = []
     for pid in page_ids:
-        page = db.get_page(pid)
+        page = await db.get_page(pid)
         if page:
-            parts.append(f"### Page `{pid[:8]}`\n\n{format_page(page, db=db)}")
+            parts.append(f"### Page `{pid[:8]}`\n\n{await format_page(page, db=db)}")
     return "\n\n---\n\n".join(parts)
 
 
-def _run_phase1(
+async def _run_phase1(
     system_prompt: str,
     context_text: str,
     state: MoveState,
@@ -110,7 +110,7 @@ def _run_phase1(
     try:
         load_tool = MOVES[MoveType.LOAD_PAGE].bind(state)
         phase1_msg = build_user_message(context_text, PHASE1_TASK)
-        agent_loop(
+        await agent_loop(
             system_prompt,
             phase1_msg,
             [load_tool],
@@ -121,11 +121,11 @@ def _run_phase1(
         for m in state.moves:
             if m.move_type == MoveType.LOAD_PAGE:
                 assert isinstance(m.payload, LoadPagePayload)
-                full_id = db.resolve_page_id(m.payload.page_id)
+                full_id = await db.resolve_page_id(m.payload.page_id)
                 if full_id:
                     loaded_ids.append(full_id)
         if loaded_ids:
-            labels = [db.page_label(pid) for pid in loaded_ids]
+            labels = [await db.page_label(pid) for pid in loaded_ids]
             print(f"  [phase1] Loaded pages: {', '.join(labels)}")
         return loaded_ids
     except Exception as e:
@@ -135,7 +135,7 @@ def _run_phase1(
         return []
 
 
-def run_call(
+async def run_call(
     call_type: CallType,
     task_description: str,
     context_text: str,
@@ -164,9 +164,9 @@ def run_call(
 
     phase1_ids: list[str] = []
     if call_type != CallType.PRIORITIZATION:
-        phase1_ids = _run_phase1(system_prompt, context_text, state, db)
+        phase1_ids = await _run_phase1(system_prompt, context_text, state, db)
         if phase1_ids:
-            extra_text = _format_loaded_pages(phase1_ids, db)
+            extra_text = await _format_loaded_pages(phase1_ids, db)
             context_text = context_text + "\n\n## Loaded Pages\n\n" + extra_text
 
     tools = [MOVES[mt].bind(state) for mt in available_moves]
@@ -176,7 +176,7 @@ def run_call(
 
     user_message = build_user_message(context_text, task_description)
 
-    agent_result = agent_loop(
+    agent_result = await agent_loop(
         system_prompt,
         user_message,
         tools,
@@ -193,14 +193,14 @@ def run_call(
     )
 
 
-def extract_loaded_page_ids(result: RunCallResult, db: DB) -> list[str]:
+async def extract_loaded_page_ids(result: RunCallResult, db: DB) -> list[str]:
     """Extract full page IDs for LOAD_PAGE moves from phase 2 only."""
     phase1_set = set(result.phase1_page_ids)
     loaded = []
     for m in result.moves:
         if m.move_type == MoveType.LOAD_PAGE:
             assert isinstance(m.payload, LoadPagePayload)
-            full_id = db.resolve_page_id(m.payload.page_id)
+            full_id = await db.resolve_page_id(m.payload.page_id)
             if full_id and full_id not in phase1_set:
                 loaded.append(full_id)
     return loaded
@@ -229,33 +229,33 @@ REVIEW_SYSTEM_PROMPT = (
 )
 
 
-def print_page_ratings(review: dict, db: DB) -> None:
+async def print_page_ratings(review: dict, db: DB) -> None:
     ratings = review.get("page_ratings", [])
     if not ratings:
         return
     score_labels = {-1: "confusing", 0: "no help", 1: "helpful", 2: "very helpful"}
     for r in ratings:
         pid = r.get("page_id", "?")
-        resolved = db.resolve_page_id(pid) if pid != "?" else None
-        page_label = db.page_label(resolved or pid) if resolved else f"[{pid}]"
+        resolved = await db.resolve_page_id(pid) if pid != "?" else None
+        page_label = await db.page_label(resolved or pid) if resolved else f"[{pid}]"
         score = r.get("score", "?")
         note = r.get("note", "")
         label = score_labels.get(score, str(score))
         print(f"  [page] {page_label} [{label}]: {note}")
 
 
-def complete_call(
+async def complete_call(
     call: Call, db: DB, summary: str, trace: CallTrace | None = None
 ) -> None:
     call.status = CallStatus.COMPLETE
     call.completed_at = datetime.now(UTC)
     call.result_summary = summary
-    db.save_call(call)
+    await db.save_call(call)
     if trace:
-        trace.save()
+        await trace.save()
 
 
-def run_closing_review(
+async def run_closing_review(
     call: Call,
     main_output: str,
     context_text: str,
@@ -267,7 +267,7 @@ def run_closing_review(
     if loaded_page_ids and db:
         page_lines = []
         for pid in loaded_page_ids:
-            page = db.get_page(pid)
+            page = await db.get_page(pid)
             if page:
                 page_lines.append(f'  - `{pid[:8]}`: "{page.summary[:120]}"')
         if page_lines:
@@ -289,7 +289,7 @@ def run_closing_review(
 
     try:
         user_message = build_user_message(context_text, review_task)
-        review = structured_call(
+        review = await structured_call(
             system_prompt=REVIEW_SYSTEM_PROMPT,
             user_message=user_message,
             response_model=ReviewResponse,
@@ -297,10 +297,10 @@ def run_closing_review(
         )
         if review and db:
             for r in review.get("page_ratings", []):
-                pid = db.resolve_page_id(r.get("page_id", ""))
+                pid = await db.resolve_page_id(r.get("page_id", ""))
                 score = r.get("score")
                 if pid and isinstance(score, int):
-                    db.save_page_rating(pid, call.id, score, r.get("note", ""))
+                    await db.save_page_rating(pid, call.id, score, r.get("note", ""))
         return review
     except Exception as e:
         status = getattr(e, "status_code", None)

--- a/src/differential/calls/dispatches.py
+++ b/src/differential/calls/dispatches.py
@@ -34,7 +34,7 @@ class DispatchDef(Generic[S]):
     ) -> Tool:
         """Return a Tool bound to a call's mutable state."""
 
-        def fn(inp: dict) -> str:
+        async def fn(inp: dict) -> str:
             validated = self.schema(**inp)
 
             if subtree_ids is not None:

--- a/src/differential/calls/ingest.py
+++ b/src/differential/calls/ingest.py
@@ -16,7 +16,7 @@ from differential.models import Call, CallStatus, CallType, Page
 from differential.tracer import CallTrace
 
 
-def run_ingest(
+async def run_ingest(
     source_page: Page,
     question_id: str,
     call: Call,
@@ -31,11 +31,11 @@ def run_ingest(
     filename = extra.get("filename", source_page.id[:8])
 
     print(
-        f"\n[INGEST] {call.id[:8]} — source '{filename}' -> {db.page_label(question_id)}"
+        f"\n[INGEST] {call.id[:8]} — source '{filename}' -> {await db.page_label(question_id)}"
     )
 
     preloaded = call.context_page_ids or []
-    question_context, _, working_page_ids = build_call_context(
+    question_context, _, working_page_ids = await build_call_context(
         question_id, db, extra_page_ids=preloaded
     )
     trace.record(
@@ -61,11 +61,11 @@ def run_ingest(
         f"Source page ID: `{source_page.id}`"
     )
 
-    db.update_call_status(call.id, CallStatus.RUNNING)
-    result = run_call(CallType.INGEST, task, context_text, call, db)
+    await db.update_call_status(call.id, CallStatus.RUNNING)
+    result = await run_call(CallType.INGEST, task, context_text, call, db)
     if result.phase1_page_ids:
         trace.record("phase1_loaded", {"page_ids": result.phase1_page_ids})
-    phase2_loaded = extract_loaded_page_ids(result, db)
+    phase2_loaded = await extract_loaded_page_ids(result, db)
     if phase2_loaded:
         trace.record("phase2_loaded", {"page_ids": phase2_loaded})
     trace.record(
@@ -76,13 +76,13 @@ def run_ingest(
         dict.fromkeys(preloaded + result.phase1_page_ids + phase2_loaded)
     )
     review_context = format_moves_for_review(result.moves)
-    review = run_closing_review(call, review_context, context_text, all_loaded_ids, db)
+    review = await run_closing_review(call, review_context, context_text, all_loaded_ids, db)
     if review:
         print(
             f"  [review] confidence={review.get('confidence_in_output', '?')}, "
             f"remaining_fruit={review.get('remaining_fruit', '?')}"
         )
-        print_page_ratings(review, db)
+        await print_page_ratings(review, db)
         trace.record(
             "review_complete",
             {
@@ -92,7 +92,7 @@ def run_ingest(
         )
 
     call.review_json = review or {}
-    complete_call(
+    await complete_call(
         call,
         db,
         f"Ingest complete. Created {len(result.created_page_ids)} pages from '{filename}'.",

--- a/src/differential/calls/prioritization.py
+++ b/src/differential/calls/prioritization.py
@@ -7,7 +7,7 @@ from differential.models import Call, CallType, MoveType
 from differential.tracer import CallTrace
 
 
-def run_prioritization(
+async def run_prioritization(
     scope_question_id: str,
     call: Call,
     budget: int,
@@ -19,13 +19,13 @@ def run_prioritization(
     """
     trace = CallTrace(call.id, db)
     print(
-        f"\n[PRIORITIZATION] {call.id[:8]} — {db.page_label(scope_question_id)} — budget {budget}"
+        f"\n[PRIORITIZATION] {call.id[:8]} — {await db.page_label(scope_question_id)} — budget {budget}"
     )
 
-    context_text, short_id_map = build_prioritization_context(
+    context_text, short_id_map = await build_prioritization_context(
         db, scope_question_id=scope_question_id
     )
-    subtree_ids = collect_subtree_ids(scope_question_id, db)
+    subtree_ids = await collect_subtree_ids(scope_question_id, db)
     trace.record("context_built", {"budget": budget})
 
     task = (
@@ -38,7 +38,7 @@ def run_prioritization(
         "Use the dispatch tool to allocate calls."
     )
 
-    result = run_call(
+    result = await run_call(
         CallType.PRIORITIZATION,
         task,
         context_text,
@@ -70,7 +70,7 @@ def run_prioritization(
         "trace": trace,
     }
 
-    complete_call(
+    await complete_call(
         call,
         db,
         f"Prioritization complete. Planned {len(result.dispatches)} dispatches.",

--- a/src/differential/calls/scout.py
+++ b/src/differential/calls/scout.py
@@ -16,7 +16,7 @@ from differential.models import Call, CallStatus, CallType
 from differential.tracer import CallTrace
 
 
-def run_scout(
+async def run_scout(
     question_id: str,
     call: Call,
     db: DB,
@@ -26,10 +26,10 @@ def run_scout(
     Returns (run_call_result, review_dict).
     """
     trace = CallTrace(call.id, db)
-    print(f"\n[SCOUT] {call.id[:8]} — {db.page_label(question_id)}")
+    print(f"\n[SCOUT] {call.id[:8]} — {await db.page_label(question_id)}")
 
     preloaded = call.context_page_ids or []
-    context_text, _, working_page_ids = build_call_context(
+    context_text, _, working_page_ids = await build_call_context(
         question_id, db, extra_page_ids=preloaded
     )
     trace.record(
@@ -45,11 +45,11 @@ def run_scout(
         f"Question ID (use this when linking considerations): `{question_id}`"
     )
 
-    db.update_call_status(call.id, CallStatus.RUNNING)
-    result = run_call(CallType.SCOUT, task, context_text, call, db)
+    await db.update_call_status(call.id, CallStatus.RUNNING)
+    result = await run_call(CallType.SCOUT, task, context_text, call, db)
     if result.phase1_page_ids:
         trace.record("phase1_loaded", {"page_ids": result.phase1_page_ids})
-    phase2_loaded = extract_loaded_page_ids(result, db)
+    phase2_loaded = await extract_loaded_page_ids(result, db)
     if phase2_loaded:
         trace.record("phase2_loaded", {"page_ids": phase2_loaded})
     trace.record(
@@ -60,7 +60,7 @@ def run_scout(
         dict.fromkeys(preloaded + result.phase1_page_ids + phase2_loaded)
     )
     review_context = format_moves_for_review(result.moves)
-    review = run_closing_review(call, review_context, context_text, all_loaded_ids, db)
+    review = await run_closing_review(call, review_context, context_text, all_loaded_ids, db)
     remaining_fruit = 5
     if review:
         remaining_fruit = review.get("remaining_fruit", 5)
@@ -68,7 +68,7 @@ def run_scout(
             f"  [review] remaining_fruit={remaining_fruit}, "
             f"confidence={review.get('confidence_in_output', '?')}"
         )
-        print_page_ratings(review, db)
+        await print_page_ratings(review, db)
         trace.record(
             "review_complete",
             {
@@ -78,7 +78,7 @@ def run_scout(
         )
 
     call.review_json = review or {}
-    complete_call(
+    await complete_call(
         call,
         db,
         f"Scout complete. Created {len(result.created_page_ids)} pages. Remaining fruit: {remaining_fruit}",

--- a/src/differential/chat.py
+++ b/src/differential/chat.py
@@ -86,7 +86,7 @@ def _parse_slash_command(text: str) -> tuple[str, str, int | None] | None:
     return command, question_text, budget
 
 
-def _add_question(question_text: str, parent_id: str, db: DB) -> str:
+async def _add_question(question_text: str, parent_id: str, db: DB) -> str:
     """Create a question page linked as a child of parent_id. Returns new page ID."""
     page = Page(
         page_type=PageType.QUESTION,
@@ -99,20 +99,20 @@ def _add_question(question_text: str, parent_id: str, db: DB) -> str:
         provenance_model="human",
         provenance_call_type="chat",
         provenance_call_id="chat",
-        extra=json.dumps({"status": "open"}),
+        extra={"status": "open"},
     )
-    db.save_page(page)
+    await db.save_page(page)
     link = PageLink(
         from_page_id=parent_id,
         to_page_id=page.id,
         link_type=LinkType.CHILD_QUESTION,
         reasoning="Added during chat session",
     )
-    db.save_link(link)
+    await db.save_link(link)
     return page.id
 
 
-def _handle_slash_command(
+async def _handle_slash_command(
     command: str,
     question_text: str,
     budget: int | None,
@@ -128,7 +128,7 @@ def _handle_slash_command(
         return
 
     if command == "add":
-        page_id = _add_question(question_text, scope_question_id, db)
+        page_id = await _add_question(question_text, scope_question_id, db)
         print(dim(f"\n  Question added: {page_id}"))
         print(
             dim(
@@ -138,31 +138,31 @@ def _handle_slash_command(
 
     elif command == "investigate":
         effective_budget = budget if budget is not None else DEFAULT_INVESTIGATE_BUDGET
-        page_id = _add_question(question_text, scope_question_id, db)
+        page_id = await _add_question(question_text, scope_question_id, db)
         print(dim(f"\n  Question added: {page_id}"))
         print(dim(f"  Investigating with budget {effective_budget}...\n"))
-        db.add_budget(effective_budget)
-        Orchestrator(db).run(page_id)
-        total, used = db.get_budget()
+        await db.add_budget(effective_budget)
+        await Orchestrator(db).run(page_id)
+        total, used = await db.get_budget()
         print(dim(f"\n  Investigation complete. Budget used: {used}/{total}"))
 
     else:
         print(dim(f"  Unknown command: /{command}. Type /help for available commands."))
 
 
-def run_chat(question_id: str, db: DB) -> None:
+async def run_chat(question_id: str, db: DB) -> None:
     """
     Start an interactive chat session grounded in the research for a question.
     Maintains conversation history for follow-up questions.
     Use slash commands to add questions for investigation.
     """
-    question = db.get_page(question_id)
+    question = await db.get_page(question_id)
     if not question:
         print(f"Question {question_id} not found.")
         return
 
     print(f"\nLoading research context for: {question.summary[:80]}")
-    research_tree = build_research_tree(question_id, db)
+    research_tree = await build_research_tree(question_id, db)
 
     if not research_tree.strip():
         print("No research found for this question yet.")
@@ -197,14 +197,14 @@ def run_chat(question_id: str, db: DB) -> None:
         parsed = _parse_slash_command(user_input)
         if parsed is not None:
             command, question_text, budget = parsed
-            _handle_slash_command(command, question_text, budget, question_id, db)
+            await _handle_slash_command(command, question_text, budget, question_id, db)
             continue
 
         # Normal chat message
         history.append({"role": "user", "content": user_input})
 
         try:
-            response = text_call(
+            response = await text_call(
                 system_prompt=system_prompt,
                 messages=history,
                 max_tokens=1024,

--- a/src/differential/context.py
+++ b/src/differential/context.py
@@ -2,22 +2,20 @@
 Build context text from workspace pages for injection into LLM prompts.
 """
 
-from typing import Optional
-
 from differential.database import DB
 from differential.models import Page, PageType, Workspace
 from differential.workspace_map import build_workspace_map
 
 
-def collect_subtree_ids(question_id: str, db: DB) -> set[str]:
+async def collect_subtree_ids(question_id: str, db: DB) -> set[str]:
     """Recursively collect all question IDs in a subtree (inclusive)."""
     result = {question_id}
-    for child in db.get_child_questions(question_id):
-        result |= collect_subtree_ids(child.id, db)
+    for child in await db.get_child_questions(question_id):
+        result |= await collect_subtree_ids(child.id, db)
     return result
 
 
-def format_page(page: Page, db: Optional[DB] = None) -> str:
+async def format_page(page: Page, db: DB | None = None) -> str:
     """Format a single page as readable text for LLM context."""
     extra = page.extra or {}
     lines = [
@@ -33,7 +31,7 @@ def format_page(page: Page, db: Optional[DB] = None) -> str:
 
     # For questions, include considerations if db provided
     if db and page.page_type == PageType.QUESTION:
-        considerations = db.get_considerations_for_question(page.id)
+        considerations = await db.get_considerations_for_question(page.id)
         if considerations:
             lines.append("")
             lines.append("**Considerations:**")
@@ -46,7 +44,7 @@ def format_page(page: Page, db: Optional[DB] = None) -> str:
                 if link.reasoning:
                     lines.append(f"  Reasoning: {link.reasoning}")
 
-        judgements = db.get_judgements_for_question(page.id)
+        judgements = await db.get_judgements_for_question(page.id)
         if judgements:
             lines.append("")
             lines.append("**Existing judgements:**")
@@ -56,17 +54,17 @@ def format_page(page: Page, db: Optional[DB] = None) -> str:
     return "\n".join(lines)
 
 
-def format_pages_block(pages: list[Page], header: str, db: Optional[DB] = None) -> str:
+async def format_pages_block(pages: list[Page], header: str, db: DB | None = None) -> str:
     if not pages:
         return ""
     parts = [f"## {header}", ""]
     for page in pages:
-        parts.append(format_page(page, db=db))
+        parts.append(await format_page(page, db=db))
         parts.append("")
     return "\n".join(parts)
 
 
-def build_context_for_question(
+async def build_context_for_question(
     question_id: str,
     db: DB,
     include_considerations: bool = True,
@@ -78,17 +76,17 @@ def build_context_for_question(
     Returns (context_text, loaded_page_ids) where loaded_page_ids lists every
     page whose full content was included.
     """
-    question = db.get_page(question_id)
+    question = await db.get_page(question_id)
     if not question:
         return f"[Question {question_id} not found]", []
 
     loaded_ids = [question_id]
     parts = ["# Workspace Context", ""]
-    parts.append(format_page(question, db=db))
+    parts.append(await format_page(question, db=db))
     parts.append("")
 
     if include_considerations:
-        considerations = db.get_considerations_for_question(question_id)
+        considerations = await db.get_considerations_for_question(question_id)
         if considerations:
             parts.append("## Existing Considerations")
             parts.append("")
@@ -105,19 +103,19 @@ def build_context_for_question(
                 parts.append("")
 
     if include_judgements:
-        judgements = db.get_judgements_for_question(question_id)
+        judgements = await db.get_judgements_for_question(question_id)
         if judgements:
             parts.append("## Existing Judgements")
             parts.append("")
             for j in judgements:
                 loaded_ids.append(j.id)
-                parts.append(format_page(j))
+                parts.append(await format_page(j))
                 parts.append("")
 
-        children = db.get_child_questions(question_id)
+        children = await db.get_child_questions(question_id)
         child_judgements = []
         for child in children:
-            for j in db.get_judgements_for_question(child.id):
+            for j in await db.get_judgements_for_question(child.id):
                 child_judgements.append((child, j))
         if child_judgements:
             parts.append("## Sub-question Judgements")
@@ -125,16 +123,16 @@ def build_context_for_question(
             for child, j in child_judgements:
                 loaded_ids.append(j.id)
                 parts.append(f"*On sub-question: {child.summary} (`{child.id}`)*")
-                parts.append(format_page(j))
+                parts.append(await format_page(j))
                 parts.append("")
 
     return "\n".join(parts), loaded_ids
 
 
-def _build_question_index(question_id: str, db: DB, indent: int = 0) -> list[str]:
+async def _build_question_index(question_id: str, db: DB, indent: int = 0) -> list[str]:
     """Recursively build a flat index of all questions in the tree with their IDs.
     Includes consideration count, last scout fruit/date, and hypothesis flag."""
-    question = db.get_page(question_id)
+    question = await db.get_page(question_id)
     if not question:
         return []
     prefix = "  " * indent
@@ -144,8 +142,8 @@ def _build_question_index(question_id: str, db: DB, indent: int = 0) -> list[str
     is_hypothesis = extra.get("hypothesis", False)
     hypothesis_tag = " [hypothesis]" if is_hypothesis else ""
 
-    n_cons = len(db.get_considerations_for_question(question_id))
-    scout_info = db.get_last_scout_info(question_id)
+    n_cons = len(await db.get_considerations_for_question(question_id))
+    scout_info = await db.get_last_scout_info(question_id)
     if scout_info:
         date_str = scout_info[0][:10]
         fruit = scout_info[1]
@@ -158,15 +156,15 @@ def _build_question_index(question_id: str, db: DB, indent: int = 0) -> list[str
         f"{prefix}{tag}{hypothesis_tag} `{question_id}` — {question.summary} "
         f"({n_cons} cons · {scout_str})"
     ]
-    for child in db.get_child_questions(question_id):
-        lines.extend(_build_question_index(child.id, db, indent + 1))
+    for child in await db.get_child_questions(question_id):
+        lines.extend(await _build_question_index(child.id, db, indent + 1))
     return lines
 
 
-def build_call_context(
+async def build_call_context(
     question_id: str,
     db: DB,
-    extra_page_ids: Optional[list[str]] = None,
+    extra_page_ids: list[str] | None = None,
 ) -> tuple[str, dict[str, str], list[str]]:
     """Build full context for a scout/assess/ingest call.
 
@@ -179,8 +177,8 @@ def build_call_context(
     part of the question's working context (question itself, considerations,
     judgements).
     """
-    map_text, short_id_map = build_workspace_map(db)
-    working_context, working_page_ids = build_context_for_question(question_id, db)
+    map_text, short_id_map = await build_workspace_map(db)
+    working_context, working_page_ids = await build_context_for_question(question_id, db)
 
     parts = [
         map_text,
@@ -193,29 +191,29 @@ def build_call_context(
 
     if extra_page_ids:
         for pid in extra_page_ids:
-            page = db.get_page(pid)
+            page = await db.get_page(pid)
             if page:
                 parts += ["", "---", "", f"## Pre-loaded Page: `{pid[:8]}`", ""]
-                parts.append(format_page(page, db=db))
+                parts.append(await format_page(page, db=db))
 
     return "\n".join(parts), short_id_map, working_page_ids
 
 
-def build_prioritization_context(
-    db: DB, scope_question_id: Optional[str] = None
+async def build_prioritization_context(
+    db: DB, scope_question_id: str | None = None
 ) -> tuple[str, dict[str, str]]:
     """Build context for a prioritization call.
 
     Returns (context_text, short_id_map) where short_id_map maps 8-char
     short IDs to full UUIDs.
     """
-    map_text, short_id_map = build_workspace_map(db)
+    map_text, short_id_map = await build_workspace_map(db)
     parts = [map_text, "", "---", "", "# Prioritization Context", ""]
 
     if scope_question_id:
-        question = db.get_page(scope_question_id)
+        question = await db.get_page(scope_question_id)
         if question:
-            index_lines = _build_question_index(scope_question_id, db)
+            index_lines = await _build_question_index(scope_question_id, db)
             parts.append("## Scope Subtree — Dispatchable Questions")
             parts.append("")
             parts.append(
@@ -230,21 +228,21 @@ def build_prioritization_context(
             # Full detail on scope question and children
             parts.append("## Scope Question")
             parts.append("")
-            parts.append(format_page(question, db=db))
+            parts.append(await format_page(question, db=db))
             parts.append("")
 
-            children = db.get_child_questions(scope_question_id)
+            children = await db.get_child_questions(scope_question_id)
             if children:
                 parts.append("## Sub-questions")
                 parts.append("")
                 for child in children:
-                    parts.append(format_page(child, db=db))
+                    parts.append(await format_page(child, db=db))
                     parts.append("")
 
     # Sources and ingest history
-    source_pages = db.get_pages(page_type=PageType.SOURCE)
+    source_pages = await db.get_pages(page_type=PageType.SOURCE)
     if source_pages:
-        ingest_history = db.get_ingest_history()
+        ingest_history = await db.get_ingest_history()
         parts.append("## Sources and Ingest History")
         parts.append("")
         for src in source_pages:
@@ -255,7 +253,7 @@ def build_prioritization_context(
             parts.append(f"[SRC] `{src.id[:8]}` — {filename} ({char_count:,} chars)")
             if question_ids:
                 for qid in question_ids:
-                    q = db.get_page(qid)
+                    q = await db.get_page(qid)
                     q_summary = q.summary[:60] if q else qid[:8]
                     parts.append(f"  Ingested for: `{qid[:8]}` — {q_summary}")
             else:

--- a/src/differential/database.py
+++ b/src/differential/database.py
@@ -8,8 +8,8 @@ from datetime import datetime, timezone
 from typing import Any, cast
 
 from postgrest.types import CountMethod
-from supabase import create_client, Client
-from supabase.lib.client_options import SyncClientOptions
+from supabase import acreate_client, AsyncClient
+from supabase.lib.client_options import AsyncClientOptions
 
 from differential.models import (
     Call,
@@ -44,14 +44,13 @@ _DEFAULT_KEY = (
 )
 
 
-def _make_client(prod: bool = False) -> Client:
+def _get_credentials(prod: bool = False) -> tuple[str, str]:
     if prod:
-        url = os.environ["SUPABASE_PROD_URL"]
-        key = os.environ["SUPABASE_PROD_KEY"]
-    else:
-        url = os.environ.get("SUPABASE_URL", _DEFAULT_URL)
-        key = os.environ.get("SUPABASE_KEY", _DEFAULT_KEY)
-    return create_client(url, key, options=SyncClientOptions(schema="public"))
+        return os.environ["SUPABASE_PROD_URL"], os.environ["SUPABASE_PROD_KEY"]
+    return (
+        os.environ.get("SUPABASE_URL", _DEFAULT_URL),
+        os.environ.get("SUPABASE_KEY", _DEFAULT_KEY),
+    )
 
 
 def _row_to_page(row: dict[str, Any]) -> Page:
@@ -115,17 +114,31 @@ class DB:
     def __init__(
         self,
         run_id: str,
-        client: Client | None = None,
-        prod: bool = False,
+        client: AsyncClient,
         project_id: str = "",
     ):
         self.run_id = run_id
-        self.client = client or _make_client(prod=prod)
+        self.client = client
         self.project_id = project_id
 
-    def get_or_create_project(self, name: str) -> Project:
+    @classmethod
+    async def create(
+        cls,
+        run_id: str,
+        prod: bool = False,
+        project_id: str = "",
+        client: AsyncClient | None = None,
+    ) -> "DB":
+        if client is None:
+            url, key = _get_credentials(prod)
+            client = await acreate_client(
+                url, key, options=AsyncClientOptions(schema="public")
+            )
+        return cls(run_id=run_id, client=client, project_id=project_id)
+
+    async def get_or_create_project(self, name: str) -> Project:
         rows = _rows(
-            self.client.table("projects").select("*").eq("name", name).execute()
+            await self.client.table("projects").select("*").eq("name", name).execute()
         )
         if rows:
             row = rows[0]
@@ -135,7 +148,7 @@ class DB:
                 created_at=datetime.fromisoformat(row["created_at"]),
             )
         row = _rows(
-            self.client.table("projects")
+            await self.client.table("projects")
             .insert({"name": name})
             .execute()
         )[0]
@@ -145,9 +158,9 @@ class DB:
             created_at=datetime.fromisoformat(row["created_at"]),
         )
 
-    def list_projects(self) -> list[Project]:
+    async def list_projects(self) -> list[Project]:
         rows = _rows(
-            self.client.table("projects")
+            await self.client.table("projects")
             .select("*")
             .order("created_at")
             .execute()
@@ -163,10 +176,10 @@ class DB:
 
     # --- Pages ---
 
-    def save_page(self, page: Page) -> None:
+    async def save_page(self, page: Page) -> None:
         if not page.project_id:
             page.project_id = self.project_id
-        self.client.table("pages").upsert(
+        await self.client.table("pages").upsert(
             {
                 "id": page.id,
                 "page_type": page.page_type.value,
@@ -188,25 +201,27 @@ class DB:
             }
         ).execute()
 
-    def get_page(self, page_id: str) -> Page | None:
-        rows = _rows(self.client.table("pages").select("*").eq("id", page_id).execute())
+    async def get_page(self, page_id: str) -> Page | None:
+        rows = _rows(
+            await self.client.table("pages").select("*").eq("id", page_id).execute()
+        )
         return _row_to_page(rows[0]) if rows else None
 
-    def resolve_page_id(self, page_id: str) -> str | None:
+    async def resolve_page_id(self, page_id: str) -> str | None:
         """Resolve a page ID to a full UUID. Handles both full UUIDs and
         8-char short IDs. Returns the full UUID if found, or None."""
         if not page_id:
             return None
         # Try exact match first
         rows = _rows(
-            self.client.table("pages").select("id").eq("id", page_id).execute()
+            await self.client.table("pages").select("id").eq("id", page_id).execute()
         )
         if rows:
             return rows[0]["id"]
         # Try prefix match for short IDs
         if len(page_id) <= 8:
             rows = _rows(
-                self.client.table("pages")
+                await self.client.table("pages")
                 .select("id")
                 .like("id", f"{page_id}%")
                 .execute()
@@ -221,14 +236,14 @@ class DB:
             return None
         return None
 
-    def page_label(self, page_id: str) -> str:
+    async def page_label(self, page_id: str) -> str:
         """Return a human-readable label like '"Summary text" [short_id]'."""
-        page = self.get_page(page_id)
+        page = await self.get_page(page_id)
         if page:
             return f'"{page.summary[:60]}" [{page_id[:8]}]'
         return f"[{page_id[:8]}]"
 
-    def get_pages(
+    async def get_pages(
         self,
         workspace: Workspace | None = None,
         page_type: PageType | None = None,
@@ -245,11 +260,11 @@ class DB:
             query = query.eq("is_superseded", False)
         return [
             _row_to_page(r)
-            for r in _rows(query.order("created_at", desc=True).execute())
+            for r in _rows(await query.order("created_at", desc=True).execute())
         ]
 
-    def supersede_page(self, old_id: str, new_id: str) -> None:
-        self.client.table("pages").update(
+    async def supersede_page(self, old_id: str, new_id: str) -> None:
+        await self.client.table("pages").update(
             {
                 "is_superseded": True,
                 "superseded_by": new_id,
@@ -258,8 +273,8 @@ class DB:
 
     # --- Links ---
 
-    def save_link(self, link: PageLink) -> None:
-        self.client.table("page_links").upsert(
+    async def save_link(self, link: PageLink) -> None:
+        await self.client.table("page_links").upsert(
             {
                 "id": link.id,
                 "from_page_id": link.from_page_id,
@@ -273,64 +288,64 @@ class DB:
             }
         ).execute()
 
-    def get_links_to(self, page_id: str) -> list[PageLink]:
+    async def get_links_to(self, page_id: str) -> list[PageLink]:
         rows = _rows(
-            self.client.table("page_links")
+            await self.client.table("page_links")
             .select("*")
             .eq("to_page_id", page_id)
             .execute()
         )
         return [_row_to_link(r) for r in rows]
 
-    def get_links_from(self, page_id: str) -> list[PageLink]:
+    async def get_links_from(self, page_id: str) -> list[PageLink]:
         rows = _rows(
-            self.client.table("page_links")
+            await self.client.table("page_links")
             .select("*")
             .eq("from_page_id", page_id)
             .execute()
         )
         return [_row_to_link(r) for r in rows]
 
-    def get_considerations_for_question(
+    async def get_considerations_for_question(
         self,
         question_id: str,
     ) -> list[tuple[Page, PageLink]]:
         """Return (claim_page, link) pairs for all considerations on a question."""
-        links = self.get_links_to(question_id)
+        links = await self.get_links_to(question_id)
         consideration_links = [
             l for l in links if l.link_type == LinkType.CONSIDERATION
         ]
         result = []
         for link in consideration_links:
-            page = self.get_page(link.from_page_id)
+            page = await self.get_page(link.from_page_id)
             if page and page.is_active():
                 result.append((page, link))
         return result
 
-    def get_child_questions(self, parent_id: str) -> list[Page]:
+    async def get_child_questions(self, parent_id: str) -> list[Page]:
         """Return sub-questions of a question."""
-        links = self.get_links_from(parent_id)
+        links = await self.get_links_from(parent_id)
         child_links = [l for l in links if l.link_type == LinkType.CHILD_QUESTION]
         result = []
         for link in child_links:
-            page = self.get_page(link.to_page_id)
+            page = await self.get_page(link.to_page_id)
             if page and page.is_active():
                 result.append(page)
         return result
 
-    def get_judgements_for_question(self, question_id: str) -> list[Page]:
-        links = self.get_links_to(question_id)
+    async def get_judgements_for_question(self, question_id: str) -> list[Page]:
+        links = await self.get_links_to(question_id)
         judgement_links = [l for l in links if l.link_type == LinkType.RELATED]
         result = []
         for link in judgement_links:
-            page = self.get_page(link.from_page_id)
+            page = await self.get_page(link.from_page_id)
             if page and page.is_active() and page.page_type == PageType.JUDGEMENT:
                 result.append(page)
         return result
 
     # --- Calls ---
 
-    def create_call(
+    async def create_call(
         self,
         call_type: CallType,
         scope_page_id: str | None = None,
@@ -348,13 +363,13 @@ class DB:
             status=CallStatus.PENDING,
             context_page_ids=context_page_ids or [],
         )
-        self.save_call(call)
+        await self.save_call(call)
         return call
 
-    def save_call(self, call: Call) -> None:
+    async def save_call(self, call: Call) -> None:
         if not call.project_id:
             call.project_id = self.project_id
-        self.client.table("calls").upsert(
+        await self.client.table("calls").upsert(
             {
                 "id": call.id,
                 "call_type": call.call_type.value,
@@ -376,11 +391,13 @@ class DB:
             }
         ).execute()
 
-    def get_call(self, call_id: str) -> Call | None:
-        rows = _rows(self.client.table("calls").select("*").eq("id", call_id).execute())
+    async def get_call(self, call_id: str) -> Call | None:
+        rows = _rows(
+            await self.client.table("calls").select("*").eq("id", call_id).execute()
+        )
         return _row_to_call(rows[0]) if rows else None
 
-    def update_call_status(
+    async def update_call_status(
         self,
         call_id: str,
         status: CallStatus,
@@ -391,7 +408,7 @@ class DB:
             if status == CallStatus.COMPLETE
             else None
         )
-        self.client.table("calls").update(
+        await self.client.table("calls").update(
             {
                 "status": status.value,
                 "result_summary": result_summary,
@@ -399,20 +416,20 @@ class DB:
             }
         ).eq("id", call_id).execute()
 
-    def increment_call_budget_used(
+    async def increment_call_budget_used(
         self,
         call_id: str,
         amount: int = 1,
     ) -> None:
-        self.client.rpc(
+        await self.client.rpc(
             "increment_call_budget_used",
             {"call_id": call_id, "amount": amount},
         ).execute()
 
     # --- Per-run budget ---
 
-    def init_budget(self, total: int) -> None:
-        self.client.table("budget").upsert(
+    async def init_budget(self, total: int) -> None:
+        await self.client.table("budget").upsert(
             {
                 "run_id": self.run_id,
                 "total": total,
@@ -420,10 +437,10 @@ class DB:
             }
         ).execute()
 
-    def get_budget(self) -> tuple[int, int]:
+    async def get_budget(self) -> tuple[int, int]:
         """Returns (total, used)."""
         rows = _rows(
-            self.client.table("budget")
+            await self.client.table("budget")
             .select("total, used")
             .eq("run_id", self.run_id)
             .execute()
@@ -432,33 +449,33 @@ class DB:
             return rows[0]["total"], rows[0]["used"]
         return 0, 0
 
-    def consume_budget(self, amount: int = 1) -> bool:
+    async def consume_budget(self, amount: int = 1) -> bool:
         """Deduct from global budget. Returns False if insufficient budget."""
-        result = self.client.rpc(
+        result = await self.client.rpc(
             "consume_budget",
             {"rid": self.run_id, "amount": amount},
         ).execute()
         return cast(bool, result.data)
 
-    def add_budget(self, amount: int) -> None:
+    async def add_budget(self, amount: int) -> None:
         """Add more calls to the existing budget (for continue runs)."""
-        self.client.rpc(
+        await self.client.rpc(
             "add_budget",
             {"rid": self.run_id, "amount": amount},
         ).execute()
 
-    def budget_remaining(self) -> int:
-        total, used = self.get_budget()
+    async def budget_remaining(self) -> int:
+        total, used = await self.get_budget()
         return max(0, total - used)
 
-    def get_last_scout_info(
+    async def get_last_scout_info(
         self,
         question_id: str,
     ) -> tuple[str, int | None] | None:
         """Return (completed_at_iso, remaining_fruit) for the most recent
         scout call on this question, or None if never scouted."""
         rows = _rows(
-            self.client.table("calls")
+            await self.client.table("calls")
             .select("completed_at, review_json")
             .eq("call_type", CallType.SCOUT.value)
             .eq("scope_page_id", question_id)
@@ -474,13 +491,13 @@ class DB:
         fruit = review.get("remaining_fruit") if isinstance(review, dict) else None
         return row["completed_at"], fruit
 
-    def get_ingest_history(self) -> dict[str, list[str]]:
+    async def get_ingest_history(self) -> dict[str, list[str]]:
         """Return {source_id: [question_id, ...]} based on considerations
         created by ingest calls."""
         params: dict[str, Any] = {}
         if self.project_id:
             params["pid"] = self.project_id
-        rows = _rows(self.client.rpc("get_ingest_history", params).execute())
+        rows = _rows(await self.client.rpc("get_ingest_history", params).execute())
         out: dict[str, list[str]] = {}
         for row in rows:
             out.setdefault(row["source_id"], []).append(row["question_id"])
@@ -488,26 +505,29 @@ class DB:
 
     # --- Traces ---
 
-    def save_call_trace(self, call_id: str, events: list[dict]) -> None:
+    async def save_call_trace(self, call_id: str, events: list[dict]) -> None:
         """Append trace events to the call's trace_json column."""
-        self.client.rpc(
+        await self.client.rpc(
             "append_call_trace",
             {"cid": call_id, "new_events": events},
         ).execute()
 
-    def get_call_trace(self, call_id: str) -> list[dict]:
+    async def get_call_trace(self, call_id: str) -> list[dict]:
         """Fetch trace events for a call."""
         rows = _rows(
-            self.client.table("calls").select("trace_json").eq("id", call_id).execute()
+            await self.client.table("calls")
+            .select("trace_json")
+            .eq("id", call_id)
+            .execute()
         )
         if rows and rows[0].get("trace_json"):
             return rows[0]["trace_json"]
         return []
 
-    def get_child_calls(self, parent_call_id: str) -> list[Call]:
+    async def get_child_calls(self, parent_call_id: str) -> list[Call]:
         """Fetch direct child calls ordered by created_at."""
         rows = _rows(
-            self.client.table("calls")
+            await self.client.table("calls")
             .select("*")
             .eq("parent_call_id", parent_call_id)
             .order("created_at")
@@ -515,11 +535,11 @@ class DB:
         )
         return [_row_to_call(r) for r in rows]
 
-    def get_root_calls_for_question(self, question_id: str) -> list[Call]:
+    async def get_root_calls_for_question(self, question_id: str) -> list[Call]:
         """Find top-level calls for a question (prioritization calls with no
         parent, or whose parent targets a different question)."""
         rows = _rows(
-            self.client.table("calls")
+            await self.client.table("calls")
             .select("*")
             .eq("scope_page_id", question_id)
             .is_("parent_call_id", "null")
@@ -531,7 +551,7 @@ class DB:
             return result
         # Fallback: return all calls scoped to this question
         rows = _rows(
-            self.client.table("calls")
+            await self.client.table("calls")
             .select("*")
             .eq("scope_page_id", question_id)
             .order("created_at")
@@ -539,14 +559,14 @@ class DB:
         )
         return [_row_to_call(r) for r in rows]
 
-    def save_page_rating(
+    async def save_page_rating(
         self,
         page_id: str,
         call_id: str,
         score: int,
         note: str = "",
     ) -> None:
-        self.client.table("page_ratings").insert(
+        await self.client.table("page_ratings").insert(
             {
                 "id": str(uuid.uuid4()),
                 "page_id": page_id,
@@ -558,7 +578,7 @@ class DB:
             }
         ).execute()
 
-    def save_page_flag(
+    async def save_page_flag(
         self,
         flag_type: str,
         call_id: str | None = None,
@@ -567,7 +587,7 @@ class DB:
         page_id_a: str | None = None,
         page_id_b: str | None = None,
     ) -> None:
-        self.client.table("page_flags").insert(
+        await self.client.table("page_flags").insert(
             {
                 "id": str(uuid.uuid4()),
                 "flag_type": flag_type,
@@ -581,7 +601,7 @@ class DB:
             }
         ).execute()
 
-    def get_root_questions(
+    async def get_root_questions(
         self,
         workspace: Workspace = Workspace.RESEARCH,
     ) -> list[Page]:
@@ -590,20 +610,20 @@ class DB:
         if self.project_id:
             params["pid"] = self.project_id
         rows = _rows(
-            self.client.rpc("get_root_questions", params).execute()
+            await self.client.rpc("get_root_questions", params).execute()
         )
         return [_row_to_page(r) for r in rows]
 
-    def count_pages_for_question(self, question_id: str) -> dict:
+    async def count_pages_for_question(self, question_id: str) -> dict:
         """Count pages linked to or created in context of a question."""
-        cons_result = (
+        cons_result = await (
             self.client.table("page_links")
             .select("id", count=CountMethod.exact)
             .eq("to_page_id", question_id)
             .eq("link_type", "consideration")
             .execute()
         )
-        judgements_result = self.client.rpc(
+        judgements_result = await self.client.rpc(
             "count_active_judgements",
             {"qid": question_id},
         ).execute()
@@ -612,12 +632,12 @@ class DB:
             "judgements": cast(int, judgements_result.data or 0),
         }
 
-    def delete_run_data(self, delete_project: bool = False) -> None:
+    async def delete_run_data(self, delete_project: bool = False) -> None:
         """Delete all data for this run_id. Used by test teardown."""
         for table in ["page_flags", "page_ratings", "page_links", "calls", "pages"]:
-            self.client.table(table).delete().eq("run_id", self.run_id).execute()
-        self.client.table("budget").delete().eq("run_id", self.run_id).execute()
+            await self.client.table(table).delete().eq("run_id", self.run_id).execute()
+        await self.client.table("budget").delete().eq("run_id", self.run_id).execute()
         if delete_project and self.project_id:
-            self.client.table("projects").delete().eq(
+            await self.client.table("projects").delete().eq(
                 "id", self.project_id
             ).execute()

--- a/src/differential/llm.py
+++ b/src/differential/llm.py
@@ -7,9 +7,9 @@ Exports three calling modes:
   - text_call: plain text call
 """
 
+import asyncio
 import os
-import time
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -56,7 +56,7 @@ class Tool:
     name: str
     description: str
     input_schema: dict
-    fn: Callable[[dict], str]
+    fn: Callable[[dict], Awaitable[str]]
 
 
 @dataclass
@@ -76,8 +76,8 @@ class AgentResult:
     tool_calls: list[ToolCall] = field(default_factory=list)
 
 
-def _call_api(
-    client: anthropic.Anthropic,
+async def _call_api(
+    client: anthropic.AsyncAnthropic,
     system_prompt: str,
     messages: list[dict],
     tools: list[dict] | None = None,
@@ -95,7 +95,7 @@ def _call_api(
 
     for attempt in range(MAX_API_RETRIES):
         try:
-            return client.messages.create(**kwargs)
+            return await client.messages.create(**kwargs)
         except Exception as e:
             status = getattr(e, "status_code", None)
             name = type(e).__name__.lower()
@@ -114,12 +114,12 @@ def _call_api(
                 f"  [llm] API temporarily unavailable ({label}), "
                 f"retrying in {wait}s... (attempt {attempt + 1}/{MAX_API_RETRIES})"
             )
-            time.sleep(wait)
+            await asyncio.sleep(wait)
 
     raise RuntimeError("Unreachable: retry loop exhausted without raising")
 
 
-def agent_loop(
+async def agent_loop(
     system_prompt: str,
     user_message: str,
     tools: list[Tool],
@@ -141,7 +141,7 @@ def agent_loop(
             "ANTHROPIC_API_KEY environment variable not set. "
             "Set it before running the workspace."
         )
-    client = anthropic.Anthropic(api_key=api_key)
+    client = anthropic.AsyncAnthropic(api_key=api_key)
 
     tool_defs = [
         {
@@ -158,7 +158,7 @@ def agent_loop(
     all_tool_calls: list[ToolCall] = []
 
     for round_num in range(max_rounds + 1):
-        response = _call_api(
+        response = await _call_api(
             client,
             system_prompt,
             messages,
@@ -193,7 +193,7 @@ def agent_loop(
                 )
             else:
                 try:
-                    result_str = fn(tu.input)
+                    result_str = await fn(tu.input)
                 except Exception as e:
                     result_str = f"Error: {e}"
                     tool_results.append(
@@ -241,7 +241,7 @@ def agent_loop(
     )
 
 
-def text_call(
+async def text_call(
     system_prompt: str,
     user_message: str = "",
     *,
@@ -255,20 +255,20 @@ def text_call(
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         raise EnvironmentError("ANTHROPIC_API_KEY environment variable not set.")
-    client = anthropic.Anthropic(api_key=api_key)
+    client = anthropic.AsyncAnthropic(api_key=api_key)
     msg_list = (
         messages
         if messages is not None
         else [{"role": "user", "content": user_message}]
     )
-    response = _call_api(client, system_prompt, msg_list, max_tokens=max_tokens)
+    response = await _call_api(client, system_prompt, msg_list, max_tokens=max_tokens)
     for block in response.content:
         if isinstance(block, TextBlock):
             return block.text
     return ""
 
 
-def structured_call(
+async def structured_call(
     system_prompt: str,
     user_message: str,
     response_model: type[BaseModel],
@@ -283,13 +283,13 @@ def structured_call(
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         raise EnvironmentError("ANTHROPIC_API_KEY environment variable not set.")
-    client = anthropic.Anthropic(api_key=api_key)
+    client = anthropic.AsyncAnthropic(api_key=api_key)
 
     messages: list[MessageParam] = [{"role": "user", "content": user_message}]
 
     for attempt in range(MAX_API_RETRIES):
         try:
-            response = client.messages.parse(
+            response = await client.messages.parse(
                 model=MODEL,
                 max_tokens=max_tokens,
                 system=system_prompt,
@@ -322,6 +322,6 @@ def structured_call(
                 f"  [llm] API temporarily unavailable ({label}), "
                 f"retrying in {wait}s... (attempt {attempt + 1}/{MAX_API_RETRIES})"
             )
-            time.sleep(wait)
+            await asyncio.sleep(wait)
 
     raise RuntimeError("Unreachable: retry loop exhausted without raising")

--- a/src/differential/mapper.py
+++ b/src/differential/mapper.py
@@ -129,12 +129,12 @@ def _render_judgement(j: Page, index: int, total: int) -> str:
 </div>"""
 
 
-def _render_question(question_id: str, db: DB, depth: int = 0) -> str:
-    question = db.get_page(question_id)
+async def _render_question(question_id: str, db: DB, depth: int = 0) -> str:
+    question = await db.get_page(question_id)
     if not question:
         return ""
 
-    considerations = db.get_considerations_for_question(question_id)
+    considerations = await db.get_considerations_for_question(question_id)
     supports = sorted(
         [
             (p, l)
@@ -164,9 +164,9 @@ def _render_question(question_id: str, db: DB, depth: int = 0) -> str:
     )
 
     judgements = sorted(
-        db.get_judgements_for_question(question_id), key=lambda j: j.created_at
+        await db.get_judgements_for_question(question_id), key=lambda j: j.created_at
     )
-    children = db.get_child_questions(question_id)
+    children = await db.get_child_questions(question_id)
 
     # Stats line
     parts = []
@@ -213,7 +213,7 @@ def _render_question(question_id: str, db: DB, depth: int = 0) -> str:
     if children:
         ch_html = '<div class="section"><h4>Sub-questions</h4>'
         for child in children:
-            ch_html += _render_question(child.id, db, depth=depth + 1)
+            ch_html += await _render_question(child.id, db, depth=depth + 1)
         ch_html += "</div>"
 
     q_sel_id = f"qb-{question_id[:8]}"
@@ -318,15 +318,15 @@ details[open] > summary { margin-bottom: 0.35rem; }
 """
 
 
-def generate_map(question_id: str, db: DB) -> Path:
+async def generate_map(question_id: str, db: DB) -> Path:
     """Generate an HTML research map and return the file path."""
     MAPS_DIR.mkdir(parents=True, exist_ok=True)
 
-    question = db.get_page(question_id)
+    question = await db.get_page(question_id)
     if not question:
         raise ValueError(f"Question {question_id} not found")
 
-    tree_html = _render_question(question_id, db)
+    tree_html = await _render_question(question_id, db)
 
     timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     slug = "".join(c if c.isalnum() or c in " -" else "" for c in question.summary[:50])

--- a/src/differential/moves/base.py
+++ b/src/differential/moves/base.py
@@ -1,6 +1,6 @@
 """Base types and shared helpers for moves."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generic, TypeVar
@@ -65,13 +65,13 @@ class MoveDef(Generic[S]):
     name: str
     description: str
     schema: type[S]
-    execute: Callable[[S, Call, DB], MoveResult]
+    execute: Callable[[S, Call, DB], Awaitable[MoveResult]]
 
     def bind(self, state: MoveState) -> "Tool":
         """Return a Tool bound to this call's mutable state."""
         from differential.llm import Tool
 
-        def fn(inp: dict) -> str:
+        async def fn(inp: dict) -> str:
             try:
                 validated = self.schema(**inp)
             except Exception as e:
@@ -79,7 +79,7 @@ class MoveDef(Generic[S]):
                 raise
             if state.last_created_id:
                 validated = _resolve_last_created(validated, state.last_created_id)
-            result = self.execute(validated, state.call, state.db)
+            result = await self.execute(validated, state.call, state.db)
             state.moves.append(Move(move_type=self.move_type, payload=validated))
             if result.created_page_id:
                 state.created_page_ids.append(result.created_page_id)
@@ -182,7 +182,7 @@ def write_page_file(page: Page) -> None:
     filepath.write_text("\n".join(lines), encoding="utf-8")
 
 
-def create_page(
+async def create_page(
     payload: CreatePagePayload,
     call: Call,
     db: DB,
@@ -225,7 +225,7 @@ def create_page(
         extra=extra,
     )
 
-    db.save_page(page)
+    await db.save_page(page)
     write_page_file(page)
     print(f"  [+] {page_type.value}: {page.summary[:70]} [{page.id[:8]}]")
 
@@ -237,7 +237,7 @@ def create_page(
     return MoveResult(message=message, created_page_id=page.id)
 
 
-def link_pages(
+async def link_pages(
     from_id: str,
     to_id: str,
     reasoning: str,
@@ -245,8 +245,8 @@ def link_pages(
     link_type: LinkType,
 ) -> MoveResult:
     """Create a link between two pages. Used by LINK_CHILD_QUESTION and LINK_RELATED."""
-    from_id = db.resolve_page_id(from_id)
-    to_id = db.resolve_page_id(to_id)
+    from_id = await db.resolve_page_id(from_id)
+    to_id = await db.resolve_page_id(to_id)
     if not from_id or not to_id:
         print(
             f"  [executor] {link_type.value} link skipped — "
@@ -260,8 +260,8 @@ def link_pages(
         link_type=link_type,
         reasoning=reasoning,
     )
-    db.save_link(link)
+    await db.save_link(link)
     print(
-        f"  [~] {link_type.value}: {db.page_label(from_id)} -> {db.page_label(to_id)}"
+        f"  [~] {link_type.value}: {await db.page_label(from_id)} -> {await db.page_label(to_id)}"
     )
     return MoveResult("Done.")

--- a/src/differential/moves/create_claim.py
+++ b/src/differential/moves/create_claim.py
@@ -5,8 +5,8 @@ from differential.models import Call, MoveType, PageLayer, PageType
 from differential.moves.base import CreatePagePayload, MoveDef, MoveResult, create_page
 
 
-def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
-    return create_page(payload, call, db, PageType.CLAIM, PageLayer.SQUIDGY)
+async def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
+    return await create_page(payload, call, db, PageType.CLAIM, PageLayer.SQUIDGY)
 
 
 MOVE = MoveDef(

--- a/src/differential/moves/create_concept.py
+++ b/src/differential/moves/create_concept.py
@@ -5,8 +5,8 @@ from differential.models import Call, MoveType, PageLayer, PageType
 from differential.moves.base import CreatePagePayload, MoveDef, MoveResult, create_page
 
 
-def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
-    return create_page(payload, call, db, PageType.CONCEPT, PageLayer.SQUIDGY)
+async def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
+    return await create_page(payload, call, db, PageType.CONCEPT, PageLayer.SQUIDGY)
 
 
 MOVE = MoveDef(

--- a/src/differential/moves/create_judgement.py
+++ b/src/differential/moves/create_judgement.py
@@ -5,8 +5,8 @@ from differential.models import Call, MoveType, PageLayer, PageType
 from differential.moves.base import CreatePagePayload, MoveDef, MoveResult, create_page
 
 
-def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
-    return create_page(payload, call, db, PageType.JUDGEMENT, PageLayer.SQUIDGY)
+async def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
+    return await create_page(payload, call, db, PageType.JUDGEMENT, PageLayer.SQUIDGY)
 
 
 MOVE = MoveDef(

--- a/src/differential/moves/create_question.py
+++ b/src/differential/moves/create_question.py
@@ -5,8 +5,8 @@ from differential.models import Call, MoveType, PageLayer, PageType
 from differential.moves.base import CreatePagePayload, MoveDef, MoveResult, create_page
 
 
-def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
-    return create_page(payload, call, db, PageType.QUESTION, PageLayer.SQUIDGY)
+async def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
+    return await create_page(payload, call, db, PageType.QUESTION, PageLayer.SQUIDGY)
 
 
 MOVE = MoveDef(

--- a/src/differential/moves/create_wiki_page.py
+++ b/src/differential/moves/create_wiki_page.py
@@ -5,8 +5,8 @@ from differential.models import Call, MoveType, PageLayer, PageType
 from differential.moves.base import CreatePagePayload, MoveDef, MoveResult, create_page
 
 
-def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
-    return create_page(payload, call, db, PageType.WIKI, PageLayer.WIKI)
+async def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
+    return await create_page(payload, call, db, PageType.WIKI, PageLayer.WIKI)
 
 
 MOVE = MoveDef(

--- a/src/differential/moves/flag_funniness.py
+++ b/src/differential/moves/flag_funniness.py
@@ -12,9 +12,9 @@ class FlagFunninessPayload(BaseModel):
     note: str = Field(description="What seems off")
 
 
-def execute(payload: FlagFunninessPayload, call: Call, db: DB) -> MoveResult:
-    page_id = db.resolve_page_id(payload.page_id)
-    db.save_page_flag("funniness", call_id=call.id, note=payload.note, page_id=page_id)
+async def execute(payload: FlagFunninessPayload, call: Call, db: DB) -> MoveResult:
+    page_id = await db.resolve_page_id(payload.page_id)
+    await db.save_page_flag("funniness", call_id=call.id, note=payload.note, page_id=page_id)
     print(f"  [flag] Funniness flagged: {payload.note}")
     return MoveResult("Done.")
 

--- a/src/differential/moves/link_child_question.py
+++ b/src/differential/moves/link_child_question.py
@@ -13,8 +13,8 @@ class LinkChildQuestionPayload(BaseModel):
     reasoning: str = Field("", description="Why this is a sub-question")
 
 
-def execute(payload: LinkChildQuestionPayload, call: Call, db: DB) -> MoveResult:
-    return link_pages(
+async def execute(payload: LinkChildQuestionPayload, call: Call, db: DB) -> MoveResult:
+    return await link_pages(
         payload.parent_id,
         payload.child_id,
         payload.reasoning,

--- a/src/differential/moves/link_consideration.py
+++ b/src/differential/moves/link_consideration.py
@@ -26,9 +26,9 @@ class LinkConsiderationPayload(BaseModel):
     )
 
 
-def execute(payload: LinkConsiderationPayload, call: Call, db: DB) -> MoveResult:
-    claim_id = db.resolve_page_id(payload.claim_id)
-    question_id = db.resolve_page_id(payload.question_id)
+async def execute(payload: LinkConsiderationPayload, call: Call, db: DB) -> MoveResult:
+    claim_id = await db.resolve_page_id(payload.claim_id)
+    question_id = await db.resolve_page_id(payload.question_id)
     if not claim_id or not question_id:
         print(
             "  [executor] LINK_CONSIDERATION skipped — one or both page IDs not found"
@@ -49,10 +49,10 @@ def execute(payload: LinkConsiderationPayload, call: Call, db: DB) -> MoveResult
         strength=payload.strength,
         reasoning=payload.reasoning,
     )
-    db.save_link(link)
+    await db.save_link(link)
     print(
-        f"  [~] Consideration: {db.page_label(claim_id)} -> "
-        f"{db.page_label(question_id)} ({direction_str})"
+        f"  [~] Consideration: {await db.page_label(claim_id)} -> "
+        f"{await db.page_label(question_id)} ({direction_str})"
     )
     return MoveResult("Done.")
 

--- a/src/differential/moves/link_related.py
+++ b/src/differential/moves/link_related.py
@@ -13,8 +13,8 @@ class LinkRelatedPayload(BaseModel):
     reasoning: str = Field("", description="Nature of the relation")
 
 
-def execute(payload: LinkRelatedPayload, call: Call, db: DB) -> MoveResult:
-    return link_pages(
+async def execute(payload: LinkRelatedPayload, call: Call, db: DB) -> MoveResult:
+    return await link_pages(
         payload.from_page_id,
         payload.to_page_id,
         payload.reasoning,

--- a/src/differential/moves/load_page.py
+++ b/src/differential/moves/load_page.py
@@ -12,16 +12,16 @@ class LoadPagePayload(BaseModel):
     page_id: str = Field(description="Short ID (first 8 chars) from the workspace map")
 
 
-def execute(payload: LoadPagePayload, call: Call, db: DB) -> MoveResult:
+async def execute(payload: LoadPagePayload, call: Call, db: DB) -> MoveResult:
     page_id = payload.page_id.strip()
-    full_id = db.resolve_page_id(page_id)
+    full_id = await db.resolve_page_id(page_id)
     if not full_id:
         return MoveResult(f"Page '{page_id}' not found.")
-    page = db.get_page(full_id)
+    page = await db.get_page(full_id)
     if not page:
         return MoveResult(f"Page '{page_id}' not found.")
-    print(f"  [load] {db.page_label(full_id)}")
-    return MoveResult(format_page(page, db=db))
+    print(f"  [load] {await db.page_label(full_id)}")
+    return MoveResult(await format_page(page, db=db))
 
 
 MOVE = MoveDef(

--- a/src/differential/moves/propose_hypothesis.py
+++ b/src/differential/moves/propose_hypothesis.py
@@ -28,8 +28,8 @@ class ProposeHypothesisPayload(BaseModel):
     strength: float = Field(2.5, description="0-5 consideration strength")
 
 
-def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult:
-    parent_id = db.resolve_page_id(payload.parent_question_id)
+async def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult:
+    parent_id = await db.resolve_page_id(payload.parent_question_id)
     if not parent_id:
         print(
             "  [executor] PROPOSE_HYPOTHESIS: parent_question_id not found: "
@@ -59,9 +59,9 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
         provenance_call_id=call.id,
         extra={"hypothesis": True},
     )
-    db.save_page(claim)
+    await db.save_page(claim)
     write_page_file(claim)
-    print(f"  [+] hypothesis claim: {db.page_label(claim.id)}")
+    print(f"  [+] hypothesis claim: {await db.page_label(claim.id)}")
 
     direction_str = payload.direction.lower()
     try:
@@ -69,7 +69,7 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
     except ValueError:
         direction = ConsiderationDirection.NEUTRAL
 
-    db.save_link(
+    await db.save_link(
         PageLink(
             from_page_id=claim.id,
             to_page_id=parent_id,
@@ -80,8 +80,8 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
         )
     )
     print(
-        f"  [~] Consideration: {db.page_label(claim.id)} -> "
-        f"{db.page_label(parent_id)} ({direction_str})"
+        f"  [~] Consideration: {await db.page_label(claim.id)} -> "
+        f"{await db.page_label(parent_id)} ({direction_str})"
     )
 
     # 2. Create the hypothesis question
@@ -99,11 +99,11 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
         provenance_call_id=call.id,
         extra={"hypothesis": True, "status": "open"},
     )
-    db.save_page(question)
+    await db.save_page(question)
     write_page_file(question)
-    print(f"  [+] hypothesis question: {db.page_label(question.id)}")
+    print(f"  [+] hypothesis question: {await db.page_label(question.id)}")
 
-    db.save_link(
+    await db.save_link(
         PageLink(
             from_page_id=parent_id,
             to_page_id=question.id,
@@ -112,8 +112,8 @@ def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> MoveResult
         )
     )
     print(
-        f"  [~] child_question: {db.page_label(parent_id)} -> "
-        f"{db.page_label(question.id)}"
+        f"  [~] child_question: {await db.page_label(parent_id)} -> "
+        f"{await db.page_label(question.id)}"
     )
 
     return MoveResult(

--- a/src/differential/moves/report_duplicate.py
+++ b/src/differential/moves/report_duplicate.py
@@ -12,10 +12,10 @@ class ReportDuplicatePayload(BaseModel):
     page_id_b: str = Field(description="Page ID of the second duplicate")
 
 
-def execute(payload: ReportDuplicatePayload, call: Call, db: DB) -> MoveResult:
-    pid_a = db.resolve_page_id(payload.page_id_a)
-    pid_b = db.resolve_page_id(payload.page_id_b)
-    db.save_page_flag("duplicate", call_id=call.id, page_id_a=pid_a, page_id_b=pid_b)
+async def execute(payload: ReportDuplicatePayload, call: Call, db: DB) -> MoveResult:
+    pid_a = await db.resolve_page_id(payload.page_id_a)
+    pid_b = await db.resolve_page_id(payload.page_id_b)
+    await db.save_page_flag("duplicate", call_id=call.id, page_id_a=pid_a, page_id_b=pid_b)
     print(f"  [flag] Duplicate reported: {payload.page_id_a} <-> {payload.page_id_b}")
     return MoveResult("Done.")
 

--- a/src/differential/moves/supersede_page.py
+++ b/src/differential/moves/supersede_page.py
@@ -11,22 +11,22 @@ class SupersedePagePayload(CreatePagePayload):
     old_page_id: str = Field(description="Page ID of the page to replace")
 
 
-def execute(payload: SupersedePagePayload, call: Call, db: DB) -> MoveResult:
-    old_id = db.resolve_page_id(payload.old_page_id)
+async def execute(payload: SupersedePagePayload, call: Call, db: DB) -> MoveResult:
+    old_id = await db.resolve_page_id(payload.old_page_id)
     if not old_id:
         print(f"  [executor] SUPERSEDE_PAGE: page {payload.old_page_id} not found")
         return MoveResult(f"Supersede skipped — page {payload.old_page_id} not found.")
 
-    old_page = db.get_page(old_id)
+    old_page = await db.get_page(old_id)
     if not old_page:
         print(f"  [executor] SUPERSEDE_PAGE: page {old_id} not found")
         return MoveResult(f"Supersede skipped — page {old_id} not found.")
 
-    result = create_page(payload, call, db, old_page.page_type, old_page.layer)
-    db.supersede_page(old_id, result.created_page_id)
+    result = await create_page(payload, call, db, old_page.page_type, old_page.layer)
+    await db.supersede_page(old_id, result.created_page_id)
     print(
-        f"  [~] Superseded {db.page_label(old_id)} -> "
-        f"{db.page_label(result.created_page_id)}"
+        f"  [~] Superseded {await db.page_label(old_id)} -> "
+        f"{await db.page_label(result.created_page_id)}"
     )
     return result
 

--- a/src/differential/orchestrator.py
+++ b/src/differential/orchestrator.py
@@ -3,8 +3,6 @@ Orchestrator: drives the research workflow using the prioritization system.
 Budget is tracked here; prioritization and review calls are free.
 """
 
-from typing import Optional
-
 from differential.calls import run_assess, run_ingest, run_prioritization, run_scout
 from differential.database import DB
 from differential.models import (
@@ -24,21 +22,21 @@ DEFAULT_INGEST_FRUIT_THRESHOLD = 5
 DEFAULT_INGEST_MAX_ROUNDS = 5
 
 
-def _consume_budget(db: DB) -> bool:
+async def _consume_budget(db: DB) -> bool:
     """Consume one unit of global budget. Returns False if exhausted."""
-    ok = db.consume_budget(1)
+    ok = await db.consume_budget(1)
     if not ok:
-        remaining = db.budget_remaining()
+        remaining = await db.budget_remaining()
         print(f"\n[budget] Budget exhausted (remaining: {remaining}). Stopping.")
     return ok
 
 
-def scout_until_done(
+async def scout_until_done(
     question_id: str,
     db: DB,
     max_rounds: int = DEFAULT_MAX_ROUNDS,
     fruit_threshold: int = DEFAULT_FRUIT_THRESHOLD,
-    parent_call_id: Optional[str] = None,
+    parent_call_id: str | None = None,
     context_page_ids: list | None = None,
 ) -> tuple[int, list[str]]:
     """
@@ -49,17 +47,17 @@ def scout_until_done(
     rounds = 0
     call_ids: list[str] = []
     for i in range(max_rounds):
-        if not _consume_budget(db):
+        if not await _consume_budget(db):
             break
 
-        call = db.create_call(
+        call = await db.create_call(
             CallType.SCOUT,
             scope_page_id=question_id,
             parent_call_id=parent_call_id,
             context_page_ids=context_page_ids,
         )
         call_ids.append(call.id)
-        _, review = run_scout(question_id, call, db)
+        _, review = await run_scout(question_id, call, db)
         rounds += 1
 
         remaining_fruit = review.get("remaining_fruit", 5) if review else 5
@@ -75,13 +73,13 @@ def scout_until_done(
     return rounds, call_ids
 
 
-def ingest_until_done(
+async def ingest_until_done(
     source_page: Page,
     question_id: str,
     db: DB,
     max_rounds: int = DEFAULT_INGEST_MAX_ROUNDS,
     fruit_threshold: int = DEFAULT_INGEST_FRUIT_THRESHOLD,
-    parent_call_id: Optional[str] = None,
+    parent_call_id: str | None = None,
 ) -> int:
     """
     Run Ingest rounds on a source/question pair until remaining_fruit falls below
@@ -91,15 +89,15 @@ def ingest_until_done(
     """
     rounds = 0
     for i in range(max_rounds):
-        if not _consume_budget(db):
+        if not await _consume_budget(db):
             break
 
-        call = db.create_call(
+        call = await db.create_call(
             CallType.INGEST,
             scope_page_id=source_page.id,
             parent_call_id=parent_call_id,
         )
-        _, review = run_ingest(source_page, question_id, call, db)
+        _, review = await run_ingest(source_page, question_id, call, db)
         rounds += 1
 
         remaining_fruit = review.get("remaining_fruit", 5) if review else 5
@@ -115,23 +113,23 @@ def ingest_until_done(
     return rounds
 
 
-def assess_question(
+async def assess_question(
     question_id: str,
     db: DB,
-    parent_call_id: Optional[str] = None,
+    parent_call_id: str | None = None,
     context_page_ids: list | None = None,
 ) -> str | None:
     """Run one Assess call on a question. Returns call ID, or None if no budget."""
-    if not _consume_budget(db):
+    if not await _consume_budget(db):
         return None
 
-    call = db.create_call(
+    call = await db.create_call(
         CallType.ASSESS,
         scope_page_id=question_id,
         parent_call_id=parent_call_id,
         context_page_ids=context_page_ids,
     )
-    run_assess(question_id, call, db)
+    await run_assess(question_id, call, db)
     return call.id
 
 
@@ -139,11 +137,11 @@ class Orchestrator:
     def __init__(self, db: DB):
         self.db = db
 
-    def investigate_question(
+    async def investigate_question(
         self,
         question_id: str,
         budget: int,
-        parent_call_id: Optional[str] = None,
+        parent_call_id: str | None = None,
         depth: int = 0,
     ) -> None:
         """
@@ -152,21 +150,21 @@ class Orchestrator:
         - Executes the plan (Scout, Assess, sub-Prioritization)
         """
         indent = "  " * depth
-        remaining = self.db.budget_remaining()
+        remaining = await self.db.budget_remaining()
         actual_budget = min(budget, remaining)
 
         if actual_budget <= 0:
             print(
-                f"{indent}[orchestrator] No budget remaining, skipping {self.db.page_label(question_id)}"
+                f"{indent}[orchestrator] No budget remaining, skipping {await self.db.page_label(question_id)}"
             )
             return
 
         print(
-            f"\n{indent}=== Investigating {self.db.page_label(question_id)} | budget={actual_budget} ==="
+            f"\n{indent}=== Investigating {await self.db.page_label(question_id)} | budget={actual_budget} ==="
         )
 
         # Run a prioritization call (free) to get a plan
-        p_call = self.db.create_call(
+        p_call = await self.db.create_call(
             CallType.PRIORITIZATION,
             scope_page_id=question_id,
             parent_call_id=parent_call_id,
@@ -174,7 +172,7 @@ class Orchestrator:
             workspace=Workspace.PRIORITIZATION,
         )
 
-        plan = run_prioritization(
+        plan = await run_prioritization(
             scope_question_id=question_id,
             call=p_call,
             budget=actual_budget,
@@ -189,19 +187,19 @@ class Orchestrator:
             print(
                 f"{indent}[orchestrator] No dispatches from prioritization, running default scout+assess"
             )
-            scout_until_done(question_id, self.db, parent_call_id=p_call.id)
-            assess_question(question_id, self.db, parent_call_id=p_call.id)
+            await scout_until_done(question_id, self.db, parent_call_id=p_call.id)
+            await assess_question(question_id, self.db, parent_call_id=p_call.id)
             return
 
         # Execute the plan one dispatch at a time
         budget_spent = 0
         for i, dispatch in enumerate(dispatches):
-            if budget_spent >= actual_budget or self.db.budget_remaining() <= 0:
+            if budget_spent >= actual_budget or await self.db.budget_remaining() <= 0:
                 break
 
             p = dispatch.payload
 
-            resolved = self.db.resolve_page_id(p.question_id)
+            resolved = await self.db.resolve_page_id(p.question_id)
             if not resolved:
                 print(
                     f"{indent}  [orchestrator] Skipping dispatch — question ID not found: {p.question_id[:8]}. "
@@ -209,7 +207,7 @@ class Orchestrator:
                 )
                 resolved = question_id
 
-            d_label = self.db.page_label(resolved)
+            d_label = await self.db.page_label(resolved)
             child_call_id: str | None = None
 
             if isinstance(p, ScoutDispatchPayload):
@@ -217,7 +215,7 @@ class Orchestrator:
                     f"{indent}  -> Dispatch: scout on {d_label} "
                     f"(fruit_threshold={p.fruit_threshold}, max_rounds={p.max_rounds}) — {p.reason}"
                 )
-                spent, child_ids = scout_until_done(
+                spent, child_ids = await scout_until_done(
                     resolved,
                     self.db,
                     max_rounds=p.max_rounds,
@@ -230,7 +228,7 @@ class Orchestrator:
 
             elif isinstance(p, AssessDispatchPayload):
                 print(f"{indent}  -> Dispatch: assess on {d_label} — {p.reason}")
-                child_call_id = assess_question(
+                child_call_id = await assess_question(
                     resolved,
                     self.db,
                     parent_call_id=p_call.id,
@@ -244,7 +242,7 @@ class Orchestrator:
                     f"{indent}  -> Dispatch: prioritization on {d_label} "
                     f"(budget={p.budget}) — {p.reason}"
                 )
-                self.investigate_question(
+                await self.investigate_question(
                     question_id=resolved,
                     budget=p.budget,
                     parent_call_id=p_call.id,
@@ -263,22 +261,22 @@ class Orchestrator:
                 p_trace.record("dispatch_executed", trace_data)
 
         if p_trace:
-            p_trace.save()
+            await p_trace.save()
 
-    def run(self, root_question_id: str) -> None:
+    async def run(self, root_question_id: str) -> None:
         """Entry point. Investigate the root question with the full budget."""
-        total, used = self.db.get_budget()
+        total, used = await self.db.get_budget()
         print(f"\n{'=' * 60}")
-        print(f"Starting research on {self.db.page_label(root_question_id)}")
+        print(f"Starting research on {await self.db.page_label(root_question_id)}")
         print(f"Total budget: {total} research calls")
         print(f"{'=' * 60}\n")
 
-        self.investigate_question(
+        await self.investigate_question(
             question_id=root_question_id,
             budget=total,
         )
 
-        total, used = self.db.get_budget()
+        total, used = await self.db.get_budget()
         print(f"\n{'=' * 60}")
         print(f"Research complete. Budget used: {used}/{total}")
         print(f"{'=' * 60}\n")

--- a/src/differential/summary.py
+++ b/src/differential/summary.py
@@ -17,7 +17,7 @@ def _load_prompt_file(name: str) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def build_research_tree(
+async def build_research_tree(
     question_id: str, db: DB, depth: int = 0, max_depth: int = 4
 ) -> str:
     """
@@ -25,7 +25,7 @@ def build_research_tree(
     the question itself, all its considerations (with full content),
     all its judgements, and all sub-questions (recursively).
     """
-    question = db.get_page(question_id)
+    question = await db.get_page(question_id)
     if not question:
         return ""
 
@@ -41,7 +41,7 @@ def build_research_tree(
         )
 
     # Considerations
-    considerations = db.get_considerations_for_question(question_id)
+    considerations = await db.get_considerations_for_question(question_id)
     if considerations:
         supports = [
             (p, l)
@@ -86,7 +86,7 @@ def build_research_tree(
             parts.append("")
 
     # Judgements — oldest first so the evolution of thinking is legible
-    judgements = db.get_judgements_for_question(question_id)
+    judgements = await db.get_judgements_for_question(question_id)
     if judgements:
         ordered = sorted(judgements, key=lambda j: j.created_at)
         for i, j in enumerate(ordered):
@@ -108,11 +108,11 @@ def build_research_tree(
 
     # Sub-questions (recurse)
     if depth < max_depth:
-        children = db.get_child_questions(question_id)
+        children = await db.get_child_questions(question_id)
         if children:
             for child in children:
                 parts.append(
-                    build_research_tree(
+                    await build_research_tree(
                         child.id, db, depth=depth + 1, max_depth=max_depth
                     )
                 )
@@ -120,16 +120,16 @@ def build_research_tree(
     return "\n".join(parts)
 
 
-def generate_summary(question_id: str, db: DB) -> str:
+async def generate_summary(question_id: str, db: DB) -> str:
     """
     Generate an executive summary of research on a question.
     Returns the summary as a string.
     """
-    question = db.get_page(question_id)
+    question = await db.get_page(question_id)
     if not question:
         raise ValueError(f"Question {question_id} not found")
 
-    research_tree = build_research_tree(question_id, db)
+    research_tree = await build_research_tree(question_id, db)
 
     if not research_tree.strip():
         return f"No research found for question: {question.summary}"
@@ -143,7 +143,7 @@ def generate_summary(question_id: str, db: DB) -> str:
         f"{closing}"
     )
 
-    return text_call(
+    return await text_call(
         system_prompt=system_prompt, user_message=user_message, max_tokens=8192
     )
 

--- a/src/differential/tracer.py
+++ b/src/differential/tracer.py
@@ -36,11 +36,11 @@ class CallTrace:
             entry["data"] = data
         self.events.append(entry)
 
-    def save(self) -> None:
+    async def save(self) -> None:
         if not self._enabled:
             return
         if self.events:
-            self.db.save_call_trace(self.call_id, self.events)
+            await self.db.save_call_trace(self.call_id, self.events)
             self.events = []
 
 
@@ -55,10 +55,10 @@ def _short(s: str) -> str:
     return s[:8] if _looks_like_uuid(s) else s
 
 
-def _render_page_chip(page_id: str, db: DB) -> str:
+async def _render_page_chip(page_id: str, db: DB) -> str:
     """Render a page ID as a clickable chip with summary and expandable content."""
     short = _short(page_id)
-    page = db.get_page(page_id) if _looks_like_uuid(page_id) else None
+    page = await db.get_page(page_id) if _looks_like_uuid(page_id) else None
     if not page:
         return f'<span class="page-chip">[{escape(short)}]</span>'
     summary = escape(page.summary)
@@ -80,11 +80,11 @@ def _render_page_chip(page_id: str, db: DB) -> str:
     )
 
 
-def _render_page_list(page_ids: list, db: DB) -> str:
+async def _render_page_list(page_ids: list, db: DB) -> str:
     """Render a list of page IDs as chips."""
     if not page_ids:
         return '<span class="empty">none</span>'
-    parts = [_render_page_chip(pid, db) for pid in page_ids]
+    parts = [await _render_page_chip(pid, db) for pid in page_ids]
     return '<div class="page-list">' + "".join(parts) + "</div>"
 
 
@@ -105,7 +105,7 @@ _MOVE_LABELS = {
 }
 
 
-def _render_move(move_data: dict, db: DB) -> str:
+async def _render_move(move_data: dict, db: DB) -> str:
     """Render a single move with its payload details."""
     move_type = move_data.get("type", "?")
     label_class, _ = _MOVE_LABELS.get(move_type, ("unknown", "?"))
@@ -133,7 +133,7 @@ def _render_move(move_data: dict, db: DB) -> str:
             and isinstance(v, str)
             and v
         ):
-            page = db.get_page(v) if _looks_like_uuid(v) else None
+            page = await db.get_page(v) if _looks_like_uuid(v) else None
             if page:
                 sv = f'[{_short(v)}] "{page.summary}"'
             else:
@@ -157,7 +157,7 @@ def _render_move(move_data: dict, db: DB) -> str:
         f"<details>"
         f"<summary>"
         f'<span class="move-badge {label_class}">{escape(move_type)}</span>'
-        f'<span class="move-summary">{escape(_move_one_liner(move_data, db))}</span>'
+        f'<span class="move-summary">{escape(await _move_one_liner(move_data, db))}</span>'
         f"</summary>"
         f"{fields_html}"
         f"</details>"
@@ -165,7 +165,7 @@ def _render_move(move_data: dict, db: DB) -> str:
     )
 
 
-def _move_one_liner(move_data: dict, db: DB | None = None) -> str:
+async def _move_one_liner(move_data: dict, db: DB | None = None) -> str:
     """Generate a short one-line summary for a move."""
     summary = move_data.get("summary", "")
     if summary:
@@ -178,7 +178,7 @@ def _move_one_liner(move_data: dict, db: DB | None = None) -> str:
     if "page_id" in move_data:
         pid = move_data["page_id"]
         if db:
-            page = db.get_page(pid) if _looks_like_uuid(pid) else None
+            page = await db.get_page(pid) if _looks_like_uuid(pid) else None
             if page:
                 return f"[{_short(pid)}] {page.summary}"
         return f"[{_short(pid)}]"
@@ -187,7 +187,7 @@ def _move_one_liner(move_data: dict, db: DB | None = None) -> str:
     return ""
 
 
-def _render_event_context_built(ev: dict, db: DB) -> str:
+async def _render_event_context_built(ev: dict, db: DB) -> str:
     data = ev.get("data", {})
     working = data.get("working_context_page_ids", [])
     preloaded = data.get("preloaded_page_ids", [])
@@ -196,31 +196,31 @@ def _render_event_context_built(ev: dict, db: DB) -> str:
 
     html = '<div class="ev-section">'
     html += '<span class="ev-label">Working context:</span>'
-    html += _render_page_list(working, db)
+    html += await _render_page_list(working, db)
     if preloaded:
         html += '<span class="ev-label">Pre-loaded (from dispatch):</span>'
-        html += _render_page_list(preloaded, db)
+        html += await _render_page_list(preloaded, db)
     if source:
         html += '<span class="ev-label">Source:</span>'
-        html += _render_page_chip(source, db)
+        html += await _render_page_chip(source, db)
     if budget is not None:
         html += f'<span class="ev-label">Budget: {budget}</span>'
     html += "</div>"
     return html
 
 
-def _render_event_pages_loaded(ev: dict, db: DB) -> str:
+async def _render_event_pages_loaded(ev: dict, db: DB) -> str:
     data = ev.get("data", {})
     page_ids = data.get("page_ids", [])
     if not page_ids:
         return '<div class="ev-section"><span class="ev-label">No pages loaded</span></div>'
     html = '<div class="ev-section">'
-    html += _render_page_list(page_ids, db)
+    html += await _render_page_list(page_ids, db)
     html += "</div>"
     return html
 
 
-def _render_event_moves(ev: dict, db: DB) -> str:
+async def _render_event_moves(ev: dict, db: DB) -> str:
     data = ev.get("data", {})
     moves = data.get("moves", [])
     created = data.get("created_page_ids", [])
@@ -235,16 +235,16 @@ def _render_event_moves(ev: dict, db: DB) -> str:
     )
     html += '<div class="moves-list">'
     for m in moves:
-        html += _render_move(m, db)
+        html += await _render_move(m, db)
     html += "</div>"
     if created:
         html += '<span class="ev-label">Created pages:</span>'
-        html += _render_page_list(created, db)
+        html += await _render_page_list(created, db)
     html += "</div>"
     return html
 
 
-def _render_event_dispatches(ev: dict, db: DB) -> str:  # noqa: ARG001
+async def _render_event_dispatches(ev: dict, db: DB) -> str:  # noqa: ARG001
     data = ev.get("data", {})
     dispatches = data.get("dispatches", [])
     if not dispatches:
@@ -272,7 +272,7 @@ def _render_event_dispatches(ev: dict, db: DB) -> str:  # noqa: ARG001
     return html
 
 
-def _render_event_review(ev: dict, db: DB) -> str:  # noqa: ARG001
+async def _render_event_review(ev: dict, db: DB) -> str:  # noqa: ARG001
     data = ev.get("data", {})
     fruit = data.get("remaining_fruit", "")
     conf = data.get("confidence", "")
@@ -306,7 +306,7 @@ _EVENT_RENDERERS = {
 }
 
 
-def _render_event(ev: dict, db: DB) -> str:
+async def _render_event(ev: dict, db: DB) -> str:
     name = ev.get("event", "")
     ts = ev.get("ts", "")
     if ts:
@@ -318,7 +318,7 @@ def _render_event(ev: dict, db: DB) -> str:
 
     renderer = _EVENT_RENDERERS.get(name)
     if renderer:
-        body_html = renderer(ev, db)
+        body_html = await renderer(ev, db)
     else:
         body_html = _render_event_generic(ev)
 
@@ -345,15 +345,15 @@ def _call_color(call_type: CallType) -> str:
     return _CALL_COLORS.get(call_type, "#f5f5f5")
 
 
-def _render_call_node(call: Call, db: DB, depth: int = 0) -> str:
-    trace_events = db.get_call_trace(call.id)
-    children = db.get_child_calls(call.id)
+async def _render_call_node(call: Call, db: DB, depth: int = 0) -> str:
+    trace_events = await db.get_call_trace(call.id)
+    children = await db.get_child_calls(call.id)
     color = _call_color(call.call_type)
     short_id = call.id[:8]
 
     scope_label = ""
     if call.scope_page_id:
-        scope_label = db.page_label(call.scope_page_id)
+        scope_label = await db.page_label(call.scope_page_id)
 
     status_badge = call.status.value
     duration = ""
@@ -412,7 +412,7 @@ def _render_call_node(call: Call, db: DB, depth: int = 0) -> str:
     if displayable:
         events_html = '<div class="events">'
         for ev in displayable:
-            events_html += _render_event(ev, db)
+            events_html += await _render_event(ev, db)
         events_html += "</div>"
 
     # Review from call record
@@ -434,7 +434,7 @@ def _render_call_node(call: Call, db: DB, depth: int = 0) -> str:
     if children:
         children_html = '<div class="children">'
         for child in children:
-            children_html += _render_call_node(child, db, depth=depth + 1)
+            children_html += await _render_call_node(child, db, depth=depth + 1)
         children_html += "</div>"
 
     return (
@@ -605,27 +605,27 @@ details[open] > summary { margin-bottom: 0.4rem; }
 """
 
 
-def generate_trace(question_id_or_call_id: str, db: DB) -> Path:
+async def generate_trace(question_id_or_call_id: str, db: DB) -> Path:
     """Generate an HTML trace visualization. Returns the file path."""
     TRACES_DIR.mkdir(parents=True, exist_ok=True)
 
-    page = db.get_page(question_id_or_call_id)
+    page = await db.get_page(question_id_or_call_id)
     if page:
         question_label = page.summary[:60]
-        root_calls = db.get_root_calls_for_question(question_id_or_call_id)
+        root_calls = await db.get_root_calls_for_question(question_id_or_call_id)
         if not root_calls:
             raise ValueError(f"No calls found for question {question_id_or_call_id}")
         body_html = ""
         for rc in root_calls:
-            body_html += _render_call_node(rc, db, depth=0)
+            body_html += await _render_call_node(rc, db, depth=0)
     else:
-        call = db.get_call(question_id_or_call_id)
+        call = await db.get_call(question_id_or_call_id)
         if not call:
             raise ValueError(
                 f"No question or call found for ID: {question_id_or_call_id}"
             )
         question_label = f"Call {call.id[:8]} ({call.call_type.value})"
-        body_html = _render_call_node(call, db, depth=0)
+        body_html = await _render_call_node(call, db, depth=0)
 
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
     slug = "".join(c if c.isalnum() or c in " -" else "" for c in question_label[:50])

--- a/src/differential/workspace_map.py
+++ b/src/differential/workspace_map.py
@@ -5,8 +5,6 @@ Returns a map text and a short_id → full_uuid lookup dict.
 Short IDs are the first 8 characters of each page UUID.
 """
 
-from typing import Optional
-
 from differential.database import DB
 from differential.models import ConsiderationDirection, Page, PageType
 
@@ -15,7 +13,7 @@ def _short_id(full_uuid: str) -> str:
     return full_uuid[:8]
 
 
-def _direction_icon(direction: Optional[ConsiderationDirection]) -> str:
+def _direction_icon(direction: ConsiderationDirection | None) -> str:
     if direction == ConsiderationDirection.SUPPORTS:
         return "↑"
     elif direction == ConsiderationDirection.OPPOSES:
@@ -24,20 +22,20 @@ def _direction_icon(direction: Optional[ConsiderationDirection]) -> str:
         return "→"
 
 
-def _build_question_lines(
+async def _build_question_lines(
     question: Page,
     db: DB,
     short_id_map: dict[str, str],
     indent: int = 0,
-    collapse_depth: Optional[int] = None,
+    collapse_depth: int | None = None,
 ) -> list[str]:
     prefix = "  " * indent
     sid = _short_id(question.id)
     short_id_map[sid] = question.id
 
-    considerations = db.get_considerations_for_question(question.id)
-    judgements = db.get_judgements_for_question(question.id)
-    children = db.get_child_questions(question.id)
+    considerations = await db.get_considerations_for_question(question.id)
+    judgements = await db.get_judgements_for_question(question.id)
+    children = await db.get_child_questions(question.id)
 
     n_cons = len(considerations)
     n_j = len(judgements)
@@ -74,15 +72,17 @@ def _build_question_lines(
     # Sub-questions (recursive)
     for child in children:
         lines.extend(
-            _build_question_lines(child, db, short_id_map, indent + 1, collapse_depth)
+            await _build_question_lines(
+                child, db, short_id_map, indent + 1, collapse_depth
+            )
         )
 
     return lines
 
 
-def build_workspace_map(
+async def build_workspace_map(
     db: DB,
-    collapse_depth: Optional[int] = None,
+    collapse_depth: int | None = None,
 ) -> tuple[str, dict[str, str]]:
     """Compact LLM-readable map of the entire workspace.
 
@@ -97,19 +97,19 @@ def build_workspace_map(
         "",
     ]
 
-    root_questions = db.get_root_questions()
+    root_questions = await db.get_root_questions()
     if root_questions:
         parts.append("### Questions")
         parts.append("")
         for q in root_questions:
-            lines = _build_question_lines(
+            lines = await _build_question_lines(
                 q, db, short_id_map, indent=0, collapse_depth=collapse_depth
             )
             parts.extend(lines)
             parts.append("")
 
     # Sources section — all source pages regardless of workspace
-    source_pages = db.get_pages(page_type=PageType.SOURCE)
+    source_pages = await db.get_pages(page_type=PageType.SOURCE)
     if source_pages:
         parts.append("### Sources")
         parts.append("")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ load_dotenv()
 os.environ["DIFFERENTIAL_TEST_MODE"] = "1"
 
 import pytest
+import pytest_asyncio
 
 from differential.database import DB
 from differential.models import (
@@ -39,20 +40,20 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_llm)
 
 
-@pytest.fixture
-def tmp_db():
+@pytest_asyncio.fixture
+async def tmp_db():
     """Create a DB with a unique run_id and throwaway project for test isolation."""
     run_id = str(uuid.uuid4())
-    db = DB(run_id=run_id)
-    project = db.get_or_create_project(f"test-{run_id[:8]}")
+    db = await DB.create(run_id=run_id)
+    project = await db.get_or_create_project(f"test-{run_id[:8]}")
     db.project_id = project.id
-    db.init_budget(100)
+    await db.init_budget(100)
     yield db
-    db.delete_run_data(delete_project=True)
+    await db.delete_run_data(delete_project=True)
 
 
-@pytest.fixture
-def question_page(tmp_db):
+@pytest_asyncio.fixture
+async def question_page(tmp_db):
     """Create and return a question page in the DB."""
     page = Page(
         page_type=PageType.QUESTION,
@@ -61,12 +62,12 @@ def question_page(tmp_db):
         content="Is the sky blue?",
         summary="Is the sky blue?",
     )
-    tmp_db.save_page(page)
+    await tmp_db.save_page(page)
     return page
 
 
-@pytest.fixture
-def scout_call(question_page):
+@pytest_asyncio.fixture
+async def scout_call(question_page):
     """Create a pending scout call (not yet saved to DB)."""
     return Call(
         call_type=CallType.SCOUT,
@@ -76,8 +77,8 @@ def scout_call(question_page):
     )
 
 
-@pytest.fixture
-def assess_call(question_page):
+@pytest_asyncio.fixture
+async def assess_call(question_page):
     """Create a pending assess call (not yet saved to DB)."""
     return Call(
         call_type=CallType.ASSESS,
@@ -87,8 +88,8 @@ def assess_call(question_page):
     )
 
 
-@pytest.fixture
-def prioritization_call(question_page):
+@pytest_asyncio.fixture
+async def prioritization_call(question_page):
     """Create a pending prioritization call (not yet saved to DB)."""
     return Call(
         call_type=CallType.PRIORITIZATION,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -10,10 +10,19 @@ from differential.llm import Tool, agent_loop, text_call, structured_call
 from pydantic import BaseModel, Field
 
 
+async def _add(inp: dict) -> str:
+    return str(inp["a"] + inp["b"])
+
+
+async def _fail(inp: dict) -> str:
+    raise ValueError("boom")
+
+
+
 @pytest.mark.llm
-def test_text_only_returns_nonempty_text():
+async def test_text_only_returns_nonempty_text():
     """agent_loop with no tools should return text."""
-    result = agent_loop(
+    result = await agent_loop(
         "You are a helpful assistant.",
         "Say hello in one word.",
         tools=[],
@@ -24,7 +33,7 @@ def test_text_only_returns_nonempty_text():
 
 
 @pytest.mark.llm
-def test_tool_is_called_and_result_recorded():
+async def test_tool_is_called_and_result_recorded():
     """When given a tool that matches the task, the LLM calls it."""
     tool = Tool(
         name="add",
@@ -37,10 +46,10 @@ def test_tool_is_called_and_result_recorded():
             },
             "required": ["a", "b"],
         },
-        fn=lambda inp: str(inp["a"] + inp["b"]),
+        fn=_add,
     )
 
-    result = agent_loop(
+    result = await agent_loop(
         "You are a calculator. Use the add tool to answer.",
         "What is 3 + 7?",
         tools=[tool],
@@ -55,16 +64,16 @@ def test_tool_is_called_and_result_recorded():
 
 
 @pytest.mark.llm
-def test_tool_error_does_not_crash_loop():
+async def test_tool_error_does_not_crash_loop():
     """If a tool raises, the loop continues and returns a result."""
     tool = Tool(
         name="fail",
         description="A tool that always fails.",
         input_schema={"type": "object", "properties": {}},
-        fn=lambda inp: (_ for _ in ()).throw(ValueError("boom")),
+        fn=_fail,
     )
 
-    result = agent_loop(
+    result = await agent_loop(
         "You are a test assistant. Try the fail tool, then respond.",
         "Please call the fail tool.",
         tools=[tool],
@@ -77,17 +86,22 @@ def test_tool_error_does_not_crash_loop():
 
 
 @pytest.mark.llm
-def test_max_rounds_limits_tool_calls():
+async def test_max_rounds_limits_tool_calls():
     """The loop should not exceed max_rounds of tool calling."""
     call_count = []
+
+    async def ping(inp: dict) -> str:
+        call_count.append(1)
+        return "pong"
+
     tool = Tool(
         name="ping",
         description="Ping. Always call this again after getting a result.",
         input_schema={"type": "object", "properties": {}},
-        fn=lambda inp: (call_count.append(1), "pong")[1],
+        fn=ping,
     )
 
-    agent_loop(
+    await agent_loop(
         "You must call the ping tool every turn. Never stop calling it.",
         "Start pinging.",
         tools=[tool],
@@ -100,9 +114,9 @@ def test_max_rounds_limits_tool_calls():
 
 
 @pytest.mark.llm
-def test_text_call_returns_string():
+async def test_text_call_returns_string():
     """text_call should return a non-empty string."""
-    result = text_call(
+    result = await text_call(
         "You are a helpful assistant.",
         "Say 'yes' and nothing else.",
         max_tokens=16,
@@ -112,14 +126,14 @@ def test_text_call_returns_string():
 
 
 @pytest.mark.llm
-def test_structured_call_returns_parsed_dict():
+async def test_structured_call_returns_parsed_dict():
     """structured_call should return a dict matching the response model."""
 
     class Rating(BaseModel):
         score: int = Field(description="A rating from 1 to 5")
         reason: str = Field(description="One-sentence reason")
 
-    result = structured_call(
+    result = await structured_call(
         "You are a rating bot.",
         "Rate the color blue on a scale of 1-5.",
         response_model=Rating,

--- a/tests/test_create_call.py
+++ b/tests/test_create_call.py
@@ -3,32 +3,32 @@
 from differential.models import CallStatus, CallType, Workspace
 
 
-def test_create_call_persists_and_returns_call(tmp_db, question_page):
-    call = tmp_db.create_call(CallType.SCOUT, scope_page_id=question_page.id)
+async def test_create_call_persists_and_returns_call(tmp_db, question_page):
+    call = await tmp_db.create_call(CallType.SCOUT, scope_page_id=question_page.id)
     assert call.call_type == CallType.SCOUT
     assert call.scope_page_id == question_page.id
     assert call.status == CallStatus.PENDING
 
-    fetched = tmp_db.get_call(call.id)
+    fetched = await tmp_db.get_call(call.id)
     assert fetched is not None
     assert fetched.scope_page_id == question_page.id
 
 
-def test_create_call_with_all_options(tmp_db, question_page):
-    call = tmp_db.create_call(
+async def test_create_call_with_all_options(tmp_db, question_page):
+    call = await tmp_db.create_call(
         CallType.PRIORITIZATION,
         scope_page_id=question_page.id,
         budget_allocated=10,
         workspace=Workspace.PRIORITIZATION,
         context_page_ids=["c1", "c2"],
     )
-    fetched = tmp_db.get_call(call.id)
+    fetched = await tmp_db.get_call(call.id)
     assert fetched is not None
     assert fetched.workspace == Workspace.PRIORITIZATION
     assert fetched.budget_allocated == 10
     assert fetched.context_page_ids == ["c1", "c2"]
 
 
-def test_create_call_defaults_context_page_ids(tmp_db):
-    call = tmp_db.create_call(CallType.ASSESS)
+async def test_create_call_defaults_context_page_ids(tmp_db):
+    call = await tmp_db.create_call(CallType.ASSESS)
     assert call.context_page_ids == []

--- a/tests/test_investigate.py
+++ b/tests/test_investigate.py
@@ -6,14 +6,14 @@ from differential.orchestrator import Orchestrator
 
 
 @pytest.mark.llm
-def test_investigate_question_creates_pages(tmp_db, question_page):
+async def test_investigate_question_creates_pages(tmp_db, question_page):
     """Budget-1 investigation should produce at least one new page."""
-    tmp_db.init_budget(1)
+    await tmp_db.init_budget(1)
     orch = Orchestrator(tmp_db)
-    orch.investigate_question(question_page.id, budget=1)
+    await orch.investigate_question(question_page.id, budget=1)
 
     rows = (
-        tmp_db.client.table("pages").select("id").eq("run_id", tmp_db.run_id).execute()
+        await tmp_db.client.table("pages").select("id").eq("run_id", tmp_db.run_id).execute()
     )
     page_ids = [r["id"] for r in rows.data]
     new_ids = [pid for pid in page_ids if pid != question_page.id]

--- a/tests/test_move_types.py
+++ b/tests/test_move_types.py
@@ -19,23 +19,23 @@ def test_move_defs_have_valid_schemas():
         assert isinstance(schema["properties"], dict)
 
 
-def test_create_claim_via_bind(tmp_db, scout_call):
+async def test_create_claim_via_bind(tmp_db, scout_call):
     """Calling a bound CREATE_CLAIM tool should create a claim page in the DB."""
     state = MoveState(scout_call, tmp_db)
     tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
-    tool.fn({"summary": "Sky is blue", "content": "The sky appears blue."})
+    await tool.fn({"summary": "Sky is blue", "content": "The sky appears blue."})
 
     assert len(state.created_page_ids) == 1
-    page = tmp_db.get_page(state.created_page_ids[0])
+    page = await tmp_db.get_page(state.created_page_ids[0])
     assert page is not None
     assert page.page_type is PageType.CLAIM
     assert page.summary == "Sky is blue"
 
 
-def test_load_page_creates_nothing(tmp_db, scout_call):
+async def test_load_page_creates_nothing(tmp_db, scout_call):
     """Calling a bound LOAD_PAGE tool should not create any pages."""
     state = MoveState(scout_call, tmp_db)
     tool = MOVES[MoveType.LOAD_PAGE].bind(state)
-    tool.fn({"page_id": "abc12345"})
+    await tool.fn({"page_id": "abc12345"})
 
     assert state.created_page_ids == []

--- a/tests/test_resolve_load_requests.py
+++ b/tests/test_resolve_load_requests.py
@@ -12,7 +12,7 @@ from differential.models import (
 from differential.moves.load_page import LoadPagePayload, execute
 
 
-def _make_page(tmp_db):
+async def _make_page(tmp_db):
     """Create a page in the DB and return it."""
     page = Page(
         page_type=PageType.CLAIM,
@@ -21,7 +21,7 @@ def _make_page(tmp_db):
         content="Test claim content",
         summary="Test claim",
     )
-    tmp_db.save_page(page)
+    await tmp_db.save_page(page)
     return page
 
 
@@ -33,24 +33,24 @@ def _dummy_call():
     )
 
 
-def test_loads_page_by_short_id(tmp_db):
-    page = _make_page(tmp_db)
-    result = execute(LoadPagePayload(page_id=page.id[:8]), _dummy_call(), tmp_db)
+async def test_loads_page_by_short_id(tmp_db):
+    page = await _make_page(tmp_db)
+    result = await execute(LoadPagePayload(page_id=page.id[:8]), _dummy_call(), tmp_db)
     assert "Test claim content" in result.message
 
 
-def test_loads_page_by_full_id(tmp_db):
-    page = _make_page(tmp_db)
-    result = execute(LoadPagePayload(page_id=page.id), _dummy_call(), tmp_db)
+async def test_loads_page_by_full_id(tmp_db):
+    page = await _make_page(tmp_db)
+    result = await execute(LoadPagePayload(page_id=page.id), _dummy_call(), tmp_db)
     assert "Test claim content" in result.message
 
 
-def test_returns_not_found_for_unknown_id(tmp_db):
-    result = execute(LoadPagePayload(page_id="nonexist"), _dummy_call(), tmp_db)
+async def test_returns_not_found_for_unknown_id(tmp_db):
+    result = await execute(LoadPagePayload(page_id="nonexist"), _dummy_call(), tmp_db)
     assert "not found" in result.message
 
 
-def test_does_not_create_pages(tmp_db):
-    _make_page(tmp_db)
-    result = execute(LoadPagePayload(page_id="nonexist"), _dummy_call(), tmp_db)
+async def test_does_not_create_pages(tmp_db):
+    await _make_page(tmp_db)
+    result = await execute(LoadPagePayload(page_id="nonexist"), _dummy_call(), tmp_db)
     assert result.created_page_id is None

--- a/tests/test_run_call.py
+++ b/tests/test_run_call.py
@@ -8,7 +8,7 @@ from differential.moves.base import MoveState
 
 
 @pytest.mark.llm
-def test_scout_run_call(tmp_db, question_page, scout_call):
+async def test_scout_run_call(tmp_db, question_page, scout_call):
     """A scout call creates pages, records valid moves, and persists them."""
     context = f"## Question\n\nID: `{question_page.id}`\n\n{question_page.content}\n"
     task = (
@@ -17,7 +17,7 @@ def test_scout_run_call(tmp_db, question_page, scout_call):
         f"Question ID: `{question_page.id}`"
     )
 
-    result = run_call(CallType.SCOUT, task, context, scout_call, tmp_db, max_rounds=3)
+    result = await run_call(CallType.SCOUT, task, context, scout_call, tmp_db, max_rounds=3)
 
     assert isinstance(result, RunCallResult)
     assert len(result.moves) > 0
@@ -27,13 +27,13 @@ def test_scout_run_call(tmp_db, question_page, scout_call):
         assert move.move_type in MoveType
 
     for page_id in result.created_page_ids:
-        page = tmp_db.get_page(page_id)
+        page = await tmp_db.get_page(page_id)
         assert page is not None
         assert page.content != ""
 
 
 @pytest.mark.llm
-def test_prioritization_produces_dispatches(tmp_db, question_page, prioritization_call):
+async def test_prioritization_produces_dispatches(tmp_db, question_page, prioritization_call):
     """A prioritization call should produce at least one dispatch."""
     context = (
         f"## Questions\n\n"
@@ -45,7 +45,7 @@ def test_prioritization_produces_dispatches(tmp_db, question_page, prioritizatio
         "Dispatch scout or assess calls for this question."
     )
 
-    result = run_call(
+    result = await run_call(
         CallType.PRIORITIZATION,
         task,
         context,
@@ -59,7 +59,7 @@ def test_prioritization_produces_dispatches(tmp_db, question_page, prioritizatio
     assert result.dispatches[0].call_type is not None
 
 
-def test_available_moves_restricts_tools(tmp_db, scout_call):
+async def test_available_moves_restricts_tools(tmp_db, scout_call):
     """When available_moves is restricted, only those move types are bound."""
     allowed = [MoveType.CREATE_CLAIM, MoveType.LOAD_PAGE]
     state = MoveState(scout_call, tmp_db)

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -2,6 +2,8 @@
 
 import uuid
 
+import pytest_asyncio
+
 from differential.context import build_call_context, build_prioritization_context
 from differential.database import DB
 from differential.models import (
@@ -16,14 +18,14 @@ from differential.models import (
 from differential.workspace_map import build_workspace_map
 
 
-def _make_db(project_name: str) -> DB:
-    db = DB(run_id=str(uuid.uuid4()))
-    project = db.get_or_create_project(project_name)
+async def _make_db(project_name: str) -> DB:
+    db = await DB.create(run_id=str(uuid.uuid4()))
+    project = await db.get_or_create_project(project_name)
     db.project_id = project.id
     return db
 
 
-def _make_question(db: DB, text: str) -> Page:
+async def _make_question(db: DB, text: str) -> Page:
     page = Page(
         page_type=PageType.QUESTION,
         layer=PageLayer.SQUIDGY,
@@ -31,11 +33,11 @@ def _make_question(db: DB, text: str) -> Page:
         content=text,
         summary=text[:120],
     )
-    db.save_page(page)
+    await db.save_page(page)
     return page
 
 
-def _make_claim(db: DB, text: str) -> Page:
+async def _make_claim(db: DB, text: str) -> Page:
     page = Page(
         page_type=PageType.CLAIM,
         layer=PageLayer.SQUIDGY,
@@ -45,14 +47,14 @@ def _make_claim(db: DB, text: str) -> Page:
         epistemic_status=4.5,
         epistemic_type="well-established",
     )
-    db.save_page(page)
+    await db.save_page(page)
     return page
 
 
-def _link_consideration(
+async def _link_consideration(
     db: DB, claim: Page, question: Page, direction: ConsiderationDirection
 ) -> None:
-    db.save_link(
+    await db.save_link(
         PageLink(
             from_page_id=claim.id,
             to_page_id=question.id,
@@ -64,7 +66,7 @@ def _link_consideration(
     )
 
 
-def _make_source(db: DB, name: str) -> Page:
+async def _make_source(db: DB, name: str) -> Page:
     page = Page(
         page_type=PageType.SOURCE,
         layer=PageLayer.SQUIDGY,
@@ -73,118 +75,134 @@ def _make_source(db: DB, name: str) -> Page:
         summary=f"Source: {name}",
         extra={"filename": name, "char_count": 100},
     )
-    db.save_page(page)
+    await db.save_page(page)
     return page
 
 
-class TestWorkspaceIsolation:
-    """Pages and calls in one project must not leak into another project's views."""
+@pytest_asyncio.fixture
+async def two_workspaces():
+    """Set up two isolated workspaces with questions, claims, and links."""
+    db_alpha = await _make_db(f"alpha-{uuid.uuid4().hex[:8]}")
+    db_beta = await _make_db(f"beta-{uuid.uuid4().hex[:8]}")
 
-    def setup_method(self):
-        self.db_alpha = _make_db(f"alpha-{uuid.uuid4().hex[:8]}")
-        self.db_beta = _make_db(f"beta-{uuid.uuid4().hex[:8]}")
+    q_alpha = await _make_question(db_alpha, "What colour is the sky?")
+    claim_alpha = await _make_claim(
+        db_alpha, "The sky is blue due to Rayleigh scattering"
+    )
+    await _link_consideration(
+        db_alpha, claim_alpha, q_alpha, ConsiderationDirection.SUPPORTS
+    )
+    source_alpha = await _make_source(db_alpha, "sky-paper.pdf")
 
-        self.q_alpha = _make_question(self.db_alpha, "What colour is the sky?")
-        self.claim_alpha = _make_claim(
-            self.db_alpha, "The sky is blue due to Rayleigh scattering"
-        )
-        _link_consideration(
-            self.db_alpha,
-            self.claim_alpha,
-            self.q_alpha,
-            ConsiderationDirection.SUPPORTS,
-        )
-        self.source_alpha = _make_source(self.db_alpha, "sky-paper.pdf")
+    q_beta = await _make_question(db_beta, "Why is the ocean salty?")
+    claim_beta = await _make_claim(
+        db_beta, "Rivers carry dissolved salts into the ocean"
+    )
+    await _link_consideration(
+        db_beta, claim_beta, q_beta, ConsiderationDirection.SUPPORTS
+    )
 
-        self.q_beta = _make_question(self.db_beta, "Why is the ocean salty?")
-        self.claim_beta = _make_claim(
-            self.db_beta, "Rivers carry dissolved salts into the ocean"
-        )
-        _link_consideration(
-            self.db_beta,
-            self.claim_beta,
-            self.q_beta,
-            ConsiderationDirection.SUPPORTS,
-        )
+    yield {
+        "db_alpha": db_alpha,
+        "db_beta": db_beta,
+        "q_alpha": q_alpha,
+        "q_beta": q_beta,
+        "claim_alpha": claim_alpha,
+        "claim_beta": claim_beta,
+        "source_alpha": source_alpha,
+    }
 
-    def teardown_method(self):
-        self.db_alpha.delete_run_data(delete_project=True)
-        self.db_beta.delete_run_data(delete_project=True)
+    await db_alpha.delete_run_data(delete_project=True)
+    await db_beta.delete_run_data(delete_project=True)
 
-    def test_root_questions_isolated(self):
-        alpha_qs = self.db_alpha.get_root_questions()
-        beta_qs = self.db_beta.get_root_questions()
 
-        alpha_ids = {q.id for q in alpha_qs}
-        beta_ids = {q.id for q in beta_qs}
+async def test_root_questions_isolated(two_workspaces):
+    w = two_workspaces
+    alpha_qs = await w["db_alpha"].get_root_questions()
+    beta_qs = await w["db_beta"].get_root_questions()
 
-        assert self.q_alpha.id in alpha_ids
-        assert self.q_beta.id not in alpha_ids
-        assert self.q_beta.id in beta_ids
-        assert self.q_alpha.id not in beta_ids
+    alpha_ids = {q.id for q in alpha_qs}
+    beta_ids = {q.id for q in beta_qs}
 
-    def test_get_pages_isolated(self):
-        alpha_pages = self.db_alpha.get_pages()
-        beta_pages = self.db_beta.get_pages()
+    assert w["q_alpha"].id in alpha_ids
+    assert w["q_beta"].id not in alpha_ids
+    assert w["q_beta"].id in beta_ids
+    assert w["q_alpha"].id not in beta_ids
 
-        alpha_ids = {p.id for p in alpha_pages}
-        beta_ids = {p.id for p in beta_pages}
 
-        assert self.claim_alpha.id in alpha_ids
-        assert self.claim_alpha.id not in beta_ids
-        assert self.claim_beta.id in beta_ids
-        assert self.claim_beta.id not in alpha_ids
+async def test_get_pages_isolated(two_workspaces):
+    w = two_workspaces
+    alpha_pages = await w["db_alpha"].get_pages()
+    beta_pages = await w["db_beta"].get_pages()
 
-    def test_sources_isolated(self):
-        alpha_sources = self.db_alpha.get_pages(page_type=PageType.SOURCE)
-        beta_sources = self.db_beta.get_pages(page_type=PageType.SOURCE)
+    alpha_ids = {p.id for p in alpha_pages}
+    beta_ids = {p.id for p in beta_pages}
 
-        assert any(s.id == self.source_alpha.id for s in alpha_sources)
-        assert not any(s.id == self.source_alpha.id for s in beta_sources)
+    assert w["claim_alpha"].id in alpha_ids
+    assert w["claim_alpha"].id not in beta_ids
+    assert w["claim_beta"].id in beta_ids
+    assert w["claim_beta"].id not in alpha_ids
 
-    def test_workspace_map_isolated(self):
-        map_alpha, ids_alpha = build_workspace_map(self.db_alpha)
-        map_beta, ids_beta = build_workspace_map(self.db_beta)
 
-        assert self.q_alpha.id[:8] in ids_alpha
-        assert self.q_alpha.id[:8] not in ids_beta
-        assert self.q_beta.id[:8] in ids_beta
-        assert self.q_beta.id[:8] not in ids_alpha
+async def test_sources_isolated(two_workspaces):
+    w = two_workspaces
+    alpha_sources = await w["db_alpha"].get_pages(page_type=PageType.SOURCE)
+    beta_sources = await w["db_beta"].get_pages(page_type=PageType.SOURCE)
 
-        assert "Rayleigh" in map_alpha
-        assert "Rayleigh" not in map_beta
-        assert "salty" in map_beta
-        assert "salty" not in map_alpha
+    assert any(s.id == w["source_alpha"].id for s in alpha_sources)
+    assert not any(s.id == w["source_alpha"].id for s in beta_sources)
 
-    def test_call_context_isolated(self):
-        ctx_alpha, _, _ = build_call_context(self.q_alpha.id, self.db_alpha)
-        ctx_beta, _, _ = build_call_context(self.q_beta.id, self.db_beta)
 
-        assert "Rayleigh" in ctx_alpha
-        assert "salty" not in ctx_alpha
-        assert "salty" in ctx_beta
-        assert "Rayleigh" not in ctx_beta
+async def test_workspace_map_isolated(two_workspaces):
+    w = two_workspaces
+    map_alpha, ids_alpha = await build_workspace_map(w["db_alpha"])
+    map_beta, ids_beta = await build_workspace_map(w["db_beta"])
 
-    def test_prioritization_context_isolated(self):
-        ctx_alpha, _ = build_prioritization_context(
-            self.db_alpha, self.q_alpha.id
-        )
-        ctx_beta, _ = build_prioritization_context(
-            self.db_beta, self.q_beta.id
-        )
+    assert w["q_alpha"].id[:8] in ids_alpha
+    assert w["q_alpha"].id[:8] not in ids_beta
+    assert w["q_beta"].id[:8] in ids_beta
+    assert w["q_beta"].id[:8] not in ids_alpha
 
-        assert "sky" in ctx_alpha.lower()
-        assert "ocean" not in ctx_alpha.lower()
-        assert "ocean" in ctx_beta.lower()
-        assert "sky" not in ctx_beta.lower()
+    assert "Rayleigh" in map_alpha
+    assert "Rayleigh" not in map_beta
+    assert "salty" in map_beta
+    assert "salty" not in map_alpha
 
-    def test_source_in_prioritization_context_isolated(self):
-        ctx_alpha, _ = build_prioritization_context(
-            self.db_alpha, self.q_alpha.id
-        )
-        ctx_beta, _ = build_prioritization_context(
-            self.db_beta, self.q_beta.id
-        )
 
-        assert "sky-paper.pdf" in ctx_alpha
-        assert "sky-paper.pdf" not in ctx_beta
+async def test_call_context_isolated(two_workspaces):
+    w = two_workspaces
+    ctx_alpha, _, _ = await build_call_context(w["q_alpha"].id, w["db_alpha"])
+    ctx_beta, _, _ = await build_call_context(w["q_beta"].id, w["db_beta"])
+
+    assert "Rayleigh" in ctx_alpha
+    assert "salty" not in ctx_alpha
+    assert "salty" in ctx_beta
+    assert "Rayleigh" not in ctx_beta
+
+
+async def test_prioritization_context_isolated(two_workspaces):
+    w = two_workspaces
+    ctx_alpha, _ = await build_prioritization_context(
+        w["db_alpha"], w["q_alpha"].id
+    )
+    ctx_beta, _ = await build_prioritization_context(
+        w["db_beta"], w["q_beta"].id
+    )
+
+    assert "sky" in ctx_alpha.lower()
+    assert "ocean" not in ctx_alpha.lower()
+    assert "ocean" in ctx_beta.lower()
+    assert "sky" not in ctx_beta.lower()
+
+
+async def test_source_in_prioritization_context_isolated(two_workspaces):
+    w = two_workspaces
+    ctx_alpha, _ = await build_prioritization_context(
+        w["db_alpha"], w["q_alpha"].id
+    )
+    ctx_beta, _ = await build_prioritization_context(
+        w["db_beta"], w["q_beta"].id
+    )
+
+    assert "sky-paper.pdf" in ctx_alpha
+    assert "sky-paper.pdf" not in ctx_beta

--- a/uv.lock
+++ b/uv.lock
@@ -281,6 +281,7 @@ pdf = [
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "ruff" },
 ]
@@ -299,6 +300,7 @@ provides-extras = ["pdf"]
 dev = [
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.15.5" },
 ]
@@ -1052,6 +1054,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Converts entire codebase to async/await (DB → AsyncClient, LLM → AsyncAnthropic, all calls/moves/orchestrator/context functions)
- Adds `--batch FILE` flag that runs multiple questions concurrently via `asyncio.gather`, each with its own `run_id` for budget isolation
- Batch entries support `{"question": "...", "budget": N}` and `{"continue": "ID", "budget": N}`

## Test plan
- [x] All 36 tests pass (`uv run pytest --llm`)
- [x] Tested batch new questions concurrently (2 questions, budget 2 each)
- [x] Tested batch continue concurrently (2 existing questions, budget 1 each)
- [x] Verified workspace isolation with `--list` after batch runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)