### PR TITLE
Rename remaining page summary references to headline

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1115,7 +1115,8 @@
           "prioritization",
           "ingest",
           "reframe",
-          "maintain"
+          "maintain",
+          "summarize"
         ],
         "title": "CallType"
       },
@@ -1697,7 +1698,8 @@
           "consideration",
           "child_question",
           "supersedes",
-          "related"
+          "related",
+          "summarizes"
         ],
         "title": "LinkType"
       },
@@ -1723,9 +1725,9 @@
             "type": "string",
             "title": "Type"
           },
-          "summary": {
+          "headline": {
             "type": "string",
-            "title": "Summary",
+            "title": "Headline",
             "default": ""
           },
           "page_refs": {
@@ -1791,9 +1793,9 @@
             "type": "string",
             "title": "Content"
           },
-          "summary": {
+          "headline": {
             "type": "string",
-            "title": "Summary"
+            "title": "Headline"
           },
           "id": {
             "type": "string",
@@ -1854,6 +1856,11 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Extra"
+          },
+          "abstract": {
+            "type": "string",
+            "title": "Abstract",
+            "default": ""
           }
         },
         "type": "object",
@@ -1862,7 +1869,7 @@
           "layer",
           "workspace",
           "content",
-          "summary",
+          "headline",
           "id",
           "project_id",
           "epistemic_status",
@@ -1873,7 +1880,8 @@
           "created_at",
           "superseded_by",
           "is_superseded",
-          "extra"
+          "extra",
+          "abstract"
         ],
         "title": "Page"
       },
@@ -1998,9 +2006,9 @@
             "type": "string",
             "title": "Id"
           },
-          "summary": {
+          "headline": {
             "type": "string",
-            "title": "Summary",
+            "title": "Headline",
             "default": ""
           }
         },
@@ -2018,7 +2026,8 @@
           "question",
           "judgement",
           "concept",
-          "wiki"
+          "wiki",
+          "summary"
         ],
         "title": "PageType"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -152,7 +152,7 @@ export type CallTraceOut = {
 /**
  * CallType
  */
-export type CallType = 'scout' | 'assess' | 'prioritization' | 'ingest' | 'reframe' | 'maintain';
+export type CallType = 'scout' | 'assess' | 'prioritization' | 'ingest' | 'reframe' | 'maintain' | 'summarize';
 
 /**
  * ConsiderationDirection
@@ -462,7 +462,7 @@ export type LinkRole = 'direct' | 'structural';
 /**
  * LinkType
  */
-export type LinkType = 'consideration' | 'child_question' | 'supersedes' | 'related';
+export type LinkType = 'consideration' | 'child_question' | 'supersedes' | 'related' | 'summarizes';
 
 /**
  * LinkedPageOut
@@ -481,9 +481,9 @@ export type MoveTraceItem = {
      */
     type: string;
     /**
-     * Summary
+     * Headline
      */
-    summary?: string;
+    headline?: string;
     /**
      * Page Refs
      */
@@ -525,9 +525,9 @@ export type Page = {
      */
     content: string;
     /**
-     * Summary
+     * Headline
      */
-    summary: string;
+    headline: string;
     /**
      * Id
      */
@@ -574,6 +574,10 @@ export type Page = {
     extra: {
         [key: string]: unknown;
     };
+    /**
+     * Abstract
+     */
+    abstract: string;
 };
 
 /**
@@ -652,15 +656,15 @@ export type PageRef = {
      */
     id: string;
     /**
-     * Summary
+     * Headline
      */
-    summary?: string;
+    headline?: string;
 };
 
 /**
  * PageType
  */
-export type PageType = 'source' | 'claim' | 'question' | 'judgement' | 'concept' | 'wiki';
+export type PageType = 'source' | 'claim' | 'question' | 'judgement' | 'concept' | 'wiki' | 'summary';
 
 /**
  * Project

--- a/frontend/src/app/ab-traces/[abRunId]/page.tsx
+++ b/frontend/src/app/ab-traces/[abRunId]/page.tsx
@@ -40,7 +40,7 @@ export default async function ABTracePage({
             href={`/pages/${trace.question.id}`}
             className="trace-back-link"
           >
-            &larr; {trace.question.summary}
+            &larr; {trace.question.headline}
           </Link>
         )}
         <div className="ab-trace-title-row">

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -107,7 +107,7 @@ function getDuration(call: Call): string | null {
 
 function PageChip({ page }: { page: PageRef }) {
   const short = page.id.slice(0, 8);
-  const label = page.summary || short;
+  const label = page.headline || short;
   return (
     <Link href={`/pages/${page.id}`} className="trace-page-chip" title={short}>
       {label}
@@ -170,8 +170,8 @@ function MoveRow({
   const hasRefs = pageRefs && pageRefs.length > 0;
 
   if (isChange && extra?.old_role && extra?.new_role) {
-    const fromPage = extra.from_page as { id: string; summary: string } | undefined;
-    const toPage = extra.to_page as { id: string; summary: string } | undefined;
+    const fromPage = extra.from_page as { id: string; headline: string } | undefined;
+    const toPage = extra.to_page as { id: string; headline: string } | undefined;
     return (
       <div className="trace-move-row">
         <span className={`trace-move-type ${typeClass}`}>
@@ -194,8 +194,8 @@ function MoveRow({
   }
 
   if (isRemove && extra?.from_page) {
-    const fromPage = extra.from_page as { id: string; summary: string } | undefined;
-    const toPage = extra.to_page as { id: string; summary: string } | undefined;
+    const fromPage = extra.from_page as { id: string; headline: string } | undefined;
+    const toPage = extra.to_page as { id: string; headline: string } | undefined;
     const role = extra.role as string | undefined;
     return (
       <div className="trace-move-row">

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -594,12 +594,12 @@ async def extract_loaded_page_ids(result: RunCallResult, db: DB) -> list[str]:
 
 
 async def resolve_page_refs(page_ids: list[str], db: DB) -> list[PageRef]:
-    """Resolve a list of page IDs to PageRef objects with summaries."""
+    """Resolve a list of page IDs to PageRef objects with headlines."""
     refs = []
     for pid in page_ids:
         page = await db.get_page(pid)
-        headline = page.headline if page else ""
-        refs.append(PageRef(id=pid, summary=headline))
+        hl = page.headline if page else ""
+        refs.append(PageRef(id=pid, headline=hl))
     return refs
 
 
@@ -615,8 +615,8 @@ async def _resolve_payload_refs(move: Move, db: DB) -> list[PageRef]:
         if not full_id:
             continue
         page = await db.get_page(full_id)
-        headline = page.headline if page else ""
-        refs.append(PageRef(id=full_id, summary=headline))
+        hl = page.headline if page else ""
+        refs.append(PageRef(id=full_id, headline=hl))
     return refs
 
 

--- a/src/rumil/calls/summarize.py
+++ b/src/rumil/calls/summarize.py
@@ -91,7 +91,7 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
     parts: list[str] = []
 
     def ref(page: Page) -> PageRef:
-        return PageRef(id=page.id, summary=page.headline)
+        return PageRef(id=page.id, headline=page.headline)
 
     page_refs: list[PageRef] = [ref(question)]
 

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -938,7 +938,7 @@ class DB:
                 if qid:
                     page = await self.get_page(qid)
                     if page:
-                        question_summary = page.summary
+                        question_summary = page.headline
                 results.append({
                     "run_id": row["id"],
                     "created_at": row["created_at"],
@@ -958,7 +958,7 @@ class DB:
             if qid:
                 page = await self.get_page(qid)
                 if page:
-                    ab_group["question_summary"] = page.summary
+                    ab_group["question_summary"] = page.headline
             results.append(ab_group)
         # Fallback: include legacy runs from calls table that don't have a runs row
         legacy_rows = _rows(

--- a/src/rumil/moves/change_link_role.py
+++ b/src/rumil/moves/change_link_role.py
@@ -33,11 +33,11 @@ async def execute(
         to_page = await db.get_page(link.to_page_id)
         trace_extra["from_page"] = {
             "id": link.from_page_id,
-            "summary": from_page.headline if from_page else "",
+            "headline": from_page.headline if from_page else "",
         }
         trace_extra["to_page"] = {
             "id": link.to_page_id,
-            "summary": to_page.headline if to_page else "",
+            "headline": to_page.headline if to_page else "",
         }
     await db.update_link_role(payload.link_id, payload.new_role)
     log.info(

--- a/src/rumil/moves/remove_link.py
+++ b/src/rumil/moves/remove_link.py
@@ -25,11 +25,11 @@ async def execute(payload: RemoveLinkPayload, call: Call, db: DB) -> MoveResult:
         to_page = await db.get_page(link.to_page_id)
         trace_extra["from_page"] = {
             "id": link.from_page_id,
-            "summary": from_page.headline if from_page else "",
+            "headline": from_page.headline if from_page else "",
         }
         trace_extra["to_page"] = {
             "id": link.to_page_id,
-            "summary": to_page.headline if to_page else "",
+            "headline": to_page.headline if to_page else "",
         }
     await db.delete_link(payload.link_id)
     log.info("Link removed: %s", payload.link_id[:8])

--- a/src/rumil/tracing/trace_events.py
+++ b/src/rumil/tracing/trace_events.py
@@ -2,12 +2,19 @@
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, BeforeValidator, Field, model_validator
 
 
 class PageRef(BaseModel):
     id: str
-    summary: str = ""
+    headline: str = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_summary(cls, values: dict) -> dict:
+        if isinstance(values, dict) and "summary" in values and "headline" not in values:
+            values["headline"] = values.pop("summary")
+        return values
 
 
 def _coerce_page_refs(v: list) -> list:


### PR DESCRIPTION
## Summary
- Renamed `PageRef.summary` → `PageRef.headline` in trace events, with a backward-compat model validator for existing trace JSON
- Fixed two stale `page.summary` references in `database.py` (recent runs listing)
- Updated trace extra dict keys in `change_link_role` and `remove_link` moves
- Updated frontend components (`PageChip`, `ABTracePage`, type casts) to use `headline`
- Regenerated frontend TypeScript types from API schema

## Test plan
- [x] `uv run pytest` — 51 passed, 29 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)