### PR TITLE
Add --integration flag for slow LLM tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,19 +27,25 @@ def _test_settings():
 
 def pytest_addoption(parser):
     parser.addoption("--llm", action="store_true", default=False, help="Run tests that call the real LLM API")
+    parser.addoption("--integration", action="store_true", default=False, help="Run slow integration tests (implies --llm)")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "llm: tests that call the real LLM API")
+    config.addinivalue_line("markers", "integration: slow integration tests that call the real LLM API")
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--llm"):
-        return
-    skip_llm = pytest.mark.skip(reason="needs --llm flag to run")
+    run_llm = config.getoption("--llm")
+    run_integration = config.getoption("--integration")
+    if run_integration:
+        run_llm = True
+
     for item in items:
-        if "llm" in item.keywords:
-            item.add_marker(skip_llm)
+        if "integration" in item.keywords and not run_integration:
+            item.add_marker(pytest.mark.skip(reason="needs --integration flag to run"))
+        elif "llm" in item.keywords and not run_llm:
+            item.add_marker(pytest.mark.skip(reason="needs --llm flag to run"))
 
 
 @pytest_asyncio.fixture

--- a/tests/test_call_lifecycle.py
+++ b/tests/test_call_lifecycle.py
@@ -97,7 +97,7 @@ async def test_ingest_lifecycle(tmp_db, question_page, ingest_call, source_page)
     assert context_event.get("source_page_id") == source_page.id
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_scout_lifecycle(tmp_db, question_page, scout_call):
     """Scout session runs rounds, checks fruit, and completes."""
     await tmp_db.init_budget(2)
@@ -126,7 +126,7 @@ async def test_scout_lifecycle(tmp_db, question_page, scout_call):
     assert "review_complete" in event_types
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_scout_stops_on_budget_exhaustion(tmp_db, question_page, scout_call):
     """Scout session stops when budget runs out mid-loop."""
     await tmp_db.init_budget(1)
@@ -161,7 +161,7 @@ async def test_complete_call(tmp_db, assess_call):
     assert refreshed.result_summary == "Test summary"
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_closing_review_saves_page_ratings(
     tmp_db, question_page, assess_call,
 ):

--- a/tests/test_cites_links.py
+++ b/tests/test_cites_links.py
@@ -135,7 +135,7 @@ async def test_cites_and_consideration_links_coexist(
     assert consideration_links[0].to_page_id == question_page.id
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_ingest_creates_cites_links(tmp_db, question_page, source_page):
     """End-to-end ingest: claims should have CITES links to the source."""
     ingest_call = Call(

--- a/tests/test_investigate.py
+++ b/tests/test_investigate.py
@@ -5,7 +5,7 @@ import pytest
 from rumil.orchestrator import Orchestrator
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_investigate_creates_pages(tmp_db, question_page):
     """Budget-1 investigation should produce at least one new page."""
     await tmp_db.init_budget(1)

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -60,7 +60,7 @@ def _assess_dispatch(question_id: str, **kwargs) -> Dispatch:
     )
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_scout_dispatch_creates_scout_call(tmp_db, question_page):
     """A scout dispatch should produce a scout call in the DB."""
     prioritizer = ScriptedPrioritizer([
@@ -79,7 +79,7 @@ async def test_scout_dispatch_creates_scout_call(tmp_db, question_page):
     assert len(rows.data) >= 1
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_assess_dispatch_creates_assess_call(tmp_db, question_page):
     """An assess dispatch should produce an assess call in the DB."""
     prioritizer = ScriptedPrioritizer([
@@ -98,7 +98,7 @@ async def test_assess_dispatch_creates_assess_call(tmp_db, question_page):
     assert len(rows.data) >= 1
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_budget_exhaustion_limits_dispatches(tmp_db, question_page):
     """Only dispatches that fit within the budget should execute."""
     await tmp_db.init_budget(1)
@@ -139,7 +139,7 @@ async def test_empty_dispatches_exits_loop(tmp_db, question_page):
     assert "assess" not in call_types
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_reprioritization_on_leftover_budget(tmp_db, question_page):
     """Prioritizer should be queried again when budget remains after execution."""
     await tmp_db.init_budget(5)
@@ -165,7 +165,7 @@ async def test_no_infinite_loop_when_nothing_spent(tmp_db, question_page):
     assert prioritizer.get_calls_count == 0
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_unresolvable_question_id_falls_back_to_root(tmp_db, question_page):
     """When a dispatch references a non-existent page, the root question is used."""
     fake_id = str(uuid.uuid4())
@@ -186,7 +186,7 @@ async def test_unresolvable_question_id_falls_back_to_root(tmp_db, question_page
     assert rows.data[0]["scope_page_id"] == question_page.id
 
 
-@pytest.mark.llm
+@pytest.mark.integration
 async def test_dispatch_executed_events_recorded(tmp_db, question_page):
     """DispatchExecutedEvent should be persisted to trace_json."""
     p_call = await tmp_db.create_call(


### PR DESCRIPTION
## Summary
- Adds `--integration` pytest flag for slow (>15s) LLM tests, separate from the existing `--llm` flag
- `--integration` implies `--llm`, so it runs all 85 tests
- `--llm` alone runs 74 tests (skips 11 integration), plain `pytest` runs 60 normal tests
- Moved 11 tests from `@pytest.mark.llm` to `@pytest.mark.integration`: full orchestrator dispatches, scout lifecycles, end-to-end ingest, and investigate

## Test plan
- [x] `uv run pytest` — 60 normal tests pass, 25 skipped
- [x] `uv run pytest --llm` — 74 tests pass, 11 skipped
- [x] `uv run pytest --integration` — all 85 tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)