### PR TITLE
Refactor call types into class hierarchy

### DIFF
--- a/src/rumil/calls/__init__.py
+++ b/src/rumil/calls/__init__.py
@@ -1,8 +1,19 @@
 """Call types for the research workspace."""
 
-from rumil.calls.scout import run_scout_session
-from rumil.calls.assess import run_assess
+from rumil.calls.assess import AssessCall, run_assess
+from rumil.calls.base import BaseCall, SimpleCall
+from rumil.calls.ingest import IngestCall, run_ingest
 from rumil.calls.prioritization import run_prioritization
-from rumil.calls.ingest import run_ingest
+from rumil.calls.scout import ScoutCall, run_scout_session
 
-__all__ = ["run_scout_session", "run_assess", "run_prioritization", "run_ingest"]
+__all__ = [
+    "BaseCall",
+    "SimpleCall",
+    "AssessCall",
+    "IngestCall",
+    "ScoutCall",
+    "run_scout_session",
+    "run_assess",
+    "run_prioritization",
+    "run_ingest",
+]

--- a/src/rumil/calls/assess.py
+++ b/src/rumil/calls/assess.py
@@ -2,23 +2,46 @@
 
 import logging
 
-from rumil.calls.common import (
-    RunCallResult,
-    complete_call,
-    extract_loaded_page_ids,
-    format_moves_for_review,
-    log_page_ratings,
-    resolve_page_refs,
-    run_call,
-    run_closing_review,
-)
+from rumil.calls.base import SimpleCall
+from rumil.calls.common import RunCallResult
 from rumil.context import build_call_context
 from rumil.database import DB
-from rumil.models import Call, CallStatus, CallType
-from rumil.tracing.trace_events import ContextBuiltEvent, ReviewCompleteEvent
-from rumil.tracing.tracer import CallTrace
+from rumil.models import Call, CallType
 
 log = logging.getLogger(__name__)
+
+
+class AssessCall(SimpleCall):
+    """Assess a question: weigh considerations and produce a judgement."""
+
+    def call_type(self) -> CallType:
+        return CallType.ASSESS
+
+    def task_description(self) -> str:
+        return (
+            "Assess this question and render a judgement.\n\n"
+            f"Question ID: `{self.question_id}`\n\n"
+            "Synthesise the considerations, weigh evidence on multiple sides, "
+            "and produce a judgement with structured confidence. "
+            "Even if uncertain, commit to a position."
+        )
+
+    def result_summary(self) -> str:
+        return f"Assess complete. Created {len(self.result.created_page_ids)} pages."
+
+    async def build_context(self) -> None:
+        self.context_text, _, self.working_page_ids = await build_call_context(
+            self.question_id, self.db, extra_page_ids=self.preloaded_ids,
+        )
+        await self._record_context_built()
+        await self._load_phase1_pages()
+
+    def _log_review(self, review: dict) -> None:
+        log.info(
+            "Assess review: confidence=%s, self_assessment=%s",
+            review.get("confidence_in_output", "?"),
+            review.get("self_assessment", "")[:80],
+        )
 
 
 async def run_assess(
@@ -31,55 +54,11 @@ async def run_assess(
 
     Returns (run_call_result, review_dict).
     """
-    trace = CallTrace(call.id, db, broadcaster=broadcaster)
     log.info("Assess starting: call=%s, question=%s", call.id[:8], question_id[:8])
-
-    preloaded = call.context_page_ids or []
-    context_text, _, working_page_ids = await build_call_context(
-        question_id, db, extra_page_ids=preloaded
-    )
-    await trace.record(ContextBuiltEvent(
-        working_context_page_ids=await resolve_page_refs(working_page_ids, db),
-        preloaded_page_ids=await resolve_page_refs(preloaded, db),
-    ))
-
-    task = (
-        "Assess this question and render a judgement.\n\n"
-        f"Question ID: `{question_id}`\n\n"
-        "Synthesise the considerations, weigh evidence on multiple sides, "
-        "and produce a judgement with structured confidence. "
-        "Even if uncertain, commit to a position."
-    )
-
-    await db.update_call_status(call.id, CallStatus.RUNNING)
-    result = await run_call(CallType.ASSESS, task, context_text, call, db, trace=trace)
-    phase2_loaded = await extract_loaded_page_ids(result, db)
-
-    all_loaded_ids = list(
-        dict.fromkeys(preloaded + result.phase1_page_ids + phase2_loaded)
-    )
-    review_context = format_moves_for_review(result.moves)
-    review = await run_closing_review(call, review_context, context_text, all_loaded_ids, db, trace)
-    if review:
-        log.info(
-            "Assess review: confidence=%s, self_assessment=%s",
-            review.get("confidence_in_output", "?"),
-            review.get("self_assessment", "")[:80],
-        )
-        await log_page_ratings(review, db)
-        await trace.record(ReviewCompleteEvent(
-            remaining_fruit=review.get("remaining_fruit"),
-            confidence=review.get("confidence_in_output"),
-        ))
-
-    call.review_json = review or {}
+    assess = AssessCall(question_id, call, db, broadcaster=broadcaster)
+    await assess.run()
     log.info(
         "Assess complete: call=%s, pages_created=%d",
-        call.id[:8], len(result.created_page_ids),
+        call.id[:8], len(assess.result.created_page_ids),
     )
-    await complete_call(
-        call,
-        db,
-        f"Assess complete. Created {len(result.created_page_ids)} pages.",
-    )
-    return result, review or {}
+    return assess.result, assess.review

--- a/src/rumil/calls/base.py
+++ b/src/rumil/calls/base.py
@@ -1,0 +1,204 @@
+"""Base class hierarchy for call types."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+
+from rumil.calls.common import (
+    RunCallResult,
+    _format_loaded_pages,
+    _run_phase1,
+    complete_call,
+    extract_loaded_page_ids,
+    format_moves_for_review,
+    log_page_ratings,
+    resolve_page_refs,
+    run_agent_loop,
+    run_closing_review,
+)
+from rumil.database import DB
+from rumil.llm import build_system_prompt, build_user_message
+from rumil.models import Call, CallStatus, CallType, MoveType
+from rumil.moves.base import MoveState
+from rumil.moves.registry import MOVES
+from rumil.settings import get_settings
+from rumil.tracing.trace_events import ContextBuiltEvent, ReviewCompleteEvent
+from rumil.tracing.tracer import CallTrace
+
+log = logging.getLogger(__name__)
+
+
+class BaseCall(ABC):
+    """Template for all call types. Subclasses override individual stages."""
+
+    def __init__(
+        self,
+        question_id: str,
+        call: Call,
+        db: DB,
+        *,
+        broadcaster=None,
+    ):
+        self.question_id = question_id
+        self.call = call
+        self.db = db
+        self.trace = CallTrace(call.id, db, broadcaster=broadcaster)
+        self.state = MoveState(call, db)
+
+        self.context_text: str = ""
+        self.working_page_ids: list[str] = []
+        self.preloaded_ids: list[str] = call.context_page_ids or []
+        self.all_loaded_ids: list[str] = []
+        self.review: dict = {}
+
+    async def run(self) -> None:
+        await self._enter_running()
+        await self.build_context()
+        await self.create_pages()
+        await self.closing_review()
+        await self._finalize()
+
+    async def _enter_running(self) -> None:
+        await self.db.update_call_status(self.call.id, CallStatus.RUNNING)
+
+    @abstractmethod
+    async def build_context(self) -> None:
+        ...
+
+    @abstractmethod
+    async def create_pages(self) -> None:
+        ...
+
+    @abstractmethod
+    async def closing_review(self) -> None:
+        ...
+
+    @abstractmethod
+    def result_summary(self) -> str:
+        ...
+
+    async def _finalize(self) -> None:
+        self.call.review_json = self.review
+        await complete_call(self.call, self.db, self.result_summary())
+
+
+class SimpleCall(BaseCall):
+    """Shared lifecycle for assess and ingest calls.
+
+    Subclasses set self.context_text in build_context(), then call
+    self._load_phase1_pages() to run the preliminary page-loading LLM call.
+    create_pages() runs the main agent loop.
+    """
+
+    def __init__(
+        self,
+        question_id: str,
+        call: Call,
+        db: DB,
+        *,
+        broadcaster=None,
+    ):
+        super().__init__(question_id, call, db, broadcaster=broadcaster)
+        self.result: RunCallResult = RunCallResult()
+        self.phase1_ids: list[str] = []
+        self.available_moves: list[MoveType] = list(MoveType)
+
+    @abstractmethod
+    def call_type(self) -> CallType:
+        ...
+
+    @abstractmethod
+    def task_description(self) -> str:
+        ...
+
+    async def _load_phase1_pages(self) -> None:
+        """Run the preliminary page-loading LLM call and append results to context.
+
+        Call this at the end of build_context() after setting self.context_text.
+        """
+        system_prompt = build_system_prompt(self.call_type().value)
+        self.phase1_ids = await _run_phase1(
+            system_prompt, self.context_text, self.call.id,
+            self.state, self.db, trace=self.trace,
+        )
+        if self.phase1_ids:
+            extra_text = await _format_loaded_pages(self.phase1_ids, self.db)
+            self.context_text += '\n\n## Loaded Pages\n\n' + extra_text
+
+    async def create_pages(self) -> None:
+        max_rounds = 1 if get_settings().is_smoke_test else 3
+        system_prompt = build_system_prompt(self.call_type().value)
+        tools = [MOVES[mt].bind(self.state) for mt in self.available_moves]
+        user_message = build_user_message(
+            self.context_text, self.task_description(),
+        )
+
+        agent_result = await run_agent_loop(
+            system_prompt, user_message, tools,
+            call_id=self.call.id,
+            db=self.db,
+            state=self.state,
+            trace=self.trace,
+            max_tokens=4096,
+            max_rounds=max_rounds,
+        )
+
+        log.info(
+            "create_pages complete: type=%s, pages_created=%d, "
+            "dispatches=%d, moves=%d",
+            self.call_type().value, len(self.state.created_page_ids),
+            len(self.state.dispatches), len(self.state.moves),
+        )
+        self.result = RunCallResult(
+            created_page_ids=self.state.created_page_ids,
+            dispatches=self.state.dispatches,
+            moves=self.state.moves,
+            phase1_page_ids=self.phase1_ids,
+            agent_result=agent_result,
+        )
+
+        phase2_loaded = await extract_loaded_page_ids(self.result, self.db)
+        self.all_loaded_ids = list(
+            dict.fromkeys(
+                self.preloaded_ids + self.phase1_ids + phase2_loaded
+            )
+        )
+
+    async def closing_review(self) -> None:
+        review_context = format_moves_for_review(self.result.moves)
+        review = await run_closing_review(
+            self.call,
+            review_context,
+            self.context_text,
+            self.all_loaded_ids,
+            self.db,
+            self.trace,
+        )
+        if review:
+            self._log_review(review)
+            await log_page_ratings(review, self.db)
+            await self.trace.record(ReviewCompleteEvent(
+                remaining_fruit=review.get("remaining_fruit"),
+                confidence=review.get("confidence_in_output"),
+            ))
+        self.review = review or {}
+
+    def _log_review(self, review: dict) -> None:
+        log.info(
+            "%s review: confidence=%s",
+            self.call_type().value.capitalize(),
+            review.get("confidence_in_output", "?"),
+        )
+
+    async def _record_context_built(
+        self, *, source_page_id: str | None = None, scout_mode: str | None = None,
+    ) -> None:
+        await self.trace.record(ContextBuiltEvent(
+            working_context_page_ids=await resolve_page_refs(
+                self.working_page_ids, self.db,
+            ),
+            preloaded_page_ids=await resolve_page_refs(self.preloaded_ids, self.db),
+            source_page_id=source_page_id,
+            scout_mode=scout_mode,
+        ))

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -492,6 +492,7 @@ async def run_call(
     max_tokens: int = 4096,
     max_rounds: int | None = None,
     trace: "CallTrace | None" = None,
+    state: MoveState | None = None,
 ) -> RunCallResult:
     """Run a workspace call (assess/ingest) with tool use.
 
@@ -513,7 +514,8 @@ async def run_call(
     if available_moves is None:
         available_moves = list(MoveType)
 
-    state = MoveState(call, db)
+    if state is None:
+        state = MoveState(call, db)
     system_prompt = build_system_prompt(call_type.value)
 
     phase1_ids: list[str] = []

--- a/src/rumil/calls/ingest.py
+++ b/src/rumil/calls/ingest.py
@@ -2,23 +2,69 @@
 
 import logging
 
-from rumil.calls.common import (
-    RunCallResult,
-    complete_call,
-    extract_loaded_page_ids,
-    format_moves_for_review,
-    log_page_ratings,
-    resolve_page_refs,
-    run_call,
-    run_closing_review,
-)
+from rumil.calls.base import SimpleCall
+from rumil.calls.common import RunCallResult
 from rumil.context import build_call_context
 from rumil.database import DB
-from rumil.models import Call, CallStatus, CallType, Page
-from rumil.tracing.trace_events import ContextBuiltEvent, ReviewCompleteEvent
-from rumil.tracing.tracer import CallTrace
+from rumil.models import Call, CallType, Page
 
 log = logging.getLogger(__name__)
+
+
+class IngestCall(SimpleCall):
+    """Ingest a source document: extract considerations for a question."""
+
+    def __init__(
+        self,
+        source_page: Page,
+        question_id: str,
+        call: Call,
+        db: DB,
+        *,
+        broadcaster=None,
+    ):
+        super().__init__(question_id, call, db, broadcaster=broadcaster)
+        self.source_page = source_page
+        extra = source_page.extra or {}
+        self.filename = extra.get("filename", source_page.id[:8])
+
+    def call_type(self) -> CallType:
+        return CallType.INGEST
+
+    def task_description(self) -> str:
+        return (
+            "Extract considerations from the source document above for this question.\n\n"
+            f"Question ID: `{self.question_id}`\n"
+            f"Source page ID: `{self.source_page.id}`"
+        )
+
+    def result_summary(self) -> str:
+        return (
+            f"Ingest complete. Created {len(self.result.created_page_ids)} "
+            f"pages from '{self.filename}'."
+        )
+
+    async def build_context(self) -> None:
+        question_context, _, self.working_page_ids = await build_call_context(
+            self.question_id, self.db, extra_page_ids=self.preloaded_ids,
+        )
+        await self._record_context_built(source_page_id=self.source_page.id)
+
+        source_section = (
+            "\n\n---\n\n## Source Document\n\n"
+            f"**File:** {self.filename}  \n"
+            f"**Source page ID:** `{self.source_page.id}`\n\n"
+            f"{self.source_page.content}"
+        )
+        self.context_text = question_context + source_section
+        await self._load_phase1_pages()
+
+    def _log_review(self, review: dict) -> None:
+        log.info(
+            "Ingest review: confidence=%s, remaining_fruit=%s",
+            review.get("confidence_in_output", "?"),
+            review.get("remaining_fruit", "?"),
+        )
 
 
 async def run_ingest(
@@ -32,67 +78,16 @@ async def run_ingest(
 
     Returns (run_call_result, review_dict).
     """
-    trace = CallTrace(call.id, db, broadcaster=broadcaster)
     extra = source_page.extra or {}
     filename = extra.get("filename", source_page.id[:8])
     log.info(
         "Ingest starting: call=%s, source=%s (%s), question=%s",
         call.id[:8], source_page.id[:8], filename, question_id[:8],
     )
-
-    preloaded = call.context_page_ids or []
-    question_context, _, working_page_ids = await build_call_context(
-        question_id, db, extra_page_ids=preloaded
-    )
-    await trace.record(ContextBuiltEvent(
-        working_context_page_ids=await resolve_page_refs(working_page_ids, db),
-        preloaded_page_ids=await resolve_page_refs(preloaded, db),
-        source_page_id=source_page.id,
-    ))
-
-    source_section = (
-        "\n\n---\n\n## Source Document\n\n"
-        f"**File:** {filename}  \n"
-        f"**Source page ID:** `{source_page.id}`\n\n"
-        f"{source_page.content}"
-    )
-    context_text = question_context + source_section
-
-    task = (
-        "Extract considerations from the source document above for this question.\n\n"
-        f"Question ID: `{question_id}`\n"
-        f"Source page ID: `{source_page.id}`"
-    )
-
-    await db.update_call_status(call.id, CallStatus.RUNNING)
-    result = await run_call(CallType.INGEST, task, context_text, call, db, trace=trace)
-    phase2_loaded = await extract_loaded_page_ids(result, db)
-
-    all_loaded_ids = list(
-        dict.fromkeys(preloaded + result.phase1_page_ids + phase2_loaded)
-    )
-    review_context = format_moves_for_review(result.moves)
-    review = await run_closing_review(call, review_context, context_text, all_loaded_ids, db, trace)
-    if review:
-        log.info(
-            "Ingest review: confidence=%s, remaining_fruit=%s",
-            review.get("confidence_in_output", "?"),
-            review.get("remaining_fruit", "?"),
-        )
-        await log_page_ratings(review, db)
-        await trace.record(ReviewCompleteEvent(
-            remaining_fruit=review.get("remaining_fruit"),
-            confidence=review.get("confidence_in_output"),
-        ))
-
-    call.review_json = review or {}
+    ingest = IngestCall(source_page, question_id, call, db, broadcaster=broadcaster)
+    await ingest.run()
     log.info(
         "Ingest complete: call=%s, pages_created=%d, source=%s",
-        call.id[:8], len(result.created_page_ids), filename,
+        call.id[:8], len(ingest.result.created_page_ids), filename,
     )
-    await complete_call(
-        call,
-        db,
-        f"Ingest complete. Created {len(result.created_page_ids)} pages from '{filename}'.",
-    )
-    return result, review or {}
+    return ingest.result, ingest.review

--- a/src/rumil/calls/scout.py
+++ b/src/rumil/calls/scout.py
@@ -1,10 +1,10 @@
 """Scout call: find missing considerations on a question."""
 
 import logging
-from dataclasses import dataclass
 
 from pydantic import BaseModel, Field
 
+from rumil.calls.base import BaseCall
 from rumil.calls.common import (
     ReviewResponse,
     _prepare_tools,
@@ -68,49 +68,6 @@ _FRUIT_CHECK_MESSAGE = (
     "angles are left unexplored. Respond with remaining_fruit (0-10) and "
     "brief_reasoning. Do not call any tools — they will have no effect here."
 )
-
-
-async def _run_fruit_check(
-    system_prompt: str,
-    agent_messages: list[dict],
-    tool_defs: list[dict],
-    *,
-    call_id: str,
-    db: DB,
-    trace: CallTrace | None = None,
-) -> int:
-    """Run a lightweight fruit check sharing the agent's cache prefix.
-
-    Appends a fruit-check user message to a *copy* of agent_messages and calls
-    structured_call with the same system prompt, tools, and tool_choice=none.
-    Returns the remaining_fruit score.
-    """
-    check_messages = list(agent_messages) + [
-        {"role": "user", "content": _FRUIT_CHECK_MESSAGE},
-    ]
-    meta = LLMExchangeMetadata(
-        call_id=call_id, phase="fruit_check", trace=trace,
-        user_message=_FRUIT_CHECK_MESSAGE,
-    )
-    result = await structured_call(
-        system_prompt=system_prompt,
-        response_model=FruitCheck,
-        messages=check_messages,
-        tools=tool_defs,
-        max_tokens=256,
-        metadata=meta,
-        db=db,
-        cache=True,
-    )
-    if result.data:
-        score = result.data.get("remaining_fruit", 5)
-        log.info(
-            "Fruit check: score=%d, reasoning=%s",
-            score, result.data.get("brief_reasoning", ""),
-        )
-        return score
-    log.warning("Fruit check returned empty data, defaulting to 5")
-    return 5
 
 
 _LINKING_TASK = (
@@ -178,7 +135,6 @@ async def link_new_pages(
     )
 
 
-
 def _resolve_round_mode(mode: ScoutMode, round_index: int) -> ScoutMode:
     """Resolve the effective mode for a given scout round."""
     if mode == ScoutMode.ALTERNATE:
@@ -213,82 +169,6 @@ _SELF_ASSESSMENT_INSTRUCTION = (
     'have no effect here.\n\n'
     'Scope question ID: `{question_id}`'
 )
-
-
-@dataclass
-class _SessionContext:
-    """Everything the scout round loop needs, built once up front."""
-
-    system_prompt: str
-    user_message: str
-    tools: list
-    tool_defs: list[dict]
-    state: MoveState
-    trace: CallTrace
-    phase1_summaries: list[tuple[str, str]]
-    preloaded_ids: list[str]
-
-
-async def _build_session_context(
-    question_id: str,
-    call: Call,
-    db: DB,
-    *,
-    mode: ScoutMode,
-    context_page_ids: list[str] | None,
-    broadcaster=None,
-) -> _SessionContext:
-    """Build all context needed for a scout session.
-
-    Runs a linking call to tag existing pages as direct/structural, then
-    builds role-aware context for the scout.
-    """
-    trace = CallTrace(call.id, db, broadcaster=broadcaster)
-    state = MoveState(call, db)
-    system_prompt = build_system_prompt(CallType.SCOUT.value)
-
-    await link_new_pages(question_id, call, db, state, trace)
-
-    working_context, working_page_ids = await format_question_for_scout(
-        question_id, db,
-    )
-
-    preloaded = context_page_ids or []
-    if preloaded:
-        working_context += await format_preloaded_pages(preloaded, db)
-
-    await trace.record(ContextBuiltEvent(
-        working_context_page_ids=await resolve_page_refs(working_page_ids, db),
-        preloaded_page_ids=await resolve_page_refs(preloaded, db),
-        scout_mode=mode.value,
-    ))
-
-    workspace_map, _ = await build_workspace_map(db)
-    phase2_context = assemble_call_context(
-        working_context, workspace_map=workspace_map,
-    )
-
-    tools = [MOVES[mt].bind(state) for mt in MoveType]
-    tool_defs, _ = _prepare_tools(tools)
-
-    round_mode = _resolve_round_mode(mode, 0)
-    mode_instruction = _CONCRETE_INSTRUCTION if round_mode == ScoutMode.CONCRETE else ''
-    task = (
-        f"Scout for missing considerations on this question.{mode_instruction}\n\n"
-        f"Question ID (use this when linking considerations): `{question_id}`"
-    )
-    user_message = build_user_message(phase2_context, task)
-
-    return _SessionContext(
-        system_prompt=system_prompt,
-        user_message=user_message,
-        tools=tools,
-        tool_defs=tool_defs,
-        state=state,
-        trace=trace,
-        phase1_summaries=[],
-        preloaded_ids=preloaded,
-    )
 
 
 async def _collect_all_loaded_summaries(
@@ -347,103 +227,277 @@ async def _build_link_inventory(question_id: str, db: DB) -> str:
     return "\n".join(lines)
 
 
-async def _run_session_review(
-    question_id: str,
-    call: Call,
-    db: DB,
-    *,
-    system_prompt: str,
-    tool_defs: list[dict],
-    resume_messages: list[dict],
-    loaded_summaries: list[tuple[str, str]],
-    state: MoveState,
-    trace: CallTrace,
-) -> dict:
-    """Run the closing review for a scout session.
+class ScoutCall(BaseCall):
+    """Multi-round scout session with fruit checking."""
 
-    Two phases:
-    1. Link modification — agent loop with remove_link and change_link_role
-       tools, given an inventory of all current links on the scope question.
-    2. Self-assessment — structured call for remaining_fruit, confidence,
-       page ratings, etc.
+    def __init__(
+        self,
+        question_id: str,
+        call: Call,
+        db: DB,
+        *,
+        max_rounds: int,
+        fruit_threshold: int,
+        mode: ScoutMode = ScoutMode.ALTERNATE,
+        context_page_ids: list[str] | None = None,
+        broadcaster=None,
+    ):
+        super().__init__(question_id, call, db, broadcaster=broadcaster)
+        self.max_rounds = max_rounds
+        self.fruit_threshold = fruit_threshold
+        self.mode = mode
+        self.context_page_ids = context_page_ids
+        self.preloaded_ids = context_page_ids or []
 
-    Returns the review data dict.
-    """
-    link_inventory = await _build_link_inventory(question_id, db)
-    link_review_msg = _LINK_REVIEW_INSTRUCTION.format(
-        link_inventory=link_inventory, question_id=question_id,
-    )
-    link_messages = list(resume_messages) + [
-        {"role": "user", "content": link_review_msg},
-    ]
+        self.resume_messages: list[dict] = []
+        self.rounds_completed = 0
+        self.last_fruit_score: int | None = None
 
-    link_tools = [MOVES[mt].bind(state) for mt in MoveType]
+        self.system_prompt: str = ""
+        self.user_message: str = ""
+        self.tools: list = []
+        self.tool_defs: list[dict] = []
 
-    link_result = await run_single_call(
-        system_prompt,
-        tools=link_tools,
-        call_id=call.id,
-        phase="link_review",
-        db=db,
-        state=state,
-        trace=trace,
-        messages=link_messages,
-        cache=True,
-    )
-    post_link_messages = list(link_result.messages)
+    async def _enter_running(self) -> None:
+        self.call.call_params = {
+            "mode": self.mode.value,
+            "max_rounds": self.max_rounds,
+            "fruit_threshold": self.fruit_threshold,
+        }
+        await self.db.update_call_status(
+            self.call.id, CallStatus.RUNNING, call_params=self.call.call_params,
+        )
 
-    page_rating_note = ""
-    if loaded_summaries:
-        page_lines = [
-            f'  - `{pid[:8]}`: "{summary[:120]}"'
-            for pid, summary in loaded_summaries
+    async def build_context(self) -> None:
+        await link_new_pages(
+            self.question_id, self.call, self.db, self.state, self.trace,
+        )
+
+        working_context, self.working_page_ids = await format_question_for_scout(
+            self.question_id, self.db,
+        )
+
+        if self.preloaded_ids:
+            working_context += await format_preloaded_pages(self.preloaded_ids, self.db)
+
+        await self.trace.record(ContextBuiltEvent(
+            working_context_page_ids=await resolve_page_refs(
+                self.working_page_ids, self.db,
+            ),
+            preloaded_page_ids=await resolve_page_refs(self.preloaded_ids, self.db),
+            scout_mode=self.mode.value,
+        ))
+
+        workspace_map, _ = await build_workspace_map(self.db)
+        phase2_context = assemble_call_context(
+            working_context, workspace_map=workspace_map,
+        )
+
+        self.tools = [MOVES[mt].bind(self.state) for mt in MoveType]
+        self.tool_defs, _ = _prepare_tools(self.tools)
+
+        self.system_prompt = build_system_prompt(CallType.SCOUT.value)
+
+        round_mode = _resolve_round_mode(self.mode, 0)
+        mode_instruction = (
+            _CONCRETE_INSTRUCTION if round_mode == ScoutMode.CONCRETE else ''
+        )
+        task = (
+            f"Scout for missing considerations on this question.{mode_instruction}\n\n"
+            f"Question ID (use this when linking considerations): "
+            f"`{self.question_id}`"
+        )
+        self.user_message = build_user_message(phase2_context, task)
+
+    async def create_pages(self) -> None:
+        for i in range(self.max_rounds):
+            if not await self.db.consume_budget(1):
+                log.info(
+                    "Budget exhausted, stopping scout session at round %d", i,
+                )
+                break
+
+            round_mode = _resolve_round_mode(self.mode, i)
+
+            if i == 0:
+                agent_result = await run_agent_loop(
+                    self.system_prompt,
+                    user_message=self.user_message,
+                    tools=self.tools,
+                    call_id=self.call.id,
+                    db=self.db,
+                    state=self.state,
+                    trace=self.trace,
+                    cache=True,
+                )
+            else:
+                mode_instruction = (
+                    _CONCRETE_INSTRUCTION
+                    if round_mode == ScoutMode.CONCRETE else ''
+                )
+                continue_msg = _CONTINUE_TEMPLATE.format(
+                    mode_instruction=mode_instruction,
+                    question_id=self.question_id,
+                )
+                self.resume_messages.append(
+                    {"role": "user", "content": continue_msg}
+                )
+                agent_result = await run_agent_loop(
+                    self.system_prompt,
+                    tools=self.tools,
+                    call_id=self.call.id,
+                    db=self.db,
+                    state=self.state,
+                    trace=self.trace,
+                    messages=self.resume_messages,
+                    cache=True,
+                )
+
+            self.rounds_completed += 1
+            self.resume_messages = list(agent_result.messages)
+
+            self.last_fruit_score = await self.run_fruit_check()
+            if self.last_fruit_score <= self.fruit_threshold:
+                log.info(
+                    "Scout fruit (%d) <= threshold (%d), stopping after round %d",
+                    self.last_fruit_score, self.fruit_threshold, i + 1,
+                )
+                break
+
+    async def run_fruit_check(self) -> int:
+        """Run a lightweight fruit check sharing the agent's cache prefix."""
+        check_messages = list(self.resume_messages) + [
+            {"role": "user", "content": _FRUIT_CHECK_MESSAGE},
         ]
-        page_rating_note = (
-            '\n\nThe following pages were loaded into your context:\n'
-            + '\n'.join(page_lines)
-            + '\n\nPlease include a rating for each in your page_ratings. '
-            'Scores: -1 = actively confusing, 0 = didn\'t help, '
-            '1 = helped, 2 = extremely helpful.'
+        meta = LLMExchangeMetadata(
+            call_id=self.call.id, phase="fruit_check", trace=self.trace,
+            user_message=_FRUIT_CHECK_MESSAGE,
+        )
+        result = await structured_call(
+            system_prompt=self.system_prompt,
+            response_model=FruitCheck,
+            messages=check_messages,
+            tools=self.tool_defs,
+            max_tokens=256,
+            metadata=meta,
+            db=self.db,
+            cache=True,
+        )
+        if result.data:
+            score = result.data.get("remaining_fruit", 5)
+            log.info(
+                "Fruit check: score=%d, reasoning=%s",
+                score, result.data.get("brief_reasoning", ""),
+            )
+            return score
+        log.warning("Fruit check returned empty data, defaulting to 5")
+        return 5
+
+    async def closing_review(self) -> None:
+        if not self.resume_messages:
+            return
+
+        assert self.last_fruit_score is not None
+        loaded_summaries = await _collect_all_loaded_summaries(
+            self.state, [], self.preloaded_ids, self.db,
+        )
+        self.review = await self.run_session_review(loaded_summaries)
+        await self.trace.record(ReviewCompleteEvent(
+            remaining_fruit=self.last_fruit_score,
+            confidence=self.review.get("confidence_in_output"),
+        ))
+
+    async def run_session_review(
+        self, loaded_summaries: list[tuple[str, str]],
+    ) -> dict:
+        """Two-phase closing: link modification then self-assessment."""
+        link_inventory = await _build_link_inventory(self.question_id, self.db)
+        link_review_msg = _LINK_REVIEW_INSTRUCTION.format(
+            link_inventory=link_inventory, question_id=self.question_id,
+        )
+        link_messages = list(self.resume_messages) + [
+            {"role": "user", "content": link_review_msg},
+        ]
+
+        link_tools = [MOVES[mt].bind(self.state) for mt in MoveType]
+
+        link_result = await run_single_call(
+            self.system_prompt,
+            tools=link_tools,
+            call_id=self.call.id,
+            phase="link_review",
+            db=self.db,
+            state=self.state,
+            trace=self.trace,
+            messages=link_messages,
+            cache=True,
+        )
+        post_link_messages = list(link_result.messages)
+
+        page_rating_note = ""
+        if loaded_summaries:
+            page_lines = [
+                f'  - `{pid[:8]}`: "{summary[:120]}"'
+                for pid, summary in loaded_summaries
+            ]
+            page_rating_note = (
+                '\n\nThe following pages were loaded into your context:\n'
+                + '\n'.join(page_lines)
+                + '\n\nPlease include a rating for each in your page_ratings. '
+                'Scores: -1 = actively confusing, 0 = didn\'t help, '
+                '1 = helped, 2 = extremely helpful.'
+            )
+
+        assessment_msg = (
+            _SELF_ASSESSMENT_INSTRUCTION.format(question_id=self.question_id)
+            + page_rating_note
+        )
+        assessment_messages = post_link_messages + [
+            {"role": "user", "content": assessment_msg},
+        ]
+        meta = LLMExchangeMetadata(
+            call_id=self.call.id, phase="closing_review", trace=self.trace,
+            user_message=assessment_msg,
+        )
+        review_result = await structured_call(
+            system_prompt=self.system_prompt,
+            response_model=ReviewResponse,
+            messages=assessment_messages,
+            tools=self.tool_defs,
+            max_tokens=4096,
+            metadata=meta,
+            db=self.db,
+            cache=True,
+        )
+        review_data = review_result.data or {}
+
+        if review_data:
+            log.info(
+                "Scout session review: confidence=%s",
+                review_data.get("confidence_in_output", "?"),
+            )
+            await log_page_ratings(review_data, self.db)
+
+            for r in review_data.get("page_ratings", []):
+                pid = await self.db.resolve_page_id(r.get("page_id", ""))
+                score = r.get("score")
+                if pid and isinstance(score, int):
+                    await self.db.save_page_rating(
+                        pid, self.call.id, score, r.get("note", ""),
+                    )
+
+        self.call.review_json = review_data
+        return review_data
+
+    def result_summary(self) -> str:
+        return (
+            f"Scout session complete. {self.rounds_completed} rounds, "
+            f"{len(self.state.created_page_ids)} pages created."
         )
 
-    assessment_msg = (
-        _SELF_ASSESSMENT_INSTRUCTION.format(question_id=question_id)
-        + page_rating_note
-    )
-    assessment_messages = post_link_messages + [
-        {"role": "user", "content": assessment_msg},
-    ]
-    meta = LLMExchangeMetadata(
-        call_id=call.id, phase="closing_review", trace=trace,
-        user_message=assessment_msg,
-    )
-    review_result = await structured_call(
-        system_prompt=system_prompt,
-        response_model=ReviewResponse,
-        messages=assessment_messages,
-        tools=tool_defs,
-        max_tokens=4096,
-        metadata=meta,
-        db=db,
-        cache=True,
-    )
-    review_data = review_result.data or {}
-
-    if review_data:
-        log.info(
-            "Scout session review: confidence=%s",
-            review_data.get("confidence_in_output", "?"),
-        )
-        await log_page_ratings(review_data, db)
-
-        for r in review_data.get("page_ratings", []):
-            pid = await db.resolve_page_id(r.get("page_id", ""))
-            score = r.get("score")
-            if pid and isinstance(score, int):
-                await db.save_page_rating(pid, call.id, score, r.get("note", ""))
-
-    call.review_json = review_data
-    return review_data
+    async def _finalize(self) -> None:
+        self.call.review_json = self.review
+        await complete_call(self.call, self.db, self.result_summary())
 
 
 async def run_scout_session(
@@ -461,105 +515,15 @@ async def run_scout_session(
 
     Builds context once, resumes the agent conversation across rounds,
     uses lightweight fruit checks, and runs linking once at the end.
-    Returns (rounds_completed, created_page_ids).
+    Returns rounds_completed.
     """
-    call.call_params = {
-        "mode": mode.value,
-        "max_rounds": max_rounds,
-        "fruit_threshold": fruit_threshold,
-    }
-    await db.update_call_status(
-        call.id, CallStatus.RUNNING, call_params=call.call_params,
-    )
-
-    ctx = await _build_session_context(
+    scout = ScoutCall(
         question_id, call, db,
-        mode=mode, context_page_ids=context_page_ids, broadcaster=broadcaster,
+        max_rounds=max_rounds,
+        fruit_threshold=fruit_threshold,
+        mode=mode,
+        context_page_ids=context_page_ids,
+        broadcaster=broadcaster,
     )
-
-    resume_messages: list[dict] = []
-    rounds_completed = 0
-    last_fruit_score: int | None = None
-
-    for i in range(max_rounds):
-        if not await db.consume_budget(1):
-            log.info("Budget exhausted, stopping scout session at round %d", i)
-            break
-
-        round_mode = _resolve_round_mode(mode, i)
-
-        if i == 0:
-            agent_result = await run_agent_loop(
-                ctx.system_prompt,
-                user_message=ctx.user_message,
-                tools=ctx.tools,
-                call_id=call.id,
-                db=db,
-                state=ctx.state,
-                trace=ctx.trace,
-                cache=True,
-            )
-        else:
-            mode_instruction = (
-                _CONCRETE_INSTRUCTION if round_mode == ScoutMode.CONCRETE else ''
-            )
-            continue_msg = _CONTINUE_TEMPLATE.format(
-                mode_instruction=mode_instruction, question_id=question_id,
-            )
-            resume_messages.append(
-                {"role": "user", "content": continue_msg}
-            )
-            agent_result = await run_agent_loop(
-                ctx.system_prompt,
-                tools=ctx.tools,
-                call_id=call.id,
-                db=db,
-                state=ctx.state,
-                trace=ctx.trace,
-                messages=resume_messages,
-                cache=True,
-            )
-
-        rounds_completed += 1
-        resume_messages = list(agent_result.messages)
-
-        last_fruit_score = await _run_fruit_check(
-            ctx.system_prompt, resume_messages, ctx.tool_defs,
-            call_id=call.id, db=db, trace=ctx.trace,
-        )
-        if last_fruit_score <= fruit_threshold:
-            log.info(
-                "Scout fruit (%d) <= threshold (%d), stopping after round %d",
-                last_fruit_score, fruit_threshold, i + 1,
-            )
-            break
-
-    if resume_messages:
-        assert last_fruit_score is not None
-        loaded_summaries = await _collect_all_loaded_summaries(
-            ctx.state, ctx.phase1_summaries, ctx.preloaded_ids, db,
-        )
-        review_data = await _run_session_review(
-            question_id, call, db,
-            system_prompt=ctx.system_prompt,
-            tool_defs=ctx.tool_defs,
-            resume_messages=resume_messages,
-            loaded_summaries=loaded_summaries,
-            state=ctx.state,
-            trace=ctx.trace,
-        )
-        await ctx.trace.record(ReviewCompleteEvent(
-            remaining_fruit=last_fruit_score,
-            confidence=review_data.get("confidence_in_output"),
-        ))
-
-    log.info(
-        "Scout session complete: call=%s, rounds=%d, pages_created=%d",
-        call.id[:8], rounds_completed, len(ctx.state.created_page_ids),
-    )
-    await complete_call(
-        call, db,
-        f"Scout session complete. {rounds_completed} rounds, "
-        f"{len(ctx.state.created_page_ids)} pages created.",
-    )
-    return rounds_completed
+    await scout.run()
+    return scout.rounds_completed

--- a/tests/test_call_lifecycle.py
+++ b/tests/test_call_lifecycle.py
@@ -1,0 +1,176 @@
+"""Lifecycle tests for call types (assess, ingest, scout).
+
+These are regression tests for the call refactor. They use real LLM calls
+(Haiku in test mode) to verify end-to-end lifecycle wiring: context building,
+page creation, closing review, and DB state transitions.
+"""
+
+import pytest
+import pytest_asyncio
+
+from rumil.calls.assess import run_assess
+from rumil.calls.common import complete_call, run_closing_review
+from rumil.calls.ingest import run_ingest
+from rumil.calls.scout import run_scout_session
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    Page,
+    PageLayer,
+    PageType,
+    ScoutMode,
+    Workspace,
+)
+
+
+@pytest_asyncio.fixture
+async def ingest_call(tmp_db, question_page):
+    call = Call(
+        call_type=CallType.INGEST,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+    return call
+
+
+@pytest_asyncio.fixture
+async def source_page(tmp_db):
+    page = Page(
+        page_type=PageType.SOURCE,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="The sky appears blue due to Rayleigh scattering of sunlight.",
+        summary="Rayleigh scattering explains blue sky",
+        extra={"filename": "sky-science.txt", "char_count": 58},
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest.mark.llm
+async def test_assess_lifecycle(tmp_db, question_page, assess_call):
+    """Assess call completes with correct DB state and review data."""
+    result, review = await run_assess(question_page.id, assess_call, tmp_db)
+
+    refreshed = await tmp_db.get_call(assess_call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+    assert refreshed.completed_at is not None
+    assert refreshed.result_summary != ""
+
+    assert assess_call.review_json is not None
+    assert isinstance(assess_call.review_json, dict)
+
+    trace = await tmp_db.get_call_trace(assess_call.id)
+    event_types = [e.get("event") for e in trace]
+    assert "context_built" in event_types
+
+    context_event = next(e for e in trace if e.get("event") == "context_built")
+    assert context_event.get("source_page_id") is None
+    assert isinstance(context_event.get("working_context_page_ids"), list)
+
+
+@pytest.mark.llm
+async def test_ingest_lifecycle(tmp_db, question_page, ingest_call, source_page):
+    """Ingest call processes source document and completes with correct DB state."""
+    result, review = await run_ingest(
+        source_page, question_page.id, ingest_call, tmp_db,
+    )
+
+    refreshed = await tmp_db.get_call(ingest_call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+    assert refreshed.completed_at is not None
+    assert "sky-science.txt" in refreshed.result_summary
+
+    assert ingest_call.review_json is not None
+    assert isinstance(ingest_call.review_json, dict)
+
+    trace = await tmp_db.get_call_trace(ingest_call.id)
+    event_types = [e.get("event") for e in trace]
+    assert "context_built" in event_types
+
+    context_event = next(e for e in trace if e.get("event") == "context_built")
+    assert context_event.get("source_page_id") == source_page.id
+
+
+@pytest.mark.llm
+async def test_scout_lifecycle(tmp_db, question_page, scout_call):
+    """Scout session runs rounds, checks fruit, and completes."""
+    await tmp_db.init_budget(2)
+    rounds = await run_scout_session(
+        question_page.id,
+        scout_call,
+        tmp_db,
+        max_rounds=2,
+        fruit_threshold=4,
+        mode=ScoutMode.ALTERNATE,
+    )
+
+    assert rounds >= 1
+
+    refreshed = await tmp_db.get_call(scout_call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+    assert refreshed.completed_at is not None
+    assert "Scout session complete" in refreshed.result_summary
+    assert refreshed.call_params is not None
+    assert refreshed.call_params["mode"] == "alternate"
+
+    trace = await tmp_db.get_call_trace(scout_call.id)
+    event_types = [e.get("event") for e in trace]
+    assert "context_built" in event_types
+    assert "review_complete" in event_types
+
+
+@pytest.mark.llm
+async def test_scout_stops_on_budget_exhaustion(tmp_db, question_page, scout_call):
+    """Scout session stops when budget runs out mid-loop."""
+    await tmp_db.init_budget(1)
+    rounds = await run_scout_session(
+        question_page.id,
+        scout_call,
+        tmp_db,
+        max_rounds=5,
+        fruit_threshold=0,
+    )
+
+    assert rounds <= 1
+
+    refreshed = await tmp_db.get_call(scout_call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+
+
+async def test_complete_call(tmp_db, assess_call):
+    """complete_call sets status, timestamp, and summary."""
+    assert assess_call.status == CallStatus.PENDING
+    assert assess_call.completed_at is None
+
+    await complete_call(assess_call, tmp_db, "Test summary")
+
+    assert assess_call.status == CallStatus.COMPLETE
+    assert assess_call.completed_at is not None
+    assert assess_call.result_summary == "Test summary"
+
+    refreshed = await tmp_db.get_call(assess_call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+    assert refreshed.result_summary == "Test summary"
+
+
+@pytest.mark.llm
+async def test_closing_review_saves_page_ratings(
+    tmp_db, question_page, assess_call,
+):
+    """run_closing_review returns a review dict and saves page ratings."""
+    review = await run_closing_review(
+        assess_call,
+        "Created a claim about sky color.",
+        f"Question: {question_page.content}",
+        loaded_page_ids=[question_page.id],
+        db=tmp_db,
+    )
+
+    assert review is not None
+    assert "remaining_fruit" in review
+    assert isinstance(review["remaining_fruit"], int)
+    assert "confidence_in_output" in review


### PR DESCRIPTION
## Summary
- Introduce `BaseCall` → `SimpleCall` → `AssessCall`/`IngestCall` and `BaseCall` → `ScoutCall` class hierarchy where each lifecycle stage (`build_context`, `create_pages`, `closing_review`) is an overridable method
- Phase1 page loading moved into `build_context()` via `_load_phase1_pages()`, keeping all context assembly in one stage
- Free-function wrappers (`run_assess`, `run_ingest`, `run_scout_session`) preserved for backward compatibility
- `available_moves` attribute on `SimpleCall` for future tool restriction

## Test plan
- [x] All 43 non-LLM tests pass (`uv run pytest -m "not llm"`)
- [x] Smoke test passes (`uv run python main.py "Is the sky blue?" --workspace class-refactor-test --smoke-test`)
- [x] New lifecycle regression tests in `tests/test_call_lifecycle.py` (LLM-backed, covering assess/ingest/scout end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)