### PR TITLE
Add create_subquestion tool for inline dispatches

### DIFF
--- a/prompts/prioritization.md
+++ b/prompts/prioritization.md
@@ -59,8 +59,10 @@ dispatching, unless it is already well-covered by questions within the workspace
 - **Non-redundant**: they don't duplicate questions already visible in the workspace map.
 - **Scoped**: each targets a specific angle, not the whole question restated.
 
-To create a subquestion: use `create_question`, then `link_child_question` to attach it
-as a child. You can then dispatch research on it.
+Use `create_subquestion` to create a subquestion, link it to its parent, and dispatch
+research on it — all in a single tool call. The `links` field attaches it as a child of
+the parent question, and the `dispatches` field queues scout, assess, or sub-prioritization
+calls that will execute after prioritization completes.
 
 This is optional — if the question already has good subquestions or is narrow enough to
 investigate directly, skip this step.

--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -265,7 +265,16 @@ async def run_call(
             extra_text = await _format_loaded_pages(phase1_ids, db)
             context_text = context_text + "\n\n## Loaded Pages\n\n" + extra_text
 
-    tools = [MOVES[mt].bind(state) for mt in available_moves]
+    if call_type == CallType.PRIORITIZATION:
+        from differential.moves.create_question import PRIORITIZATION_MOVE
+        tools = []
+        for mt in available_moves:
+            if mt == MoveType.CREATE_QUESTION:
+                tools.append(PRIORITIZATION_MOVE.bind(state))
+            else:
+                tools.append(MOVES[mt].bind(state))
+    else:
+        tools = [MOVES[mt].bind(state) for mt in available_moves]
     if call_type == CallType.PRIORITIZATION:
         for ddef in DISPATCH_DEFS.values():
             tools.append(ddef.bind(state, subtree_ids, short_id_map))

--- a/src/differential/models.py
+++ b/src/differential/models.py
@@ -6,7 +6,9 @@ from datetime import UTC, datetime
 from enum import Enum
 import uuid
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Discriminator, Field
 
 
 def _all_fields_required(schema: dict) -> None:
@@ -97,8 +99,7 @@ class ConsiderationDirection(str, Enum):
     NEUTRAL = "neutral"
 
 
-class BaseDispatchPayload(BaseModel):
-    question_id: str = Field(description="Page ID of the question to investigate")
+class _DispatchBase(BaseModel):
     reason: str = Field("", description="Why this dispatch is a good use of budget")
     context_page_ids: list[str] = Field(
         default_factory=list,
@@ -109,7 +110,11 @@ class BaseDispatchPayload(BaseModel):
     )
 
 
-class ScoutDispatchPayload(BaseDispatchPayload):
+class BaseDispatchPayload(_DispatchBase):
+    question_id: str = Field(description="Page ID of the question to investigate")
+
+
+class _ScoutFields(BaseModel):
     mode: ScoutMode = Field(
         ScoutMode.ALTERNATE,
         description=(
@@ -125,12 +130,38 @@ class ScoutDispatchPayload(BaseDispatchPayload):
     )
 
 
+class _PrioritizationFields(BaseModel):
+    budget: int = Field(description="Budget to allocate for the sub-investigation")
+
+
+class ScoutDispatchPayload(BaseDispatchPayload, _ScoutFields):
+    pass
+
+
 class AssessDispatchPayload(BaseDispatchPayload):
     pass
 
 
-class PrioritizationDispatchPayload(BaseDispatchPayload):
-    budget: int = Field(description="Budget to allocate for the sub-investigation")
+class PrioritizationDispatchPayload(BaseDispatchPayload, _PrioritizationFields):
+    pass
+
+
+class InlineScoutDispatch(_DispatchBase, _ScoutFields):
+    call_type: Literal["scout"] = "scout"
+
+
+class InlineAssessDispatch(_DispatchBase):
+    call_type: Literal["assess"] = "assess"
+
+
+class InlinePrioritizationDispatch(_DispatchBase, _PrioritizationFields):
+    call_type: Literal["prioritization"] = "prioritization"
+
+
+InlineDispatch = Annotated[
+    InlineScoutDispatch | InlineAssessDispatch | InlinePrioritizationDispatch,
+    Discriminator("call_type"),
+]
 
 
 class Move(BaseModel):

--- a/src/differential/moves/base.py
+++ b/src/differential/moves/base.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Generic, TypeVar
 
@@ -35,6 +35,7 @@ class MoveResult:
 
     message: str
     created_page_id: str | None = None
+    dispatches: list[Dispatch] = field(default_factory=list)
 
 
 class MoveState:
@@ -85,6 +86,8 @@ class MoveDef(Generic[S]):
                 validated = _resolve_last_created(validated, state.last_created_id)
             result = await self.execute(validated, state.call, state.db)
             state.moves.append(Move(move_type=self.move_type, payload=validated))
+            if result.dispatches:
+                state.dispatches.extend(result.dispatches)
             if result.created_page_id:
                 state.created_page_ids.append(result.created_page_id)
                 state.last_created_id = result.created_page_id

--- a/src/differential/moves/create_question.py
+++ b/src/differential/moves/create_question.py
@@ -5,7 +5,21 @@ import logging
 from pydantic import Field
 
 from differential.database import DB
-from differential.models import Call, LinkType, MoveType, PageLayer, PageLink, PageType
+from differential.models import (
+    AssessDispatchPayload,
+    BaseDispatchPayload,
+    Call,
+    CallType,
+    Dispatch,
+    InlineDispatch,
+    LinkType,
+    MoveType,
+    PageLayer,
+    PageLink,
+    PageType,
+    PrioritizationDispatchPayload,
+    ScoutDispatchPayload,
+)
 from differential.moves.base import CreatePagePayload, MoveDef, MoveResult, create_page
 from differential.moves.link_child_question import ChildQuestionLinkFields
 
@@ -48,6 +62,64 @@ async def execute(payload: CreateQuestionPayload, call: Call, db: DB) -> MoveRes
         )
 
     return result
+
+
+class CreateSubquestionPayload(CreateQuestionPayload):
+    dispatches: list[InlineDispatch] = Field(
+        default_factory=list,
+        description=(
+            "Research calls to dispatch on this question immediately upon creation. "
+            "Each dispatch is queued and executed after prioritization completes."
+        ),
+    )
+
+
+_INLINE_DISPATCH_TO_PAYLOAD = {
+    "scout": (CallType.SCOUT, ScoutDispatchPayload),
+    "assess": (CallType.ASSESS, AssessDispatchPayload),
+    "prioritization": (CallType.PRIORITIZATION, PrioritizationDispatchPayload),
+}
+
+
+def _inline_to_dispatch(
+    inline: InlineDispatch, question_id: str,
+) -> Dispatch:
+    call_type, payload_cls = _INLINE_DISPATCH_TO_PAYLOAD[inline.call_type]
+    fields = inline.model_dump(exclude={"call_type"})
+    fields["question_id"] = question_id
+    return Dispatch(call_type=call_type, payload=payload_cls(**fields))
+
+
+async def execute_subquestion(
+    payload: CreateSubquestionPayload, call: Call, db: DB,
+) -> MoveResult:
+    result = await execute(payload, call, db)
+    if not result.created_page_id or not payload.dispatches:
+        return result
+    dispatches = [
+        _inline_to_dispatch(d, result.created_page_id)
+        for d in payload.dispatches
+    ]
+    return MoveResult(
+        message=result.message,
+        created_page_id=result.created_page_id,
+        dispatches=dispatches,
+    )
+
+
+PRIORITIZATION_MOVE = MoveDef(
+    move_type=MoveType.CREATE_QUESTION,
+    name="create_subquestion",
+    description=(
+        "Create a new research sub-question and optionally dispatch research "
+        "calls on it immediately. Use the dispatches field to queue scout, "
+        "assess, or sub-prioritization calls that will execute after "
+        "prioritization completes. Use the links field to attach this "
+        "question as a child of a parent question."
+    ),
+    schema=CreateSubquestionPayload,
+    execute=execute_subquestion,
+)
 
 
 MOVE = MoveDef(

--- a/tests/test_move_types.py
+++ b/tests/test_move_types.py
@@ -1,8 +1,10 @@
 """Tests for MoveType enum, move definitions, and move execution."""
 
-from differential.models import LinkType, MoveType, PageType
+from differential.models import CallType, LinkType, MoveType, PageType
 from differential.moves import MOVES
 from differential.moves.base import MoveState
+from differential.moves.create_question import MOVE as CREATE_QUESTION_MOVE
+from differential.moves.create_question import PRIORITIZATION_MOVE
 
 
 def test_all_move_types_have_definitions():
@@ -99,3 +101,81 @@ async def test_no_links_creates_no_links(tmp_db, scout_call):
     claim_id = state.created_page_ids[0]
     links = await tmp_db.get_links_from(claim_id)
     assert len(links) == 0
+
+
+async def test_inline_dispatch_on_create_subquestion(
+    tmp_db, prioritization_call, question_page,
+):
+    """create_subquestion with dispatches should populate state.dispatches."""
+    state = MoveState(prioritization_call, tmp_db)
+    tool = PRIORITIZATION_MOVE.bind(state)
+    await tool.fn({
+        "summary": "What causes atmospheric scattering?",
+        "content": "Sub-question about light scattering mechanisms.",
+        "links": [{
+            "parent_id": question_page.id[:8],
+            "reasoning": "Decomposition of main question",
+        }],
+        "dispatches": [{
+            "call_type": "scout",
+            "reason": "Need initial evidence",
+            "max_rounds": 3,
+        }],
+    })
+
+    assert len(state.created_page_ids) == 1
+    assert len(state.dispatches) == 1
+    d = state.dispatches[0]
+    assert d.call_type is CallType.SCOUT
+    assert d.payload.question_id == state.created_page_ids[0]
+
+
+async def test_inline_dispatch_multiple_types(
+    tmp_db, prioritization_call, question_page,
+):
+    """create_subquestion with multiple dispatch types should create all."""
+    state = MoveState(prioritization_call, tmp_db)
+    tool = PRIORITIZATION_MOVE.bind(state)
+    await tool.fn({
+        "summary": "What is the role of wavelength in scattering?",
+        "content": "Investigating wavelength dependence.",
+        "links": [{
+            "parent_id": question_page.id[:8],
+            "reasoning": "Decomposition",
+        }],
+        "dispatches": [
+            {"call_type": "scout", "reason": "Explore", "max_rounds": 2},
+            {"call_type": "assess", "reason": "Evaluate"},
+        ],
+    })
+
+    assert len(state.dispatches) == 2
+    assert state.dispatches[0].call_type is CallType.SCOUT
+    assert state.dispatches[1].call_type is CallType.ASSESS
+    for d in state.dispatches:
+        assert d.payload.question_id == state.created_page_ids[0]
+
+
+async def test_no_dispatches_creates_no_dispatches(tmp_db, prioritization_call):
+    """create_subquestion without dispatches should still create the question."""
+    state = MoveState(prioritization_call, tmp_db)
+    tool = PRIORITIZATION_MOVE.bind(state)
+    await tool.fn({
+        "summary": "A plain subquestion",
+        "content": "No dispatches here.",
+    })
+
+    assert len(state.created_page_ids) == 1
+    assert len(state.dispatches) == 0
+    page = await tmp_db.get_page(state.created_page_ids[0])
+    assert page is not None
+    assert page.page_type is PageType.QUESTION
+
+
+def test_create_subquestion_schema_includes_dispatches():
+    """PRIORITIZATION_MOVE schema has dispatches; MOVE schema does not."""
+    sub_schema = PRIORITIZATION_MOVE.schema.model_json_schema()
+    assert "dispatches" in sub_schema["properties"]
+
+    base_schema = CREATE_QUESTION_MOVE.schema.model_json_schema()
+    assert "dispatches" not in base_schema["properties"]

--- a/tests/test_run_call.py
+++ b/tests/test_run_call.py
@@ -148,3 +148,32 @@ async def test_create_question_with_inline_links(tmp_db, question_page, scout_ca
         'Expected at least one child_question link from the parent to the new question'
     )
     assert child_links[0].from_page_id == question_page.id
+
+
+@pytest.mark.llm
+async def test_create_subquestion_with_inline_dispatches(
+    tmp_db, question_page, prioritization_call,
+):
+    """Prioritization should create subquestions with inline dispatches."""
+    context = (
+        f"## Questions\n\n"
+        f"- `{question_page.id[:8]}`: {question_page.summary} (0 considerations)\n"
+    )
+    task = (
+        "You have a budget of **2 research calls** to allocate.\n\n"
+        f"Scope question ID: `{question_page.id}`\n\n"
+        "Create a subquestion using `create_subquestion` and dispatch a scout on it "
+        "using the `dispatches` field. Link it as a child of the scope question "
+        "using the `links` field."
+    )
+
+    result = await run_call(
+        CallType.PRIORITIZATION,
+        task,
+        context,
+        prioritization_call,
+        tmp_db,
+    )
+
+    assert len(result.created_page_ids) >= 1
+    assert len(result.dispatches) >= 1


### PR DESCRIPTION
## Summary

- Adds a `create_subquestion` tool available during prioritization that bundles question creation + parent linking + dispatch in a single tool call, fixing the problem where prioritization couldn't dispatch on subquestions it just created (since it didn't know their IDs yet)
- Uses inheritance with `_DispatchBase` and field mixins (`_ScoutFields`, `_PrioritizationFields`) to share field definitions between inline and regular dispatch payload types
- Verified with 16 concurrent Opus runs (8 at budget=2, 8 at budget=5): **16/16 prioritization calls produced dispatches > 0**, with 7/8 budget=5 runs using `create_subquestion` to decompose and dispatch in one shot

## Test plan

- [x] `uv run pytest -x` — all 38 existing + 4 new unit tests pass
- [x] `uv run pytest tests/test_run_call.py --llm` — all 6 LLM tests pass (including new `test_create_subquestion_with_inline_dispatches`)
- [x] 8 concurrent Opus runs at budget=2 — all produce dispatches
- [x] 8 concurrent Opus runs at budget=5 — all produce dispatches, 7/8 create subquestions with inline dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)