### PR TITLE
Add progressive summarisation to avoid context-limit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ uv run python main.py --map QUESTION_ID
 # Generate executive summary
 uv run python main.py --summary QUESTION_ID
 
+# Control how deep the summary traverses and where it switches to compact mode.
+# --max-depth N        How many levels of sub-questions to include (default: 4).
+# --summarize-after-depth N  Levels 0..N-1 show full claim/judgement content;
+#                            deeper levels show only one-line page summaries.
+#                            Default: max-depth // 2. Decrease to shrink context
+#                            when hitting LLM context-length errors.
+uv run python main.py --summary QUESTION_ID --max-depth 6 --summarize-after-depth 3
+
 # Generate execution trace visualization
 uv run python main.py --trace QUESTION_ID
 # Or trace a specific call:

--- a/main.py
+++ b/main.py
@@ -251,7 +251,12 @@ async def cmd_trace(trace_id: str, db: DB) -> None:
     print("Open that file in your browser to view it.")
 
 
-async def cmd_summary(question_id: str, db: DB) -> None:
+async def cmd_summary(
+    question_id: str,
+    db: DB,
+    max_depth: int = 4,
+    summary_cutoff: int | None = None,
+) -> None:
     question = await db.get_page(question_id)
     if not question:
         print(
@@ -262,7 +267,9 @@ async def cmd_summary(question_id: str, db: DB) -> None:
     print(f"\nGenerating summary for: {question.summary[:80]}")
     print("(This will use one LLM call but does not count against research budget)\n")
 
-    summary_text = await generate_summary(question_id, db)
+    summary_text = await generate_summary(
+        question_id, db, max_depth=max_depth, summary_cutoff=summary_cutoff
+    )
     path = save_summary(summary_text, question.summary)
 
     print(summary_text)
@@ -469,6 +476,21 @@ async def async_main():
         help="Generate an executive summary for a question",
     )
     parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=4,
+        help="Maximum tree depth for --summary (default: 4)",
+    )
+    parser.add_argument(
+        "--summarize-after-depth",
+        type=int,
+        default=None,
+        help=(
+            "Depth at which --summary switches from full content to page "
+            "summaries only (default: max-depth // 2)"
+        ),
+    )
+    parser.add_argument(
         "--map",
         dest="map_id",
         metavar="QUESTION_ID",
@@ -599,7 +621,11 @@ async def async_main():
     elif args.map_id:
         await cmd_map(args.map_id, db)
     elif args.summary_id:
-        await cmd_summary(args.summary_id, db)
+        await cmd_summary(
+            args.summary_id, db,
+            max_depth=args.max_depth,
+            summary_cutoff=args.summarize_after_depth,
+        )
     elif args.continue_id:
         await cmd_continue(args.continue_id, args.budget, db)
     elif args.batch_file:

--- a/src/differential/summary.py
+++ b/src/differential/summary.py
@@ -18,26 +18,39 @@ def _load_prompt_file(name: str) -> str:
 
 
 async def build_research_tree(
-    question_id: str, db: DB, depth: int = 0, max_depth: int = 4
+    question_id: str,
+    db: DB,
+    depth: int = 0,
+    max_depth: int = 4,
+    summary_cutoff: int | None = None,
 ) -> str:
     """
-    Recursively build a full picture of the research on a question:
-    the question itself, all its considerations (with full content),
-    all its judgements, and all sub-questions (recursively).
+    Recursively build a full picture of the research on a question.
+
+    The first ``summary_cutoff`` levels render full content (claims,
+    reasoning, judgement bodies). Deeper levels render only page summaries
+    to keep total context size manageable. Defaults to max_depth // 2.
     """
     question = await db.get_page(question_id)
     if not question:
         return ""
 
+    if summary_cutoff is None:
+        summary_cutoff = max_depth // 2
+    full_detail = depth < summary_cutoff
     indent = "  " * depth
     parts = []
 
     # Question heading
     if depth == 0:
         parts.append(f"# Research Question\n\n{question.content}\n")
-    else:
+    elif full_detail:
         parts.append(
             f"{'#' * (depth + 2)} Sub-question: {question.summary}\n\n{question.content}\n"
+        )
+    else:
+        parts.append(
+            f"{'#' * (depth + 2)} Sub-question: {question.summary}\n"
         )
 
     # Considerations
@@ -61,11 +74,13 @@ async def build_research_tree(
 
         def format_consideration(claim, link) -> str:
             strength_note = f" (strength {link.strength:.1f})" if link.strength else ""
-            lines = [f"- **{claim.summary}**{strength_note}"]
-            lines.append(f"  {claim.content}")
-            if link.reasoning:
-                lines.append(f"  *Bearing on question: {link.reasoning}*")
-            return "\n".join(lines)
+            if full_detail:
+                lines = [f"- **{claim.summary}**{strength_note}"]
+                lines.append(f"  {claim.content}")
+                if link.reasoning:
+                    lines.append(f"  *Bearing on question: {link.reasoning}*")
+                return '\n'.join(lines)
+            return f"- {claim.summary}{strength_note}"
 
         if supports:
             parts.append(f"{indent}**Supporting considerations:**\n")
@@ -95,15 +110,21 @@ async def build_research_tree(
                 if len(ordered) > 1
                 else "Judgement"
             )
-            parts.append(
-                f"{indent}**{label}** (confidence {j.epistemic_status:.2f} — {j.epistemic_type}):\n"
-            )
-            parts.append(j.content)
-            extra = j.extra or {}
-            if extra.get("key_dependencies"):
-                parts.append(f"\n*Key dependencies: {extra['key_dependencies']}*")
-            if extra.get("sensitivity_analysis"):
-                parts.append(f"\n*Sensitivity: {extra['sensitivity_analysis']}*")
+            if full_detail:
+                parts.append(
+                    f"{indent}**{label}** (confidence {j.epistemic_status:.2f} — {j.epistemic_type}):\n"
+                )
+                parts.append(j.content)
+                extra = j.extra or {}
+                if extra.get("key_dependencies"):
+                    parts.append(f"\n*Key dependencies: {extra['key_dependencies']}*")
+                if extra.get("sensitivity_analysis"):
+                    parts.append(f"\n*Sensitivity: {extra['sensitivity_analysis']}*")
+            else:
+                parts.append(
+                    f"{indent}**{label}** (confidence {j.epistemic_status:.2f} — "
+                    f"{j.epistemic_type}): {j.summary}"
+                )
             parts.append("")
 
     # Sub-questions (recurse)
@@ -113,14 +134,22 @@ async def build_research_tree(
             for child in children:
                 parts.append(
                     await build_research_tree(
-                        child.id, db, depth=depth + 1, max_depth=max_depth
+                        child.id, db,
+                        depth=depth + 1,
+                        max_depth=max_depth,
+                        summary_cutoff=summary_cutoff,
                     )
                 )
 
     return "\n".join(parts)
 
 
-async def generate_summary(question_id: str, db: DB) -> str:
+async def generate_summary(
+    question_id: str,
+    db: DB,
+    max_depth: int = 4,
+    summary_cutoff: int | None = None,
+) -> str:
     """
     Generate an executive summary of research on a question.
     Returns the summary as a string.
@@ -129,7 +158,9 @@ async def generate_summary(question_id: str, db: DB) -> str:
     if not question:
         raise ValueError(f"Question {question_id} not found")
 
-    research_tree = await build_research_tree(question_id, db)
+    research_tree = await build_research_tree(
+        question_id, db, max_depth=max_depth, summary_cutoff=summary_cutoff
+    )
 
     if not research_tree.strip():
         return f"No research found for question: {question.summary}"


### PR DESCRIPTION
## Summary
- Deep research trees were hitting LLM context-length errors because `build_research_tree` rendered full content at every depth
- The first `summary_cutoff` levels (default: `max_depth // 2`) now render full claim content, reasoning, and judgement bodies; deeper levels render only one-line page summaries
- New CLI flags `--max-depth` and `--summarize-after-depth` let users tune the tradeoff between detail and context size

## Test plan
- [x] Existing tests pass (`uv run pytest` — 30 passed)
- [x] Integration test confirms three modes: default cutoff, cutoff=0 (all summary), cutoff=10 (all full detail)
- [x] CLI `--help` shows new flags with descriptions
- [ ] Manual test on a large research tree that was previously hitting context errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)