### PR TITLE
Change default link role from structural to direct

### DIFF
--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -71,7 +71,7 @@ def _row_to_link(row: dict[str, Any]) -> PageLink:
         ),
         strength=row["strength"],
         reasoning=row["reasoning"] or "",
-        role=LinkRole(row.get("role", "structural")),
+        role=LinkRole(row.get("role", "direct")),
         created_at=datetime.fromisoformat(row["created_at"]),
     )
 

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -220,7 +220,7 @@ class PageLink(BaseModel):
     direction: ConsiderationDirection | None = None  # for CONSIDERATION links
     strength: float = 2.5  # 0-5
     reasoning: str = ""
-    role: LinkRole = LinkRole.STRUCTURAL
+    role: LinkRole = LinkRole.DIRECT
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -251,7 +251,7 @@ async def link_pages(
     reasoning: str,
     db: DB,
     link_type: LinkType,
-    role: LinkRole = LinkRole.STRUCTURAL,
+    role: LinkRole = LinkRole.DIRECT,
 ) -> MoveResult:
     """Create a link between two pages. Used by LINK_CHILD_QUESTION and LINK_RELATED."""
     resolved_from = await db.resolve_page_id(from_id)

--- a/supabase/migrations/20260314005706_change_link_role_default_to_direct.sql
+++ b/supabase/migrations/20260314005706_change_link_role_default_to_direct.sql
@@ -1,0 +1,2 @@
+UPDATE page_links SET role = 'direct';
+ALTER TABLE page_links ALTER COLUMN role SET DEFAULT 'direct';


### PR DESCRIPTION
## Summary
- Adds data migration to set all existing link roles to `direct` and changes the DB column default from `structural` to `direct`
- Updates Python defaults in `PageLink`, `link_pages()`, and `_row_to_link()` to match
- Migration applied to both local and production databases

## Test plan
- [x] Migration applied to local DB
- [x] Migration applied to prod DB
- [ ] Verify new links default to `direct` role

🤖 Generated with [Claude Code](https://claude.com/claude-code)