### PR TITLE
Make frontend API base URL configurable

### DIFF
--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -1,0 +1,5 @@
+import { client } from './client.gen';
+
+const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+client.setConfig({ baseUrl });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import "@/api/config";
 import "./globals.css";
 
 const geistSans = Geist({


### PR DESCRIPTION
## Summary
- Add `frontend/src/api/config.ts` that overrides the auto-generated client's hardcoded `baseUrl` with `process.env.NEXT_PUBLIC_API_URL` (defaults to `http://localhost:8000`)
- Import the config from the root layout so it runs before any API calls

## Test plan
- [ ] `pnpm dev` works as before with no env var set (defaults to localhost:8000)
- [x] `NEXT_PUBLIC_API_URL=http://localhost:9000 pnpm dev` points the client at port 9000

🤖 Generated with [Claude Code](https://claude.com/claude-code)