### PR TITLE
Instruct LLM to minimize non-tool-call text output

### DIFF
--- a/prompts/preamble.md
+++ b/prompts/preamble.md
@@ -41,7 +41,7 @@ Accompany every epistemic_status with an epistemic_type: a brief description of 
 
 ## Key Principles
 
-- **Use tools for all output.** Do not include unstructured prose in your response — record all reasoning inside tool call payloads.
+- **Use tools for all output.** The only way to modify the workspace is through tool calls. Non-tool-call text is not recorded and serves no purpose. Keep text output to an absolute minimum — ideally empty. Never narrate, summarize, or explain what you are about to do or just did. Just make tool calls.
 - **Be specific.** Vague gestures at considerations are not useful. Each claim should stand alone as a substantive assertion.
 - **Epistemic honesty.** Do not overstate confidence. Flag genuine uncertainty.
 - **Fix forward.** If something in the workspace is wrong, supersede the bad page rather than ignoring it.


### PR DESCRIPTION
## Summary
- Strengthens the preamble prompt to explicitly tell the model that non-tool-call text serves no purpose and should ideally be empty
- ~13% output token reduction observed in budget-1 test runs (2183 → 1890 output tokens)

## Test plan
- [x] Ran budget-1 "Is water wet?" before and after, compared output tokens via trace data

🤖 Generated with [Claude Code](https://claude.com/claude-code)