### PR TITLE
Specialize agent loop and centralize exchange logging

### DIFF
--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -6,6 +6,8 @@ import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+import anthropic
+from anthropic.types import TextBlock, ToolUseBlock
 from pydantic import BaseModel, Field
 
 from differential.context import format_page
@@ -14,12 +16,12 @@ from differential.settings import get_settings
 from differential.llm import (
     AgentResult,
     RoundRecord,
-    StructuredCallResult,
+    Tool,
+    ToolCall,
     build_system_prompt,
     build_user_message,
+    call_api,
     structured_call,
-    agent_loop,
-    single_call_with_tools,
 )
 from differential.models import (
     Call,
@@ -33,9 +35,6 @@ from differential.calls.dispatches import DISPATCH_DEFS
 from differential.moves.base import MoveState
 from differential.moves.load_page import LoadPagePayload
 from differential.moves.registry import MOVES
-
-log = logging.getLogger(__name__)
-
 from differential.trace_events import (
     LLMExchangeEvent,
     MoveTraceItem,
@@ -44,6 +43,8 @@ from differential.trace_events import (
     WarningEvent,
 )
 from differential.tracer import CallTrace
+
+log = logging.getLogger(__name__)
 
 PAGE_ID_FIELDS: dict[MoveType, list[str]] = {
     MoveType.LOAD_PAGE: ["page_id"],
@@ -64,6 +65,353 @@ PHASE1_TASK = (
     'before the main task begins; load everything relevant in one go. '
     'The main task description will follow in the next turn.'
 )
+
+
+async def _execute_tool_uses(
+    tool_uses: list[ToolUseBlock],
+    tool_fns: dict,
+) -> tuple[list[ToolCall], list[dict]]:
+    """Execute tool calls and build tool_result messages."""
+    tool_calls: list[ToolCall] = []
+    tool_results: list[dict] = []
+    for tu in tool_uses:
+        fn = tool_fns.get(tu.name)
+        if fn is None:
+            result_str = f"Unknown tool: {tu.name}"
+            log.warning("Unknown tool called by LLM: %s", tu.name)
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": tu.id,
+                "content": result_str,
+                "is_error": True,
+            })
+        else:
+            try:
+                result_str = await fn(tu.input)
+            except Exception as e:
+                log.error(
+                    "Tool %s raised an exception: %s", tu.name, e, exc_info=True,
+                )
+                result_str = f"Error: {e}"
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tu.id,
+                    "content": result_str,
+                    "is_error": True,
+                })
+            else:
+                log.debug(
+                    "Tool %s returned: %s",
+                    tu.name, result_str[:200] if result_str else "(empty)",
+                )
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tu.id,
+                    "content": result_str,
+                })
+        tool_calls.append(ToolCall(name=tu.name, input=tu.input, result=result_str))
+    return tool_calls, tool_results
+
+
+async def _save_round(
+    rr: RoundRecord,
+    *,
+    call_id: str,
+    phase: str,
+    system_prompt: str,
+    user_message: str,
+    db: DB,
+    trace: "CallTrace | None",
+    state: MoveState,
+    move_cursor: int,
+    move_tool_names: set[str],
+) -> int:
+    """Save a round's exchange and trace events. Returns updated move_cursor."""
+    if not trace:
+        return move_cursor
+    tc_data = [
+        {"name": tc.name, "input": tc.input, "result": tc.result[:500]}
+        for tc in rr.tool_calls
+    ]
+    exchange_id = await db.save_llm_exchange(
+        call_id=call_id,
+        phase=phase,
+        round_num=rr.round,
+        system_prompt=system_prompt,
+        user_message=user_message if rr.round == 0 else None,
+        response_text=rr.response_text,
+        tool_calls=tc_data,
+        input_tokens=rr.input_tokens,
+        output_tokens=rr.output_tokens,
+        error=rr.error,
+        duration_ms=rr.duration_ms or None,
+    )
+    await trace.record(LLMExchangeEvent(
+        exchange_id=exchange_id,
+        phase=phase,
+        round=rr.round if phase == "inner_loop" else None,
+        input_tokens=rr.input_tokens,
+        output_tokens=rr.output_tokens,
+        duration_ms=rr.duration_ms or None,
+    ))
+    round_move_count = sum(
+        1 for tc in rr.tool_calls if tc.name in move_tool_names
+    )
+    if round_move_count > 0:
+        round_moves = state.moves[move_cursor:move_cursor + round_move_count]
+        round_created = state.move_created_ids[
+            move_cursor:move_cursor + round_move_count
+        ]
+        move_cursor += round_move_count
+        await trace.record(
+            await moves_to_trace_event(round_moves, round_created, db)
+        )
+    return move_cursor
+
+
+def _prepare_tools(tools: list[Tool]) -> tuple[list[dict], dict]:
+    """Build API tool definitions and function lookup from Tool list."""
+    tool_defs = [
+        {"name": t.name, "description": t.description, "input_schema": t.input_schema}
+        for t in tools
+    ]
+    tool_fns = {t.name: t.fn for t in tools}
+    return tool_defs, tool_fns
+
+
+async def run_single_call(
+    system_prompt: str,
+    user_message: str,
+    tools: list[Tool],
+    *,
+    call_id: str,
+    phase: str,
+    db: DB,
+    state: MoveState,
+    trace: "CallTrace | None" = None,
+    max_tokens: int = 4096,
+) -> AgentResult:
+    """Single LLM call with tools, plus exchange/trace persistence.
+
+    Executes tool calls but does NOT loop back. Used for phase-1 page
+    loading and single-call prioritization.
+    """
+    settings = get_settings()
+    client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
+    tool_defs, tool_fns = _prepare_tools(tools)
+    move_tool_names = {md.name for md in MOVES.values()}
+
+    log.debug(
+        "run_single_call: phase=%s, max_tokens=%d, tools=%s",
+        phase, max_tokens, [t.name for t in tools],
+    )
+
+    messages: list[dict] = [{"role": "user", "content": user_message}]
+    all_warnings: list[str] = []
+    api_resp = await call_api(
+        client, settings.model, system_prompt, messages,
+        tool_defs or None, max_tokens, warnings=all_warnings,
+    )
+    response = api_resp.message
+
+    text_parts: list[str] = []
+    tool_uses: list[ToolUseBlock] = []
+    for block in response.content:
+        if isinstance(block, TextBlock):
+            text_parts.append(block.text)
+        elif isinstance(block, ToolUseBlock):
+            tool_uses.append(block)
+
+    all_tool_calls, _ = await _execute_tool_uses(tool_uses, tool_fns)
+
+    rr = RoundRecord(
+        round=0,
+        response_text="\n".join(text_parts),
+        tool_calls=all_tool_calls,
+        input_tokens=response.usage.input_tokens,
+        output_tokens=response.usage.output_tokens,
+        duration_ms=api_resp.duration_ms,
+    )
+
+    moves_before = len(state.moves)
+    await _save_round(
+        rr,
+        call_id=call_id,
+        phase=phase,
+        system_prompt=system_prompt,
+        user_message=user_message,
+        db=db,
+        trace=trace,
+        state=state,
+        move_cursor=moves_before,
+        move_tool_names=move_tool_names,
+    )
+    for w in all_warnings:
+        if trace:
+            await trace.record(WarningEvent(message=w))
+
+    log.info(
+        "run_single_call complete: %d tool calls, %d text chars",
+        len(all_tool_calls), sum(len(t) for t in text_parts),
+    )
+    return AgentResult(
+        text="\n".join(text_parts),
+        tool_calls=all_tool_calls,
+        rounds=[rr],
+        system_prompt=system_prompt,
+        user_message=user_message,
+        warnings=all_warnings,
+    )
+
+
+async def run_agent_loop(
+    system_prompt: str,
+    user_message: str,
+    tools: list[Tool],
+    *,
+    call_id: str,
+    db: DB,
+    state: MoveState,
+    trace: "CallTrace | None" = None,
+    max_tokens: int = 4096,
+    max_rounds: int | None = None,
+) -> AgentResult:
+    """Tool-use conversation loop with per-round exchange/trace persistence.
+
+    Each Tool's fn is called when the LLM invokes it. The fn's return value
+    is sent back as the tool_result content. If fn raises, the exception
+    message is sent back as an error result.
+    """
+    settings = get_settings()
+    effective_rounds = max_rounds if max_rounds is not None else (
+        2 if settings.is_smoke_test else 6
+    )
+    client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
+    tool_defs, tool_fns = _prepare_tools(tools)
+    move_tool_names = {md.name for md in MOVES.values()}
+
+    log.debug(
+        "run_agent_loop starting: max_rounds=%d, max_tokens=%d, tools=%s",
+        effective_rounds, max_tokens, [t.name for t in tools],
+    )
+
+    messages: list[dict] = [{"role": "user", "content": user_message}]
+    text_parts: list[str] = []
+    all_tool_calls: list[ToolCall] = []
+    all_rounds: list[RoundRecord] = []
+    all_warnings: list[str] = []
+    move_cursor = len(state.moves)
+    round_num = 0
+
+    for round_num in range(effective_rounds + 1):
+        log.debug("run_agent_loop round %d/%d", round_num + 1, effective_rounds)
+        api_resp = await call_api(
+            client, settings.model, system_prompt, messages,
+            tool_defs or None, max_tokens, warnings=all_warnings,
+        )
+        response = api_resp.message
+
+        tool_uses: list[ToolUseBlock] = []
+        round_text_parts: list[str] = []
+        for block in response.content:
+            if isinstance(block, TextBlock):
+                text_parts.append(block.text)
+                round_text_parts.append(block.text)
+            elif isinstance(block, ToolUseBlock):
+                tool_uses.append(block)
+
+        if response.stop_reason == "end_turn" or not tool_uses:
+            log.debug(
+                "run_agent_loop ending: stop_reason=%s, tool_uses=%d, rounds_used=%d",
+                response.stop_reason, len(tool_uses), round_num + 1,
+            )
+            rr = RoundRecord(
+                round=round_num,
+                response_text="\n".join(round_text_parts),
+                tool_calls=[],
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                duration_ms=api_resp.duration_ms,
+            )
+            all_rounds.append(rr)
+            move_cursor = await _save_round(
+                rr,
+                call_id=call_id,
+                phase="inner_loop",
+                system_prompt=system_prompt,
+                user_message=user_message,
+                db=db,
+                trace=trace,
+                state=state,
+                move_cursor=move_cursor,
+                move_tool_names=move_tool_names,
+            )
+            break
+
+        log.debug(
+            "run_agent_loop round %d: %d tool call(s): %s",
+            round_num + 1, len(tool_uses), [tu.name for tu in tool_uses],
+        )
+
+        round_tool_calls, tool_results = await _execute_tool_uses(tool_uses, tool_fns)
+        all_tool_calls.extend(round_tool_calls)
+
+        rr = RoundRecord(
+            round=round_num,
+            response_text="\n".join(round_text_parts),
+            tool_calls=round_tool_calls,
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+            duration_ms=api_resp.duration_ms,
+        )
+        all_rounds.append(rr)
+        move_cursor = await _save_round(
+            rr,
+            call_id=call_id,
+            phase="inner_loop",
+            system_prompt=system_prompt,
+            user_message=user_message,
+            db=db,
+            trace=trace,
+            state=state,
+            move_cursor=move_cursor,
+            move_tool_names=move_tool_names,
+        )
+
+        remaining = effective_rounds - round_num
+        if remaining == 1:
+            budget_note = {
+                "type": "text",
+                "text": "This is your final round — finish your work now.",
+            }
+        else:
+            budget_note = {
+                "type": "text",
+                "text": (
+                    f"After this round of tool calls, you will have "
+                    f"{remaining - 1} rounds remaining."
+                ),
+            }
+
+        messages.append({"role": "assistant", "content": response.content})
+        messages.append({"role": "user", "content": tool_results + [budget_note]})
+
+    for w in all_warnings:
+        if trace:
+            await trace.record(WarningEvent(message=w))
+
+    log.info(
+        "run_agent_loop complete: %d rounds, %d tool calls, %d text chars",
+        round_num + 1, len(all_tool_calls), sum(len(t) for t in text_parts),
+    )
+    return AgentResult(
+        text="\n".join(text_parts),
+        tool_calls=all_tool_calls,
+        rounds=all_rounds,
+        system_prompt=system_prompt,
+        user_message=user_message,
+        warnings=all_warnings,
+    )
 
 
 class PageRating(BaseModel):
@@ -114,66 +462,6 @@ class RunCallResult:
     agent_result: AgentResult = field(default_factory=AgentResult)
 
 
-async def _save_exchanges(
-    agent_result: AgentResult,
-    call_id: str,
-    phase: str,
-    db: DB,
-    trace: "CallTrace | None" = None,
-    moves: list[Move] | None = None,
-    move_created_ids: list[list[str]] | None = None,
-) -> None:
-    """Save LLM exchange records and interleave moves per round."""
-    move_tool_names = {md.name for md in MOVES.values()}
-    move_idx = 0
-    for rr in agent_result.rounds:
-        tc_data = [
-            {"name": tc.name, "input": tc.input, "result": tc.result[:500]}
-            for tc in rr.tool_calls
-        ]
-        exchange_id = await db.save_llm_exchange(
-            call_id=call_id,
-            phase=phase,
-            round_num=rr.round,
-            system_prompt=agent_result.system_prompt,
-            user_message=agent_result.user_message if rr.round == 0 else None,
-            response_text=rr.response_text,
-            tool_calls=tc_data,
-            input_tokens=rr.input_tokens,
-            output_tokens=rr.output_tokens,
-            error=rr.error,
-            duration_ms=rr.duration_ms or None,
-        )
-        if trace:
-            has_rounds = phase == "inner_loop"
-            await trace.record(LLMExchangeEvent(
-                exchange_id=exchange_id,
-                phase=phase,
-                round=rr.round if has_rounds else None,
-                input_tokens=rr.input_tokens,
-                output_tokens=rr.output_tokens,
-                duration_ms=rr.duration_ms or None,
-            ))
-        if trace and moves:
-            round_move_count = sum(
-                1 for tc in rr.tool_calls if tc.name in move_tool_names
-            )
-            if round_move_count > 0:
-                round_moves = moves[move_idx:move_idx + round_move_count]
-                round_created = (
-                    move_created_ids[move_idx:move_idx + round_move_count]
-                    if move_created_ids
-                    else [[] for _ in round_moves]
-                )
-                move_idx += round_move_count
-                await trace.record(
-                    await moves_to_trace_event(round_moves, round_created, db)
-                )
-    for w in agent_result.warnings:
-        if trace:
-            await trace.record(WarningEvent(message=w))
-
-
 async def _format_loaded_pages(page_ids: list[str], db: DB) -> str:
     """Format loaded pages as context text for phase 2."""
     parts = []
@@ -187,6 +475,7 @@ async def _format_loaded_pages(page_ids: list[str], db: DB) -> str:
 async def _run_phase1(
     system_prompt: str,
     context_text: str,
+    call_id: str,
     state: MoveState,
     db: DB,
     trace: "CallTrace | None" = None,
@@ -199,21 +488,17 @@ async def _run_phase1(
     try:
         phase1_msg = build_user_message(context_text, PHASE1_TASK)
         load_page_tool = MOVES[MoveType.LOAD_PAGE].bind(state)
-        moves_before = len(state.moves)
-        result = await single_call_with_tools(
+        result = await run_single_call(
             system_prompt=system_prompt,
             user_message=phase1_msg,
             tools=[load_page_tool],
+            call_id=call_id,
+            phase="initial_page_loads",
+            db=db,
+            state=state,
+            trace=trace,
             max_tokens=2048,
         )
-        phase1_moves = state.moves[moves_before:]
-        phase1_created = state.move_created_ids[moves_before:]
-        if trace:
-            await _save_exchanges(
-                result, trace.call_id, "initial_page_loads", db, trace,
-                moves=phase1_moves,
-                move_created_ids=phase1_created,
-            )
         loaded_ids = []
         for tc in result.tool_calls:
             if tc.name == "load_page":
@@ -270,7 +555,9 @@ async def run_call(
 
     phase1_ids: list[str] = []
     if call_type != CallType.PRIORITIZATION:
-        phase1_ids = await _run_phase1(system_prompt, context_text, state, db, trace=trace)
+        phase1_ids = await _run_phase1(
+            system_prompt, context_text, call.id, state, db, trace=trace,
+        )
         if phase1_ids:
             extra_text = await _format_loaded_pages(phase1_ids, db)
             context_text = context_text + "\n\n## Loaded Pages\n\n" + extra_text
@@ -291,79 +578,26 @@ async def run_call(
 
     user_message = build_user_message(context_text, task_description)
 
-    phase = "prioritization" if call_type == CallType.PRIORITIZATION else "inner_loop"
-    moves_before = len(state.moves)
     if call_type == CallType.PRIORITIZATION:
-        agent_result = await single_call_with_tools(
-            system_prompt,
-            user_message,
-            tools,
+        agent_result = await run_single_call(
+            system_prompt, user_message, tools,
+            call_id=call.id,
+            phase="prioritization",
+            db=db,
+            state=state,
+            trace=trace,
             max_tokens=max_tokens,
         )
-        phase_moves = state.moves[moves_before:]
-        phase_move_created = state.move_created_ids[moves_before:]
-        if trace:
-            await _save_exchanges(
-                agent_result, call.id, phase, db, trace,
-                moves=phase_moves, move_created_ids=phase_move_created,
-            )
     else:
-        move_tool_names = {md.name for md in MOVES.values()}
-        move_cursor = moves_before
-
-        async def _on_round(rr: RoundRecord) -> None:
-            nonlocal move_cursor
-            if not trace:
-                return
-            tc_data = [
-                {"name": tc.name, "input": tc.input, "result": tc.result[:500]}
-                for tc in rr.tool_calls
-            ]
-            exchange_id = await db.save_llm_exchange(
-                call_id=call.id,
-                phase=phase,
-                round_num=rr.round,
-                system_prompt=system_prompt,
-                user_message=user_message if rr.round == 0 else None,
-                response_text=rr.response_text,
-                tool_calls=tc_data,
-                input_tokens=rr.input_tokens,
-                output_tokens=rr.output_tokens,
-                error=rr.error,
-                duration_ms=rr.duration_ms or None,
-            )
-            await trace.record(LLMExchangeEvent(
-                exchange_id=exchange_id,
-                phase=phase,
-                round=rr.round,
-                input_tokens=rr.input_tokens,
-                output_tokens=rr.output_tokens,
-                duration_ms=rr.duration_ms or None,
-            ))
-            round_move_count = sum(
-                1 for tc in rr.tool_calls if tc.name in move_tool_names
-            )
-            if round_move_count > 0:
-                round_moves = state.moves[move_cursor:move_cursor + round_move_count]
-                round_created = state.move_created_ids[
-                    move_cursor:move_cursor + round_move_count
-                ]
-                move_cursor += round_move_count
-                await trace.record(
-                    await moves_to_trace_event(round_moves, round_created, db)
-                )
-
-        agent_result = await agent_loop(
-            system_prompt,
-            user_message,
-            tools,
+        agent_result = await run_agent_loop(
+            system_prompt, user_message, tools,
+            call_id=call.id,
+            db=db,
+            state=state,
+            trace=trace,
             max_tokens=max_tokens,
             max_rounds=max_rounds,
-            on_round=_on_round,
         )
-        for w in agent_result.warnings:
-            if trace:
-                await trace.record(WarningEvent(message=w))
 
     log.info(
         "run_call complete: type=%s, pages_created=%d, dispatches=%d, moves=%d",

--- a/src/differential/calls/common.py
+++ b/src/differential/calls/common.py
@@ -15,6 +15,7 @@ from differential.database import DB
 from differential.settings import get_settings
 from differential.llm import (
     AgentResult,
+    LLMExchangeMetadata,
     RoundRecord,
     Tool,
     ToolCall,
@@ -36,7 +37,6 @@ from differential.moves.base import MoveState
 from differential.moves.load_page import LoadPagePayload
 from differential.moves.registry import MOVES
 from differential.trace_events import (
-    LLMExchangeEvent,
     MoveTraceItem,
     MovesExecutedEvent,
     PageRef,
@@ -113,47 +113,16 @@ async def _execute_tool_uses(
     return tool_calls, tool_results
 
 
-async def _save_round(
+async def _record_round_moves(
     rr: RoundRecord,
     *,
-    call_id: str,
-    phase: str,
-    system_prompt: str,
-    user_message: str,
-    db: DB,
-    trace: "CallTrace | None",
+    trace: CallTrace,
     state: MoveState,
     move_cursor: int,
     move_tool_names: set[str],
+    db: DB,
 ) -> int:
-    """Save a round's exchange and trace events. Returns updated move_cursor."""
-    if not trace:
-        return move_cursor
-    tc_data = [
-        {"name": tc.name, "input": tc.input, "result": tc.result[:500]}
-        for tc in rr.tool_calls
-    ]
-    exchange_id = await db.save_llm_exchange(
-        call_id=call_id,
-        phase=phase,
-        round_num=rr.round,
-        system_prompt=system_prompt,
-        user_message=user_message if rr.round == 0 else None,
-        response_text=rr.response_text,
-        tool_calls=tc_data,
-        input_tokens=rr.input_tokens,
-        output_tokens=rr.output_tokens,
-        error=rr.error,
-        duration_ms=rr.duration_ms or None,
-    )
-    await trace.record(LLMExchangeEvent(
-        exchange_id=exchange_id,
-        phase=phase,
-        round=rr.round if phase == "inner_loop" else None,
-        input_tokens=rr.input_tokens,
-        output_tokens=rr.output_tokens,
-        duration_ms=rr.duration_ms or None,
-    ))
+    """Record move trace events for tools executed in this round. Returns updated move_cursor."""
     round_move_count = sum(
         1 for tc in rr.tool_calls if tc.name in move_tool_names
     )
@@ -208,9 +177,14 @@ async def run_single_call(
 
     messages: list[dict] = [{"role": "user", "content": user_message}]
     all_warnings: list[str] = []
+    meta = LLMExchangeMetadata(
+        call_id=call_id, phase=phase, trace=trace,
+        user_message=user_message,
+    )
     api_resp = await call_api(
         client, settings.model, system_prompt, messages,
         tool_defs or None, max_tokens, warnings=all_warnings,
+        metadata=meta, db=db,
     )
     response = api_resp.message
 
@@ -233,19 +207,15 @@ async def run_single_call(
         duration_ms=api_resp.duration_ms,
     )
 
-    moves_before = len(state.moves)
-    await _save_round(
-        rr,
-        call_id=call_id,
-        phase=phase,
-        system_prompt=system_prompt,
-        user_message=user_message,
-        db=db,
-        trace=trace,
-        state=state,
-        move_cursor=moves_before,
-        move_tool_names=move_tool_names,
-    )
+    if trace:
+        await _record_round_moves(
+            rr,
+            trace=trace,
+            state=state,
+            move_cursor=len(state.moves),
+            move_tool_names=move_tool_names,
+            db=db,
+        )
     for w in all_warnings:
         if trace:
             await trace.record(WarningEvent(message=w))
@@ -305,9 +275,15 @@ async def run_agent_loop(
 
     for round_num in range(effective_rounds + 1):
         log.debug("run_agent_loop round %d/%d", round_num + 1, effective_rounds)
+        meta = LLMExchangeMetadata(
+            call_id=call_id, phase="inner_loop", trace=trace,
+            round_num=round_num,
+            user_message=user_message if round_num == 0 else None,
+        )
         api_resp = await call_api(
             client, settings.model, system_prompt, messages,
             tool_defs or None, max_tokens, warnings=all_warnings,
+            metadata=meta, db=db,
         )
         response = api_resp.message
 
@@ -334,18 +310,6 @@ async def run_agent_loop(
                 duration_ms=api_resp.duration_ms,
             )
             all_rounds.append(rr)
-            move_cursor = await _save_round(
-                rr,
-                call_id=call_id,
-                phase="inner_loop",
-                system_prompt=system_prompt,
-                user_message=user_message,
-                db=db,
-                trace=trace,
-                state=state,
-                move_cursor=move_cursor,
-                move_tool_names=move_tool_names,
-            )
             break
 
         log.debug(
@@ -365,18 +329,15 @@ async def run_agent_loop(
             duration_ms=api_resp.duration_ms,
         )
         all_rounds.append(rr)
-        move_cursor = await _save_round(
-            rr,
-            call_id=call_id,
-            phase="inner_loop",
-            system_prompt=system_prompt,
-            user_message=user_message,
-            db=db,
-            trace=trace,
-            state=state,
-            move_cursor=move_cursor,
-            move_tool_names=move_tool_names,
-        )
+        if trace:
+            move_cursor = await _record_round_moves(
+                rr,
+                trace=trace,
+                state=state,
+                move_cursor=move_cursor,
+                move_tool_names=move_tool_names,
+                db=db,
+            )
 
         remaining = effective_rounds - round_num
         if remaining == 1:
@@ -749,33 +710,19 @@ async def run_closing_review(
     )
     try:
         user_message = build_user_message(context_text, review_task)
+        meta = LLMExchangeMetadata(
+            call_id=call.id, phase="closing_review",
+            trace=trace, user_message=user_message,
+        ) if db else None
         result = await structured_call(
             system_prompt=REVIEW_SYSTEM_PROMPT,
             user_message=user_message,
             response_model=ReviewResponse,
             max_tokens=2048,
+            metadata=meta,
+            db=db,
         )
         review = result.data
-        if trace and db:
-            exchange_id = await db.save_llm_exchange(
-                call_id=call.id,
-                phase="closing_review",
-                round_num=0,
-                system_prompt=REVIEW_SYSTEM_PROMPT,
-                user_message=user_message,
-                response_text=result.response_text,
-                tool_calls=[],
-                input_tokens=result.input_tokens,
-                output_tokens=result.output_tokens,
-                duration_ms=result.duration_ms,
-            )
-            await trace.record(LLMExchangeEvent(
-                exchange_id=exchange_id,
-                phase="closing_review",
-                input_tokens=result.input_tokens,
-                output_tokens=result.output_tokens,
-                duration_ms=result.duration_ms,
-            ))
         if review:
             log.info(
                 "Closing review complete: call=%s, fruit=%s, confidence=%s",

--- a/src/differential/database.py
+++ b/src/differential/database.py
@@ -648,7 +648,6 @@ class DB:
         self,
         call_id: str,
         phase: str,
-        round_num: int,
         system_prompt: str | None,
         user_message: str | None,
         response_text: str | None,
@@ -657,6 +656,7 @@ class DB:
         output_tokens: int | None = None,
         error: str | None = None,
         duration_ms: int | None = None,
+        round_num: int | None = None,
     ) -> str:
         exchange_id = str(uuid.uuid4())
         await self.client.table("call_llm_exchanges").insert(

--- a/src/differential/llm.py
+++ b/src/differential/llm.py
@@ -1,21 +1,24 @@
 """
 LLM interface. Anthropic-specific details are confined to this module.
 
-Exports three calling modes:
-  - agent_loop: generic tool-use conversation loop
-  - structured_call: structured output via messages.parse
+Exports:
+  - call_api: low-level API call with retries
   - text_call: plain text call
+  - structured_call: structured output via messages.parse
+
+Data types: Tool, ToolCall, RoundRecord, AgentResult, APIResponse.
 """
 
 import asyncio
 import logging
 import time
-from collections.abc import Callable, Awaitable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from collections.abc import Awaitable, Callable
+
 import anthropic
-from anthropic.types import MessageParam, TextBlock, ToolUseBlock
+from anthropic.types import MessageParam, TextBlock
 from pydantic import BaseModel
 
 from differential.settings import get_settings
@@ -61,7 +64,7 @@ class Tool:
 
 @dataclass
 class ToolCall:
-    """Record of a single tool call made during agent_loop."""
+    """Record of a single tool call made during an agent loop."""
 
     name: str
     input: dict
@@ -78,7 +81,7 @@ class APIResponse:
 
 @dataclass
 class RoundRecord:
-    """Record of a single API round within an agent_loop."""
+    """Record of a single API round within an agent loop."""
 
     round: int
     response_text: str
@@ -91,7 +94,7 @@ class RoundRecord:
 
 @dataclass
 class AgentResult:
-    """Result of an agent_loop run."""
+    """Result of an agent loop run."""
 
     text: str = ""
     tool_calls: list[ToolCall] = field(default_factory=list)
@@ -101,7 +104,7 @@ class AgentResult:
     warnings: list[str] = field(default_factory=list)
 
 
-async def _call_api(
+async def call_api(
     client: anthropic.AsyncAnthropic,
     model: str,
     system_prompt: str,
@@ -166,283 +169,6 @@ async def _call_api(
     raise RuntimeError("Unreachable: retry loop exhausted without raising")
 
 
-async def agent_loop(
-    system_prompt: str,
-    user_message: str,
-    tools: list[Tool],
-    *,
-    max_tokens: int = 4096,
-    max_rounds: int | None = None,
-    on_round: Callable[[RoundRecord], Awaitable[None]] | None = None,
-) -> AgentResult:
-    """Run a tool-use conversation loop.
-
-    Each Tool's fn is called when the LLM invokes it. The fn's return value
-    is sent back as the tool_result content. If fn raises, the exception
-    message is sent back as an error result.
-
-    Returns AgentResult with concatenated text and a log of all tool calls.
-    """
-    settings = get_settings()
-    effective_rounds = max_rounds if max_rounds is not None else (
-        2 if settings.is_smoke_test else 6
-    )
-    api_key = settings.require_anthropic_key()
-    model = settings.model
-    client = anthropic.AsyncAnthropic(api_key=api_key)
-
-    tool_defs = [
-        {
-            "name": t.name,
-            "description": t.description,
-            "input_schema": t.input_schema,
-        }
-        for t in tools
-    ]
-    tool_fns = {t.name: t.fn for t in tools}
-
-    tool_names = [t.name for t in tools]
-    log.debug(
-        "agent_loop starting: max_rounds=%d, max_tokens=%d, tools=%s",
-        effective_rounds, max_tokens, tool_names,
-    )
-
-    messages: list[dict] = [{"role": "user", "content": user_message}]
-    text_parts: list[str] = []
-    all_tool_calls: list[ToolCall] = []
-    all_rounds: list[RoundRecord] = []
-    all_warnings: list[str] = []
-    round_num = 0
-
-    for round_num in range(effective_rounds + 1):
-        log.debug("agent_loop round %d/%d", round_num + 1, effective_rounds)
-        api_resp = await _call_api(
-            client,
-            model,
-            system_prompt,
-            messages,
-            tool_defs or None,
-            max_tokens,
-            warnings=all_warnings,
-        )
-        response = api_resp.message
-
-        # Collect text and tool_use blocks
-        tool_uses: list[ToolUseBlock] = []
-        round_text_parts: list[str] = []
-        for block in response.content:
-            if isinstance(block, TextBlock):
-                text_parts.append(block.text)
-                round_text_parts.append(block.text)
-            elif isinstance(block, ToolUseBlock):
-                tool_uses.append(block)
-
-        round_tool_calls: list[ToolCall] = []
-
-        if response.stop_reason == "end_turn" or not tool_uses:
-            log.debug(
-                "agent_loop ending: stop_reason=%s, tool_uses=%d, rounds_used=%d",
-                response.stop_reason, len(tool_uses), round_num + 1,
-            )
-            rr = RoundRecord(
-                round=round_num,
-                response_text="\n".join(round_text_parts),
-                tool_calls=round_tool_calls,
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
-                duration_ms=api_resp.duration_ms,
-            )
-            all_rounds.append(rr)
-            if on_round:
-                await on_round(rr)
-            break
-
-        log.debug(
-            "agent_loop round %d: %d tool call(s): %s",
-            round_num + 1, len(tool_uses), [tu.name for tu in tool_uses],
-        )
-
-        # Call each tool and build tool_result messages
-        tool_results: list[dict] = []
-        for tu in tool_uses:
-            fn = tool_fns.get(tu.name)
-            if fn is None:
-                result_str = f"Unknown tool: {tu.name}"
-                log.warning("Unknown tool called by LLM: %s", tu.name)
-                tool_results.append(
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": tu.id,
-                        "content": result_str,
-                        "is_error": True,
-                    }
-                )
-            else:
-                try:
-                    result_str = await fn(tu.input)
-                except Exception as e:
-                    log.error(
-                        "Tool %s raised an exception: %s", tu.name, e, exc_info=True,
-                    )
-                    result_str = f"Error: {e}"
-                    tool_results.append(
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": tu.id,
-                            "content": result_str,
-                            "is_error": True,
-                        }
-                    )
-                else:
-                    log.debug(
-                        "Tool %s returned: %s",
-                        tu.name, result_str[:200] if result_str else "(empty)",
-                    )
-                    tool_results.append(
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": tu.id,
-                            "content": result_str,
-                        }
-                    )
-            tc = ToolCall(name=tu.name, input=tu.input, result=result_str)
-            all_tool_calls.append(tc)
-            round_tool_calls.append(tc)
-
-        rr = RoundRecord(
-            round=round_num,
-            response_text="\n".join(round_text_parts),
-            tool_calls=round_tool_calls,
-            input_tokens=response.usage.input_tokens,
-            output_tokens=response.usage.output_tokens,
-            duration_ms=api_resp.duration_ms,
-        )
-        all_rounds.append(rr)
-        if on_round:
-            await on_round(rr)
-
-        remaining = effective_rounds - round_num
-        if remaining == 1:
-            budget_note = {
-                "type": "text",
-                "text": "This is your final round — finish your work now.",
-            }
-        else:
-            budget_note = {
-                "type": "text",
-                "text": f"After this round of tool calls, you will have {remaining - 1} rounds remaining.",
-            }
-
-        messages.append({"role": "assistant", "content": response.content})
-        messages.append({"role": "user", "content": tool_results + [budget_note]})
-
-    log.info(
-        "agent_loop complete: %d rounds, %d tool calls, %d text chars",
-        round_num + 1, len(all_tool_calls), sum(len(t) for t in text_parts),
-    )
-    return AgentResult(
-        text="\n".join(text_parts),
-        tool_calls=all_tool_calls,
-        rounds=all_rounds,
-        system_prompt=system_prompt,
-        user_message=user_message,
-        warnings=all_warnings,
-    )
-
-
-async def single_call_with_tools(
-    system_prompt: str,
-    user_message: str,
-    tools: list[Tool],
-    *,
-    max_tokens: int = 4096,
-) -> AgentResult:
-    """Make a single LLM call with tools. Executes any tool calls the LLM
-    makes but does NOT loop back — the results are returned directly.
-
-    Use this when you want the LLM to pick and invoke tools in one shot
-    (e.g. phase-1 page loading, single-call prioritization).
-    """
-    settings = get_settings()
-    api_key = settings.require_anthropic_key()
-    model = settings.model
-    client = anthropic.AsyncAnthropic(api_key=api_key)
-
-    tool_defs = [
-        {
-            "name": t.name,
-            "description": t.description,
-            "input_schema": t.input_schema,
-        }
-        for t in tools
-    ]
-    tool_fns = {t.name: t.fn for t in tools}
-
-    log.debug(
-        "single_call: max_tokens=%d, tools=%s",
-        max_tokens, [t.name for t in tools],
-    )
-
-    messages: list[dict] = [{"role": "user", "content": user_message}]
-    all_warnings: list[str] = []
-    api_resp = await _call_api(
-        client, model, system_prompt, messages, tool_defs or None, max_tokens,
-        warnings=all_warnings,
-    )
-    response = api_resp.message
-
-    text_parts: list[str] = []
-    all_tool_calls: list[ToolCall] = []
-
-    for block in response.content:
-        if isinstance(block, TextBlock):
-            text_parts.append(block.text)
-        elif isinstance(block, ToolUseBlock):
-            fn = tool_fns.get(block.name)
-            if fn is None:
-                result_str = f"Unknown tool: {block.name}"
-                log.warning("Unknown tool called by LLM: %s", block.name)
-            else:
-                try:
-                    result_str = await fn(block.input)
-                except Exception as e:
-                    log.error(
-                        "Tool %s raised an exception: %s",
-                        block.name, e, exc_info=True,
-                    )
-                    result_str = f"Error: {e}"
-                else:
-                    log.debug(
-                        "Tool %s returned: %s",
-                        block.name, result_str[:200] if result_str else "(empty)",
-                    )
-            all_tool_calls.append(
-                ToolCall(name=block.name, input=block.input, result=result_str)
-            )
-
-    round_record = RoundRecord(
-        round=0,
-        response_text="\n".join(text_parts),
-        tool_calls=all_tool_calls,
-        input_tokens=response.usage.input_tokens,
-        output_tokens=response.usage.output_tokens,
-        duration_ms=api_resp.duration_ms,
-    )
-
-    log.info(
-        "single_call complete: %d tool calls, %d text chars",
-        len(all_tool_calls), sum(len(t) for t in text_parts),
-    )
-    return AgentResult(
-        text="\n".join(text_parts),
-        tool_calls=all_tool_calls,
-        rounds=[round_record],
-        system_prompt=system_prompt,
-        user_message=user_message,
-        warnings=all_warnings,
-    )
-
-
 async def text_call(
     system_prompt: str,
     user_message: str = "",
@@ -464,7 +190,7 @@ async def text_call(
         else [{"role": "user", "content": user_message}]
     )
     log.debug("text_call: max_tokens=%d, messages=%d", max_tokens, len(msg_list))
-    api_resp = await _call_api(client, model, system_prompt, msg_list, max_tokens=max_tokens)
+    api_resp = await call_api(client, model, system_prompt, msg_list, max_tokens=max_tokens)
     for block in api_resp.message.content:
         if isinstance(block, TextBlock):
             log.debug("text_call returned %d chars", len(block.text))

--- a/src/differential/llm.py
+++ b/src/differential/llm.py
@@ -1,27 +1,36 @@
 """
-LLM interface. Anthropic-specific details are confined to this module.
+LLM interface. Wraps the Anthropic API and handles exchange persistence.
 
 Exports:
-  - call_api: low-level API call with retries
+  - call_api: API call with retries and optional exchange logging
   - text_call: plain text call
   - structured_call: structured output via messages.parse
 
-Data types: Tool, ToolCall, RoundRecord, AgentResult, APIResponse.
+Data types: Tool, ToolCall, RoundRecord, AgentResult, APIResponse,
+            LLMExchangeMetadata.
 """
+
+from __future__ import annotations
 
 import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from collections.abc import Awaitable, Callable
 
 import anthropic
-from anthropic.types import MessageParam, TextBlock
+from anthropic.types import MessageParam, TextBlock, ToolUseBlock
 from pydantic import BaseModel
 
 from differential.settings import get_settings
+from differential.trace_events import LLMExchangeEvent
+
+if TYPE_CHECKING:
+    from differential.database import DB
+    from differential.tracer import CallTrace
 
 PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
 
@@ -104,6 +113,55 @@ class AgentResult:
     warnings: list[str] = field(default_factory=list)
 
 
+@dataclass
+class LLMExchangeMetadata:
+    """Context for automatically saving an LLM exchange to the database.
+
+    Encapsulates the parameters needed by save_llm_exchange that are not
+    already present in the call_api / structured_call signatures.
+    """
+
+    call_id: str
+    phase: str
+    trace: CallTrace | None = None
+    round_num: int | None = None
+    user_message: str | None = None
+
+
+async def _save_exchange(
+    metadata: LLMExchangeMetadata,
+    db: DB,
+    system_prompt: str,
+    response_text: str | None,
+    tool_calls: list[dict],
+    input_tokens: int,
+    output_tokens: int,
+    duration_ms: int,
+) -> None:
+    """Persist an LLM exchange and record a trace event."""
+    exchange_id = await db.save_llm_exchange(
+        call_id=metadata.call_id,
+        phase=metadata.phase,
+        system_prompt=system_prompt,
+        user_message=metadata.user_message,
+        response_text=response_text,
+        tool_calls=tool_calls,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        duration_ms=duration_ms,
+        round_num=metadata.round_num,
+    )
+    if metadata.trace:
+        await metadata.trace.record(LLMExchangeEvent(
+            exchange_id=exchange_id,
+            phase=metadata.phase,
+            round=metadata.round_num,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            duration_ms=duration_ms,
+        ))
+
+
 async def call_api(
     client: anthropic.AsyncAnthropic,
     model: str,
@@ -112,8 +170,16 @@ async def call_api(
     tools: list[dict] | None = None,
     max_tokens: int = 4096,
     warnings: list[str] | None = None,
+    metadata: LLMExchangeMetadata | None = None,
+    db: DB | None = None,
 ) -> APIResponse:
-    """Make a single Anthropic API call with retry logic."""
+    """Make a single Anthropic API call with retry logic.
+
+    If metadata and db are provided, the exchange is automatically saved
+    to the database and a trace event is recorded.
+    """
+    if bool(metadata) != bool(db):
+        raise ValueError("metadata and db must be provided together")
     kwargs: dict = {
         "model": model,
         "max_tokens": max_tokens,
@@ -141,6 +207,26 @@ async def call_api(
                 response.usage.output_tokens,
                 elapsed_ms,
             )
+            if metadata and db:
+                text_parts = []
+                tool_call_data = []
+                for block in response.content:
+                    if isinstance(block, TextBlock):
+                        text_parts.append(block.text)
+                    elif isinstance(block, ToolUseBlock):
+                        tool_call_data.append(
+                            {"name": block.name, "input": block.input}
+                        )
+                await _save_exchange(
+                    metadata,
+                    db=db,
+                    system_prompt=system_prompt,
+                    response_text="\n".join(text_parts) or None,
+                    tool_calls=tool_call_data,
+                    input_tokens=response.usage.input_tokens,
+                    output_tokens=response.usage.output_tokens,
+                    duration_ms=elapsed_ms,
+                )
             return APIResponse(message=response, duration_ms=elapsed_ms)
         except Exception as e:
             status = getattr(e, "status_code", None)
@@ -216,12 +302,16 @@ async def structured_call(
     response_model: type[BaseModel],
     *,
     max_tokens: int = 1024,
+    metadata: LLMExchangeMetadata | None = None,
+    db: DB | None = None,
 ) -> StructuredCallResult:
     """Run an LLM call that returns structured output matching response_model.
 
     Uses the Anthropic structured output API (messages.parse with output_format).
     Returns a StructuredCallResult with the parsed data and usage metadata.
     """
+    if bool(metadata) != bool(db):
+        raise ValueError("metadata and db must be provided together")
     settings = get_settings()
     api_key = settings.require_anthropic_key()
     model = settings.model
@@ -248,6 +338,17 @@ async def structured_call(
             for block in response.content:
                 if isinstance(block, TextBlock):
                     response_text += block.text
+            if metadata and db:
+                await _save_exchange(
+                    metadata,
+                    db=db,
+                    system_prompt=system_prompt,
+                    response_text=response_text or None,
+                    tool_calls=[],
+                    input_tokens=response.usage.input_tokens,
+                    output_tokens=response.usage.output_tokens,
+                    duration_ms=elapsed_ms,
+                )
             if response.parsed_output is not None:
                 log.debug(
                     "structured_call success: %s, usage=%d/%d tokens",

--- a/supabase/migrations/20260312154950_make_exchange_round_nullable.sql
+++ b/supabase/migrations/20260312154950_make_exchange_round_nullable.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.call_llm_exchanges
+    ALTER COLUMN round DROP NOT NULL,
+    ALTER COLUMN round SET DEFAULT NULL;

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,13 +1,15 @@
-"""Tests for the generic agent_loop in llm.py.
+"""Tests for the agent loop and LLM calling functions.
 
-These call the real LLM (Haiku in test mode) to verify the agent loop
+These call the real LLM (Haiku in test mode) to verify the loop
 works end-to-end without coupling to Anthropic response internals.
 """
 
 import pytest
-
-from differential.llm import Tool, agent_loop, text_call, structured_call
 from pydantic import BaseModel, Field
+
+from differential.calls.common import run_agent_loop
+from differential.llm import Tool, text_call, structured_call
+from differential.moves.base import MoveState
 
 
 async def _add(inp: dict) -> str:
@@ -18,45 +20,59 @@ async def _fail(inp: dict) -> str:
     raise ValueError("boom")
 
 
+ADD_TOOL = Tool(
+    name="add",
+    description="Add two numbers and return the sum.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer", "description": "First number"},
+            "b": {"type": "integer", "description": "Second number"},
+        },
+        "required": ["a", "b"],
+    },
+    fn=_add,
+)
+
+FAIL_TOOL = Tool(
+    name="fail",
+    description="A tool that always fails.",
+    input_schema={"type": "object", "properties": {}},
+    fn=_fail,
+)
+
 
 @pytest.mark.llm
-async def test_text_only_returns_nonempty_text():
-    """agent_loop with no tools should return text."""
-    result = await agent_loop(
+async def test_text_only_returns_nonempty_text(tmp_db, scout_call):
+    """run_agent_loop with no tools should return text."""
+    state = MoveState(scout_call, tmp_db)
+    result = await run_agent_loop(
         "You are a helpful assistant.",
         "Say hello in one word.",
         tools=[],
+        call_id=scout_call.id,
+        db=tmp_db,
+        state=state,
         max_tokens=64,
     )
-    assert len(result.text.strip()) > 0
+    assert result.text.strip()
     assert result.tool_calls == []
 
 
 @pytest.mark.llm
-async def test_tool_is_called_and_result_recorded():
+async def test_tool_is_called_and_result_recorded(tmp_db, scout_call):
     """When given a tool that matches the task, the LLM calls it."""
-    tool = Tool(
-        name="add",
-        description="Add two numbers and return the sum.",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "a": {"type": "integer", "description": "First number"},
-                "b": {"type": "integer", "description": "Second number"},
-            },
-            "required": ["a", "b"],
-        },
-        fn=_add,
-    )
-
-    result = await agent_loop(
+    state = MoveState(scout_call, tmp_db)
+    result = await run_agent_loop(
         "You are a calculator. Use the add tool to answer.",
         "What is 3 + 7?",
-        tools=[tool],
+        tools=[ADD_TOOL],
+        call_id=scout_call.id,
+        db=tmp_db,
+        state=state,
         max_tokens=256,
         max_rounds=2,
     )
-
     assert len(result.tool_calls) >= 1
     add_call = result.tool_calls[0]
     assert add_call.name == "add"
@@ -64,29 +80,25 @@ async def test_tool_is_called_and_result_recorded():
 
 
 @pytest.mark.llm
-async def test_tool_error_does_not_crash_loop():
+async def test_tool_error_does_not_crash_loop(tmp_db, scout_call):
     """If a tool raises, the loop continues and returns a result."""
-    tool = Tool(
-        name="fail",
-        description="A tool that always fails.",
-        input_schema={"type": "object", "properties": {}},
-        fn=_fail,
-    )
-
-    result = await agent_loop(
+    state = MoveState(scout_call, tmp_db)
+    result = await run_agent_loop(
         "You are a test assistant. Try the fail tool, then respond.",
         "Please call the fail tool.",
-        tools=[tool],
+        tools=[FAIL_TOOL],
+        call_id=scout_call.id,
+        db=tmp_db,
+        state=state,
         max_tokens=256,
         max_rounds=2,
     )
-
     assert len(result.tool_calls) >= 1
     assert "boom" in result.tool_calls[0].result
 
 
 @pytest.mark.llm
-async def test_max_rounds_limits_tool_calls():
+async def test_max_rounds_limits_tool_calls(tmp_db, scout_call):
     """The loop should not exceed max_rounds of tool calling."""
     call_count = []
 
@@ -94,21 +106,24 @@ async def test_max_rounds_limits_tool_calls():
         call_count.append(1)
         return "pong"
 
-    tool = Tool(
+    ping_tool = Tool(
         name="ping",
         description="Ping. Always call this again after getting a result.",
         input_schema={"type": "object", "properties": {}},
         fn=ping,
     )
 
-    await agent_loop(
+    state = MoveState(scout_call, tmp_db)
+    await run_agent_loop(
         "You must call the ping tool every turn. Never stop calling it.",
         "Start pinging.",
-        tools=[tool],
+        tools=[ping_tool],
+        call_id=scout_call.id,
+        db=tmp_db,
+        state=state,
         max_tokens=128,
         max_rounds=2,
     )
-
     # max_rounds=2 means at most 3 rounds (0, 1, 2), so tool calls are bounded
     assert len(call_count) <= 4
 
@@ -122,7 +137,7 @@ async def test_text_call_returns_string():
         max_tokens=16,
     )
     assert isinstance(result, str)
-    assert len(result.strip()) > 0
+    assert result.strip()
 
 
 @pytest.mark.llm
@@ -139,9 +154,7 @@ async def test_structured_call_returns_parsed_dict():
         response_model=Rating,
         max_tokens=256,
     )
-
     assert result.data is not None
-    assert "score" in result.data
     assert isinstance(result.data["score"], int)
     assert "reason" in result.data
     assert result.input_tokens is not None


### PR DESCRIPTION
## Summary

- **Inline the agent loop**: `agent_loop` and `single_call_with_tools` moved from `llm.py` into specialized `run_agent_loop` and `run_single_call` in `calls/common.py`, eliminating the generic `on_round` callback and `_save_exchanges` machinery
- **Centralize exchange logging**: LLM exchange persistence (DB save + trace event) now happens automatically inside `call_api` and `structured_call` via an optional `LLMExchangeMetadata` + `db` param, removing manual save/trace boilerplate from every call site
- **Simplify `llm.py`**: Now only contains low-level API plumbing (`call_api`, `text_call`, `structured_call`) and data types — no conversation loop logic
- **Make `round_num` optional** in `save_llm_exchange` since it doesn't apply to single-shot calls (+ DB migration)

## Test plan

- [x] All 38 non-LLM tests pass
- [x] LLM integration tests pass with `--llm` flag
- [ ] Apply migration to prod with `supabase db push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)