### PR TITLE
Add --smoke-test flag for fast validation runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ uv run python main.py --list-workspaces
 # List questions in a specific workspace
 uv run python main.py --list --workspace my-project
 
+# Smoke-test mode: uses Haiku, fewer agent rounds, budget defaults to 1
+uv run python main.py "Your question here" --smoke-test
+
 # Any command can target the production database
 uv run python main.py --prod-db --list
 

--- a/main.py
+++ b/main.py
@@ -67,7 +67,8 @@ async def cmd_add_question(
     print(f"\nQuestion added: {page.id}")
     print(f"Text:           {question_text}")
 
-    effective_budget = 5 if budget is None else budget
+    smoke = get_settings().is_smoke_test
+    effective_budget = budget if budget is not None else (1 if smoke else 5)
     if effective_budget > 0:
         print(
             f"Budget:         {effective_budget} research call{'s' if effective_budget != 1 else ''}\n"
@@ -204,7 +205,7 @@ async def cmd_new(
     db: DB,
     ingest_files: list[str] | None = None,
 ) -> None:
-    budget = budget if budget is not None else 10
+    budget = budget if budget is not None else (1 if get_settings().is_smoke_test else 10)
     await db.init_budget(budget)
     question_id = await create_root_question(question_text, db)
 
@@ -298,7 +299,9 @@ async def cmd_batch(batch_file: str, db: DB) -> None:
 
 
 async def cmd_continue(question_id: str, additional_budget: int | None, db: DB) -> None:
-    additional_budget = additional_budget if additional_budget is not None else 10
+    additional_budget = additional_budget if additional_budget is not None else (
+        1 if get_settings().is_smoke_test else 10
+    )
     question = await db.get_page(question_id)
     if not question:
         print(
@@ -451,6 +454,12 @@ async def async_main():
         '[{"question": "...", "budget": 10}, ...]',
     )
     parser.add_argument(
+        "--smoke-test",
+        dest="smoke_test",
+        action="store_true",
+        help="Smoke-test mode: use Haiku, fewer rounds, lower budget defaults",
+    )
+    parser.add_argument(
         "--prod-db",
         dest="prod_db",
         action="store_true",
@@ -482,6 +491,8 @@ async def async_main():
     )
     logging.getLogger("differential").setLevel(log_level)
 
+    if args.smoke_test:
+        get_settings().differential_smoke_test = "1"
     if args.no_trace:
         get_settings().tracing_enabled = False
 

--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 
 from differential.context import format_page
 from differential.database import DB
+from differential.settings import get_settings
 from differential.llm import (
     AgentResult,
     build_system_prompt,
@@ -149,7 +150,7 @@ async def run_call(
     *,
     available_moves: list[MoveType] | None = None,
     max_tokens: int = 4096,
-    max_rounds: int = 3,
+    max_rounds: int | None = None,
     subtree_ids: set[str] | None = None,
     short_id_map: dict[str, str] | None = None,
 ) -> RunCallResult:
@@ -160,6 +161,9 @@ async def run_call(
     when the LLM calls them. Returns a RunCallResult with created page IDs,
     dispatches, and the raw agent result.
     """
+
+    if max_rounds is None:
+        max_rounds = 1 if get_settings().is_smoke_test else 3
 
     log.info(
         "run_call: type=%s, call=%s, scope=%s",

--- a/src/differential/llm.py
+++ b/src/differential/llm.py
@@ -139,7 +139,7 @@ async def agent_loop(
     tools: list[Tool],
     *,
     max_tokens: int = 4096,
-    max_rounds: int = 6,
+    max_rounds: int | None = None,
 ) -> AgentResult:
     """Run a tool-use conversation loop.
 
@@ -150,6 +150,9 @@ async def agent_loop(
     Returns AgentResult with concatenated text and a log of all tool calls.
     """
     settings = get_settings()
+    effective_rounds = max_rounds if max_rounds is not None else (
+        2 if settings.is_smoke_test else 6
+    )
     api_key = settings.require_anthropic_key()
     model = settings.model
     client = anthropic.AsyncAnthropic(api_key=api_key)
@@ -167,7 +170,7 @@ async def agent_loop(
     tool_names = [t.name for t in tools]
     log.debug(
         "agent_loop starting: max_rounds=%d, max_tokens=%d, tools=%s",
-        max_rounds, max_tokens, tool_names,
+        effective_rounds, max_tokens, tool_names,
     )
 
     messages: list[dict] = [{"role": "user", "content": user_message}]
@@ -175,8 +178,8 @@ async def agent_loop(
     all_tool_calls: list[ToolCall] = []
     round_num = 0
 
-    for round_num in range(max_rounds + 1):
-        log.debug("agent_loop round %d/%d", round_num + 1, max_rounds)
+    for round_num in range(effective_rounds + 1):
+        log.debug("agent_loop round %d/%d", round_num + 1, effective_rounds)
         response = await _call_api(
             client,
             model,
@@ -257,7 +260,7 @@ async def agent_loop(
                 )
             )
 
-        remaining = max_rounds - round_num
+        remaining = effective_rounds - round_num
         if remaining == 1:
             budget_note = {
                 "type": "text",

--- a/src/differential/orchestrator.py
+++ b/src/differential/orchestrator.py
@@ -7,6 +7,7 @@ import logging
 
 from differential.calls import run_assess, run_ingest, run_prioritization, run_scout
 from differential.database import DB
+from differential.settings import get_settings
 from differential.models import (
     AssessDispatchPayload,
     CallType,
@@ -27,6 +28,9 @@ DEFAULT_FRUIT_THRESHOLD = 4
 DEFAULT_MAX_ROUNDS = 5
 DEFAULT_INGEST_FRUIT_THRESHOLD = 5
 DEFAULT_INGEST_MAX_ROUNDS = 5
+
+SMOKE_TEST_MAX_ROUNDS = 1
+SMOKE_TEST_INGEST_MAX_ROUNDS = 1
 
 
 async def create_root_question(question_text: str, db: DB) -> str:
@@ -70,7 +74,7 @@ def _resolve_round_mode(mode: ScoutMode, round_index: int) -> ScoutMode:
 async def scout_until_done(
     question_id: str,
     db: DB,
-    max_rounds: int = DEFAULT_MAX_ROUNDS,
+    max_rounds: int | None = None,
     fruit_threshold: int = DEFAULT_FRUIT_THRESHOLD,
     parent_call_id: str | None = None,
     context_page_ids: list | None = None,
@@ -82,6 +86,11 @@ async def scout_until_done(
     fruit_threshold is the primary stopping condition; max_rounds is a failsafe.
     mode: 'alternate' (default) alternates abstract/concrete; 'abstract' or 'concrete' locks to one.
     """
+    if max_rounds is None:
+        max_rounds = (
+            SMOKE_TEST_MAX_ROUNDS if get_settings().is_smoke_test
+            else DEFAULT_MAX_ROUNDS
+        )
     log.info(
         "scout_until_done: question=%s, max_rounds=%d, fruit_threshold=%d, mode=%s",
         question_id[:8], max_rounds, fruit_threshold, mode.value,
@@ -124,7 +133,7 @@ async def ingest_until_done(
     source_page: Page,
     question_id: str,
     db: DB,
-    max_rounds: int = DEFAULT_INGEST_MAX_ROUNDS,
+    max_rounds: int | None = None,
     fruit_threshold: int = DEFAULT_INGEST_FRUIT_THRESHOLD,
     parent_call_id: str | None = None,
 ) -> int:
@@ -134,6 +143,11 @@ async def ingest_until_done(
     fruit_threshold is the primary stopping condition; max_rounds is a failsafe.
     Each round sees previously extracted claims via the question's working context.
     """
+    if max_rounds is None:
+        max_rounds = (
+            SMOKE_TEST_INGEST_MAX_ROUNDS if get_settings().is_smoke_test
+            else DEFAULT_INGEST_MAX_ROUNDS
+        )
     log.info(
         "ingest_until_done: source=%s, question=%s, max_rounds=%d",
         source_page.id[:8], question_id[:8], max_rounds,

--- a/src/differential/settings.py
+++ b/src/differential/settings.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     differential_test_mode: str = ""
     differential_prod_db: str = ""
+    differential_smoke_test: str = ""
     tracing_enabled: bool = True
 
     supabase_url: str = "http://127.0.0.1:54321"
@@ -28,10 +29,14 @@ class Settings(BaseSettings):
         return bool(self.differential_test_mode)
 
     @property
+    def is_smoke_test(self) -> bool:
+        return bool(self.differential_smoke_test)
+
+    @property
     def model(self) -> str:
         return (
             "claude-haiku-4-5-20251001"
-            if self.is_test_mode
+            if self.is_test_mode or self.is_smoke_test
             else "claude-opus-4-6"
         )
 


### PR DESCRIPTION
## Summary
- Adds `--smoke-test` CLI flag that switches to Haiku, reduces agent loop rounds (6→2), run_call rounds (3→1), scout/ingest loop rounds (5→1), and defaults budget to 1
- Implemented via `is_smoke_test` property on `Settings`, checked at each layer where defaults are resolved
- All existing tests pass; no behavior change without the flag

## Test plan
- [x] Run `uv run python main.py "Is the sky blue?" --smoke-test --workspace smoke-scratch` and verify it completes quickly with Haiku
- [ ] Confirm `--budget N` still overrides the default when combined with `--smoke-test`
- [x] Run `uv run pytest` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)