### PR TITLE
Unify DB config under USE_PROD_DB and --prod flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,14 @@ An LLM-powered research workspace. Users pose questions, and the system recursiv
 
 ## Running
 
-Requires `ANTHROPIC_API_KEY` in environment. Uses `anthropic` Python SDK and `claude-opus-4-6`. Environment managed with `uv`. Data is stored in Supabase — local by default, or production with `--prod-db`.
+Requires `ANTHROPIC_API_KEY` in environment. Uses `anthropic` Python SDK and `claude-opus-4-6`. Environment managed with `uv`. Data is stored in Supabase — local by default, or production with `--prod`.
 
 ```bash
 # New investigation
 uv run python main.py "Your question here" --budget 20
 
 # Use production database (any command)
-uv run python main.py --prod-db "Your question here" --budget 20
+uv run python main.py --prod "Your question here" --budget 20
 
 # Continue existing question
 uv run python main.py --continue QUESTION_ID --budget 10
@@ -40,7 +40,7 @@ uv run python main.py --list-workspaces
 
 Tests: `uv run pytest`. Optional dependency: `pypdf` for PDF ingestion (`uv sync --extra pdf`).
 
-**Database:** Runs against local Supabase by default (`supabase start`). Pass `--prod-db` to any command to target production. Production requires `SUPABASE_PROD_URL` and `SUPABASE_PROD_KEY` (service_role) in `.env`. Migrations live in `supabase/migrations/` and are pushed to prod with `supabase db push`.
+**Database:** Runs against local Supabase by default (`supabase start`). Pass `--prod` to any command to target production. Production requires `SUPABASE_PROD_URL` and `SUPABASE_PROD_KEY` (service_role) in `.env`. Migrations live in `supabase/migrations/` and are pushed to prod with `supabase db push`.
 Always use the supabase cli to create new migrations: `supabase migration new`.
 
 ## Architecture
@@ -82,7 +82,7 @@ Each call ends with a closing review that produces `remaining_fruit` (0-10 scale
 
 ## Key Conventions
 
-- **NEVER pass `--prod-db` when running `main.py` unless the user explicitly asks you to.** The production database contains real research data. Default to the local database for all testing, development, and exploratory runs.
+- **NEVER pass `--prod` when running `main.py` unless the user explicitly asks you to.** The production database contains real research data. Default to the local database for all testing, development, and exploratory runs.
 - **Never run `supabase db reset`** — this wipes the database and is destructive. To apply pending migrations, use `supabase migration up` instead. If you find yourself wanting to reset the database, stop and ask the user first.
 - Always scope your test runs to a temp/scratch workspace, e.g. `uv run main.py "Is the sky blue?" --workspace skyblue-scratch`
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ SUPABASE_PROD_URL=https://<project-ref>.supabase.co
 SUPABASE_PROD_KEY=<service_role key from Supabase dashboard>
 ```
 
-Then pass `--prod-db` to any command. Without it, all commands target the local database.
+Then pass `--prod` to any command. Without it, all commands target the local database.
 
 To push migrations to production:
 
@@ -107,7 +107,7 @@ uv run python main.py --list --workspace my-project
 uv run python main.py "Your question here" --smoke-test
 
 # Any command can target the production database
-uv run python main.py --prod-db --list
+uv run python main.py --prod --list
 
 # Suppress info-level logging (only warnings and errors)
 uv run python main.py "Your question" --budget 5 -q
@@ -151,7 +151,7 @@ uv run uvicorn differential.api.app:app --reload
 cd frontend && pnpm dev
 ```
 
-To point the API at the production database, set `DIFFERENTIAL_PROD_DB=1` before starting uvicorn.
+To point the API at the production database, set `USE_PROD_DB=1` before starting uvicorn.
 
 ## Tests
 

--- a/main.py
+++ b/main.py
@@ -453,7 +453,7 @@ async def async_main():
         help="Smoke-test mode: use Haiku, fewer rounds, lower budget defaults",
     )
     parser.add_argument(
-        "--prod-db",
+        "--prod",
         dest="prod_db",
         action="store_true",
         help="Use production Supabase (requires SUPABASE_PROD_URL and SUPABASE_PROD_KEY)",
@@ -486,6 +486,8 @@ async def async_main():
 
     if args.smoke_test:
         get_settings().differential_smoke_test = "1"
+    if args.prod_db:
+        get_settings().use_prod_db = "1"
     if args.no_trace:
         get_settings().tracing_enabled = False
 

--- a/src/differential/api/app.py
+++ b/src/differential/api/app.py
@@ -295,11 +295,9 @@ async def get_llm_exchange(exchange_id: str):
 
 @app.get("/api/realtime/config", response_model=RealtimeConfigOut)
 def get_realtime_config():
-    url = os.environ.get("SUPABASE_URL", "http://127.0.0.1:54321")
-    anon_key = os.environ.get(
-        "SUPABASE_ANON_KEY",
-        "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH",
-    )
+    settings = get_settings()
+    url, key = settings.get_supabase_credentials(prod=settings.is_prod_db)
+    anon_key = os.environ.get("SUPABASE_ANON_KEY", key)
     return RealtimeConfigOut(url=url, anon_key=anon_key)
 
 

--- a/src/differential/orchestrator.py
+++ b/src/differential/orchestrator.py
@@ -216,14 +216,9 @@ def _create_broadcaster(db: DB) -> Broadcaster | None:
     """Create a broadcaster for the given DB's run_id, or None if disabled."""
     if os.environ.get("DIFFERENTIAL_TEST_MODE"):
         return None
-    supabase_url = os.environ.get("SUPABASE_URL", "http://127.0.0.1:54321")
-    supabase_key = os.environ.get(
-        "SUPABASE_KEY",
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-        "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0."
-        "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU",
-    )
-    return Broadcaster(db.run_id, supabase_url, supabase_key)
+    settings = get_settings()
+    url, key = settings.get_supabase_credentials(prod=settings.is_prod_db)
+    return Broadcaster(db.run_id, url, key)
 
 
 class Orchestrator:

--- a/src/differential/settings.py
+++ b/src/differential/settings.py
@@ -11,12 +11,12 @@ class Settings(BaseSettings):
 
     anthropic_api_key: str = ""
     differential_test_mode: str = ""
-    differential_prod_db: str = ""
     differential_smoke_test: str = ""
+    use_prod_db: str = ""
     tracing_enabled: bool = True
 
-    supabase_url: str = "http://127.0.0.1:54321"
-    supabase_key: str = (
+    supabase_local_url: str = "http://127.0.0.1:54321"
+    supabase_local_key: str = (
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
         "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0."
         "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
@@ -43,7 +43,7 @@ class Settings(BaseSettings):
 
     @property
     def is_prod_db(self) -> bool:
-        return self.differential_prod_db.lower() in ("1", "true")
+        return self.use_prod_db.lower() in ("1", "true")
 
     def get_supabase_credentials(self, prod: bool = False) -> tuple[str, str]:
         if prod:
@@ -52,7 +52,7 @@ class Settings(BaseSettings):
                     "SUPABASE_PROD_URL and SUPABASE_PROD_KEY must be set for production."
                 )
             return self.supabase_prod_url, self.supabase_prod_key
-        return self.supabase_url, self.supabase_key
+        return self.supabase_local_url, self.supabase_local_key
 
     def require_anthropic_key(self) -> str:
         if not self.anthropic_api_key:


### PR DESCRIPTION
## Summary
- Replace `DIFFERENTIAL_PROD_DB` env var with `USE_PROD_DB` for controlling prod/local DB selection (used by uvicorn: `USE_PROD_DB=1 uvicorn ...`)
- Rename `--prod-db` CLI flag to `--prod`
- Rename `supabase_url`/`supabase_key` settings to `supabase_local_url`/`supabase_local_key` for clarity
- Consolidate hardcoded `os.environ` reads in orchestrator and API realtime endpoint to use `settings.get_supabase_credentials()`

## Test plan
- [x] `uv run pytest` — 38 passed
- [x] `uv run python main.py --prod --list` — connects to prod DB
- [x] `USE_PROD_DB=1 uvicorn` — API serves from prod DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)