### PR TITLE
Move embeddings to separate table with field-name discriminator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Each call ends with a closing review that produces `remaining_fruit` (0-10 scale
 - Always use absolute imports: `from rumil.module import name` (no relative imports)
 - Always put imports at the top of the file, not inside functions
 - Use modern type syntax: `X | None` not `Optional[X]`, `list[str]` not `List[str]`, etc. No `from typing import Optional, List, Dict`.
+- Prefer `Sequence` over `list` in type hints for parameters and return types. Only use `list` where mutation (e.g. `.append()`) is actually needed.
 - Pages are immutable once written (squidgy layer); updates use SUPERSEDE_PAGE to create a new version pointing back to the old one
 - Multiline strings use parenthesized concatenation of single-quoted lines (`"line 1 " "line 2"`), not triple-quoted strings (`"""`). Only use `f""` on lines that actually contain `{placeholder}` expressions.
 - Do not add section divider comments (e.g. `# ----------` banners). Use blank lines between logical sections; the code should speak for itself.

--- a/scripts/backfill_summary_embeddings.py
+++ b/scripts/backfill_summary_embeddings.py
@@ -1,0 +1,58 @@
+"""Backfill summary embeddings for all pages in the database.
+
+Usage:
+    uv run python scripts/backfill_summary_embeddings.py
+    uv run python scripts/backfill_summary_embeddings.py --prod
+    uv run python scripts/backfill_summary_embeddings.py --batch-size 100
+"""
+
+import argparse
+import asyncio
+import logging
+import uuid
+
+from rumil.database import DB
+from rumil.embeddings import backfill_embeddings
+
+
+async def run(args: argparse.Namespace) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    db = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod)
+
+    total = 0
+    while True:
+        count = await backfill_embeddings(
+            db, field_name="summary", batch_size=args.batch_size,
+        )
+        total += count
+        if count < args.batch_size:
+            break
+        print(f"  ...embedded {total} pages so far")
+
+    print(f"Done. Embedded summaries for {total} pages.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill summary embeddings for all pages.",
+    )
+    parser.add_argument(
+        "--prod", action="store_true",
+        help="Run against production database",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=50,
+        help="Pages per batch (default: 50)",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rumil/embeddings.py
+++ b/src/rumil/embeddings.py
@@ -1,9 +1,9 @@
 """Embedding creation (Voyage AI) and vector search (Supabase pgvector)."""
 
 import logging
-from typing import Any
+from typing import Any, Sequence
 
-import voyageai
+from voyageai.client_async import AsyncClient
 
 from rumil.database import DB, _Rows, _row_to_page, _rows
 from rumil.models import Page, Workspace
@@ -15,19 +15,19 @@ EMBEDDING_MODEL = "voyage-4-large"
 EMBEDDING_DIMENSIONS = 1024
 
 
-def _get_client() -> voyageai.AsyncClient:
+def _get_client() -> AsyncClient:
     key = get_settings().voyage_ai_api_key
     if not key:
         raise EnvironmentError(
             "VOYAGE_AI_API_KEY not set. Add it to .env to use embeddings."
         )
-    return voyageai.AsyncClient(api_key=key)
+    return AsyncClient(api_key=key)
 
 
 async def embed_texts(
     texts: list[str],
     input_type: str = "document",
-) -> list[list[float]]:
+) -> Sequence[Sequence[float]]:
     """Create embeddings for a list of texts via Voyage AI.
 
     input_type should be "document" for content being stored, or "query"
@@ -45,32 +45,55 @@ async def embed_texts(
     return result.embeddings
 
 
-async def embed_query(text: str) -> list[float]:
+async def embed_query(text: str) -> Sequence[float]:
     """Create an embedding for a search query."""
     embeddings = await embed_texts([text], input_type="query")
     return embeddings[0]
 
 
-async def embed_page(page: Page) -> list[float]:
-    """Create an embedding for a page's content."""
-    text = f"{page.summary}\n\n{page.content}"
+def page_text_for_field(page: Page, field_name: str) -> str:
+    """Return the text to embed for a given page field."""
+    if field_name == "content":
+        return f"{page.summary}\n\n{page.content}"
+    if field_name == "summary":
+        return page.summary
+    raise ValueError(f"Unknown embedding field: {field_name}")
+
+
+async def embed_page(page: Page, field_name: str = "content") -> Sequence[float]:
+    """Create an embedding for a page field."""
+    text = page_text_for_field(page, field_name)
     embeddings = await embed_texts([text], input_type="document")
     return embeddings[0]
 
 
-async def store_embedding(db: DB, page_id: str, embedding: list[float]) -> None:
-    """Store an embedding vector for a page."""
+async def store_embedding(
+    db: DB,
+    page_id: str,
+    field_name: str,
+    embedding: Sequence[float],
+) -> None:
+    """Store an embedding vector for a page field (upsert)."""
     embedding_str = '[' + ','.join(str(x) for x in embedding) + ']'
-    await db.client.table("pages").update(
-        {"embedding": embedding_str}
-    ).eq("id", page_id).execute()
-    log.debug("Stored embedding for page %s", page_id[:8])
+    await db.client.table("page_embeddings").upsert(
+        {
+            "page_id": page_id,
+            "field_name": field_name,
+            "embedding": embedding_str,
+        },
+        on_conflict="page_id,field_name",
+    ).execute()
+    log.debug("Stored %s embedding for page %s", field_name, page_id[:8])
 
 
-async def embed_and_store_page(db: DB, page: Page) -> None:
-    """Create and store an embedding for a page in one step."""
-    embedding = await embed_page(page)
-    await store_embedding(db, page.id, embedding)
+async def embed_and_store_page(
+    db: DB,
+    page: Page,
+    field_name: str = "content",
+) -> None:
+    """Create and store an embedding for a page field in one step."""
+    embedding = await embed_page(page, field_name=field_name)
+    await store_embedding(db, page.id, field_name, embedding)
 
 
 async def search_pages(
@@ -79,10 +102,12 @@ async def search_pages(
     match_threshold: float = 0.5,
     match_count: int = 10,
     workspace: Workspace | None = None,
+    field_name: str | None = None,
 ) -> list[tuple[Page, float]]:
     """Search for pages similar to a query string.
 
     Returns (page, similarity_score) pairs sorted by descending similarity.
+    Optionally filter to embeddings of a specific field_name.
     """
     query_embedding = await embed_query(query)
     return await search_pages_by_vector(
@@ -91,19 +116,22 @@ async def search_pages(
         match_threshold=match_threshold,
         match_count=match_count,
         workspace=workspace,
+        field_name=field_name,
     )
 
 
 async def search_pages_by_vector(
     db: DB,
-    query_embedding: list[float],
+    query_embedding: Sequence[float],
     match_threshold: float = 0.5,
     match_count: int = 10,
     workspace: Workspace | None = None,
+    field_name: str | None = None,
 ) -> list[tuple[Page, float]]:
     """Search for pages similar to a given embedding vector.
 
     Returns (page, similarity_score) pairs sorted by descending similarity.
+    Optionally filter to embeddings of a specific field_name.
     """
     embedding_str = '[' + ','.join(str(x) for x in query_embedding) + ']'
     params: dict[str, Any] = {
@@ -115,6 +143,8 @@ async def search_pages_by_vector(
         params["filter_workspace"] = workspace.value
     if db.project_id:
         params["filter_project_id"] = db.project_id
+    if field_name:
+        params["filter_field_name"] = field_name
     rows: _Rows = _rows(await db.client.rpc("match_pages", params).execute())
     results = []
     for row in rows:
@@ -126,30 +156,31 @@ async def search_pages_by_vector(
 
 async def backfill_embeddings(
     db: DB,
+    field_name: str = "content",
     workspace: Workspace | None = None,
     batch_size: int = 50,
 ) -> int:
-    """Generate and store embeddings for all pages that don't have one yet.
+    """Generate and store embeddings for pages missing a given field embedding.
 
     Returns the number of pages embedded.
     """
-    query = (
-        db.client.table("pages")
-        .select("*")
-        .is_("embedding", "null")
-        .eq("is_superseded", False)
-    )
+    params: dict[str, Any] = {
+        "p_field_name": field_name,
+        "p_limit": batch_size,
+    }
     if workspace:
-        query = query.eq("workspace", workspace.value)
+        params["p_workspace"] = workspace.value
     if db.project_id:
-        query = query.eq("project_id", db.project_id)
-    rows: _Rows = _rows(await query.limit(batch_size).execute())
+        params["p_project_id"] = db.project_id
+    rows: _Rows = _rows(
+        await db.client.rpc("pages_missing_embedding", params).execute()
+    )
     if not rows:
         return 0
     pages = [_row_to_page(r) for r in rows]
-    texts = [f"{p.summary}\n\n{p.content}" for p in pages]
+    texts = [page_text_for_field(p, field_name) for p in pages]
     embeddings = await embed_texts(texts, input_type="document")
     for page, embedding in zip(pages, embeddings):
-        await store_embedding(db, page.id, embedding)
-    log.info("Backfilled embeddings for %d pages", len(pages))
+        await store_embedding(db, page.id, field_name, embedding)
+    log.info("Backfilled %s embeddings for %d pages", field_name, len(pages))
     return len(pages)

--- a/supabase/migrations/20260317141611_page_embeddings_table.sql
+++ b/supabase/migrations/20260317141611_page_embeddings_table.sql
@@ -1,0 +1,94 @@
+-- Separate embeddings table: one row per (page, field) pair.
+-- Replaces the embedding column on pages.
+
+CREATE TABLE page_embeddings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    page_id TEXT NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    field_name TEXT NOT NULL,
+    embedding extensions.vector(1024) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (page_id, field_name)
+);
+
+CREATE INDEX idx_page_embeddings_vector ON page_embeddings
+    USING ivfflat (embedding extensions.vector_cosine_ops)
+    WITH (lists = 100);
+
+CREATE INDEX idx_page_embeddings_page_id ON page_embeddings (page_id);
+
+-- Migrate existing embeddings from pages table
+INSERT INTO page_embeddings (page_id, field_name, embedding)
+SELECT id, 'content', embedding
+FROM pages
+WHERE embedding IS NOT NULL;
+
+-- Drop old column and index
+DROP INDEX IF EXISTS idx_pages_embedding;
+ALTER TABLE pages DROP COLUMN IF EXISTS embedding;
+
+-- Drop old match_pages (different param list = separate overload in Postgres)
+DROP FUNCTION IF EXISTS match_pages(
+    extensions.vector, DOUBLE PRECISION, INTEGER, TEXT, UUID
+);
+
+-- Replace match_pages to query through page_embeddings
+CREATE OR REPLACE FUNCTION match_pages(
+    query_embedding extensions.vector(1024),
+    match_threshold DOUBLE PRECISION DEFAULT 0.5,
+    match_count INTEGER DEFAULT 10,
+    filter_workspace TEXT DEFAULT NULL,
+    filter_project_id UUID DEFAULT NULL,
+    filter_field_name TEXT DEFAULT NULL
+)
+RETURNS TABLE(
+    id TEXT,
+    page_type TEXT,
+    layer TEXT,
+    workspace TEXT,
+    content TEXT,
+    summary TEXT,
+    project_id UUID,
+    epistemic_status DOUBLE PRECISION,
+    epistemic_type TEXT,
+    provenance_model TEXT,
+    provenance_call_type TEXT,
+    provenance_call_id TEXT,
+    created_at TIMESTAMPTZ,
+    superseded_by TEXT,
+    is_superseded BOOLEAN,
+    extra JSONB,
+    run_id TEXT,
+    field_name TEXT,
+    similarity DOUBLE PRECISION
+)
+LANGUAGE sql STABLE AS $$
+    SELECT
+        p.id,
+        p.page_type,
+        p.layer,
+        p.workspace,
+        p.content,
+        p.summary,
+        p.project_id,
+        p.epistemic_status,
+        p.epistemic_type,
+        p.provenance_model,
+        p.provenance_call_type,
+        p.provenance_call_id,
+        p.created_at,
+        p.superseded_by,
+        p.is_superseded,
+        p.extra,
+        p.run_id,
+        pe.field_name,
+        1 - (pe.embedding <=> query_embedding) AS similarity
+    FROM page_embeddings pe
+    JOIN pages p ON p.id = pe.page_id
+    WHERE p.is_superseded = FALSE
+      AND 1 - (pe.embedding <=> query_embedding) > match_threshold
+      AND (filter_workspace IS NULL OR p.workspace = filter_workspace)
+      AND (filter_project_id IS NULL OR p.project_id = filter_project_id)
+      AND (filter_field_name IS NULL OR pe.field_name = filter_field_name)
+    ORDER BY pe.embedding <=> query_embedding
+    LIMIT match_count;
+$$;

--- a/supabase/migrations/20260317145246_pages_missing_embedding_rpc.sql
+++ b/supabase/migrations/20260317145246_pages_missing_embedding_rpc.sql
@@ -1,0 +1,19 @@
+-- Return pages that have no embedding row for the given field_name.
+CREATE OR REPLACE FUNCTION pages_missing_embedding(
+    p_field_name TEXT,
+    p_limit INTEGER DEFAULT 50,
+    p_workspace TEXT DEFAULT NULL,
+    p_project_id UUID DEFAULT NULL
+)
+RETURNS SETOF pages
+LANGUAGE sql STABLE AS $$
+    SELECT p.*
+    FROM pages p
+    LEFT JOIN page_embeddings pe
+        ON pe.page_id = p.id AND pe.field_name = p_field_name
+    WHERE pe.id IS NULL
+      AND p.is_superseded = FALSE
+      AND (p_workspace IS NULL OR p.workspace = p_workspace)
+      AND (p_project_id IS NULL OR p.project_id = p_project_id)
+    LIMIT p_limit;
+$$;

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -46,3 +46,30 @@ async def test_store_and_search_round_trip(tmp_db):
     assert page.id in returned_ids
     similarity = next(s for p, s in results if p.id == page.id)
     assert 0.3 < similarity <= 1.0
+
+
+async def test_store_and_search_with_field_filter(tmp_db):
+    """Embeddings stored with a field_name can be filtered by that field."""
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Quantum entanglement links particles across distances.",
+        summary="Quantum entanglement links distant particles",
+    )
+    await tmp_db.save_page(page)
+    await embed_and_store_page(tmp_db, page, field_name="summary")
+
+    results_with_filter = await search_pages(
+        tmp_db, "quantum particles", match_threshold=0.3,
+        field_name="summary",
+    )
+    returned_ids = [p.id for p, _ in results_with_filter]
+    assert page.id in returned_ids
+
+    results_wrong_field = await search_pages(
+        tmp_db, "quantum particles", match_threshold=0.3,
+        field_name="content",
+    )
+    wrong_ids = [p.id for p, _ in results_wrong_field]
+    assert page.id not in wrong_ids


### PR DESCRIPTION
## Summary
- Replaces the `embedding` column on `pages` with a dedicated `page_embeddings` table keyed by `(page_id, field_name)`, enabling multiple embeddings per page (e.g. summary vs content)
- Updates `match_pages` RPC to join through the new table with an optional `filter_field_name` parameter
- Adds `pages_missing_embedding` RPC for correct batched backfill (fixes bug where Python-side filtering caused early loop termination)
- Adds `scripts/backfill_summary_embeddings.py` for backfilling summary embeddings
- CLAUDE.md: prefer `Sequence` over `list` in type hints

## Test plan
- [ ] `uv run pytest` — existing tests pass
- [ ] `uv run pytest tests/test_embeddings.py -m llm` — new field_name filter test passes
- [ ] `supabase migration up --local` applies cleanly
- [ ] `uv run python scripts/backfill_summary_embeddings.py` embeds all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)