### PR TITLE
Add inline consideration links to create_judgement

### DIFF
--- a/src/differential/moves/create_judgement.py
+++ b/src/differential/moves/create_judgement.py
@@ -1,12 +1,73 @@
 """CREATE_JUDGEMENT move: create a considered position on a question."""
 
+import logging
+
+from pydantic import Field
+
 from differential.database import DB
-from differential.models import Call, MoveType, PageLayer, PageType
+from differential.models import (
+    Call,
+    ConsiderationDirection,
+    LinkType,
+    MoveType,
+    PageLayer,
+    PageLink,
+    PageType,
+)
 from differential.moves.base import CreatePagePayload, MoveDef, MoveResult, create_page
+from differential.moves.link_consideration import ConsiderationLinkFields
+
+log = logging.getLogger(__name__)
 
 
-async def execute(payload: CreatePagePayload, call: Call, db: DB) -> MoveResult:
-    return await create_page(payload, call, db, PageType.JUDGEMENT, PageLayer.SQUIDGY)
+class CreateJudgementPayload(CreatePagePayload):
+    links: list[ConsiderationLinkFields] = Field(
+        default_factory=list,
+        description=(
+            "Question links to create for this judgement. Each entry "
+            "links this judgement as a consideration bearing on an "
+            "existing question, with direction and strength."
+        ),
+    )
+
+
+async def execute(payload: CreateJudgementPayload, call: Call, db: DB) -> MoveResult:
+    result = await create_page(payload, call, db, PageType.JUDGEMENT, PageLayer.SQUIDGY)
+    if not result.created_page_id or not payload.links:
+        return result
+
+    for link_spec in payload.links:
+        resolved = await db.resolve_page_id(link_spec.question_id)
+        if not resolved:
+            log.warning(
+                "Inline judgement link skipped: question %s not found",
+                link_spec.question_id,
+            )
+            continue
+
+        direction_str = link_spec.direction.lower()
+        try:
+            direction = ConsiderationDirection(direction_str)
+        except ValueError:
+            log.debug(
+                "Invalid direction '%s' defaulting to neutral", direction_str,
+            )
+            direction = ConsiderationDirection.NEUTRAL
+
+        await db.save_link(PageLink(
+            from_page_id=result.created_page_id,
+            to_page_id=resolved,
+            link_type=LinkType.CONSIDERATION,
+            direction=direction,
+            strength=link_spec.strength,
+            reasoning=link_spec.reasoning,
+        ))
+        log.info(
+            "Inline judgement linked: %s -> %s (%s)",
+            result.created_page_id[:8], resolved[:8], direction_str,
+        )
+
+    return result
 
 
 MOVE = MoveDef(
@@ -16,8 +77,9 @@ MOVE = MoveDef(
         "Create a judgement — a considered position synthesising the "
         "considerations bearing on a question. Must engage with "
         "considerations on multiple sides. Include key_dependencies and "
-        "sensitivity_analysis fields."
+        "sensitivity_analysis fields. Use the links field to simultaneously "
+        "attach this judgement as a consideration on one or more questions."
     ),
-    schema=CreatePagePayload,
+    schema=CreateJudgementPayload,
     execute=execute,
 )

--- a/tests/test_run_call.py
+++ b/tests/test_run_call.py
@@ -151,6 +151,45 @@ async def test_create_question_with_inline_links(tmp_db, question_page, scout_ca
 
 
 @pytest.mark.llm
+async def test_create_judgement_with_inline_links(tmp_db, question_page, scout_call):
+    """The LLM should create a judgement linked as a consideration in a single tool call."""
+    context = (
+        f"## Question\n\n"
+        f"ID: `{question_page.id[:8]}`\n\n"
+        f"{question_page.content}\n"
+    )
+    task = (
+        'Create a judgement on this question and link it '
+        'as a supporting consideration.\n\n'
+        f'Question ID: `{question_page.id[:8]}`'
+    )
+
+    result = await run_call(
+        CallType.SCOUT,
+        task,
+        context,
+        scout_call,
+        tmp_db,
+        available_moves=[MoveType.CREATE_JUDGEMENT, MoveType.LOAD_PAGE],
+        max_rounds=2,
+    )
+
+    assert len(result.created_page_ids) >= 1
+
+    judgement_id = result.created_page_ids[0]
+    judgement = await tmp_db.get_page(judgement_id)
+    assert judgement is not None
+    assert judgement.page_type is PageType.JUDGEMENT
+
+    links = await tmp_db.get_links_from(judgement_id)
+    consideration_links = [l for l in links if l.link_type == LinkType.CONSIDERATION]
+    assert len(consideration_links) >= 1, (
+        'Expected at least one consideration link from the judgement to the question'
+    )
+    assert consideration_links[0].to_page_id == question_page.id
+
+
+@pytest.mark.llm
 async def test_create_subquestion_with_inline_dispatches(
     tmp_db, question_page, prioritization_call,
 ):


### PR DESCRIPTION
## Summary
- Adds a `links` field to `create_judgement` accepting `ConsiderationLinkFields`, mirroring the pattern used by `create_question` for inline child-question links
- Judgements can now be linked as considerations (with direction/strength) on their parent question(s) in a single tool call, removing the need for a separate `link_consideration` call
- Adds an LLM integration test that verifies the model discovers and uses the `links` field without explicit field-name prompting

## Test plan
- [x] All existing tests pass (`uv run pytest`)
- [x] New LLM test passes (`uv run pytest tests/test_run_call.py::test_create_judgement_with_inline_links --llm`)
- [x] Full LLM test suite passes (`uv run pytest tests/test_run_call.py --llm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)