### PR TITLE
Add concept-generation and validation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ uv run python main.py --map QUESTION_ID
 # Generate executive summary
 uv run python main.py --summary QUESTION_ID
 
+# Run a concept-generation session (propose and assess conceptual tools for the research)
+uv run python main.py --concepts QUESTION_ID
+
 # Control how deep the summary traverses and where it switches to compact mode.
 # --max-depth N        How many levels of sub-questions to include (default: 4).
 # --summarize-after-depth N  Levels 0..N-1 show full claim/judgement content;

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from rumil.database import DB
 from rumil.models import Page, PageLayer, PageLink, PageType, LinkType, Workspace
-from rumil.orchestrator import Orchestrator, create_root_question
+from rumil.orchestrator import Orchestrator, create_root_question, run_concept_session
 from rumil.sources import create_source_page, run_ingest_calls
 from rumil.chat import run_chat
 from rumil.mapper import generate_map
@@ -380,7 +380,7 @@ async def cmd_continue(
     counts = await db.count_pages_for_question(question_id)
     await db.init_budget(additional_budget)
     await db.create_run(
-        name=name or f'continue: {question.summary[:100]}',
+        name=name or f'continue: {question.headline[:100]}',
         question_id=question_id,
         config=get_settings().capture_config(),
     )
@@ -396,6 +396,27 @@ async def cmd_continue(
 
     await Orchestrator(db).run(question_id)
     await _print_summary(db)
+
+
+async def cmd_concepts(question_id: str, db: DB) -> None:
+    question = await db.get_page(question_id)
+    if not question:
+        print(
+            f"Error: question '{question_id}' not found. Run --list to see existing questions."
+        )
+        sys.exit(1)
+    print(f"\nRunning concept session for: {question.headline[:80]}")
+    print(f"Question ID: {question_id}")
+    print("(Concept generation does not consume research budget)\n")
+    await run_concept_session(question_id, db)
+    registry = await db.get_concept_registry()
+    promoted = [p for p in registry if p.extra.get("promoted")]
+    print(f"\nConcept session complete.")
+    print(f"Registry: {len(registry)} total proposals, {len(promoted)} promoted.")
+    if promoted:
+        print("\nPromoted concepts:")
+        for p in promoted:
+            print(f"  {p.id[:8]}  {p.headline}")
 
 
 async def _print_summary(db: DB) -> None:
@@ -466,6 +487,12 @@ async def async_main():
         dest="chat_id",
         metavar="QUESTION_ID",
         help="Chat interactively about the research on a question",
+    )
+    parser.add_argument(
+        "--concepts",
+        dest="concepts_id",
+        metavar="QUESTION_ID",
+        help="Run a concept-generation session for a question",
     )
     parser.add_argument(
         "--add-question",
@@ -588,6 +615,8 @@ async def async_main():
     if args.list:
         await cmd_list(db, args.workspace_name)
         return
+    elif args.concepts_id:
+        await cmd_concepts(args.concepts_id, db)
     elif args.chat_id:
         await run_chat(args.chat_id, db)
     elif args.add_question:

--- a/prompts/assess_concept.md
+++ b/prompts/assess_concept.md
@@ -1,0 +1,40 @@
+# Assess Concept Call Instructions
+
+## Your Task
+
+You are performing an **Assess Concept** call — a focused evaluation of a single concept proposal. Your job is to test whether this concept, if adopted into the research workspace, would genuinely improve the investigation.
+
+## How to Test a Concept
+
+A concept earns its place if it:
+- Allows existing claims to be restated more precisely or usefully
+- Reveals considerations or tensions that weren't visible before
+- Resolves apparent contradictions by showing they operate at different levels
+- Makes a question more tractable by clarifying what kind of answer is possible
+
+Concretely: load claims and judgements from the workspace, then try to apply the concept to them. Ask yourself:
+- Would I state this differently if I had this concept available?
+- Does this concept reveal that two claims are actually talking past each other?
+- Does it suggest a consideration I haven't seen anywhere in the workspace?
+
+## Screening Phase
+
+In this phase, your job is to form a quick verdict: is there enough promise here to warrant deeper investigation?
+
+You are **not** deciding whether to promote the concept — only whether it deserves more thorough assessment. Set `screening_passed` to true if you see genuine potential, even if you're not yet sure it earns promotion.
+
+Load a few representative pages and test the concept against them. A light pass is sufficient at this stage.
+
+## Validation Phase
+
+In this phase, the concept has already passed screening. Now do thorough testing.
+
+Load more pages. Try to restate claims through the concept lens. Look for edge cases where the concept breaks down. Consider whether it would add noise rather than signal in contexts where it doesn't apply.
+
+If, after thorough testing, you are confident the concept genuinely improves the research, call `promote_concept`. If the deeper investigation reveals it doesn't earn its place, let the review reflect that — `remaining_fruit` should be low.
+
+## Quality Bar
+
+- **Be honest about failures.** Most concept proposals should not be promoted. A concept that doesn't earn its place is still valuable data.
+- **Test against actual content.** Do not assess the concept in the abstract — load pages and try to use it.
+- **Do not promote prematurely.** Only call `promote_concept` when you are genuinely confident. The concept will become visible to all future research calls.

--- a/prompts/scout_concepts.md
+++ b/prompts/scout_concepts.md
@@ -1,0 +1,32 @@
+# Scout Concepts Call Instructions
+
+## Your Task
+
+You are performing a **Scout Concepts** call — a generative, exploratory mode focused on identifying conceptual tools that could sharpen the research.
+
+Your job is to survey the research workspace and the concept registry, then propose 1–3 concepts or distinctions that would meaningfully clarify the investigation.
+
+## What to Look For
+
+A good concept proposal:
+- Draws a distinction that is currently blurry or conflated in the workspace
+- Names a category that groups existing claims in a useful way
+- Reframes a question in a way that makes the answer more tractable
+- Resolves a terminological ambiguity that is generating apparent contradictions
+
+A bad concept proposal:
+- Renames something that already has a clear name
+- Creates a distinction without a difference
+- Adds jargon without adding clarity
+- Repeats something already in the concept registry
+
+## How to Proceed
+
+1. Load pages you need to understand the current state of the research — judgements, key claims, questions that seem contested or tangled.
+2. Check the concept registry. Do not re-propose concepts already there (even if they haven't been promoted yet).
+3. Use `propose_concept` for each concept you identify as worth assessing.
+
+## Constraints
+
+- Propose only concepts you genuinely believe could improve the research. Quality over quantity — one strong proposal beats three weak ones.
+- Do not create claims, questions, or judgements. Your only output tools are `propose_concept` and `load_page`.

--- a/src/rumil/calls/assess_concept.py
+++ b/src/rumil/calls/assess_concept.py
@@ -1,0 +1,252 @@
+"""Assess Concept call: evaluate a staged concept proposal."""
+
+import logging
+
+from pydantic import BaseModel, Field
+
+from rumil.calls.base import SimpleCall
+from rumil.calls.common import (
+    format_moves_for_review,
+    resolve_page_refs,
+)
+from rumil.context import format_page
+from rumil.database import DB
+from rumil.llm import build_user_message, structured_call, LLMExchangeMetadata
+from rumil.models import Call, CallStage, CallType, MoveType
+from rumil.settings import get_settings
+from rumil.tracing.trace_events import ContextBuiltEvent, ReviewCompleteEvent
+from rumil.workspace_map import build_workspace_map
+
+log = logging.getLogger(__name__)
+
+SCREENING_PHASE = "screening"
+VALIDATION_PHASE = "validation"
+
+SCREENING_MAX_ROUNDS = 2
+VALIDATION_MAX_ROUNDS = 8
+SCREENING_FRUIT_THRESHOLD = 5
+VALIDATION_FRUIT_THRESHOLD = 3
+
+
+class ConceptAssessmentReview(BaseModel):
+    remaining_fruit: int = Field(
+        description=(
+            "0-10: how much more testing would meaningfully change your assessment. "
+            "0 = verdict is settled; 10 = barely started."
+        )
+    )
+    confidence_in_output: float = Field(description="0-5 confidence in this assessment")
+    score: int = Field(
+        description=(
+            "1-10: overall usefulness of this concept for the research. "
+            "1-4 = not useful enough to warrant promotion; "
+            "5-7 = moderately useful, borderline; "
+            "8-10 = clearly useful, strong candidate for promotion."
+        )
+    )
+    what_worked: str = Field(description="Where the concept added clarity or revealed something")
+    what_didnt: str = Field(description="Where the concept failed or added noise")
+    could_existing_claims_be_restated: bool = Field(
+        description="Whether existing claims could be stated more usefully with this concept"
+    )
+    did_it_reveal_new_considerations: bool = Field(
+        description="Whether applying the concept surfaced considerations not already in the workspace"
+    )
+    did_it_resolve_existing_tensions: bool = Field(
+        description="Whether the concept dissolved any apparent contradictions or tensions"
+    )
+    suggested_refinements: str = Field(
+        "", description="How the concept could be sharpened or narrowed to be more useful"
+    )
+    screening_passed: bool = Field(
+        description=(
+            "Whether this concept warrants deeper validation. "
+            "True if there is genuine promise, even if uncertain. "
+            "False if the concept clearly does not add value."
+        )
+    )
+
+
+REVIEW_SYSTEM_PROMPT = (
+    "You are a research assistant completing a closing review of a concept assessment "
+    "you just performed. Be honest and specific. Most concept proposals should not be "
+    "promoted — a clear 'no' is more useful than an uncertain 'maybe'."
+)
+
+
+class AssessConceptCall(SimpleCall):
+    """Assess a staged concept proposal: one round of testing."""
+
+    def __init__(
+        self,
+        concept_page_id: str,
+        call: Call,
+        db: DB,
+        *,
+        phase: str = SCREENING_PHASE,
+        broadcaster=None,
+        up_to_stage: CallStage | None = None,
+    ):
+        super().__init__(
+            concept_page_id, call, db,
+            broadcaster=broadcaster, up_to_stage=up_to_stage,
+        )
+        self.phase = phase
+        self.concept_assessment: dict = {}
+
+    def call_type(self) -> CallType:
+        return CallType.ASSESS_CONCEPT
+
+    def task_description(self) -> str:
+        phase_note = (
+            "This is the **screening phase** — form a quick initial verdict. "
+            "Load a few representative pages and test the concept against them. "
+            "Set `screening_passed` based on whether you see genuine potential."
+            if self.phase == SCREENING_PHASE
+            else
+            "This is the **validation phase** — do thorough testing. "
+            "Load more pages, try to restate claims through the concept lens, "
+            "look for edge cases. "
+            "Call `promote_concept` if and only if you are confident it earns its place."
+        )
+        return (
+            f"Assess the concept proposal above.\n\n{phase_note}\n\n"
+            f"Concept page ID: `{self.question_id}`"
+        )
+
+    def result_summary(self) -> str:
+        score = self.concept_assessment.get("score")
+        screening = self.concept_assessment.get("screening_passed")
+        return (
+            f"Assess concept complete ({self.phase}). "
+            f"score={score}, screening_passed={screening}."
+        )
+
+    async def build_context(self) -> None:
+        concept = await self.db.get_page(self.question_id)
+        if not concept:
+            self.context_text = f"[Concept page {self.question_id} not found]"
+            return
+
+        map_text, _ = await build_workspace_map(self.db)
+        concept_text = await format_page(concept, db=self.db)
+
+        extra = concept.extra or {}
+        assessment_rounds = extra.get("assessment_rounds", [])
+        history_section = ""
+        if assessment_rounds:
+            lines = ["## Previous Assessment Rounds", ""]
+            for i, r in enumerate(assessment_rounds):
+                lines.append(
+                    f"Round {i + 1} ({r.get('phase', '?')}): "
+                    f"score={r.get('score', '?')}, "
+                    f"remaining_fruit={r.get('remaining_fruit', '?')}"
+                )
+                if r.get("what_worked"):
+                    lines.append(f"  Worked: {r['what_worked']}")
+                if r.get("what_didnt"):
+                    lines.append(f"  Didn't: {r['what_didnt']}")
+            history_section = "\n\n" + "\n".join(lines)
+
+        self.context_text = "\n\n".join([
+            map_text,
+            "---",
+            "## Concept Under Assessment",
+            "",
+            concept_text,
+        ]) + history_section
+
+        self.working_page_ids = [self.question_id]
+        await self.trace.record(ContextBuiltEvent(
+            working_context_page_ids=await resolve_page_refs(
+                self.working_page_ids, self.db,
+            ),
+            preloaded_page_ids=await resolve_page_refs(self.preloaded_ids, self.db),
+        ))
+        await self._load_phase1_pages()
+
+    async def create_pages(self) -> None:
+        if self.phase == VALIDATION_PHASE:
+            self.available_moves = [MoveType.PROMOTE_CONCEPT, MoveType.LOAD_PAGE]
+        else:
+            self.available_moves = [MoveType.LOAD_PAGE]
+        await super().create_pages()
+
+    async def closing_review(self) -> None:
+        review_context = format_moves_for_review(self.result.moves)
+        review_task = (
+            f"You have just completed an assess_concept call ({self.phase} phase).\n\n"
+            f"Here is your output from that call:\n{review_context}\n\n"
+            "Please review your assessment and provide structured feedback."
+        )
+
+        user_message = build_user_message(self.context_text, review_task)
+        meta = LLMExchangeMetadata(
+            call_id=self.call.id, phase="closing_review",
+            trace=self.trace, user_message=user_message,
+        )
+        try:
+            result = await structured_call(
+                system_prompt=REVIEW_SYSTEM_PROMPT,
+                user_message=user_message,
+                response_model=ConceptAssessmentReview,
+                max_tokens=2048,
+                metadata=meta,
+                db=self.db,
+            )
+            review = result.data
+        except Exception as e:
+            log.error(
+                "Concept closing review failed for call=%s: %s",
+                self.call.id[:8], e, exc_info=True,
+            )
+            self.review = {}
+            return
+
+        if not review:
+            self.review = {}
+            return
+
+        log.info(
+            "Concept review (%s): score=%s, screening_passed=%s, fruit=%s",
+            self.phase,
+            review.get("score"),
+            review.get("screening_passed"),
+            review.get("remaining_fruit"),
+        )
+
+        self.concept_assessment = review
+        self.review = review
+
+        await self.trace.record(ReviewCompleteEvent(
+            remaining_fruit=review.get("remaining_fruit"),
+            confidence=review.get("confidence_in_output"),
+        ))
+
+        await self._persist_assessment_round(review)
+
+    async def _persist_assessment_round(self, review: dict) -> None:
+        """Append this round's assessment to the concept page's extra.assessment_rounds."""
+        concept = await self.db.get_page(self.question_id)
+        if not concept:
+            return
+        extra = dict(concept.extra or {})
+        rounds = list(extra.get("assessment_rounds", []))
+        rounds.append({
+            "phase": self.phase,
+            "call_id": self.call.id,
+            "score": review.get("score"),
+            "remaining_fruit": review.get("remaining_fruit"),
+            "screening_passed": review.get("screening_passed"),
+            "what_worked": review.get("what_worked", ""),
+            "what_didnt": review.get("what_didnt", ""),
+            "could_existing_claims_be_restated": review.get("could_existing_claims_be_restated"),
+            "did_it_reveal_new_considerations": review.get("did_it_reveal_new_considerations"),
+            "did_it_resolve_existing_tensions": review.get("did_it_resolve_existing_tensions"),
+            "suggested_refinements": review.get("suggested_refinements", ""),
+        })
+        extra["assessment_rounds"] = rounds
+        extra["score"] = review.get("score")
+        extra["screening_passed"] = review.get("screening_passed")
+        extra["stage"] = "validated" if self.phase == VALIDATION_PHASE else "screened"
+        await self.db.update_page_extra(self.question_id, extra)

--- a/src/rumil/calls/call_registry.py
+++ b/src/rumil/calls/call_registry.py
@@ -5,8 +5,10 @@ look up the concrete class by a short string name stored in settings.
 """
 
 from rumil.calls.assess import AssessCall, EmbeddingAssessCall
+from rumil.calls.assess_concept import AssessConceptCall
 from rumil.calls.ingest import EmbeddingIngestCall, IngestCall
 from rumil.calls.scout import EmbeddingScoutCall, ScoutCall
+from rumil.calls.scout_concepts import ScoutConceptsCall
 
 SCOUT_CALL_CLASSES: dict[str, type[ScoutCall]] = {
     "default": ScoutCall,
@@ -21,4 +23,12 @@ ASSESS_CALL_CLASSES: dict[str, type[AssessCall]] = {
 INGEST_CALL_CLASSES: dict[str, type[IngestCall]] = {
     "default": IngestCall,
     "embedding": EmbeddingIngestCall,
+}
+
+SCOUT_CONCEPTS_CALL_CLASSES: dict[str, type[ScoutConceptsCall]] = {
+    "default": ScoutConceptsCall,
+}
+
+ASSESS_CONCEPT_CALL_CLASSES: dict[str, type[AssessConceptCall]] = {
+    "default": AssessConceptCall,
 }

--- a/src/rumil/calls/scout_concepts.py
+++ b/src/rumil/calls/scout_concepts.py
@@ -1,0 +1,67 @@
+"""Scout Concepts call: identify concept proposals from the research workspace."""
+
+import logging
+
+from rumil.calls.base import SimpleCall
+from rumil.context import build_call_context
+from rumil.models import CallType, MoveType
+from rumil.page_graph import PageGraph
+
+log = logging.getLogger(__name__)
+
+
+class ScoutConceptsCall(SimpleCall):
+    """Survey the research workspace and propose concepts for assessment."""
+
+    def call_type(self) -> CallType:
+        return CallType.SCOUT_CONCEPTS
+
+    def task_description(self) -> str:
+        return (
+            "Survey the research workspace and the concept registry above. "
+            "Identify 1-3 concepts or distinctions that would meaningfully "
+            "clarify the investigation. Use `propose_concept` to record each proposal."
+        )
+
+    def result_summary(self) -> str:
+        return (
+            f"Scout concepts complete. "
+            f"Proposed {len(self.result.created_page_ids)} concept(s)."
+        )
+
+    async def build_context(self) -> None:
+        graph = await PageGraph.load(self.db)
+        self.context_text, _, self.working_page_ids = await build_call_context(
+            self.question_id, self.db, extra_page_ids=self.preloaded_ids,
+            graph=graph,
+        )
+
+        registry = await self.db.get_concept_registry()
+        if registry:
+            lines = ["## Concept Registry", ""]
+            lines.append(
+                "The following concepts have already been proposed (do not re-propose them):"
+            )
+            lines.append("")
+            for concept in registry:
+                extra = concept.extra or {}
+                stage = extra.get("stage", "proposed")
+                score = extra.get("score")
+                promoted = extra.get("promoted", False)
+                status = "promoted" if promoted else (
+                    f"score={score}" if score is not None else stage
+                )
+                lines.append(
+                    f"- [{status}] `{concept.id[:8]}` — {concept.headline}"
+                )
+            self.context_text += "\n\n" + "\n".join(lines)
+
+        await self._record_context_built()
+        await self._load_phase1_pages()
+
+    def _get_available_moves(self) -> list[MoveType]:
+        return [MoveType.PROPOSE_CONCEPT, MoveType.LOAD_PAGE]
+
+    async def create_pages(self) -> None:
+        self.available_moves = self._get_available_moves()
+        await super().create_pages()

--- a/src/rumil/calls/summarize.py
+++ b/src/rumil/calls/summarize.py
@@ -240,7 +240,7 @@ async def summarize_question(
         ))
         user_message = build_user_message(context, TASK)
 
-        meta = LLMExchangeMetadata(call_id=call.id, phase="summarize", trace=trace, db=db)
+        meta = LLMExchangeMetadata(call_id=call.id, phase="summarize", trace=trace)
         result = await structured_call(
             system_prompt=SYSTEM_PROMPT,
             user_message=user_message,

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -32,12 +32,18 @@ async def collect_subtree_ids(
     question_id: str,
     db: DB,
     graph: PageGraph | None = None,
+    _visited: set[str] | None = None,
 ) -> set[str]:
     """Recursively collect all question IDs in a subtree (inclusive)."""
+    if _visited is None:
+        _visited = set()
+    if question_id in _visited:
+        return set()
+    _visited = _visited | {question_id}
     source: DB | PageGraph = graph if graph is not None else db
     result = {question_id}
     for child in await source.get_child_questions(question_id):
-        result |= await collect_subtree_ids(child.id, db, graph=graph)
+        result |= await collect_subtree_ids(child.id, db, graph=graph, _visited=_visited)
     return result
 
 
@@ -311,9 +317,16 @@ async def _build_question_index(
     db: DB,
     indent: int = 0,
     graph: PageGraph | None = None,
+    _visited: set[str] | None = None,
 ) -> list[str]:
     """Recursively build a flat index of all questions in the tree with their IDs.
     Includes consideration count, last scout fruit/date, and hypothesis flag."""
+    if _visited is None:
+        _visited = set()
+    if question_id in _visited:
+        return [f"{'  ' * indent}[child] `{question_id}` — *** cycle detected ***"]
+    _visited = _visited | {question_id}
+
     source: DB | PageGraph = graph if graph is not None else db
     question = await source.get_page(question_id)
     if not question:
@@ -340,7 +353,9 @@ async def _build_question_index(
         f"({n_cons} cons · {scout_str})"
     ]
     for child in await source.get_child_questions(question_id):
-        lines.extend(await _build_question_index(child.id, db, indent + 1, graph=graph))
+        lines.extend(await _build_question_index(
+            child.id, db, indent + 1, graph=graph, _visited=_visited,
+        ))
     return lines
 
 

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -208,6 +208,20 @@ class DB:
             }
         ).execute()
 
+    async def update_page_extra(self, page_id: str, extra: dict) -> None:
+        """Update the extra JSONB field on a page in place."""
+        await self.client.table("pages").update(
+            {"extra": extra}
+        ).eq("id", page_id).execute()
+
+    async def get_concept_registry(self) -> list[Page]:
+        """Return all concept proposals in the concept_staging workspace."""
+        return await self.get_pages(
+            workspace=Workspace.CONCEPT_STAGING,
+            page_type=PageType.CONCEPT,
+            active_only=False,
+        )
+
     async def update_page_summaries(
         self, page_id: str, headline: str, abstract: str
     ) -> None:

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -39,6 +39,7 @@ class PageLayer(str, Enum):
 class Workspace(str, Enum):
     RESEARCH = "research"
     PRIORITIZATION = "prioritization"
+    CONCEPT_STAGING = "concept_staging"
 
 
 class CallType(str, Enum):
@@ -49,6 +50,8 @@ class CallType(str, Enum):
     REFRAME = "reframe"
     MAINTAIN = "maintain"
     SUMMARIZE = "summarize"
+    SCOUT_CONCEPTS = "scout_concepts"
+    ASSESS_CONCEPT = "assess_concept"
 
 
 # The subset of CallTypes that prioritization can dispatch.
@@ -90,6 +93,8 @@ class MoveType(str, Enum):
     LOAD_PAGE = "LOAD_PAGE"
     REMOVE_LINK = "REMOVE_LINK"
     CHANGE_LINK_ROLE = "CHANGE_LINK_ROLE"
+    PROPOSE_CONCEPT = "PROPOSE_CONCEPT"
+    PROMOTE_CONCEPT = "PROMOTE_CONCEPT"
 
 
 class CallStage(str, Enum):

--- a/src/rumil/moves/link_child_question.py
+++ b/src/rumil/moves/link_child_question.py
@@ -1,6 +1,6 @@
 """LINK_CHILD_QUESTION move: mark a question as a sub-question of another."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from rumil.database import DB
 from rumil.models import Call, LinkRole, LinkType, MoveType
@@ -9,6 +9,14 @@ from rumil.moves.base import MoveDef, MoveResult, link_pages
 
 class ChildQuestionLinkFields(BaseModel):
     parent_id: str = Field(description="Page ID of the parent question")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_question_id(cls, data: object) -> object:
+        if isinstance(data, dict) and "question_id" in data and "parent_id" not in data:
+            data = dict(data)
+            data["parent_id"] = data.pop("question_id")
+        return data
     reasoning: str = Field("", description="Why this is a sub-question")
     role: LinkRole = Field(
         LinkRole.STRUCTURAL,

--- a/src/rumil/moves/promote_concept.py
+++ b/src/rumil/moves/promote_concept.py
@@ -1,0 +1,84 @@
+"""PROMOTE_CONCEPT move: promote a validated concept from staging to research workspace."""
+
+import logging
+
+from pydantic import BaseModel, Field
+
+from rumil.database import DB
+from rumil.models import Call, MoveType, Page, PageLayer, PageType, Workspace
+from rumil.moves.base import MoveDef, MoveResult, write_page_file
+
+log = logging.getLogger(__name__)
+
+
+class PromoteConceptPayload(BaseModel):
+    concept_page_id: str = Field(
+        description="Full or short ID of the staged concept page to promote."
+    )
+    reasoning: str = Field(
+        "",
+        description="Why this concept has earned a place in the research workspace.",
+    )
+
+
+async def execute(payload: PromoteConceptPayload, call: Call, db: DB) -> MoveResult:
+    resolved = await db.resolve_page_id(payload.concept_page_id)
+    if not resolved:
+        return MoveResult(f"Concept page '{payload.concept_page_id}' not found.")
+
+    staging_page = await db.get_page(resolved)
+    if not staging_page:
+        return MoveResult(f"Concept page '{resolved[:8]}' not found.")
+
+    if staging_page.workspace != Workspace.CONCEPT_STAGING:
+        return MoveResult(
+            f"Page '{resolved[:8]}' is not a staged concept "
+            f"(workspace: {staging_page.workspace.value})."
+        )
+
+    research_page = Page(
+        page_type=PageType.CONCEPT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=staging_page.content,
+        headline=staging_page.headline,
+        epistemic_status=staging_page.epistemic_status,
+        epistemic_type=staging_page.epistemic_type,
+        provenance_model="claude-opus-4-6",
+        provenance_call_type=call.call_type.value,
+        provenance_call_id=call.id,
+        extra={
+            **staging_page.extra,
+            "promoted": True,
+            "promoted_from": resolved,
+            "promotion_reasoning": payload.reasoning,
+        },
+    )
+    await db.save_page(research_page)
+    write_page_file(research_page)
+    await db.supersede_page(resolved, research_page.id)
+
+    log.info(
+        "Concept promoted: staging=%s -> research=%s, headline=%s",
+        resolved[:8], research_page.id[:8], research_page.headline[:60],
+    )
+    return MoveResult(
+        message=(
+            f"Promoted concept [{research_page.id[:8]}]: {research_page.headline}. "
+            f"Now active in research workspace."
+        ),
+        created_page_id=research_page.id,
+    )
+
+
+MOVE = MoveDef(
+    move_type=MoveType.PROMOTE_CONCEPT,
+    name="promote_concept",
+    description=(
+        "Promote a validated staged concept into the research workspace, making it "
+        "visible to all future research calls. Only call this when you are confident "
+        "the concept genuinely clarifies the research."
+    ),
+    schema=PromoteConceptPayload,
+    execute=execute,
+)

--- a/src/rumil/moves/propose_concept.py
+++ b/src/rumil/moves/propose_concept.py
@@ -1,0 +1,66 @@
+"""PROPOSE_CONCEPT move: propose a concept candidate for assessment."""
+
+from pydantic import BaseModel, Field
+
+from rumil.database import DB
+from rumil.models import Call, MoveType, Page, PageLayer, PageType, Workspace
+from rumil.moves.base import MoveDef, MoveResult, write_page_file
+
+
+class ProposeConceptPayload(BaseModel):
+    headline: str = Field(
+        description=(
+            "10-15 word headline (20 word ceiling). A sharp, self-contained label "
+            "for the concept or distinction being proposed."
+        )
+    )
+    content: str = Field(
+        description=(
+            "Full definition and explanation of the concept. Include: what distinction "
+            "it draws, why it is useful for the research, and which parts of the "
+            "investigation it might clarify."
+        )
+    )
+    epistemic_status: float = Field(2.5, description="0-5 confidence that this concept is useful")
+    epistemic_type: str = Field("", description="Nature of uncertainty about this concept's value")
+
+
+async def execute(payload: ProposeConceptPayload, call: Call, db: DB) -> MoveResult:
+    page = Page(
+        page_type=PageType.CONCEPT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.CONCEPT_STAGING,
+        content=payload.content,
+        headline=payload.headline,
+        epistemic_status=payload.epistemic_status,
+        epistemic_type=payload.epistemic_type,
+        provenance_model="claude-opus-4-6",
+        provenance_call_type=call.call_type.value,
+        provenance_call_id=call.id,
+        extra={
+            "stage": "proposed",
+            "score": None,
+            "screening_passed": None,
+            "promoted": False,
+            "assessment_rounds": [],
+        },
+    )
+    await db.save_page(page)
+    write_page_file(page)
+    return MoveResult(
+        message=f"Proposed concept [{page.id[:8]}]: {payload.headline}",
+        created_page_id=page.id,
+    )
+
+
+MOVE = MoveDef(
+    move_type=MoveType.PROPOSE_CONCEPT,
+    name="propose_concept",
+    description=(
+        "Propose a concept or distinction for assessment. The concept will be "
+        "evaluated before entering the research workspace — it is not immediately "
+        "visible to other research calls."
+    ),
+    schema=ProposeConceptPayload,
+    execute=execute,
+)

--- a/src/rumil/moves/registry.py
+++ b/src/rumil/moves/registry.py
@@ -17,6 +17,8 @@ from rumil.moves.propose_hypothesis import MOVE as _propose_hypothesis
 from rumil.moves.load_page import MOVE as _load_page
 from rumil.moves.remove_link import MOVE as _remove_link
 from rumil.moves.change_link_role import MOVE as _change_link_role
+from rumil.moves.propose_concept import MOVE as _propose_concept
+from rumil.moves.promote_concept import MOVE as _promote_concept
 
 MOVES: dict[MoveType, MoveDef] = {
     m.move_type: m
@@ -36,5 +38,7 @@ MOVES: dict[MoveType, MoveDef] = {
         _load_page,
         _remove_link,
         _change_link_role,
+        _propose_concept,
+        _promote_concept,
     ]
 }

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -10,8 +10,10 @@ from rumil.tracing.broadcast import Broadcaster
 from rumil.calls.summarize import summarize_question
 from rumil.calls.call_registry import (
     ASSESS_CALL_CLASSES,
+    ASSESS_CONCEPT_CALL_CLASSES,
     INGEST_CALL_CLASSES,
     SCOUT_CALL_CLASSES,
+    SCOUT_CONCEPTS_CALL_CLASSES,
 )
 from rumil.database import DB
 from rumil.settings import get_settings
@@ -202,6 +204,132 @@ async def assess_question(
     assess = cls(question_id, call, db, broadcaster=broadcaster)
     await assess.run()
     return call.id
+
+
+async def _run_assess_concept_loop(
+    concept_id: str,
+    db: DB,
+    phase: str,
+    max_rounds: int,
+    fruit_threshold: int,
+    parent_call_id: str | None = None,
+    broadcaster=None,
+) -> dict:
+    """Run assess_concept rounds until fruit drops below threshold or max_rounds reached.
+
+    Returns the review dict from the final round.
+    """
+    from rumil.calls.assess_concept import SCREENING_PHASE, VALIDATION_PHASE
+    log.info(
+        "_run_assess_concept_loop: concept=%s, phase=%s, max_rounds=%d, threshold=%d",
+        concept_id[:8], phase, max_rounds, fruit_threshold,
+    )
+    last_review: dict = {}
+    for i in range(max_rounds):
+        call = await db.create_call(
+            CallType.ASSESS_CONCEPT,
+            scope_page_id=concept_id,
+            parent_call_id=parent_call_id,
+        )
+        cls = ASSESS_CONCEPT_CALL_CLASSES[get_settings().assess_call_variant]
+        assess = cls(concept_id, call, db, phase=phase, broadcaster=broadcaster)
+        await assess.run()
+        last_review = assess.concept_assessment
+
+        remaining_fruit = last_review.get("remaining_fruit", 10)
+        log.info(
+            "Assess concept round %d/%d (%s): fruit=%d, score=%s",
+            i + 1, max_rounds, phase,
+            remaining_fruit, last_review.get("score"),
+        )
+        if remaining_fruit <= fruit_threshold:
+            log.info(
+                "Concept fruit (%d) at or below threshold (%d), stopping %s phase",
+                remaining_fruit, fruit_threshold, phase,
+            )
+            break
+
+    return last_review
+
+
+async def run_concept_session(
+    question_id: str,
+    db: DB,
+    broadcaster=None,
+) -> None:
+    """Run a full concept-generation session for a research question.
+
+    1. Scout concepts — generate proposals for the question's subtree.
+    2. For each proposal: run stage-1 screening.
+    3. If screening passes: automatically run stage-2 validation.
+    """
+    from rumil.calls.assess_concept import (
+        SCREENING_PHASE,
+        SCREENING_FRUIT_THRESHOLD,
+        SCREENING_MAX_ROUNDS,
+        VALIDATION_PHASE,
+        VALIDATION_FRUIT_THRESHOLD,
+        VALIDATION_MAX_ROUNDS,
+    )
+    log.info("run_concept_session: question=%s", question_id[:8])
+
+    scout_call = await db.create_call(
+        CallType.SCOUT_CONCEPTS,
+        scope_page_id=question_id,
+    )
+    cls = SCOUT_CONCEPTS_CALL_CLASSES["default"]
+    scout = cls(question_id, scout_call, db, broadcaster=broadcaster)
+    await scout.run()
+    proposed_ids = scout.result.created_page_ids
+
+    log.info(
+        "Scout concepts complete: %d proposals for question=%s",
+        len(proposed_ids), question_id[:8],
+    )
+
+    for concept_id in proposed_ids:
+        concept = await db.get_page(concept_id)
+        label = concept.headline[:60] if concept else concept_id[:8]
+        log.info("Screening concept: %s [%s]", label, concept_id[:8])
+
+        screening_review = await _run_assess_concept_loop(
+            concept_id, db,
+            phase=SCREENING_PHASE,
+            max_rounds=SCREENING_MAX_ROUNDS,
+            fruit_threshold=SCREENING_FRUIT_THRESHOLD,
+            parent_call_id=scout_call.id,
+            broadcaster=broadcaster,
+        )
+
+        if not screening_review.get("screening_passed"):
+            log.info(
+                "Concept [%s] did not pass screening (score=%s)",
+                concept_id[:8], screening_review.get("score"),
+            )
+            continue
+
+        log.info(
+            "Concept [%s] passed screening (score=%s), proceeding to validation",
+            concept_id[:8], screening_review.get("score"),
+        )
+
+        validation_review = await _run_assess_concept_loop(
+            concept_id, db,
+            phase=VALIDATION_PHASE,
+            max_rounds=VALIDATION_MAX_ROUNDS,
+            fruit_threshold=VALIDATION_FRUIT_THRESHOLD,
+            parent_call_id=scout_call.id,
+            broadcaster=broadcaster,
+        )
+
+        concept_page = await db.get_page(concept_id)
+        if concept_page and concept_page.is_superseded:
+            log.info("Concept [%s] was promoted to research workspace", concept_id[:8])
+        else:
+            log.info(
+                "Concept [%s] completed validation but was not promoted (score=%s)",
+                concept_id[:8], validation_review.get("score"),
+            )
 
 
 def _create_broadcaster(db: DB) -> Broadcaster | None:

--- a/src/rumil/workspace_map.py
+++ b/src/rumil/workspace_map.py
@@ -21,7 +21,14 @@ async def _build_question_lines(
     source: DB | PageGraph,
     short_id_map: dict[str, str],
     indent: int = 0,
+    _visited: set[str] | None = None,
 ) -> list[str]:
+    if _visited is None:
+        _visited = set()
+    if question.id in _visited:
+        return [f"{'  ' * indent}[Q] `{_short_id(question.id)}` — *** cycle detected ***"]
+    _visited = _visited | {question.id}
+
     prefix = "  " * indent
     sid = _short_id(question.id)
     short_id_map[sid] = question.id
@@ -53,7 +60,9 @@ async def _build_question_lines(
         lines.append(f"{prefix}  [J {j.epistemic_status:.1f}] `{j_sid}` — {j.headline}")
 
     for child in children:
-        lines.extend(await _build_question_lines(child, source, short_id_map, indent + 1))
+        lines.extend(await _build_question_lines(
+            child, source, short_id_map, indent + 1, _visited,
+        ))
 
     return lines
 


### PR DESCRIPTION
Two-stage pipeline: scout_concepts proposes candidates from the research workspace, then assess_concept screens (max 2 rounds) and validates (max 8 rounds) each proposal. Concepts are staged in a new concept_staging workspace and only promoted to research on explicit LLM action. Assessment history is persisted on page.extra.

Also fixes three pre-existing bugs:
- Recursive cycle crash in workspace_map and context tree walkers
- LLMExchangeMetadata called with unexpected 'db' arg in summarize.py
- create_question links accepting 'question_id' as alias for 'parent_id'
- Page.summary -> Page.headline in cmd_continue