### PR TITLE
Inline page refs into move trace items

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1486,6 +1486,14 @@
             "type": "string",
             "title": "Summary",
             "default": ""
+          },
+          "page_refs": {
+            "items": {
+              "$ref": "#/components/schemas/PageRef"
+            },
+            "type": "array",
+            "title": "Page Refs",
+            "default": []
           }
         },
         "additionalProperties": true,
@@ -1516,14 +1524,6 @@
             },
             "type": "array",
             "title": "Moves",
-            "default": []
-          },
-          "created_page_ids": {
-            "items": {
-              "$ref": "#/components/schemas/PageRef"
-            },
-            "type": "array",
-            "title": "Created Page Ids",
             "default": []
           }
         },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -411,6 +411,10 @@ export type MoveTraceItem = {
      * Summary
      */
     summary?: string;
+    /**
+     * Page Refs
+     */
+    page_refs?: Array<PageRef>;
     [key: string]: unknown;
 };
 
@@ -434,10 +438,6 @@ export type MovesExecutedEventOut = {
      * Moves
      */
     moves?: Array<MoveTraceItem>;
-    /**
-     * Created Page Ids
-     */
-    created_page_ids?: Array<PageRef>;
 };
 
 /**

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -66,7 +66,15 @@ function PageList({ pages }: { pages: PageRef[] }) {
   );
 }
 
-function MoveRow({ moveType, summary }: { moveType: string; summary: string }) {
+function MoveRow({
+  moveType,
+  summary,
+  pageRefs,
+}: {
+  moveType: string;
+  summary: string;
+  pageRefs?: PageRef[];
+}) {
   const isCreate = moveType.startsWith("CREATE_");
   const isLink = moveType.startsWith("LINK_");
   const isSupersede = moveType === "SUPERSEDE_PAGE";
@@ -85,12 +93,23 @@ function MoveRow({ moveType, summary }: { moveType: string; summary: string }) {
             ? "trace-move-load"
             : "trace-move-default";
 
+  const hasRefs = pageRefs && pageRefs.length > 0;
+
   return (
     <div className="trace-move-row">
       <span className={`trace-move-type ${typeClass}`}>
         {moveType.replace(/_/g, " ").toLowerCase()}
       </span>
-      {summary && <span className="trace-move-summary">{summary}</span>}
+      {!hasRefs && summary && (
+        <span className="trace-move-summary">{summary}</span>
+      )}
+      {hasRefs && (
+        <span className="trace-page-list">
+          {pageRefs.map((p) => (
+            <PageChip key={p.id} page={p} />
+          ))}
+        </span>
+      )}
     </div>
   );
 }
@@ -275,14 +294,13 @@ function EventSection({ event }: { event: TraceEvent }) {
       {event.event === "moves_executed" && (
         <div className="trace-event-body">
           {(event.moves ?? []).map((m, i) => (
-            <MoveRow key={i} moveType={m.type} summary={m.summary || ""} />
+            <MoveRow
+              key={i}
+              moveType={m.type}
+              summary={m.summary || ""}
+              pageRefs={m.page_refs}
+            />
           ))}
-          {(event.created_page_ids ?? []).length > 0 && (
-            <div className="trace-kv" style={{ marginTop: "6px" }}>
-              <span className="trace-kv-key">created</span>
-              <PageList pages={event.created_page_ids ?? []} />
-            </div>
-          )}
         </div>
       )}
 

--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -36,16 +36,22 @@ log = logging.getLogger(__name__)
 
 from differential.trace_events import (
     LLMExchangeEvent,
+    MoveTraceItem,
     MovesExecutedEvent,
     PageRef,
     WarningEvent,
 )
 from differential.tracer import CallTrace
 
-PAGE_CREATING_MOVES = {
-    MoveType.CREATE_CLAIM, MoveType.CREATE_QUESTION, MoveType.CREATE_JUDGEMENT,
-    MoveType.CREATE_CONCEPT, MoveType.CREATE_WIKI_PAGE,
-    MoveType.PROPOSE_HYPOTHESIS, MoveType.SUPERSEDE_PAGE,
+PAGE_ID_FIELDS: dict[MoveType, list[str]] = {
+    MoveType.LOAD_PAGE: ["page_id"],
+    MoveType.LINK_CONSIDERATION: ["claim_id", "question_id"],
+    MoveType.LINK_CHILD_QUESTION: ["child_id", "parent_id"],
+    MoveType.LINK_RELATED: ["from_page_id", "to_page_id"],
+    MoveType.SUPERSEDE_PAGE: ["old_page_id"],
+    MoveType.FLAG_FUNNINESS: ["page_id"],
+    MoveType.REPORT_DUPLICATE: ["page_id_a", "page_id_b"],
+    MoveType.PROPOSE_HYPOTHESIS: ["parent_question_id"],
 }
 
 
@@ -113,12 +119,11 @@ async def _save_exchanges(
     db: DB,
     trace: "CallTrace | None" = None,
     moves: list[Move] | None = None,
-    created_page_ids: list[str] | None = None,
+    move_created_ids: list[list[str]] | None = None,
 ) -> None:
     """Save LLM exchange records and interleave moves per round."""
     move_tool_names = {md.name for md in MOVES.values()}
     move_idx = 0
-    create_idx = 0
     for rr in agent_result.rounds:
         tc_data = [
             {"name": tc.name, "input": tc.input, "result": tc.result[:500]}
@@ -152,15 +157,15 @@ async def _save_exchanges(
             )
             if round_move_count > 0:
                 round_moves = moves[move_idx:move_idx + round_move_count]
+                round_created = (
+                    move_created_ids[move_idx:move_idx + round_move_count]
+                    if move_created_ids
+                    else [[] for _ in round_moves]
+                )
                 move_idx += round_move_count
-                round_created: list[str] = []
-                if created_page_ids:
-                    for m in round_moves:
-                        if (m.move_type in PAGE_CREATING_MOVES
-                                and create_idx < len(created_page_ids)):
-                            round_created.append(created_page_ids[create_idx])
-                            create_idx += 1
-                await trace.record(await moves_to_trace_event(round_moves, round_created, db))
+                await trace.record(
+                    await moves_to_trace_event(round_moves, round_created, db)
+                )
     for w in agent_result.warnings:
         if trace:
             await trace.record(WarningEvent(message=w))
@@ -199,10 +204,12 @@ async def _run_phase1(
             max_tokens=2048,
         )
         phase1_moves = state.moves[moves_before:]
+        phase1_created = state.move_created_ids[moves_before:]
         if trace:
             await _save_exchanges(
                 result, trace.call_id, "initial_page_loads", db, trace,
                 moves=phase1_moves,
+                move_created_ids=phase1_created,
             )
         loaded_ids = []
         for tc in result.tool_calls:
@@ -274,7 +281,6 @@ async def run_call(
 
     phase = "prioritization" if call_type == CallType.PRIORITIZATION else "inner_loop"
     moves_before = len(state.moves)
-    created_before = len(state.created_page_ids)
     if call_type == CallType.PRIORITIZATION:
         agent_result = await single_call_with_tools(
             system_prompt,
@@ -291,11 +297,11 @@ async def run_call(
             max_rounds=max_rounds,
         )
     phase_moves = state.moves[moves_before:]
-    phase_created = state.created_page_ids[created_before:]
+    phase_move_created = state.move_created_ids[moves_before:]
     if trace:
         await _save_exchanges(
             agent_result, call.id, phase, db, trace,
-            moves=phase_moves, created_page_ids=phase_created,
+            moves=phase_moves, move_created_ids=phase_move_created,
         )
 
     log.info(
@@ -335,23 +341,46 @@ async def resolve_page_refs(page_ids: list[str], db: DB) -> list[PageRef]:
     return refs
 
 
+async def _resolve_payload_refs(move: Move, db: DB) -> list[PageRef]:
+    """Resolve page IDs referenced in a move's payload fields."""
+    fields = PAGE_ID_FIELDS.get(move.move_type, [])
+    refs: list[PageRef] = []
+    for field_name in fields:
+        raw = getattr(move.payload, field_name, None)
+        if not raw:
+            continue
+        full_id = await db.resolve_page_id(raw)
+        if not full_id:
+            continue
+        page = await db.get_page(full_id)
+        summary = page.summary if page else ""
+        refs.append(PageRef(id=full_id, summary=summary))
+    return refs
+
+
 async def moves_to_trace_event(
     moves: list[Move],
-    created_page_ids: list[str],
+    move_created_ids: list[list[str]],
     db: DB,
 ) -> MovesExecutedEvent:
     """Build a typed MovesExecutedEvent from a list of moves."""
-    refs = await resolve_page_refs(created_page_ids, db)
-    return MovesExecutedEvent(
-        moves=[
-            {
-                "type": m.move_type.value,
-                **m.payload.model_dump(exclude_none=True, exclude_defaults=True),
-            }
-            for m in moves
-        ],
-        created_page_ids=refs,
-    )
+    trace_items = []
+    for i, m in enumerate(moves):
+        created_ids = move_created_ids[i] if i < len(move_created_ids) else []
+        created_refs = await resolve_page_refs(created_ids, db)
+        payload_refs = await _resolve_payload_refs(m, db)
+        seen = {r.id for r in created_refs}
+        for pr in payload_refs:
+            if pr.id not in seen:
+                created_refs.append(pr)
+                seen.add(pr.id)
+        payload_data = m.payload.model_dump(exclude_none=True, exclude_defaults=True)
+        trace_items.append(MoveTraceItem(
+            type=m.move_type.value,
+            page_refs=created_refs,
+            **payload_data,
+        ))
+    return MovesExecutedEvent(moves=trace_items)
 
 
 REVIEW_SYSTEM_PROMPT = (

--- a/src/differential/moves/base.py
+++ b/src/differential/moves/base.py
@@ -35,6 +35,7 @@ class MoveResult:
 
     message: str
     created_page_id: str | None = None
+    extra_created_ids: list[str] | None = None
 
 
 class MoveState:
@@ -46,6 +47,7 @@ class MoveState:
         self.last_created_id: str | None = None
         self.created_page_ids: list[str] = []
         self.moves: list[Move] = []
+        self.move_created_ids: list[list[str]] = []
         self.dispatches: list[Dispatch] = []
 
 
@@ -85,13 +87,18 @@ class MoveDef(Generic[S]):
                 validated = _resolve_last_created(validated, state.last_created_id)
             result = await self.execute(validated, state.call, state.db)
             state.moves.append(Move(move_type=self.move_type, payload=validated))
+            move_page_ids: list[str] = []
             if result.created_page_id:
                 state.created_page_ids.append(result.created_page_id)
                 state.last_created_id = result.created_page_id
+                move_page_ids.append(result.created_page_id)
                 log.debug(
                     "Move %s created page: %s",
                     self.name, result.created_page_id[:8],
                 )
+            if result.extra_created_ids:
+                move_page_ids.extend(result.extra_created_ids)
+            state.move_created_ids.append(move_page_ids)
             log.debug("Move %s result: %s", self.name, result.message[:100])
             return result.message
 

--- a/src/differential/moves/propose_hypothesis.py
+++ b/src/differential/moves/propose_hypothesis.py
@@ -124,6 +124,7 @@ async def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> Move
     return MoveResult(
         f"Created hypothesis claim [{claim.id[:8]}] and question [{question.id[:8]}].",
         created_page_id=question.id,
+        extra_created_ids=[claim.id],
     )
 
 

--- a/src/differential/trace_events.py
+++ b/src/differential/trace_events.py
@@ -21,6 +21,7 @@ PageRefList = Annotated[list[PageRef], BeforeValidator(_coerce_page_refs)]
 class MoveTraceItem(BaseModel):
     type: str
     summary: str = ""
+    page_refs: list[PageRef] = []
     model_config = {"extra": "allow"}
 
 
@@ -51,7 +52,6 @@ class Phase2LoadedEvent(BaseModel):
 class MovesExecutedEvent(BaseModel):
     event: Literal["moves_executed"] = "moves_executed"
     moves: list[MoveTraceItem] = []
-    created_page_ids: PageRefList = []
 
 
 class ReviewCompleteEvent(BaseModel):


### PR DESCRIPTION
## Summary
- Resolves page IDs referenced in move payloads into `PageRef` objects (with summaries) and attaches them as `page_refs` on each `MoveTraceItem`
- Moves the "created pages" refs from a separate section on the event into each individual move's `page_refs`, so CREATE_CLAIM shows its page chip inline
- Frontend `MoveRow` renders `PageChip`s with summaries when `page_refs` are present, instead of showing raw text summaries or bare IDs

Previously, LOAD_PAGE moves showed nothing next to them, and CREATE_QUESTION moves showed only plain text summaries. Now both show clickable page chips with resolved summaries.

## Test plan
- [ ] Run a trace with scout calls and verify LOAD_PAGE moves show page chips with summaries
- [ ] Verify CREATE_QUESTION / CREATE_CLAIM moves show page chips for created pages
- [ ] Verify existing traces render correctly (backwards-compatible with old data missing `page_refs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)