### PR TITLE
Document --workspace flag and add README update convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@ uv run python main.py --summary QUESTION_ID
 
 # Generate execution trace (accepts question ID or call ID)
 uv run python main.py --trace QUESTION_ID
+
+# Use a named workspace to isolate investigations
+uv run python main.py "Your question here" --workspace my-project --budget 10
+
+# List all workspaces
+uv run python main.py --list-workspaces
 ```
 
 Tests: `uv run pytest`. Optional dependency: `pypdf` for PDF ingestion (`uv sync --extra pdf`).
@@ -94,3 +100,4 @@ Each call ends with a closing review that produces `remaining_fruit` (0-10 scale
 - Pages are immutable once written (squidgy layer); updates use SUPERSEDE_PAGE to create a new version pointing back to the old one
 - Multiline strings use parenthesized concatenation of single-quoted lines (`"line 1 " "line 2"`), not triple-quoted strings (`"""`). Only use `f""` on lines that actually contain `{placeholder}` expressions.
 - Do not add section divider comments (e.g. `# ----------` banners). Use blank lines between logical sections; the code should speak for itself.
+- When adding new user-facing CLI flags or commands to `main.py`, always update `README.md` with corresponding documentation.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ uv run python main.py --trace CALL_ID
 # Batch mode: investigate multiple questions concurrently
 uv run python main.py --batch questions.json
 
+# Use a named workspace to isolate investigations
+uv run python main.py "Your question here" --workspace my-project --budget 10
+
+# List all workspaces
+uv run python main.py --list-workspaces
+
+# List questions in a specific workspace
+uv run python main.py --list --workspace my-project
+
 # Any command can target the production database
 uv run python main.py --prod-db --list
 ```


### PR DESCRIPTION
## Summary
- Add usage examples for `--workspace` and `--list-workspaces` flags to README.md and CLAUDE.md
- Add a convention to CLAUDE.md requiring README updates whenever new user-facing CLI flags are added to `main.py`

## Test plan
- [ ] Verify documentation matches actual CLI behavior (`--workspace` and `--list-workspaces` flags in `main.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)