### PR TITLE
Replace page.extra source_id with formal CITES links

### DIFF
--- a/prompts/ingest.md
+++ b/prompts/ingest.md
@@ -25,7 +25,7 @@ Calibrate your `epistemic_status` and `epistemic_type` accordingly. A well-evide
 
 Extract **3–5 considerations** that bear on the primary question. Quality over quantity — if only 2 genuinely matter, produce 2.
 
-For each consideration, create the claim and link it to the primary question. Set the `source_id` field on each claim to the source page ID.
+For each consideration, create the claim and link it to the primary question. Set the `source_ids` field on each claim to include the source page ID.
 
 ### Cross-question extraction
 

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -81,6 +81,7 @@ class LinkType(str, Enum):
     SUPERSEDES = "supersedes"  # page replaces another
     RELATED = "related"  # general relation
     SUMMARIZES = "summarizes"  # summary page covers a question subtree
+    CITES = "cites"  # claim cites a source
 
 
 class MoveType(str, Enum):

--- a/src/rumil/moves/create_claim.py
+++ b/src/rumil/moves/create_claim.py
@@ -1,7 +1,7 @@
 """CREATE_CLAIM move: create an assertion with supporting reasoning."""
 
 import logging
-from typing import Any
+from collections.abc import Sequence
 
 from pydantic import Field
 
@@ -21,8 +21,9 @@ log = logging.getLogger(__name__)
 
 
 class CreateClaimPayload(CreatePagePayload):
-    source_id: str | None = Field(
-        None, description="Source page ID — set when extracting claims from a source"
+    source_ids: Sequence[str] = Field(
+        default_factory=list,
+        description="Source page IDs this claim cites. Creates citation links.",
     )
     links: list[ConsiderationLinkFields] = Field(
         default_factory=list,
@@ -32,16 +33,10 @@ class CreateClaimPayload(CreatePagePayload):
         ),
     )
 
-    def page_extra_fields(self) -> dict[str, Any]:
-        extra = super().page_extra_fields()
-        if self.source_id is not None:
-            extra["source_id"] = self.source_id
-        return extra
-
 
 async def execute(payload: CreateClaimPayload, call: Call, db: DB) -> MoveResult:
     result = await create_page(payload, call, db, PageType.CLAIM, PageLayer.SQUIDGY)
-    if not result.created_page_id or not payload.links:
+    if not result.created_page_id:
         return result
 
     for link_spec in payload.links:
@@ -64,6 +59,24 @@ async def execute(payload: CreateClaimPayload, call: Call, db: DB) -> MoveResult
         log.info(
             "Inline consideration linked: %s -> %s (%.1f)",
             result.created_page_id[:8], resolved[:8], link_spec.strength,
+        )
+
+    for sid in payload.source_ids:
+        resolved = await db.resolve_page_id(sid)
+        if not resolved:
+            log.warning(
+                "Citation link skipped: source %s not found", sid,
+            )
+            continue
+
+        await db.save_link(PageLink(
+            from_page_id=result.created_page_id,
+            to_page_id=resolved,
+            link_type=LinkType.CITES,
+        ))
+        log.info(
+            "Citation linked: %s -> %s",
+            result.created_page_id[:8], resolved[:8],
         )
 
     return result

--- a/supabase/migrations/20260319120037_convert_source_id_extra_to_cites_links.sql
+++ b/supabase/migrations/20260319120037_convert_source_id_extra_to_cites_links.sql
@@ -1,0 +1,19 @@
+-- Convert page.extra['source_id'] metadata into proper CITES links,
+-- then remove the source_id key from extra.
+
+INSERT INTO page_links (id, from_page_id, to_page_id, link_type, strength, reasoning)
+SELECT
+    gen_random_uuid()::text,
+    p.id,
+    p.extra->>'source_id',
+    'cites',
+    2.5,
+    'Migrated from page.extra.source_id'
+FROM pages p
+WHERE p.extra->>'source_id' IS NOT NULL
+  AND EXISTS (SELECT 1 FROM pages s WHERE s.id = p.extra->>'source_id')
+ON CONFLICT DO NOTHING;
+
+UPDATE pages
+SET extra = extra - 'source_id'
+WHERE extra->>'source_id' IS NOT NULL;

--- a/tests/test_cites_links.py
+++ b/tests/test_cites_links.py
@@ -1,0 +1,165 @@
+"""Tests for CITES link creation when claims cite sources."""
+
+import pytest
+import pytest_asyncio
+
+from rumil.calls.ingest import IngestCall
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+from rumil.moves import MOVES
+from rumil.moves.base import MoveState
+from rumil.moves.create_claim import MoveType
+
+
+@pytest_asyncio.fixture
+async def source_page(tmp_db):
+    page = Page(
+        page_type=PageType.SOURCE,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="The sky appears blue due to Rayleigh scattering of sunlight.",
+        headline="Rayleigh scattering explains blue sky",
+        extra={"filename": "sky-science.txt", "char_count": 58},
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def second_source_page(tmp_db):
+    page = Page(
+        page_type=PageType.SOURCE,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Shorter wavelengths scatter more in the atmosphere.",
+        headline="Wavelength dependence of atmospheric scattering",
+        extra={"filename": "optics-101.txt", "char_count": 50},
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+async def test_cites_link_created_for_source(tmp_db, scout_call, source_page):
+    """A claim with source_ids should get a CITES link and no source_id in extra."""
+    state = MoveState(scout_call, tmp_db)
+    tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
+    await tool.fn({
+        "headline": "Blue sky from scattering",
+        "content": "Rayleigh scattering causes blue sky.",
+        "source_ids": [source_page.id[:8]],
+    })
+
+    assert len(state.created_page_ids) == 1
+    claim_id = state.created_page_ids[0]
+
+    links = await tmp_db.get_links_from(claim_id)
+    cites_links = [l for l in links if l.link_type == LinkType.CITES]
+    assert len(cites_links) == 1
+    assert cites_links[0].to_page_id == source_page.id
+
+    page = await tmp_db.get_page(claim_id)
+    assert "source_id" not in page.extra
+
+
+async def test_no_cites_link_when_source_ids_empty(tmp_db, scout_call):
+    """A claim without source_ids should have no CITES links."""
+    state = MoveState(scout_call, tmp_db)
+    tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
+    await tool.fn({
+        "headline": "Unsourced claim",
+        "content": "This claim cites nothing.",
+    })
+
+    assert len(state.created_page_ids) == 1
+    claim_id = state.created_page_ids[0]
+    links = await tmp_db.get_links_from(claim_id)
+    cites_links = [l for l in links if l.link_type == LinkType.CITES]
+    assert len(cites_links) == 0
+
+
+async def test_multiple_cites_links(
+    tmp_db, scout_call, source_page, second_source_page,
+):
+    """A claim citing multiple sources should get one CITES link per source."""
+    state = MoveState(scout_call, tmp_db)
+    tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
+    await tool.fn({
+        "headline": "Combined scattering evidence",
+        "content": "Multiple sources confirm scattering.",
+        "source_ids": [source_page.id[:8], second_source_page.id[:8]],
+    })
+
+    assert len(state.created_page_ids) == 1
+    claim_id = state.created_page_ids[0]
+    links = await tmp_db.get_links_from(claim_id)
+    cites_links = [l for l in links if l.link_type == LinkType.CITES]
+    assert len(cites_links) == 2
+    cited_ids = {l.to_page_id for l in cites_links}
+    assert cited_ids == {source_page.id, second_source_page.id}
+
+
+async def test_cites_and_consideration_links_coexist(
+    tmp_db, scout_call, question_page, source_page,
+):
+    """A claim with both source_ids and links should create both link types."""
+    state = MoveState(scout_call, tmp_db)
+    tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
+    await tool.fn({
+        "headline": "Sourced and linked claim",
+        "content": "This claim cites a source and bears on a question.",
+        "source_ids": [source_page.id[:8]],
+        "links": [{
+            "question_id": question_page.id[:8],
+            "strength": 3.5,
+            "reasoning": "Bears on the question",
+        }],
+    })
+
+    assert len(state.created_page_ids) == 1
+    claim_id = state.created_page_ids[0]
+    links = await tmp_db.get_links_from(claim_id)
+
+    cites_links = [l for l in links if l.link_type == LinkType.CITES]
+    consideration_links = [l for l in links if l.link_type == LinkType.CONSIDERATION]
+    assert len(cites_links) == 1
+    assert cites_links[0].to_page_id == source_page.id
+    assert len(consideration_links) == 1
+    assert consideration_links[0].to_page_id == question_page.id
+
+
+@pytest.mark.llm
+async def test_ingest_creates_cites_links(tmp_db, question_page, source_page):
+    """End-to-end ingest: claims should have CITES links to the source."""
+    ingest_call = Call(
+        call_type=CallType.INGEST,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(ingest_call)
+
+    ingest = IngestCall(source_page, question_page.id, ingest_call, tmp_db)
+    await ingest.run()
+
+    refreshed = await tmp_db.get_call(ingest_call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+
+    source_links = await tmp_db.get_links_to(source_page.id)
+    cites_links = [l for l in source_links if l.link_type == LinkType.CITES]
+    assert len(cites_links) >= 1, "Ingest should create at least one claim citing the source"
+
+    question_links = await tmp_db.get_links_to(question_page.id)
+    consideration_links = [
+        l for l in question_links if l.link_type == LinkType.CONSIDERATION
+    ]
+    assert len(consideration_links) >= 1, (
+        "Ingest should create at least one consideration linked to the question"
+    )


### PR DESCRIPTION
## Summary
- Adds `CITES` link type to `LinkType` enum for claim→source citation relationships
- Replaces `source_id: str | None` with `source_ids: Sequence[str]` on `CreateClaimPayload`, supporting multiple citations per claim
- Removes `page_extra_fields()` override — citations are now proper `page_links` entries, not informal metadata
- Data migration converts existing `extra.source_id` entries into CITES links and strips the key from `extra`

## Test plan
- [x] Unit test: CITES link created when `source_ids` has one entry, `page.extra` has no `source_id`
- [x] Unit test: no CITES link when `source_ids` is empty
- [x] Unit test: multiple CITES links for multiple `source_ids`
- [x] Unit test: CITES and consideration links coexist
- [x] Integration test (`--llm`): end-to-end ingest creates CITES links to source and consideration links to question
- [ ] Apply migration to prod after merge (`supabase db push`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)