### PR TITLE
Migrate env var setup to pydantic-settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,10 +17,6 @@ import sys
 import uuid
 from pathlib import Path
 
-from dotenv import load_dotenv
-
-load_dotenv()
-
 from differential.database import DB
 from differential.models import Page, PageLayer, PageLink, PageType, LinkType, Workspace
 from differential.orchestrator import Orchestrator, create_root_question
@@ -28,7 +24,7 @@ from differential.sources import create_source_page, run_ingest_calls
 from differential.chat import run_chat
 from differential.mapper import generate_map
 from differential.summary import generate_summary, save_summary
-from differential import tracer
+from differential.settings import get_settings
 from differential.tracer import generate_trace
 
 PAGES_DIR = Path(__file__).parent / "pages"
@@ -487,7 +483,7 @@ async def async_main():
     logging.getLogger("differential").setLevel(log_level)
 
     if args.no_trace:
-        tracer.TRACING_ENABLED = False
+        get_settings().tracing_enabled = False
 
     PAGES_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "anthropic>=0.84.0",
     "fastapi>=0.135.1",
     "pydantic>=2.0",
-    "python-dotenv>=1.2.2",
+    "pydantic-settings>=2.0",
     "supabase>=2.0.0",
     "uvicorn[standard]>=0.41.0",
 ]

--- a/src/differential/api/app.py
+++ b/src/differential/api/app.py
@@ -4,7 +4,6 @@ FastAPI application for the Differential research workspace.
 Read-only API for browsing projects, pages, links, and calls.
 """
 
-import os
 import uuid
 
 from fastapi import FastAPI, HTTPException, Query
@@ -12,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from differential.database import DB
 from differential.models import PageType, Workspace
+from differential.settings import get_settings
 from differential.api.schemas import (
     CallOut,
     ConsiderationOut,
@@ -38,7 +38,7 @@ app.add_middleware(
 
 
 def _get_db(project_id: str = "") -> DB:
-    prod = os.environ.get("DIFFERENTIAL_PROD_DB", "").lower() in ("1", "true")
+    prod = get_settings().is_prod_db
     return DB(
         run_id=str(uuid.uuid4()),
         prod=prod,

--- a/src/differential/database.py
+++ b/src/differential/database.py
@@ -3,7 +3,6 @@ Supabase database layer for the research workspace.
 """
 
 import logging
-import os
 import uuid
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -12,6 +11,7 @@ from postgrest.types import CountMethod
 from supabase import acreate_client, AsyncClient
 from supabase.lib.client_options import AsyncClientOptions
 
+from differential.settings import get_settings
 from differential.models import (
     Call,
     CallStatus,
@@ -36,24 +36,6 @@ _Rows = list[dict[str, Any]]
 def _rows(response: Any) -> _Rows:
     """Extract rows from a Supabase API response with proper typing."""
     return cast(_Rows, response.data) if response.data else []
-
-
-# Default local Supabase credentials (from `supabase status`)
-_DEFAULT_URL = "http://127.0.0.1:54321"
-_DEFAULT_KEY = (
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-    "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0."
-    "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
-)
-
-
-def _get_credentials(prod: bool = False) -> tuple[str, str]:
-    if prod:
-        return os.environ["SUPABASE_PROD_URL"], os.environ["SUPABASE_PROD_KEY"]
-    return (
-        os.environ.get("SUPABASE_URL", _DEFAULT_URL),
-        os.environ.get("SUPABASE_KEY", _DEFAULT_KEY),
-    )
 
 
 def _row_to_page(row: dict[str, Any]) -> Page:
@@ -133,7 +115,7 @@ class DB:
         client: AsyncClient | None = None,
     ) -> "DB":
         if client is None:
-            url, key = _get_credentials(prod)
+            url, key = get_settings().get_supabase_credentials(prod)
             client = await acreate_client(
                 url, key, options=AsyncClientOptions(schema="public")
             )

--- a/src/differential/llm.py
+++ b/src/differential/llm.py
@@ -9,7 +9,6 @@ Exports three calling modes:
 
 import asyncio
 import logging
-import os
 from collections.abc import Callable, Awaitable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,12 +17,9 @@ import anthropic
 from anthropic.types import MessageParam, TextBlock, ToolUseBlock
 from pydantic import BaseModel
 
+from differential.settings import get_settings
+
 PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
-MODEL = (
-    "claude-haiku-4-5-20251001"
-    if os.environ.get("DIFFERENTIAL_TEST_MODE")
-    else "claude-opus-4-6"
-)
 
 log = logging.getLogger(__name__)
 
@@ -81,6 +77,7 @@ class AgentResult:
 
 async def _call_api(
     client: anthropic.AsyncAnthropic,
+    model: str,
     system_prompt: str,
     messages: list[dict],
     tools: list[dict] | None = None,
@@ -88,7 +85,7 @@ async def _call_api(
 ) -> anthropic.types.Message:
     """Make a single Anthropic API call with retry logic."""
     kwargs: dict = {
-        "model": MODEL,
+        "model": model,
         "max_tokens": max_tokens,
         "system": system_prompt,
         "messages": messages,
@@ -99,7 +96,7 @@ async def _call_api(
     n_tools = len(tools) if tools else 0
     log.debug(
         "API call: model=%s, max_tokens=%d, tools=%d, system_prompt_len=%d, messages=%d",
-        MODEL, max_tokens, n_tools, len(system_prompt), len(messages),
+        model, max_tokens, n_tools, len(system_prompt), len(messages),
     )
 
     for attempt in range(MAX_API_RETRIES):
@@ -152,12 +149,9 @@ async def agent_loop(
 
     Returns AgentResult with concatenated text and a log of all tool calls.
     """
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise EnvironmentError(
-            "ANTHROPIC_API_KEY environment variable not set. "
-            "Set it before running the workspace."
-        )
+    settings = get_settings()
+    api_key = settings.require_anthropic_key()
+    model = settings.model
     client = anthropic.AsyncAnthropic(api_key=api_key)
 
     tool_defs = [
@@ -185,6 +179,7 @@ async def agent_loop(
         log.debug("agent_loop round %d/%d", round_num + 1, max_rounds)
         response = await _call_api(
             client,
+            model,
             system_prompt,
             messages,
             tool_defs or None,
@@ -300,9 +295,9 @@ async def single_call_with_tools(
     Use this when you want the LLM to pick and invoke tools in one shot
     (e.g. phase-1 page loading, single-call prioritization).
     """
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise EnvironmentError("ANTHROPIC_API_KEY environment variable not set.")
+    settings = get_settings()
+    api_key = settings.require_anthropic_key()
+    model = settings.model
     client = anthropic.AsyncAnthropic(api_key=api_key)
 
     tool_defs = [
@@ -322,7 +317,7 @@ async def single_call_with_tools(
 
     messages: list[dict] = [{"role": "user", "content": user_message}]
     response = await _call_api(
-        client, system_prompt, messages, tool_defs or None, max_tokens,
+        client, model, system_prompt, messages, tool_defs or None, max_tokens,
     )
 
     text_parts: list[str] = []
@@ -375,9 +370,9 @@ async def text_call(
 
     Pass `messages` for multi-turn conversations, or `user_message` for single-turn.
     """
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise EnvironmentError("ANTHROPIC_API_KEY environment variable not set.")
+    settings = get_settings()
+    api_key = settings.require_anthropic_key()
+    model = settings.model
     client = anthropic.AsyncAnthropic(api_key=api_key)
     msg_list = (
         messages
@@ -385,7 +380,7 @@ async def text_call(
         else [{"role": "user", "content": user_message}]
     )
     log.debug("text_call: max_tokens=%d, messages=%d", max_tokens, len(msg_list))
-    response = await _call_api(client, system_prompt, msg_list, max_tokens=max_tokens)
+    response = await _call_api(client, model, system_prompt, msg_list, max_tokens=max_tokens)
     for block in response.content:
         if isinstance(block, TextBlock):
             log.debug("text_call returned %d chars", len(block.text))
@@ -406,21 +401,21 @@ async def structured_call(
     Uses the Anthropic structured output API (messages.parse with output_format).
     Returns the parsed response as a dict, or None on failure.
     """
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        raise EnvironmentError("ANTHROPIC_API_KEY environment variable not set.")
+    settings = get_settings()
+    api_key = settings.require_anthropic_key()
+    model = settings.model
     client = anthropic.AsyncAnthropic(api_key=api_key)
 
     messages: list[MessageParam] = [{"role": "user", "content": user_message}]
     log.debug(
         "structured_call: model=%s, response_model=%s, max_tokens=%d",
-        MODEL, response_model.__name__, max_tokens,
+        model, response_model.__name__, max_tokens,
     )
 
     for attempt in range(MAX_API_RETRIES):
         try:
             response = await client.messages.parse(
-                model=MODEL,
+                model=model,
                 max_tokens=max_tokens,
                 system=system_prompt,
                 messages=messages,

--- a/src/differential/settings.py
+++ b/src/differential/settings.py
@@ -1,0 +1,86 @@
+"""Centralised configuration loaded from environment variables and .env files."""
+
+from contextlib import contextmanager
+from collections.abc import Iterator
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    model_config = {"env_file": ".env", "extra": "ignore", "validate_assignment": True}
+
+    anthropic_api_key: str = ""
+    differential_test_mode: str = ""
+    differential_prod_db: str = ""
+    tracing_enabled: bool = True
+
+    supabase_url: str = "http://127.0.0.1:54321"
+    supabase_key: str = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0."
+        "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
+    )
+    supabase_prod_url: str = ""
+    supabase_prod_key: str = ""
+
+    @property
+    def is_test_mode(self) -> bool:
+        return bool(self.differential_test_mode)
+
+    @property
+    def model(self) -> str:
+        return (
+            "claude-haiku-4-5-20251001"
+            if self.is_test_mode
+            else "claude-opus-4-6"
+        )
+
+    @property
+    def is_prod_db(self) -> bool:
+        return self.differential_prod_db.lower() in ("1", "true")
+
+    def get_supabase_credentials(self, prod: bool = False) -> tuple[str, str]:
+        if prod:
+            if not self.supabase_prod_url or not self.supabase_prod_key:
+                raise KeyError(
+                    "SUPABASE_PROD_URL and SUPABASE_PROD_KEY must be set for production."
+                )
+            return self.supabase_prod_url, self.supabase_prod_key
+        return self.supabase_url, self.supabase_key
+
+    def require_anthropic_key(self) -> str:
+        if not self.anthropic_api_key:
+            raise EnvironmentError(
+                "ANTHROPIC_API_KEY environment variable not set. "
+                "Set it before running the workspace."
+            )
+        return self.anthropic_api_key
+
+
+_current: Settings | None = None
+
+
+def get_settings() -> Settings:
+    """Return the cached settings singleton (created on first call)."""
+    global _current
+    if _current is None:
+        _current = Settings()
+    return _current
+
+
+@contextmanager
+def override_settings(**overrides: object) -> Iterator[Settings]:
+    """Replace the cached settings with a copy that has the given overrides.
+
+    Usage (in tests)::
+
+        with override_settings(differential_test_mode="1"):
+            assert get_settings().is_test_mode
+    """
+    global _current
+    previous = _current
+    _current = Settings(**overrides)  # type: ignore[arg-type]
+    try:
+        yield _current
+    finally:
+        _current = previous

--- a/src/differential/tracer.py
+++ b/src/differential/tracer.py
@@ -1,19 +1,16 @@
 """Execution tracing: capture call events and generate HTML visualizations."""
 
 import json
-import os
 from datetime import datetime, timezone
 from html import escape
 from pathlib import Path
 
 from differential.database import DB
 from differential.models import Call, CallType
+from differential.settings import get_settings
 
 PAGES_DIR = Path(__file__).parent.parent.parent / "pages"
 TRACES_DIR = PAGES_DIR / "traces"
-
-
-TRACING_ENABLED = not os.environ.get("DIFFERENTIAL_TEST_MODE")
 
 
 class CallTrace:
@@ -23,7 +20,7 @@ class CallTrace:
         self.call_id = call_id
         self.db = db
         self.events: list[dict] = []
-        self._enabled = TRACING_ENABLED
+        self._enabled = get_settings().tracing_enabled
 
     def record(self, event: str, data: dict | None = None) -> None:
         if not self._enabled:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,11 @@
 """Shared fixtures for tests."""
 
-import os
 import uuid
-
-from dotenv import load_dotenv
-
-load_dotenv()
-os.environ["DIFFERENTIAL_TEST_MODE"] = "1"
 
 import pytest
 import pytest_asyncio
 
+from differential.settings import override_settings
 from differential.database import DB
 from differential.models import (
     Call,
@@ -21,6 +16,13 @@ from differential.models import (
     PageType,
     Workspace,
 )
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _test_settings():
+    """Activate test-mode settings for the entire test session."""
+    with override_settings(differential_test_mode="1"):
+        yield
 
 
 def pytest_addoption(parser):

--- a/uv.lock
+++ b/uv.lock
@@ -278,7 +278,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "fastapi" },
     { name = "pydantic" },
-    { name = "python-dotenv" },
+    { name = "pydantic-settings" },
     { name = "supabase" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -302,8 +302,8 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.84.0" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pypdf", marker = "extra == 'pdf'", specifier = ">=6.7.5" },
-    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "supabase", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
 ]
@@ -970,6 +970,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
     { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
     { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace scattered `os.environ` lookups with a centralised `Settings` class in `src/differential/settings.py`, backed by `pydantic-settings`
- Settings are cached as a singleton via `get_settings()` and read `.env` natively (removing the `python-dotenv` dependency)
- Tests override settings cleanly via `override_settings()` context manager instead of mutating `os.environ` before imports

## Test plan
- [x] `uv run pytest` — all 33 tests pass
- [x] Verified haiku model activates in test mode and opus in normal mode
- [x] Verified `override_settings()` properly scopes and restores settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)