### PR TITLE
Show page summaries instead of UUIDs in trace viewer

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -996,7 +996,7 @@
           },
           "working_context_page_ids": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/PageRef"
             },
             "type": "array",
             "title": "Working Context Page Ids",
@@ -1004,7 +1004,7 @@
           },
           "preloaded_page_ids": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/PageRef"
             },
             "type": "array",
             "title": "Preloaded Page Ids",
@@ -1485,7 +1485,7 @@
           },
           "created_page_ids": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/PageRef"
             },
             "type": "array",
             "title": "Created Page Ids",
@@ -1683,6 +1683,24 @@
         ],
         "title": "PageLink"
       },
+      "PageRef": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "PageRef"
+      },
       "PageType": {
         "type": "string",
         "enum": [
@@ -1712,7 +1730,7 @@
           },
           "page_ids": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/PageRef"
             },
             "type": "array",
             "title": "Page Ids",
@@ -1744,7 +1762,7 @@
           },
           "page_ids": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/PageRef"
             },
             "type": "array",
             "title": "Page Ids",

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -136,11 +136,11 @@ export type ContextBuiltEventOut = {
     /**
      * Working Context Page Ids
      */
-    working_context_page_ids?: Array<string>;
+    working_context_page_ids?: Array<PageRef>;
     /**
      * Preloaded Page Ids
      */
-    preloaded_page_ids?: Array<string>;
+    preloaded_page_ids?: Array<PageRef>;
     /**
      * Source Page Id
      */
@@ -425,7 +425,7 @@ export type MovesExecutedEventOut = {
     /**
      * Created Page Ids
      */
-    created_page_ids?: Array<string>;
+    created_page_ids?: Array<PageRef>;
 };
 
 /**
@@ -543,6 +543,20 @@ export type PageLink = {
 };
 
 /**
+ * PageRef
+ */
+export type PageRef = {
+    /**
+     * Id
+     */
+    id: string;
+    /**
+     * Summary
+     */
+    summary?: string;
+};
+
+/**
  * PageType
  */
 export type PageType = 'source' | 'claim' | 'question' | 'judgement' | 'concept' | 'wiki';
@@ -566,7 +580,7 @@ export type Phase1LoadedEventOut = {
     /**
      * Page Ids
      */
-    page_ids?: Array<string>;
+    page_ids?: Array<PageRef>;
 };
 
 /**
@@ -588,7 +602,7 @@ export type Phase2LoadedEventOut = {
     /**
      * Page Ids
      */
-    page_ids?: Array<string>;
+    page_ids?: Array<PageRef>;
 };
 
 /**

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -7,6 +7,7 @@ import type {
   CallTraceOut,
   DispatchExecutedEventOut,
   DispatchesPlannedEventOut,
+  PageRef,
 } from "@/api/types.gen";
 import { LLMExchangeDetail } from "./llm-exchange-detail";
 
@@ -43,22 +44,23 @@ function getDuration(call: Call): string | null {
   return `${Math.floor(secs / 60)}m${secs % 60}s`;
 }
 
-function PageChip({ pageId }: { pageId: string }) {
-  const short = typeof pageId === "string" ? pageId.slice(0, 8) : pageId;
+function PageChip({ page }: { page: PageRef }) {
+  const short = page.id.slice(0, 8);
+  const label = page.summary || short;
   return (
-    <Link href={`/pages/${pageId}`} className="trace-page-chip">
-      {short}
+    <Link href={`/pages/${page.id}`} className="trace-page-chip" title={short}>
+      {label}
     </Link>
   );
 }
 
-function PageList({ pageIds }: { pageIds: string[] }) {
-  if (!pageIds || pageIds.length === 0)
+function PageList({ pages }: { pages: PageRef[] }) {
+  if (!pages || pages.length === 0)
     return <span className="trace-empty">none</span>;
   return (
     <span className="trace-page-list">
-      {pageIds.map((id) => (
-        <PageChip key={id} pageId={id} />
+      {pages.map((p, i) => (
+        <PageChip key={p.id} page={p} />
       ))}
     </span>
   );
@@ -121,13 +123,13 @@ function EventSection({ event }: { event: TraceEvent }) {
           {(event.working_context_page_ids ?? []).length > 0 && (
             <div className="trace-kv">
               <span className="trace-kv-key">working context</span>
-              <PageList pageIds={event.working_context_page_ids ?? []} />
+              <PageList pages={event.working_context_page_ids ?? []} />
             </div>
           )}
           {(event.preloaded_page_ids ?? []).length > 0 && (
             <div className="trace-kv">
               <span className="trace-kv-key">preloaded</span>
-              <PageList pageIds={event.preloaded_page_ids ?? []} />
+              <PageList pages={event.preloaded_page_ids ?? []} />
             </div>
           )}
           {event.budget != null && (
@@ -141,7 +143,7 @@ function EventSection({ event }: { event: TraceEvent }) {
 
       {(event.event === "phase1_loaded" || event.event === "phase2_loaded") && (
         <div className="trace-event-body">
-          <PageList pageIds={event.page_ids ?? []} />
+          <PageList pages={event.page_ids ?? []} />
         </div>
       )}
 
@@ -155,7 +157,7 @@ function EventSection({ event }: { event: TraceEvent }) {
           {(event.created_page_ids ?? []).length > 0 && (
             <div className="trace-kv" style={{ marginTop: "6px" }}>
               <span className="trace-kv-key">created</span>
-              <PageList pageIds={event.created_page_ids ?? []} />
+              <PageList pages={event.created_page_ids ?? []} />
             </div>
           )}
         </div>

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -257,26 +257,28 @@
 /* Page chips */
 
 .trace-page-list {
-  display: inline-flex;
+  display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 5px;
 }
 
 .trace-page-chip {
-  font-family: var(--font-geist-mono), monospace;
-  font-size: 11px;
-  color: #555;
-  background: #f0f0f0;
-  padding: 2px 7px;
-  border-radius: 3px;
+  font-size: 12px;
+  color: #444;
+  background: #f6f6f6;
+  padding: 3px 10px;
+  border-radius: 4px;
   text-decoration: none;
-  transition: all 0.1s;
-  border: 1px solid #e4e4e4;
+  transition: all 0.15s ease;
+  border: 1px solid #e0e0e0;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
 }
 .trace-page-chip:hover {
-  color: #222;
-  background: #e8e8e8;
-  border-color: #ccc;
+  color: #111;
+  background: #eaeaea;
+  border-color: #bbb;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 }
 
 .trace-empty {

--- a/src/differential/calls/assess.py
+++ b/src/differential/calls/assess.py
@@ -9,6 +9,7 @@ from differential.calls.common import (
     format_moves_for_review,
     log_page_ratings,
     moves_to_trace_event,
+    resolve_page_refs,
     run_call,
     run_closing_review,
 )
@@ -44,8 +45,8 @@ async def run_assess(
         question_id, db, extra_page_ids=preloaded
     )
     await trace.record(ContextBuiltEvent(
-        working_context_page_ids=working_page_ids,
-        preloaded_page_ids=preloaded,
+        working_context_page_ids=await resolve_page_refs(working_page_ids, db),
+        preloaded_page_ids=await resolve_page_refs(preloaded, db),
     ))
 
     task = (
@@ -59,11 +60,15 @@ async def run_assess(
     await db.update_call_status(call.id, CallStatus.RUNNING)
     result = await run_call(CallType.ASSESS, task, context_text, call, db, trace=trace)
     if result.phase1_page_ids:
-        await trace.record(Phase1LoadedEvent(page_ids=result.phase1_page_ids))
+        await trace.record(Phase1LoadedEvent(
+            page_ids=await resolve_page_refs(result.phase1_page_ids, db),
+        ))
     phase2_loaded = await extract_loaded_page_ids(result, db)
     if phase2_loaded:
-        await trace.record(Phase2LoadedEvent(page_ids=phase2_loaded))
-    await trace.record(moves_to_trace_event(result.moves, result.created_page_ids))
+        await trace.record(Phase2LoadedEvent(
+            page_ids=await resolve_page_refs(phase2_loaded, db),
+        ))
+    await trace.record(await moves_to_trace_event(result.moves, result.created_page_ids, db))
 
     all_loaded_ids = list(
         dict.fromkeys(preloaded + result.phase1_page_ids + phase2_loaded)

--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -34,7 +34,12 @@ from differential.moves.registry import MOVES
 
 log = logging.getLogger(__name__)
 
-from differential.trace_events import LLMExchangeEvent, MovesExecutedEvent, WarningEvent
+from differential.trace_events import (
+    LLMExchangeEvent,
+    MovesExecutedEvent,
+    PageRef,
+    WarningEvent,
+)
 from differential.tracer import CallTrace
 
 
@@ -279,11 +284,23 @@ async def extract_loaded_page_ids(result: RunCallResult, db: DB) -> list[str]:
     return loaded
 
 
-def moves_to_trace_event(
+async def resolve_page_refs(page_ids: list[str], db: DB) -> list[PageRef]:
+    """Resolve a list of page IDs to PageRef objects with summaries."""
+    refs = []
+    for pid in page_ids:
+        page = await db.get_page(pid)
+        summary = page.summary if page else ""
+        refs.append(PageRef(id=pid, summary=summary))
+    return refs
+
+
+async def moves_to_trace_event(
     moves: list[Move],
     created_page_ids: list[str],
+    db: DB,
 ) -> MovesExecutedEvent:
     """Build a typed MovesExecutedEvent from a list of moves."""
+    refs = await resolve_page_refs(created_page_ids, db)
     return MovesExecutedEvent(
         moves=[
             {
@@ -292,7 +309,7 @@ def moves_to_trace_event(
             }
             for m in moves
         ],
-        created_page_ids=created_page_ids,
+        created_page_ids=refs,
     )
 
 

--- a/src/differential/calls/ingest.py
+++ b/src/differential/calls/ingest.py
@@ -9,6 +9,7 @@ from differential.calls.common import (
     format_moves_for_review,
     log_page_ratings,
     moves_to_trace_event,
+    resolve_page_refs,
     run_call,
     run_closing_review,
 )
@@ -50,8 +51,8 @@ async def run_ingest(
         question_id, db, extra_page_ids=preloaded
     )
     await trace.record(ContextBuiltEvent(
-        working_context_page_ids=working_page_ids,
-        preloaded_page_ids=preloaded,
+        working_context_page_ids=await resolve_page_refs(working_page_ids, db),
+        preloaded_page_ids=await resolve_page_refs(preloaded, db),
         source_page_id=source_page.id,
     ))
 
@@ -72,11 +73,15 @@ async def run_ingest(
     await db.update_call_status(call.id, CallStatus.RUNNING)
     result = await run_call(CallType.INGEST, task, context_text, call, db, trace=trace)
     if result.phase1_page_ids:
-        await trace.record(Phase1LoadedEvent(page_ids=result.phase1_page_ids))
+        await trace.record(Phase1LoadedEvent(
+            page_ids=await resolve_page_refs(result.phase1_page_ids, db),
+        ))
     phase2_loaded = await extract_loaded_page_ids(result, db)
     if phase2_loaded:
-        await trace.record(Phase2LoadedEvent(page_ids=phase2_loaded))
-    await trace.record(moves_to_trace_event(result.moves, result.created_page_ids))
+        await trace.record(Phase2LoadedEvent(
+            page_ids=await resolve_page_refs(phase2_loaded, db),
+        ))
+    await trace.record(await moves_to_trace_event(result.moves, result.created_page_ids, db))
 
     all_loaded_ids = list(
         dict.fromkeys(preloaded + result.phase1_page_ids + phase2_loaded)

--- a/src/differential/calls/prioritization.py
+++ b/src/differential/calls/prioritization.py
@@ -64,7 +64,7 @@ async def run_prioritization(
             for d in result.dispatches
         ],
     ))
-    await trace.record(moves_to_trace_event(result.moves, result.created_page_ids))
+    await trace.record(await moves_to_trace_event(result.moves, result.created_page_ids, db))
 
     summary = {
         "dispatches": result.dispatches,

--- a/src/differential/calls/scout.py
+++ b/src/differential/calls/scout.py
@@ -9,6 +9,7 @@ from differential.calls.common import (
     format_moves_for_review,
     log_page_ratings,
     moves_to_trace_event,
+    resolve_page_refs,
     run_call,
     run_closing_review,
 )
@@ -59,8 +60,8 @@ async def run_scout(
         question_id, db, extra_page_ids=preloaded
     )
     await trace.record(ContextBuiltEvent(
-        working_context_page_ids=working_page_ids,
-        preloaded_page_ids=preloaded,
+        working_context_page_ids=await resolve_page_refs(working_page_ids, db),
+        preloaded_page_ids=await resolve_page_refs(preloaded, db),
         scout_mode=mode.value,
     ))
 
@@ -73,11 +74,15 @@ async def run_scout(
     await db.update_call_status(call.id, CallStatus.RUNNING)
     result = await run_call(CallType.SCOUT, task, context_text, call, db, trace=trace)
     if result.phase1_page_ids:
-        await trace.record(Phase1LoadedEvent(page_ids=result.phase1_page_ids))
+        await trace.record(Phase1LoadedEvent(
+            page_ids=await resolve_page_refs(result.phase1_page_ids, db),
+        ))
     phase2_loaded = await extract_loaded_page_ids(result, db)
     if phase2_loaded:
-        await trace.record(Phase2LoadedEvent(page_ids=phase2_loaded))
-    await trace.record(moves_to_trace_event(result.moves, result.created_page_ids))
+        await trace.record(Phase2LoadedEvent(
+            page_ids=await resolve_page_refs(phase2_loaded, db),
+        ))
+    await trace.record(await moves_to_trace_event(result.moves, result.created_page_ids, db))
 
     all_loaded_ids = list(
         dict.fromkeys(preloaded + result.phase1_page_ids + phase2_loaded)

--- a/src/differential/trace_events.py
+++ b/src/differential/trace_events.py
@@ -2,7 +2,20 @@
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, BeforeValidator, Field
+
+
+class PageRef(BaseModel):
+    id: str
+    summary: str = ""
+
+
+def _coerce_page_refs(v: list) -> list:
+    """Accept both bare ID strings (legacy traces) and PageRef dicts."""
+    return [{"id": x} if isinstance(x, str) else x for x in v]
+
+
+PageRefList = Annotated[list[PageRef], BeforeValidator(_coerce_page_refs)]
 
 
 class MoveTraceItem(BaseModel):
@@ -18,8 +31,8 @@ class DispatchTraceItem(BaseModel):
 
 class ContextBuiltEvent(BaseModel):
     event: Literal["context_built"] = "context_built"
-    working_context_page_ids: list[str] = []
-    preloaded_page_ids: list[str] = []
+    working_context_page_ids: PageRefList = []
+    preloaded_page_ids: PageRefList = []
     source_page_id: str | None = None
     budget: int | None = None
     scout_mode: str | None = None
@@ -27,18 +40,18 @@ class ContextBuiltEvent(BaseModel):
 
 class Phase1LoadedEvent(BaseModel):
     event: Literal["phase1_loaded"] = "phase1_loaded"
-    page_ids: list[str] = []
+    page_ids: PageRefList = []
 
 
 class Phase2LoadedEvent(BaseModel):
     event: Literal["phase2_loaded"] = "phase2_loaded"
-    page_ids: list[str] = []
+    page_ids: PageRefList = []
 
 
 class MovesExecutedEvent(BaseModel):
     event: Literal["moves_executed"] = "moves_executed"
     moves: list[MoveTraceItem] = []
-    created_page_ids: list[str] = []
+    created_page_ids: PageRefList = []
 
 
 class ReviewCompleteEvent(BaseModel):


### PR DESCRIPTION
## Summary
- Trace events now store `PageRef` objects (`{id, summary}`) instead of bare UUID strings for all page ID fields
- Frontend page chips display the 10-15 word page summary as a clickable link instead of an 8-char UUID
- Backward compatible: Pydantic `BeforeValidator` coerces legacy `list[str]` traces into `PageRef` objects
- Refined chip styling (slightly larger, softer borders, subtle hover shadow)

## Test plan
- [x] `uv run pytest` — 34 passed
- [x] TypeScript compiles clean
- [x] Smoke test (`--smoke-test --budget 2`) generates correct PageRef data in DB
- [x] Trace viewer renders summaries for working context, preloaded, phase-loaded, and created pages
- [x] No React key warnings or console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)