### PR TITLE
Improve write-tests skill triggering

### DIFF
--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Writing tests for the differential codebase
+description: Use this skill any time a user wants NEW test code written. This covers creating unit tests, integration tests, regression tests, or test coverage for anything — functions, modules, CLI flags, API calls, models, moves, logic, or behavior. Trigger when the user says things like "write a test", "add a test", "test this", "add coverage", "make sure X is tested", "write a regression test", or describes specific behavior they want verified in a test. Also trigger when someone describes a bug and asks for a test to capture it. Do NOT trigger for fixing existing broken tests, configuring pytest, reviewing what's already covered, debugging production code, or tasks unrelated to test authorship.
 ---
 
 # Writing Tests


### PR DESCRIPTION
## Summary
- Expanded the write-tests skill description from a generic 8-word label to ~100 words with explicit trigger phrases, scope boundaries, and exclusions
- The previous description ("Writing tests for the differential codebase") never auto-triggered — confirmed 0% recall across 10 test queries
- New description includes specific phrases Claude matches on ("write a test", "add coverage", "make sure X is tested", etc.) and clear exclusions (fixing broken tests, configuring pytest, debugging)

## Test plan
- [ ] Verify the skill triggers when asking to write new tests (e.g. "add test coverage for the new move type")
- [ ] Verify the skill does NOT trigger for non-test-writing tasks (e.g. "fix the failing test", "run pytest")

🤖 Generated with [Claude Code](https://claude.com/claude-code)