### PR TITLE
Redesign trace viewer

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -12,18 +12,13 @@ import { LLMExchangeDetail } from "./llm-exchange-detail";
 
 type TraceEvent = CallTraceOut["events"][number];
 
-const CALL_TYPE_COLORS: Record<string, string> = {
-  scout: "bg-blue-100 text-blue-800",
-  assess: "bg-purple-100 text-purple-800",
-  prioritization: "bg-orange-100 text-orange-800",
-  ingest: "bg-green-100 text-green-800",
-};
-
-const STATUS_STYLES: Record<string, string> = {
-  running: "bg-yellow-100 text-yellow-700 animate-pulse",
-  complete: "bg-green-100 text-green-700",
-  failed: "bg-red-100 text-red-700",
-  pending: "bg-gray-100 text-gray-500",
+const CALL_TYPE_ACCENT: Record<string, string> = {
+  scout: "#5b8def",
+  assess: "#a07cdf",
+  prioritization: "#d4943a",
+  ingest: "#4dab6f",
+  reframe: "#c46b6b",
+  maintain: "#7a8a9e",
 };
 
 function formatTime(ts: string): string {
@@ -51,10 +46,7 @@ function getDuration(call: Call): string | null {
 function PageChip({ pageId }: { pageId: string }) {
   const short = typeof pageId === "string" ? pageId.slice(0, 8) : pageId;
   return (
-    <Link
-      href={`/pages/${pageId}`}
-      className="inline-block text-xs font-mono bg-gray-100 border rounded px-1.5 py-0.5 hover:bg-gray-200"
-    >
+    <Link href={`/pages/${pageId}`} className="trace-page-chip">
       {short}
     </Link>
   );
@@ -62,96 +54,107 @@ function PageChip({ pageId }: { pageId: string }) {
 
 function PageList({ pageIds }: { pageIds: string[] }) {
   if (!pageIds || pageIds.length === 0)
-    return <span className="text-xs text-gray-400 italic">none</span>;
+    return <span className="trace-empty">none</span>;
   return (
-    <div className="flex flex-wrap gap-1">
+    <span className="trace-page-list">
       {pageIds.map((id) => (
         <PageChip key={id} pageId={id} />
       ))}
-    </div>
-  );
-}
-
-function MoveBadge({ moveType }: { moveType: string }) {
-  const colors: Record<string, string> = {
-    CREATE_CLAIM: "bg-green-100 text-green-700",
-    CREATE_QUESTION: "bg-green-100 text-green-700",
-    CREATE_JUDGEMENT: "bg-green-100 text-green-700",
-    CREATE_CONCEPT: "bg-green-100 text-green-700",
-    LINK_CONSIDERATION: "bg-blue-100 text-blue-700",
-    LINK_CHILD_QUESTION: "bg-blue-100 text-blue-700",
-    SUPERSEDE_PAGE: "bg-red-100 text-red-700",
-    PROPOSE_HYPOTHESIS: "bg-yellow-100 text-yellow-700",
-  };
-  return (
-    <span
-      className={`text-xs font-semibold uppercase px-1.5 py-0.5 rounded ${colors[moveType] || "bg-gray-100 text-gray-600"}`}
-    >
-      {moveType}
     </span>
   );
 }
 
-function EventSection({ event }: { event: TraceEvent }) {
-  const warningBorder =
-    event.event === "warning"
-      ? "border-l-2 border-yellow-400 pl-2"
-      : event.event === "error"
-        ? "border-l-2 border-red-400 pl-2"
-        : "";
+function MoveRow({ moveType, summary }: { moveType: string; summary: string }) {
+  const isCreate = moveType.startsWith("CREATE_");
+  const isLink = moveType.startsWith("LINK_");
+  const isSupersede = moveType === "SUPERSEDE_PAGE";
+  const isHypothesis = moveType === "PROPOSE_HYPOTHESIS";
+
+  const typeClass = isCreate
+    ? "trace-move-create"
+    : isLink
+      ? "trace-move-link"
+      : isSupersede
+        ? "trace-move-supersede"
+        : isHypothesis
+          ? "trace-move-hypothesis"
+          : "trace-move-default";
 
   return (
-    <div className={`py-1.5 border-b border-gray-100 last:border-0 ${warningBorder}`}>
-      <div className="flex items-baseline gap-2 mb-0.5">
-        <span className="text-xs font-medium bg-gray-100 px-1.5 rounded">
-          {event.event}
-        </span>
-        <span className="text-xs text-gray-400 font-mono">
-          {formatTime(event.ts)}
-        </span>
+    <div className="trace-move-row">
+      <span className={`trace-move-type ${typeClass}`}>
+        {moveType.replace(/_/g, " ").toLowerCase()}
+      </span>
+      {summary && <span className="trace-move-summary">{summary}</span>}
+    </div>
+  );
+}
+
+function StatusDot({ status }: { status: string }) {
+  const colorClass =
+    status === "running"
+      ? "trace-dot-running"
+      : status === "complete"
+        ? "trace-dot-complete"
+        : status === "failed"
+          ? "trace-dot-failed"
+          : "trace-dot-pending";
+
+  return <span className={`trace-status-dot ${colorClass}`} />;
+}
+
+function EventSection({ event }: { event: TraceEvent }) {
+  const isWarning = event.event === "warning";
+  const isError = event.event === "error";
+
+  return (
+    <div
+      className={`trace-event ${isWarning ? "trace-event-warning" : ""} ${isError ? "trace-event-error" : ""}`}
+    >
+      <div className="trace-event-header">
+        <span className="trace-event-label">{event.event.replace(/_/g, " ")}</span>
+        <span className="trace-event-time">{formatTime(event.ts)}</span>
       </div>
 
       {event.event === "context_built" && (
-        <div className="ml-2 text-xs space-y-1">
+        <div className="trace-event-body">
           {(event.working_context_page_ids ?? []).length > 0 && (
-            <div>
-              <span className="text-gray-500 font-medium">Working context: </span>
+            <div className="trace-kv">
+              <span className="trace-kv-key">working context</span>
               <PageList pageIds={event.working_context_page_ids ?? []} />
             </div>
           )}
           {(event.preloaded_page_ids ?? []).length > 0 && (
-            <div>
-              <span className="text-gray-500 font-medium">Preloaded: </span>
+            <div className="trace-kv">
+              <span className="trace-kv-key">preloaded</span>
               <PageList pageIds={event.preloaded_page_ids ?? []} />
             </div>
           )}
           {event.budget != null && (
-            <div className="text-gray-500">Budget: {event.budget}</div>
+            <div className="trace-kv">
+              <span className="trace-kv-key">budget</span>
+              <span className="trace-kv-value">{event.budget}</span>
+            </div>
           )}
         </div>
       )}
 
       {(event.event === "phase1_loaded" || event.event === "phase2_loaded") && (
-        <div className="ml-2 text-xs">
+        <div className="trace-event-body">
           <PageList pageIds={event.page_ids ?? []} />
         </div>
       )}
 
       {event.event === "moves_executed" && (
-        <div className="ml-2 text-xs space-y-1">
+        <div className="trace-event-body">
           {(event.moves ?? [])
             .filter((m) => m.type !== "LOAD_PAGE")
             .map((m, i) => (
-              <div key={i} className="flex items-baseline gap-1.5">
-                <MoveBadge moveType={m.type} />
-                <span className="text-gray-600">
-                  {m.summary || ""}
-                </span>
-              </div>
+              <MoveRow key={i} moveType={m.type} summary={m.summary || ""} />
             ))}
           {(event.created_page_ids ?? []).length > 0 && (
-            <div>
-              <span className="text-gray-500 font-medium">Created: </span>
+            <div className="trace-kv" style={{ marginTop: "6px" }}>
+              <span className="trace-kv-key">created</span>
               <PageList pageIds={event.created_page_ids ?? []} />
             </div>
           )}
@@ -159,55 +162,57 @@ function EventSection({ event }: { event: TraceEvent }) {
       )}
 
       {event.event === "review_complete" && (
-        <div className="ml-2 text-xs text-gray-600">
-          fruit={String(event.remaining_fruit)}, confidence=
-          {String(event.confidence)}
+        <div className="trace-event-body">
+          <div className="trace-review-metrics">
+            <span className="trace-kv-key">remaining fruit</span>
+            <span className="trace-kv-value">{String(event.remaining_fruit)}</span>
+            <span className="trace-kv-key">confidence</span>
+            <span className="trace-kv-value">{String(event.confidence)}</span>
+          </div>
         </div>
       )}
 
       {event.event === "llm_exchange" && (
-        <div className="ml-2 text-xs text-gray-500">
-          {event.phase} round {event.round}
-          {event.input_tokens != null && (
-            <span>
-              {" "}
-              ({event.input_tokens}/{event.output_tokens} tokens)
-            </span>
-          )}
+        <div className="trace-event-body">
+          <span className="trace-exchange-info">
+            {event.phase} r{event.round}
+            {event.input_tokens != null && (
+              <span className="trace-token-count">
+                {event.input_tokens.toLocaleString()}/{event.output_tokens?.toLocaleString()} tok
+              </span>
+            )}
+          </span>
         </div>
       )}
 
       {event.event === "warning" && (
-        <div className="ml-2 text-xs text-yellow-700">
+        <div className="trace-event-body trace-warning-text">
           {event.message}
         </div>
       )}
 
       {event.event === "error" && (
-        <div className="ml-2 text-xs text-red-700">
+        <div className="trace-event-body trace-error-text">
           {event.message}
         </div>
       )}
 
       {event.event === "dispatches_planned" && (
-        <div className="ml-2 text-xs space-y-0.5">
-          {(event.dispatches ?? []).map(
-            (d, i) => (
-              <div key={i} className="flex items-baseline gap-1.5">
-                <span className="text-gray-400">{i + 1}.</span>
-                <span
-                  className={`text-xs font-semibold uppercase px-1.5 py-0.5 rounded ${CALL_TYPE_COLORS[d.call_type] || "bg-gray-100"}`}
-                >
-                  {d.call_type}
-                </span>
-                {d.reason ? (
-                  <span className="text-gray-500">
-                    &mdash; {String(d.reason)}
-                  </span>
-                ) : null}
-              </div>
-            ),
-          )}
+        <div className="trace-event-body">
+          {(event.dispatches ?? []).map((d, i) => (
+            <div key={i} className="trace-dispatch-row">
+              <span className="trace-dispatch-index">{i + 1}</span>
+              <span
+                className="trace-dispatch-type"
+                style={{ color: CALL_TYPE_ACCENT[d.call_type] || "#7a8a9e" }}
+              >
+                {d.call_type}
+              </span>
+              {d.reason ? (
+                <span className="trace-dispatch-reason">{String(d.reason)}</span>
+              ) : null}
+            </div>
+          ))}
         </div>
       )}
     </div>
@@ -226,6 +231,7 @@ export function CallNode({
   const { call, events, children } = trace;
   const shortId = call.id.slice(0, 8);
   const duration = getDuration(call);
+  const accent = CALL_TYPE_ACCENT[call.call_type] || "#7a8a9e";
 
   const warningCount = events.filter((e) => e.event === "warning").length;
   const errorCount = events.filter((e) => e.event === "error").length;
@@ -246,65 +252,58 @@ export function CallNode({
   return (
     <div
       id={`call-${shortId}`}
-      className={`border rounded-lg ${depth > 0 ? "ml-4" : ""}`}
-      style={{
-        borderLeftColor:
-          call.call_type === "scout"
-            ? "#93c5fd"
-            : call.call_type === "assess"
-              ? "#c084fc"
-              : call.call_type === "prioritization"
-                ? "#fdba74"
-                : call.call_type === "ingest"
-                  ? "#86efac"
-                  : "#d1d5db",
-        borderLeftWidth: "3px",
-      }}
+      className="trace-call-node"
+      style={
+        {
+          "--call-accent": accent,
+          marginLeft: depth > 0 ? "20px" : "0",
+        } as React.CSSProperties
+      }
     >
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-gray-50"
+        className="trace-call-header"
       >
-        <span className="text-xs text-gray-400">{isOpen ? "▼" : "▶"}</span>
-        <span
-          className={`text-xs font-semibold uppercase px-1.5 py-0.5 rounded ${CALL_TYPE_COLORS[call.call_type] || "bg-gray-100"}`}
-        >
+        <span className="trace-call-accent" style={{ backgroundColor: accent }} />
+        <span className="trace-call-type" style={{ color: accent }}>
           {call.call_type}
         </span>
-        <span className="text-xs font-mono text-gray-400">[{shortId}]</span>
-        <span
-          className={`text-xs px-1.5 py-0.5 rounded ${STATUS_STYLES[call.status] || "bg-gray-100"}`}
-        >
-          {call.status}
-          {duration && ` (${duration})`}
+        <span className="trace-call-id">{shortId}</span>
+        <span className="trace-call-meta">
+          <StatusDot status={call.status} />
+          <span className="trace-call-status">{call.status}</span>
+          {duration && <span className="trace-call-duration">{duration}</span>}
         </span>
         {warningCount > 0 && (
-          <span className="text-xs bg-yellow-100 text-yellow-700 px-1.5 py-0.5 rounded">
-            {warningCount} warning{warningCount > 1 ? "s" : ""}
+          <span className="trace-badge-warning">
+            {warningCount} warn
           </span>
         )}
         {errorCount > 0 && (
-          <span className="text-xs bg-red-100 text-red-700 px-1.5 py-0.5 rounded">
-            {errorCount} error{errorCount > 1 ? "s" : ""}
+          <span className="trace-badge-error">
+            {errorCount} err
           </span>
         )}
+        <span className="trace-call-chevron">{isOpen ? "\u2013" : "+"}</span>
       </button>
 
       {isOpen && (
-        <div className="px-3 pb-3 space-y-2">
+        <div className="trace-call-body">
           {dispatchEvents.length > 0 && (
-            <div className="bg-gray-50 rounded p-2 text-xs">
-              <strong className="text-gray-600">Dispatches:</strong>
-              <ol className="list-decimal ml-4 mt-1 space-y-0.5">
+            <div className="trace-dispatches">
+              <div className="trace-section-label">dispatches</div>
+              <div className="trace-dispatch-list">
                 {(dispatchEvents[0]?.dispatches ?? []).map((d, i) => {
                   const ex = executedMap.get(i);
                   const childCallId = ex?.child_call_id;
                   return (
-                    <li key={i}>
+                    <div key={i} className="trace-dispatch-item">
+                      <span className="trace-dispatch-index">{i + 1}</span>
                       {childCallId ? (
                         <a
                           href={`#call-${childCallId.slice(0, 8)}`}
-                          className="hover:underline"
+                          className="trace-dispatch-link"
+                          style={{ color: CALL_TYPE_ACCENT[d.call_type] || "#7a8a9e" }}
                           onClick={(e) => {
                             e.preventDefault();
                             document
@@ -314,34 +313,31 @@ export function CallNode({
                               ?.scrollIntoView({ behavior: "smooth" });
                           }}
                         >
-                          <span
-                            className={`font-semibold uppercase px-1 rounded ${CALL_TYPE_COLORS[d.call_type] || ""}`}
-                          >
-                            {d.call_type}
-                          </span>
+                          {d.call_type}
                         </a>
                       ) : (
                         <span
-                          className={`font-semibold uppercase px-1 rounded opacity-50 ${CALL_TYPE_COLORS[d.call_type] || ""}`}
+                          className="trace-dispatch-skipped"
+                          style={{ color: CALL_TYPE_ACCENT[d.call_type] || "#7a8a9e" }}
                         >
                           {d.call_type}
                           {!ex && " (skipped)"}
                         </span>
                       )}
                       {d.reason ? (
-                        <span className="text-gray-500 ml-1">
+                        <span className="trace-dispatch-reason">
                           {String(d.reason)}
                         </span>
                       ) : null}
-                    </li>
+                    </div>
                   );
                 })}
-              </ol>
+              </div>
             </div>
           )}
 
           {displayableEvents.length > 0 && (
-            <div>
+            <div className="trace-events">
               {displayableEvents.map((ev, i) => (
                 <EventSection key={`${ev.ts}-${i}`} event={ev} />
               ))}
@@ -350,14 +346,14 @@ export function CallNode({
 
           <button
             onClick={() => setShowExchanges(!showExchanges)}
-            className="text-xs text-blue-600 hover:underline"
+            className="trace-toggle-exchanges"
           >
-            {showExchanges ? "Hide" : "Show"} LLM exchanges
+            {showExchanges ? "\u2013 Hide" : "+ Show"} LLM exchanges
           </button>
           {showExchanges && <LLMExchangeDetail callId={call.id} />}
 
           {children.length > 0 && (
-            <div className="space-y-2 mt-2">
+            <div className="trace-children">
               {children.map((child) => (
                 <CallNode key={child.call.id} trace={child} depth={depth + 1} />
               ))}

--- a/frontend/src/app/traces/[runId]/llm-exchange-detail.tsx
+++ b/frontend/src/app/traces/[runId]/llm-exchange-detail.tsx
@@ -40,25 +40,24 @@ function CollapsiblePre({
   const [open, setOpen] = useState(false);
   if (!content) return null;
 
-  const preview = content.slice(0, 200);
-  const isLong = content.length > 200;
-
   return (
-    <div className="mb-2">
+    <div className="trace-collapsible">
       <button
         onClick={() => setOpen(!open)}
-        className="text-xs font-medium text-gray-600 hover:text-gray-800"
+        className="trace-collapsible-toggle"
       >
-        {open ? "▼" : "▶"} {label} ({content.length.toLocaleString()} chars)
+        <span className="trace-collapsible-icon">{open ? "\u2013" : "+"}</span>
+        <span>{label}</span>
+        <span className="trace-collapsible-meta">
+          {content.length.toLocaleString()} chars
+        </span>
       </button>
       {open && (
-        <pre className="mt-1 text-xs bg-gray-50 border rounded p-2 overflow-x-auto whitespace-pre-wrap max-h-96 overflow-y-auto">
-          {content}
-        </pre>
+        <pre className="trace-collapsible-content">{content}</pre>
       )}
-      {!open && isLong && (
-        <pre className="mt-1 text-xs bg-gray-50 border rounded p-2 text-gray-400 truncate">
-          {preview}...
+      {!open && content.length > 200 && (
+        <pre className="trace-collapsible-preview">
+          {content.slice(0, 200)}...
         </pre>
       )}
     </div>
@@ -88,50 +87,44 @@ function ExchangeRow({ summary }: { summary: ExchangeSummary }) {
   }
 
   return (
-    <div className="border-b border-gray-100 py-1.5">
-      <button
-        onClick={loadDetail}
-        className="flex items-center gap-2 text-xs hover:bg-gray-50 w-full text-left px-1 py-0.5 rounded"
-      >
-        <span className="text-gray-400">{open ? "▼" : "▶"}</span>
-        <span className="font-medium text-gray-700">{summary.phase}</span>
-        <span className="text-gray-500">round {summary.round}</span>
+    <div className="trace-exchange-row">
+      <button onClick={loadDetail} className="trace-exchange-toggle">
+        <span className="trace-exchange-icon">{open ? "\u2013" : "+"}</span>
+        <span className="trace-exchange-phase">{summary.phase}</span>
+        <span className="trace-exchange-round">r{summary.round}</span>
         {summary.input_tokens != null && (
-          <span className="text-gray-400">
-            {summary.input_tokens}/{summary.output_tokens} tokens
+          <span className="trace-exchange-tokens">
+            {summary.input_tokens.toLocaleString()}/{summary.output_tokens?.toLocaleString()} tok
           </span>
         )}
         {summary.error && (
-          <span className="text-red-600 font-medium">error</span>
+          <span className="trace-exchange-error-flag">error</span>
         )}
         {loading && (
-          <span className="text-gray-400 animate-pulse">loading...</span>
+          <span className="trace-exchange-loading">loading...</span>
         )}
       </button>
 
       {open && detail && (
-        <div className="ml-4 mt-1 space-y-1">
+        <div className="trace-exchange-detail">
           <CollapsiblePre label="System prompt" content={detail.system_prompt} />
           <CollapsiblePre label="User message" content={detail.user_message} />
-          <CollapsiblePre
-            label="Response"
-            content={detail.response_text}
-          />
+          <CollapsiblePre label="Response" content={detail.response_text} />
           {detail.tool_calls.length > 0 && (
-            <div>
-              <span className="text-xs font-medium text-gray-600">
-                Tool calls ({detail.tool_calls.length}):
-              </span>
+            <div className="trace-tool-calls">
+              <div className="trace-tool-calls-label">
+                Tool calls ({detail.tool_calls.length})
+              </div>
               {detail.tool_calls.map((tc, i) => (
-                <details key={i} className="ml-2 text-xs">
-                  <summary className="cursor-pointer text-gray-600 hover:text-gray-800">
+                <details key={i} className="trace-tool-call">
+                  <summary className="trace-tool-call-name">
                     {tc.name as string}
                   </summary>
-                  <pre className="bg-gray-50 border rounded p-1.5 mt-0.5 overflow-x-auto whitespace-pre-wrap text-xs">
+                  <pre className="trace-tool-call-input">
                     {JSON.stringify(tc.input, null, 2)}
                   </pre>
                   {tc.result ? (
-                    <pre className="bg-gray-50 border-l-2 border-green-300 rounded p-1.5 mt-0.5 overflow-x-auto whitespace-pre-wrap text-xs">
+                    <pre className="trace-tool-call-output">
                       {String(tc.result)}
                     </pre>
                   ) : null}
@@ -140,7 +133,7 @@ function ExchangeRow({ summary }: { summary: ExchangeSummary }) {
             </div>
           )}
           {detail.error && (
-            <div className="text-xs text-red-600 bg-red-50 rounded p-1.5">
+            <div className="trace-exchange-error-detail">
               {detail.error}
             </div>
           )}
@@ -163,22 +156,20 @@ export function LLMExchangeDetail({ callId }: { callId: string }) {
 
   if (loading) {
     return (
-      <div className="text-xs text-gray-400 animate-pulse">
-        Loading exchanges...
-      </div>
+      <div className="trace-exchange-loading">Loading exchanges...</div>
     );
   }
 
   if (exchanges.length === 0) {
     return (
-      <div className="text-xs text-gray-400 italic">No LLM exchanges recorded</div>
+      <div className="trace-empty">No LLM exchanges recorded</div>
     );
   }
 
   return (
-    <div className="border rounded p-2 bg-white">
-      <div className="text-xs font-medium text-gray-600 mb-1">
-        LLM Exchanges ({exchanges.length})
+    <div className="trace-exchanges-container">
+      <div className="trace-section-label">
+        LLM exchanges ({exchanges.length})
       </div>
       {exchanges.map((ex) => (
         <ExchangeRow key={ex.id} summary={ex} />

--- a/frontend/src/app/traces/[runId]/page.tsx
+++ b/frontend/src/app/traces/[runId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { RunTraceOut } from "@/api/types.gen";
 import { TraceViewer } from "./trace-viewer";
+import "./trace.css";
 
 const API_BASE = process.env.API_BASE_URL || "http://localhost:8000";
 
@@ -40,9 +41,9 @@ export default async function TracePage({
 
   if (!trace) {
     return (
-      <main className="max-w-6xl mx-auto p-8">
-        <p className="text-red-500">Run not found: {runId}</p>
-        <Link href="/" className="text-blue-600 hover:underline text-sm">
+      <main className="trace-page">
+        <p className="trace-error">Run not found: {runId}</p>
+        <Link href="/" className="trace-back-link">
           &larr; Back
         </Link>
       </main>
@@ -50,19 +51,21 @@ export default async function TracePage({
   }
 
   return (
-    <main className="max-w-6xl mx-auto p-8">
-      {trace.question && (
-        <Link
-          href={`/questions/${trace.question.id}`}
-          className="text-blue-600 hover:underline text-sm"
-        >
-          &larr; {trace.question.summary}
-        </Link>
-      )}
-      <h1 className="text-2xl font-semibold mt-2 mb-1">Execution Trace</h1>
-      <p className="text-sm text-gray-500 mb-6 font-mono">
-        run {runId.slice(0, 8)}
-      </p>
+    <main className="trace-page">
+      <header className="trace-header">
+        {trace.question && (
+          <Link
+            href={`/questions/${trace.question.id}`}
+            className="trace-back-link"
+          >
+            &larr; {trace.question.summary}
+          </Link>
+        )}
+        <div className="trace-title-row">
+          <h1 className="trace-title">Execution Trace</h1>
+          <span className="trace-run-id">{runId.slice(0, 8)}</span>
+        </div>
+      </header>
       <TraceViewer
         initialTrace={trace}
         runId={runId}

--- a/frontend/src/app/traces/[runId]/trace-viewer.tsx
+++ b/frontend/src/app/traces/[runId]/trace-viewer.tsx
@@ -74,12 +74,12 @@ export function TraceViewer({
   }, [runId, realtimeConfig]);
 
   return (
-    <div className="space-y-4">
+    <div className="trace-root">
       {trace.root_calls.map((ct) => (
         <CallNode key={ct.call.id} trace={ct} depth={0} />
       ))}
       {trace.root_calls.length === 0 && (
-        <p className="text-gray-500 text-sm">
+        <p className="trace-empty">
           No calls recorded for this run yet.
         </p>
       )}

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -1,0 +1,648 @@
+/* Trace Viewer — minimal, information-dense design */
+
+.trace-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 32px 80px;
+}
+
+.trace-header {
+  margin-bottom: 40px;
+}
+
+.trace-back-link {
+  font-size: 14px;
+  color: #666;
+  text-decoration: none;
+  letter-spacing: 0.01em;
+  transition: color 0.15s;
+}
+.trace-back-link:hover {
+  color: #222;
+}
+
+.trace-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.trace-title {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: #111;
+  margin: 0;
+}
+
+.trace-run-id {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 13px;
+  color: #888;
+  letter-spacing: 0.02em;
+}
+
+.trace-error {
+  color: #c44;
+  font-size: 15px;
+}
+
+/* Root */
+
+.trace-root {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Call Node */
+
+.trace-call-node {
+  position: relative;
+}
+
+.trace-call-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  border-bottom: 1px solid #e8e8e8;
+  transition: background-color 0.1s;
+}
+.trace-call-header:hover {
+  background-color: #f8f8f8;
+}
+
+.trace-call-accent {
+  width: 3px;
+  height: 18px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.trace-call-type {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.trace-call-id {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  color: #999;
+}
+
+.trace-call-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.trace-call-status {
+  font-size: 12px;
+  color: #666;
+  text-transform: lowercase;
+}
+
+.trace-call-duration {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  color: #888;
+}
+
+.trace-call-chevron {
+  font-size: 14px;
+  color: #aaa;
+  width: 16px;
+  text-align: center;
+  font-weight: 300;
+}
+
+.trace-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.trace-dot-running {
+  background-color: #e5a93e;
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+.trace-dot-complete {
+  background-color: #4dab6f;
+}
+.trace-dot-failed {
+  background-color: #c44;
+}
+.trace-dot-pending {
+  background-color: #aaa;
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.trace-badge-warning {
+  font-size: 12px;
+  font-weight: 500;
+  color: #b8860b;
+  background: #fdf6e3;
+  padding: 1px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.02em;
+}
+
+.trace-badge-error {
+  font-size: 12px;
+  font-weight: 500;
+  color: #c44;
+  background: #fdf2f2;
+  padding: 1px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.02em;
+}
+
+/* Call body */
+
+.trace-call-body {
+  padding: 8px 0 16px 14px;
+  border-left: 1px solid #e0e0e0;
+  margin-left: 1px;
+}
+
+/* Events */
+
+.trace-events {
+  padding: 0;
+}
+
+.trace-event {
+  padding: 8px 0;
+  border-bottom: 1px solid #efefef;
+}
+.trace-event:last-child {
+  border-bottom: none;
+}
+
+.trace-event-warning {
+  border-left: 2px solid #e5a93e;
+  padding-left: 10px;
+  margin-left: -2px;
+}
+
+.trace-event-error {
+  border-left: 2px solid #c44;
+  padding-left: 10px;
+  margin-left: -2px;
+}
+
+.trace-event-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 3px;
+}
+
+.trace-event-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #555;
+  letter-spacing: 0.02em;
+}
+
+.trace-event-time {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+  color: #aaa;
+}
+
+.trace-event-body {
+  padding-left: 0;
+  margin-top: 4px;
+  font-size: 13px;
+}
+
+/* Key-value pairs */
+
+.trace-kv {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 3px;
+  flex-wrap: wrap;
+}
+
+.trace-kv-key {
+  font-size: 12px;
+  color: #777;
+  flex-shrink: 0;
+}
+
+.trace-kv-value {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  color: #333;
+}
+
+/* Page chips */
+
+.trace-page-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.trace-page-chip {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+  color: #555;
+  background: #f0f0f0;
+  padding: 2px 7px;
+  border-radius: 3px;
+  text-decoration: none;
+  transition: all 0.1s;
+  border: 1px solid #e4e4e4;
+}
+.trace-page-chip:hover {
+  color: #222;
+  background: #e8e8e8;
+  border-color: #ccc;
+}
+
+.trace-empty {
+  font-size: 13px;
+  color: #999;
+  font-style: italic;
+}
+
+/* Moves */
+
+.trace-move-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 3px 0;
+}
+
+.trace-move-type {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
+}
+
+.trace-move-create { color: #2d8a4e; }
+.trace-move-link { color: #4272c4; }
+.trace-move-supersede { color: #b33; }
+.trace-move-hypothesis { color: #b87c1e; }
+.trace-move-default { color: #777; }
+
+.trace-move-summary {
+  font-size: 13px;
+  color: #444;
+  line-height: 1.4;
+}
+
+/* Review metrics */
+
+.trace-review-metrics {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+/* Exchange info (inline in events) */
+
+.trace-exchange-info {
+  font-size: 13px;
+  color: #666;
+}
+
+.trace-token-count {
+  font-family: var(--font-geist-mono), monospace;
+  color: #999;
+  margin-left: 6px;
+  font-size: 12px;
+}
+
+.trace-warning-text {
+  color: #8a6508;
+  font-size: 13px;
+}
+
+.trace-error-text {
+  color: #b33;
+  font-size: 13px;
+}
+
+/* Dispatches section */
+
+.trace-dispatches {
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #efefef;
+}
+
+.trace-section-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #999;
+  margin-bottom: 6px;
+}
+
+.trace-dispatch-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.trace-dispatch-item,
+.trace-dispatch-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.trace-dispatch-index {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  color: #aaa;
+  width: 14px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.trace-dispatch-type {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.trace-dispatch-link {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  transition: opacity 0.1s;
+}
+.trace-dispatch-link:hover {
+  opacity: 0.7;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.trace-dispatch-skipped {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.35;
+}
+
+.trace-dispatch-reason {
+  font-size: 13px;
+  color: #666;
+}
+
+/* Toggle exchanges button */
+
+.trace-toggle-exchanges {
+  font-size: 13px;
+  color: #777;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px 0;
+  transition: color 0.1s;
+  letter-spacing: 0.01em;
+}
+.trace-toggle-exchanges:hover {
+  color: #333;
+}
+
+/* Children */
+
+.trace-children {
+  margin-top: 12px;
+}
+
+/* LLM Exchanges */
+
+.trace-exchanges-container {
+  border-top: 1px solid #e8e8e8;
+  padding-top: 8px;
+  margin-top: 4px;
+}
+
+.trace-exchange-row {
+  border-bottom: 1px solid #f0f0f0;
+}
+.trace-exchange-row:last-child {
+  border-bottom: none;
+}
+
+.trace-exchange-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+  transition: background-color 0.1s;
+}
+.trace-exchange-toggle:hover {
+  background-color: #f8f8f8;
+}
+
+.trace-exchange-icon {
+  font-size: 12px;
+  color: #aaa;
+  width: 14px;
+  text-align: center;
+  font-weight: 300;
+}
+
+.trace-exchange-phase {
+  font-weight: 500;
+  color: #333;
+  font-size: 13px;
+}
+
+.trace-exchange-round {
+  color: #777;
+  font-size: 13px;
+}
+
+.trace-exchange-tokens {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  color: #999;
+}
+
+.trace-exchange-error-flag {
+  font-size: 12px;
+  font-weight: 600;
+  color: #c44;
+}
+
+.trace-exchange-loading {
+  font-size: 13px;
+  color: #999;
+  font-style: italic;
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+.trace-exchange-detail {
+  padding: 8px 0 8px 22px;
+}
+
+/* Collapsible pre */
+
+.trace-collapsible {
+  margin-bottom: 8px;
+}
+
+.trace-collapsible-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  color: #555;
+  padding: 2px 0;
+  transition: color 0.1s;
+}
+.trace-collapsible-toggle:hover {
+  color: #222;
+}
+
+.trace-collapsible-icon {
+  font-size: 12px;
+  color: #aaa;
+  width: 12px;
+  text-align: center;
+  font-weight: 300;
+}
+
+.trace-collapsible-meta {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+  color: #aaa;
+}
+
+.trace-collapsible-content {
+  margin-top: 4px;
+  font-size: 12px;
+  font-family: var(--font-geist-mono), monospace;
+  background: #f7f7f7;
+  border: 1px solid #e8e8e8;
+  border-radius: 4px;
+  padding: 10px 12px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  max-height: 400px;
+  overflow-y: auto;
+  color: #333;
+  line-height: 1.55;
+}
+
+.trace-collapsible-preview {
+  margin-top: 4px;
+  font-size: 12px;
+  font-family: var(--font-geist-mono), monospace;
+  color: #999;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+/* Tool calls */
+
+.trace-tool-calls {
+  margin-top: 8px;
+}
+
+.trace-tool-calls-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.trace-tool-call {
+  margin-left: 0;
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+
+.trace-tool-call-name {
+  cursor: pointer;
+  font-size: 13px;
+  color: #444;
+  padding: 2px 0;
+  transition: color 0.1s;
+}
+.trace-tool-call-name:hover {
+  color: #111;
+}
+
+.trace-tool-call-input {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  background: #f7f7f7;
+  border: 1px solid #e8e8e8;
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin-top: 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  color: #333;
+  line-height: 1.5;
+}
+
+.trace-tool-call-output {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  background: #f7f7f7;
+  border-left: 2px solid #4dab6f;
+  border-radius: 0 4px 4px 0;
+  padding: 8px 10px;
+  margin-top: 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  color: #333;
+  line-height: 1.5;
+}
+
+.trace-exchange-error-detail {
+  font-size: 13px;
+  color: #b33;
+  background: #fdf2f2;
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin-top: 4px;
+}


### PR DESCRIPTION
## Summary
- Replace inline Tailwind classes with a dedicated `trace.css` stylesheet for the trace viewer
- Cleaner minimal aesthetic: restrained color, clear typographic hierarchy, subtle dividers instead of heavy bordered cards
- Call types identified by thin accent bars + colored text instead of colored badge pills
- All information, interactivity, and real-time updates preserved

## Test plan
- [ ] Open a trace page and verify all call types render with correct accent colors
- [ ] Expand/collapse call nodes and LLM exchange details
- [ ] Verify page chips link correctly
- [ ] Check warning/error events display with left border accents
- [ ] Verify dispatch links scroll to child calls
- [ ] Test real-time event streaming still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)