### PR TITLE
Trace cache token reads/writes with visual token meter

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -22,6 +22,67 @@ const CALL_TYPE_ACCENT: Record<string, string> = {
   maintain: "#7a8a9e",
 };
 
+function compactTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 10_000) return `${(n / 1_000).toFixed(0)}k`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function TokenMeter({
+  inputTokens,
+  outputTokens,
+  cacheRead,
+  cacheCreate,
+  costUsd,
+}: {
+  inputTokens: number;
+  outputTokens: number | null | undefined;
+  cacheRead: number | null | undefined;
+  cacheCreate: number | null | undefined;
+  costUsd: number | null | undefined;
+}) {
+  const cr = cacheRead || 0;
+  const cc = cacheCreate || 0;
+  const total = inputTokens + cr + cc;
+  const hasCache = cr > 0 || cc > 0;
+  const readPct = total > 0 ? (cr / total) * 100 : 0;
+  const createPct = total > 0 ? (cc / total) * 100 : 0;
+  const cacheHitPct = total > 0 ? Math.round((cr / total) * 100) : 0;
+
+  return (
+    <span className="trace-token-meter">
+      {hasCache && (
+        <span className="trace-token-bar-wrap" title={
+          `Cache read: ${cr.toLocaleString()} · `
+          + `Cache write: ${cc.toLocaleString()} · `
+          + `Fresh: ${inputTokens.toLocaleString()}`
+        }>
+          <span className="trace-token-bar">
+            <span
+              className="trace-token-bar-read"
+              style={{ width: `${readPct}%` }}
+            />
+            <span
+              className="trace-token-bar-create"
+              style={{ width: `${createPct}%` }}
+            />
+          </span>
+          {cacheHitPct > 0 && (
+            <span className="trace-cache-pct">{cacheHitPct}%</span>
+          )}
+        </span>
+      )}
+      <span className="trace-token-compact">
+        {compactTokens(inputTokens + cr + cc)}{"\u2009\u2192\u2009"}{outputTokens != null ? compactTokens(outputTokens) : "?"}
+      </span>
+      {costUsd != null && (
+        <span className="trace-cost">${costUsd.toFixed(4)}</span>
+      )}
+    </span>
+  );
+}
+
 function formatTime(ts: string): string {
   try {
     const d = new Date(ts);
@@ -247,12 +308,13 @@ function EventSection({ event }: { event: TraceEvent }) {
           <span className="trace-exchange-info">
             {event.phase.replace(/_/g, " ")}{event.round != null ? ` round ${event.round}` : ""}
             {event.input_tokens != null && (
-              <span className="trace-token-count">
-                input tokens: {event.input_tokens.toLocaleString()} output tokens: {event.output_tokens?.toLocaleString()}
-                {event.cost_usd != null && (
-                  <span className="trace-cost"> ${event.cost_usd.toFixed(4)}</span>
-                )}
-              </span>
+              <TokenMeter
+                inputTokens={event.input_tokens}
+                outputTokens={event.output_tokens}
+                cacheRead={event.cache_read_input_tokens}
+                cacheCreate={event.cache_creation_input_tokens}
+                costUsd={event.cost_usd}
+              />
             )}
             {event.duration_ms != null && (
               <span className="trace-duration">

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -388,6 +388,54 @@
   color: #666;
 }
 
+.trace-token-meter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 6px;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  color: #999;
+}
+
+.trace-token-bar-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: help;
+}
+
+.trace-token-bar {
+  display: inline-flex;
+  width: 48px;
+  height: 5px;
+  background: #e0e0e0;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.trace-token-bar-read {
+  height: 100%;
+  background: #3dba6e;
+  border-radius: 3px 0 0 3px;
+}
+
+.trace-token-bar-create {
+  height: 100%;
+  background: #e5a93e;
+}
+
+.trace-cache-pct {
+  font-size: 10px;
+  font-weight: 600;
+  color: #3dba6e;
+  letter-spacing: 0.01em;
+}
+
+.trace-token-compact {
+  white-space: nowrap;
+}
+
 .trace-token-count {
   font-family: var(--font-geist-mono), monospace;
   color: #999;
@@ -779,6 +827,9 @@
   .trace-move-summary { color: #bbb; }
 
   .trace-exchange-info { color: #888; }
+  .trace-token-meter { color: #666; }
+  .trace-token-bar { background: #333; }
+  .trace-cache-pct { color: #4dd88a; }
   .trace-token-count { color: #666; }
   .trace-duration { color: #666; }
   .trace-warning-text { color: #d4a017; }

--- a/src/differential/database.py
+++ b/src/differential/database.py
@@ -657,6 +657,8 @@ class DB:
         error: str | None = None,
         duration_ms: int | None = None,
         round_num: int | None = None,
+        cache_creation_input_tokens: int | None = None,
+        cache_read_input_tokens: int | None = None,
     ) -> str:
         exchange_id = str(uuid.uuid4())
         await self.client.table("call_llm_exchanges").insert(
@@ -674,6 +676,8 @@ class DB:
                 "output_tokens": output_tokens,
                 "error": error,
                 "duration_ms": duration_ms,
+                "cache_creation_input_tokens": cache_creation_input_tokens,
+                "cache_read_input_tokens": cache_read_input_tokens,
             }
         ).execute()
         return exchange_id
@@ -681,7 +685,7 @@ class DB:
     async def get_llm_exchanges(self, call_id: str) -> list[dict[str, Any]]:
         rows = _rows(
             await self.client.table("call_llm_exchanges")
-            .select("id, call_id, phase, round, input_tokens, output_tokens, duration_ms, error, created_at")
+            .select("id, call_id, phase, round, input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens, duration_ms, error, created_at")
             .eq("call_id", call_id)
             .order("round")
             .execute()

--- a/src/differential/llm.py
+++ b/src/differential/llm.py
@@ -154,6 +154,8 @@ async def _save_exchange(
         output_tokens=output_tokens,
         duration_ms=duration_ms,
         round_num=metadata.round_num,
+        cache_creation_input_tokens=cache_creation_input_tokens or None,
+        cache_read_input_tokens=cache_read_input_tokens or None,
     )
     cost_usd = compute_cost(
         model=model,

--- a/supabase/migrations/20260313003428_add_cache_tokens_to_llm_exchanges.sql
+++ b/supabase/migrations/20260313003428_add_cache_tokens_to_llm_exchanges.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.call_llm_exchanges
+  ADD COLUMN cache_creation_input_tokens INT,
+  ADD COLUMN cache_read_input_tokens INT;


### PR DESCRIPTION
## Summary
- Persist `cache_creation_input_tokens` and `cache_read_input_tokens` in the `call_llm_exchanges` table (new migration + database.py + llm.py plumbing)
- Replace the verbose token text display in the trace viewer with a compact `TokenMeter` component: a proportional bar (green = cache read, amber = cache write, gray = fresh) with cache hit percentage and abbreviated token counts (e.g. `12.4k → 2.1k`)
- Full dark mode support for the new elements

## Test plan
- [x] Backend tests pass (`uv run pytest`)
- [x] Frontend builds cleanly (`pnpm build`)
- [x] Migration applied locally
- [ ] Run an investigation and verify cache bar renders in the trace viewer
- [ ] Hover over the bar to confirm tooltip shows full token breakdown
- [ ] Verify dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)