### PR TITLE
Reduce redundancy in prioritization context

### DIFF
--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -48,6 +48,29 @@ async def collect_subtree_ids(
     return result
 
 
+async def collect_all_subtree_page_ids(
+    question_id: str,
+    db: DB,
+    graph: PageGraph | None = None,
+    _visited: set[str] | None = None,
+) -> set[str]:
+    """Recursively collect all page IDs in a subtree: questions, considerations, and judgements."""
+    if _visited is None:
+        _visited = set()
+    if question_id in _visited:
+        return set()
+    _visited = _visited | {question_id}
+    source: DB | PageGraph = graph if graph is not None else db
+    result: set[str] = {question_id}
+    for page, _ in await source.get_considerations_for_question(question_id):
+        result.add(page.id)
+    for j in await source.get_judgements_for_question(question_id):
+        result.add(j.id)
+    for child in await source.get_child_questions(question_id):
+        result |= await collect_all_subtree_page_ids(child.id, db, graph=graph, _visited=_visited)
+    return result
+
+
 async def render_subtree(
     root_id: str,
     db: DB,
@@ -99,7 +122,10 @@ async def render_subtree(
                 if link.reasoning:
                     parts.append(f'{indent}  Reasoning: {link.reasoning}')
 
-        judgements = await graph.get_judgements_for_question(question.id)
+        all_judgements = await graph.get_judgements_for_question(question.id)
+        judgements = (
+            [max(all_judgements, key=lambda j: j.created_at)] if all_judgements else []
+        )
         if judgements:
             parts.append('')
             parts.append(f'{indent}**Judgements:**')
@@ -472,10 +498,14 @@ async def build_prioritization_context(
     if scope_question_id:
         question = await source.get_page(scope_question_id)
         if question:
+            subtree_page_ids = await collect_all_subtree_page_ids(
+                scope_question_id, db, graph=graph,
+            )
             embedding_result = await build_embedding_based_context(
                 question.headline,
                 db,
                 scope_question_id=scope_question_id,
+                headline_only_ids=subtree_page_ids,
             )
             if embedding_result.context_text:
                 parts.append(embedding_result.context_text)
@@ -549,6 +579,7 @@ async def build_embedding_based_context(
     db: DB,
     *,
     scope_question_id: str | None = None,
+    headline_only_ids: set[str] | None = None,
     context_char_budget: int | None = None,
     distillation_page_char_fraction: float | None = None,
     full_page_char_fraction: float | None = None,
@@ -614,7 +645,9 @@ async def build_embedding_based_context(
     summary_ids: list[str] = []
     summary_chars = 0
 
+    _headline_only = headline_only_ids or set()
     distillation_page_id_set = {p.id for p, _ in distillation_pages}
+
     for page, _sim in distillation_pages:
         formatted = await format_page(page, PageDetail.CONTENT, db=db, linked_detail=None)
         if distillation_chars + len(formatted) <= distillation_budget:
@@ -624,6 +657,18 @@ async def build_embedding_based_context(
 
     for page, _sim in ranked:
         if page.id in distillation_page_id_set:
+            continue
+        if page.id in _headline_only:
+            formatted = await format_page(page, PageDetail.HEADLINE, linked_detail=None)
+            summary_parts.append(formatted)
+            summary_ids.append(page.id)
+            summary_chars += len(formatted)
+            continue
+
+    for page, _sim in ranked:
+        if page.id in distillation_page_id_set:
+            continue
+        if page.id in _headline_only:
             continue
 
         if full_chars < full_budget:


### PR DESCRIPTION
In the embedding-based top block, pages that appear in the scope subtree detail section are now shown at headline level only (instead of full/abstract), since the full content appears below. Also limits judgements in render_subtree to the most recent one per question.