### PR TITLE
Add slim page loading to avoid fetching content in bulk operations

### DIFF
--- a/src/rumil/calls/scout.py
+++ b/src/rumil/calls/scout.py
@@ -110,7 +110,7 @@ async def link_new_pages(
         return
 
     workspace_map, _ = await build_workspace_map(db, graph=graph)
-    question_text = await format_page(question)
+    question_text = await format_page(question, db=db)
     existing_links = await _build_link_inventory(question_id, db, graph=graph)
     working_context = (
         workspace_map + '\n\n---\n\n'
@@ -585,11 +585,7 @@ class EmbeddingScoutCall(ScoutCall):
             scout_mode=self.mode.value,
         ))
 
-        graph = await PageGraph.load(self.db)
-        workspace_map, _ = await build_workspace_map(self.db, graph=graph)
-        self.context_text = assemble_call_context(
-            emb_result.context_text, workspace_map=workspace_map,
-        )
+        self.context_text = assemble_call_context(emb_result.context_text)
 
         self.tools = [MOVES[mt].bind(self.state) for mt in MoveType]
         self.tool_defs, _ = _prepare_tools(self.tools)

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -53,6 +53,10 @@ async def format_page(
     graph: PageGraph | None = None,
 ) -> str:
     """Format a single page as readable text for LLM context."""
+    if not page.content and db:
+        full = await db.get_page(page.id)
+        if full:
+            page = full
     source: DB | PageGraph | None = graph if graph is not None else db
     extra = page.extra or {}
     lines = [
@@ -149,7 +153,7 @@ async def build_context_for_question(
             parts.append("")
             for j in judgements:
                 loaded_ids.append(j.id)
-                parts.append(await format_page(j))
+                parts.append(await format_page(j, db=db))
                 parts.append("")
 
         children = await source.get_child_questions(question_id)
@@ -163,7 +167,7 @@ async def build_context_for_question(
             for child, j in child_judgements:
                 loaded_ids.append(j.id)
                 parts.append(f"*On sub-question: {child.headline} (`{child.id}`)*")
-                parts.append(await format_page(j))
+                parts.append(await format_page(j, db=db))
                 parts.append("")
 
     return "\n".join(parts), loaded_ids
@@ -234,7 +238,7 @@ async def format_question_for_scout(
 
     loaded_ids = [question_id]
     parts = ["# Scope Question", ""]
-    parts.append(await format_page(question))
+    parts.append(await format_page(question, db=db))
     parts.append("")
 
     considerations = await source.get_considerations_for_question(question_id)
@@ -272,6 +276,10 @@ async def format_question_for_scout(
         parts.append("")
         for claim, link in structural_cons:
             loaded_ids.append(claim.id)
+            if not claim.content:
+                full = await db.get_page(claim.id)
+                if full:
+                    claim = full
             parts.append(f"### [{claim.page_type.value.upper()}] {claim.headline}")
             parts.append(f"ID: {claim.id}")
             parts.append(f"Strength: {link.strength:.1f}/5")
@@ -280,6 +288,10 @@ async def format_question_for_scout(
             parts.append("")
         for child, link in structural_children:
             loaded_ids.append(child.id)
+            if not child.content:
+                full = await db.get_page(child.id)
+                if full:
+                    child = full
             parts.append(f"### [QUESTION] {child.headline}")
             parts.append(f"ID: {child.id}")
             parts.append("")
@@ -292,7 +304,7 @@ async def format_question_for_scout(
         parts.append("")
         for j in judgements:
             loaded_ids.append(j.id)
-            parts.append(await format_page(j))
+            parts.append(await format_page(j, db=db))
             parts.append("")
 
     children = await source.get_child_questions(question_id)
@@ -306,7 +318,7 @@ async def format_question_for_scout(
         for child, j in child_judgements:
             loaded_ids.append(j.id)
             parts.append(f"*On sub-question: {child.headline} (`{child.id}`)*")
-            parts.append(await format_page(j))
+            parts.append(await format_page(j, db=db))
             parts.append("")
 
     return "\n".join(parts), loaded_ids
@@ -411,13 +423,15 @@ async def build_prioritization_context(
     """Build context for a prioritization call.
 
     Returns (context_text, short_id_map) where short_id_map maps 8-char
-    short IDs to full UUIDs.
+    short IDs to full UUIDs for the scope subtree only.
     """
     source: DB | PageGraph = graph if graph is not None else db
-    map_text, short_id_map = await build_workspace_map(db, graph=graph)
-    parts = [map_text, "", "---", "", "# Prioritization Context", ""]
+    parts = ["# Prioritization Context", ""]
 
+    short_id_map: dict[str, str] = {}
     if scope_question_id:
+        subtree_ids = await collect_subtree_ids(scope_question_id, db, graph=graph)
+        short_id_map = {sid[:8]: sid for sid in subtree_ids}
         question = await source.get_page(scope_question_id)
         if question:
             index_lines = await _build_question_index(

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -39,24 +39,31 @@ def _rows(response: Any) -> _Rows:
     return cast(_Rows, response.data) if response.data else []
 
 
+_SLIM_PAGE_COLUMNS = (
+    "id,page_type,layer,workspace,headline,abstract,"
+    "epistemic_status,epistemic_type,extra,is_superseded,"
+    "project_id,created_at,superseded_by,run_id"
+)
+
+
 def _row_to_page(row: dict[str, Any]) -> Page:
     return Page(
         id=row["id"],
         page_type=PageType(row["page_type"]),
         layer=PageLayer(row["layer"]),
         workspace=Workspace(row["workspace"]),
-        content=row["content"],
-        headline=row["headline"],
+        content=row.get("content") or "",
+        headline=row.get("headline") or "",
         project_id=row.get("project_id") or "",
-        epistemic_status=row["epistemic_status"],
-        epistemic_type=row["epistemic_type"] or "",
-        provenance_model=row["provenance_model"] or "",
-        provenance_call_type=row["provenance_call_type"] or "",
-        provenance_call_id=row["provenance_call_id"] or "",
+        epistemic_status=row.get("epistemic_status") or 0.0,
+        epistemic_type=row.get("epistemic_type") or "",
+        provenance_model=row.get("provenance_model") or "",
+        provenance_call_type=row.get("provenance_call_type") or "",
+        provenance_call_id=row.get("provenance_call_id") or "",
         created_at=datetime.fromisoformat(row["created_at"]),
-        superseded_by=row["superseded_by"],
-        is_superseded=bool(row["is_superseded"]),
-        extra=row["extra"] or {},
+        superseded_by=row.get("superseded_by"),
+        is_superseded=bool(row.get("is_superseded", False)),
+        extra=row.get("extra") or {},
         abstract=row.get("abstract") or "",
     )
 
@@ -278,6 +285,21 @@ class DB:
         if page:
             return f'"{page.headline[:60]}" [{page_id[:8]}]'
         return f"[{page_id[:8]}]"
+
+    async def get_pages_slim(self, active_only: bool = True) -> list[Page]:
+        """Fetch all pages without the content field — safe for bulk loads."""
+        query = self.client.table("pages").select(_SLIM_PAGE_COLUMNS)
+        if self.project_id:
+            query = query.eq("project_id", self.project_id)
+        if active_only:
+            query = query.eq("is_superseded", False)
+        query = self._ab_filter(query)
+        return [
+            _row_to_page(r)
+            for r in _rows(
+                await query.order("created_at", desc=True).limit(10000).execute()
+            )
+        ]
 
     async def get_pages(
         self,

--- a/src/rumil/embeddings.py
+++ b/src/rumil/embeddings.py
@@ -52,11 +52,17 @@ async def embed_query(text: str) -> Sequence[float]:
 
 
 def page_text_for_field(page: Page, field_name: str) -> str:
-    """Return the text to embed for a given page field."""
+    """Return the text to embed for a given page field.
+
+    For the 'abstract' field, falls back to headline+content when abstract is empty
+    (pages that pre-date summary generation or haven't been through closing review).
+    """
     if field_name == "content":
         return f"{page.headline}\n\n{page.content}"
     if field_name == "abstract":
-        return page.abstract
+        if page.abstract and page.abstract.strip():
+            return page.abstract
+        return f"{page.headline}\n\n{page.content}"
     raise ValueError(f"Unknown embedding field: {field_name}")
 
 
@@ -180,9 +186,13 @@ async def backfill_embeddings(
     if not rows:
         return 0
     pages = [_row_to_page(r) for r in rows]
-    texts = [page_text_for_field(p, field_name) for p in pages]
-    embeddings = await embed_texts(texts, input_type="document")
-    for page, embedding in zip(pages, embeddings):
+    eligible = [(p, page_text_for_field(p, field_name)) for p in pages]
+    eligible = [(p, t) for p, t in eligible if t and t.strip()]
+    if not eligible:
+        return 0
+    pages_to_embed, texts = zip(*eligible)
+    embeddings = await embed_texts(list(texts), input_type="document")
+    for page, embedding in zip(pages_to_embed, embeddings):
         await store_embedding(db, page.id, field_name, embedding)
-    log.info("Backfilled %s embeddings for %d pages", field_name, len(pages))
-    return len(pages)
+    log.info("Backfilled %s embeddings for %d pages", field_name, len(pages_to_embed))
+    return len(pages_to_embed)

--- a/src/rumil/page_graph.py
+++ b/src/rumil/page_graph.py
@@ -49,7 +49,7 @@ class PageGraph:
 
     @classmethod
     async def load(cls, db: "PageSource") -> "PageGraph":
-        pages = await db.get_pages(active_only=True)
+        pages = await db.get_pages_slim(active_only=True)
         links = await db.get_all_links()
         log.debug(
             'PageGraph.load: %d pages, %d links', len(pages), len(links),

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,7 +7,7 @@ project_id = "rumil"
 [api]
 enabled = true
 # Port to use for the API URL.
-port = 54321
+port = 54391
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
@@ -26,7 +26,7 @@ enabled = false
 
 [db]
 # Port to use for the local database URL.
-port = 54322
+port = 54399
 # Port used by db diff command to initialize the shadow database.
 shadow_port = 54320
 # Maximum amount of time to wait for health check when starting the local database.
@@ -84,7 +84,7 @@ enabled = true
 [studio]
 enabled = true
 # Port to use for Supabase Studio.
-port = 54323
+port = 54393
 # External URL of the API server that frontend connects to.
 api_url = "http://127.0.0.1"
 # OpenAI API Key to use for Supabase AI in the Supabase Studio.
@@ -95,7 +95,7 @@ openai_api_key = "env(OPENAI_API_KEY)"
 [inbucket]
 enabled = true
 # Port to use for the email testing server web interface.
-port = 54324
+port = 54394
 # Uncomment to expose additional ports for testing user applications that send emails.
 # smtp_port = 54325
 # pop3_port = 54326
@@ -366,7 +366,7 @@ deno_version = 2
 
 [analytics]
 enabled = true
-port = 54327
+port = 54397
 # Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"
 


### PR DESCRIPTION
Introduces get_pages_slim() which omits the content field, used by PageGraph.load() to reduce memory and query cost. Full content is fetched lazily in format_page() and format_question_for_scout() when needed. Also fixes embedding backfill to skip pages with empty text, and removes workspace map prepending from EmbeddingScoutCall context.