### PR TITLE
Document log level CLI flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ uv run python main.py --list --workspace my-project
 
 # Any command can target the production database
 uv run python main.py --prod-db --list
+
+# Enable info-level logging to stderr
+uv run python main.py "Your question" --budget 5 -v
+
+# Enable debug-level logging to stderr (very verbose)
+uv run python main.py "Your question" --budget 5 --debug
 ```
 
 ### Batch mode


### PR DESCRIPTION
## Summary
- Add usage examples for `-v`/`--verbose` (info-level) and `--debug` (debug-level) logging flags to the README

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)