### PR TITLE
Display call params in trace viewer

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -821,6 +821,18 @@
             "type": "object",
             "title": "Review Json"
           },
+          "call_params": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Params"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -853,6 +865,7 @@
           "context_page_ids",
           "result_summary",
           "review_json",
+          "call_params",
           "created_at",
           "completed_at"
         ],

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -50,6 +50,12 @@ export type Call = {
         [key: string]: unknown;
     };
     /**
+     * Call Params
+     */
+    call_params: {
+        [key: string]: unknown;
+    } | null;
+    /**
      * Created At
      */
     created_at: string;

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -422,6 +422,19 @@ export function CallNode({
 
       {isOpen && (
         <div className="trace-call-body">
+          {call.call_params && Object.keys(call.call_params).length > 0 && (
+            <div className="trace-call-params">
+              {Object.entries(call.call_params).map(([key, value]) => (
+                <span key={key} className="trace-call-param">
+                  <span className="trace-call-param-label">
+                    {key.replace(/_/g, " ")}
+                  </span>
+                  <span className="trace-call-param-value">{String(value)}</span>
+                </span>
+              ))}
+            </div>
+          )}
+
           {dispatchEvents.length > 0 && (
             <div className="trace-dispatches">
               <div className="trace-section-label">dispatches</div>

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -170,6 +170,35 @@
   padding: 8px 0 16px 14px;
 }
 
+/* Call params */
+
+.trace-call-params {
+  display: flex;
+  gap: 14px;
+  margin-bottom: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid #efefef;
+}
+
+.trace-call-param {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+}
+
+.trace-call-param-label {
+  font-size: 11px;
+  color: #888;
+  letter-spacing: 0.02em;
+}
+
+.trace-call-param-value {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--call-accent, #5b8def);
+}
+
 /* Events */
 
 .trace-events {
@@ -683,6 +712,9 @@
 
   .trace-badge-warning { color: #d4a017; background: #1f1a06; }
   .trace-badge-error { color: #e66; background: #1f0808; }
+
+  .trace-call-params { border-bottom-color: #1e1e1e; }
+  .trace-call-param-label { color: #666; }
 
   .trace-call-body { border-left-color: #2a2a2a; }
 

--- a/src/differential/calls/scout.py
+++ b/src/differential/calls/scout.py
@@ -38,11 +38,18 @@ async def run_scout(
     db: DB,
     mode: ScoutMode = ScoutMode.ABSTRACT,
     broadcaster=None,
+    max_rounds: int | None = None,
+    fruit_threshold: int | None = None,
 ) -> tuple[RunCallResult, dict]:
     """Run a Scout call on a question.
 
     Returns (run_call_result, review_dict).
     """
+    call.call_params = {"mode": mode.value}
+    if max_rounds is not None:
+        call.call_params["max_rounds"] = max_rounds
+    if fruit_threshold is not None:
+        call.call_params["fruit_threshold"] = fruit_threshold
     trace = CallTrace(call.id, db, broadcaster=broadcaster)
     log.info(
         "Scout starting: call=%s, question=%s, mode=%s",

--- a/src/differential/database.py
+++ b/src/differential/database.py
@@ -88,6 +88,7 @@ def _row_to_call(row: dict[str, Any]) -> Call:
         context_page_ids=row.get("context_page_ids") or [],
         result_summary=row.get("result_summary") or "",
         review_json=row.get("review_json") or {},
+        call_params=row.get("call_params"),
         created_at=datetime.fromisoformat(row["created_at"]),
         completed_at=(
             datetime.fromisoformat(row["completed_at"]) if row["completed_at"] else None
@@ -391,6 +392,7 @@ class DB:
                 "context_page_ids": call.context_page_ids,
                 "result_summary": call.result_summary,
                 "review_json": call.review_json,
+                "call_params": call.call_params,
                 "created_at": call.created_at.isoformat(),
                 "completed_at": (
                     call.completed_at.isoformat() if call.completed_at else None

--- a/src/differential/models.py
+++ b/src/differential/models.py
@@ -230,5 +230,6 @@ class Call(BaseModel):
     context_page_ids: list[str] = Field(default_factory=list)
     result_summary: str = ""
     review_json: dict = Field(default_factory=dict)
+    call_params: dict | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     completed_at: datetime | None = None

--- a/src/differential/orchestrator.py
+++ b/src/differential/orchestrator.py
@@ -115,6 +115,7 @@ async def scout_until_done(
         call_ids.append(call.id)
         _, review = await run_scout(
             question_id, call, db, mode=round_mode, broadcaster=broadcaster,
+            max_rounds=max_rounds, fruit_threshold=fruit_threshold,
         )
         rounds += 1
 

--- a/supabase/migrations/20260312045111_add_call_params.sql
+++ b/supabase/migrations/20260312045111_add_call_params.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.calls ADD COLUMN call_params JSONB;


### PR DESCRIPTION
## Summary
- Adds a `call_params` JSONB column to the `calls` table to store arbitrary per-call parameters
- Scout calls record their `mode`, `max_rounds`, and `fruit_threshold` as call params
- The trace viewer generically renders `call_params` at the top of any call body, using the call type's accent color

## Test plan
- [x] Verified call_params round-trips through DB (save_call → get_call)
- [x] Verified API returns call_params on call objects
- [x] Confirmed params display in trace viewer for scout calls
- [ ] Run `supabase db push` to apply migration to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)