### PR TITLE
Fix nullable round field in LLM exchange API schemas

### DIFF
--- a/src/differential/api/schemas.py
+++ b/src/differential/api/schemas.py
@@ -92,7 +92,7 @@ TraceEventOut = Annotated[
 class LLMExchangeSummaryOut(BaseModel):
     id: str
     phase: str
-    round: int
+    round: int | None
     input_tokens: int | None
     output_tokens: int | None
     duration_ms: int | None
@@ -104,7 +104,7 @@ class LLMExchangeOut(BaseModel):
     id: str
     call_id: str
     phase: str
-    round: int
+    round: int | None
     system_prompt: str | None
     user_message: str | None
     response_text: str | None


### PR DESCRIPTION
## Summary
- `round` column in `call_llm_exchanges` was made nullable in migration `20260312154950`, but `LLMExchangeOut` and `LLMExchangeSummaryOut` still declared `round: int`
- This caused a pydantic `ValidationError` (HTTP 500) when fetching any exchange where `round` is null
- Fix: `round: int` → `round: int | None` in both schemas

## Test plan
- [ ] Fetch an LLM exchange with null round via `/api/llm-exchanges/{id}` — should return 200 instead of 500
- [ ] Fetch exchange list via `/api/calls/{id}/llm-exchanges` — should return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)