### PR TITLE
Add four new scout call types for initial question exploration

### DIFF
--- a/prompts/scout_analogies.md
+++ b/prompts/scout_analogies.md
@@ -1,0 +1,34 @@
+# Scout Analogies Call Instructions
+
+## Your Task
+
+You are performing a **Scout Analogies** call — an initial exploration focused on identifying **analogies** that may be informative about the parent question. Your job is to find situations, historical precedents, or structural parallels that could shed light on the question, describe them, and create research targets for exploring their relevance.
+
+## What to Produce
+
+For each analogy (aim for 1–3):
+
+1. **A claim** describing the analogy and why it may be relevant. Explain the structural parallel: what features of the analogous situation map onto the current question, and what the analogy would predict or suggest if it holds. Set epistemic status to reflect how strong you think the parallel is.
+
+2. **A subquestion** asking about the relevance, limits, or details of the analogy — e.g. "How closely does [analogy] parallel [situation in the parent question]?" or "What does the [analogous case] suggest about [specific aspect]?". Link it as a child of the parent question.
+
+3. Optionally, **link related** pages if the analogy connects to existing claims or questions elsewhere in the workspace.
+
+## How to Proceed
+
+1. Read the parent question and consider: what other domains, historical episodes, or known situations share structural features with this question?
+2. For each analogy, create a claim describing it using `create_claim`, then `link_consideration` to the parent question.
+3. Create a subquestion for further exploration using `create_question` and `link_child_question`.
+4. If the analogy connects to existing pages in the workspace, use `link_related` to make those connections visible.
+
+## What Makes a Good Analogy
+
+- **Structural, not superficial.** The parallel should be in the causal or logical structure, not just surface resemblance. "Both involve technology" is superficial. "Both involve a new technology disrupting an incumbent with high switching costs and regulatory capture" is structural.
+- **Informative.** The analogy should suggest something non-obvious about the parent question — a dynamic to watch for, a likely outcome, a hidden risk, or a useful framing.
+- **Specific.** Name the analogous case concretely. "Historical precedents" is vague. "The transition from horse-drawn transport to automobiles in US cities, 1900–1930" is specific.
+
+## Quality Bar
+
+- **One illuminating analogy beats three weak parallels.** Only propose analogies that genuinely advance understanding.
+- **Acknowledge limits.** Every analogy breaks down somewhere. Note where the parallel is strongest and where it may diverge — this is valuable for later investigation.
+- **Do not duplicate** analogies already present in the workspace.

--- a/prompts/scout_estimates.md
+++ b/prompts/scout_estimates.md
@@ -1,0 +1,27 @@
+# Scout Estimates Call Instructions
+
+## Your Task
+
+You are performing a **Scout Estimates** call — an initial exploration focused on identifying **quantities** whose estimates would be highly informative about the parent question. Your job is to find the key numbers, make initial guesses about their values, and create subquestions so those estimates can be refined.
+
+## What to Produce
+
+For each informative quantity (aim for 2–4):
+
+1. **A claim** stating your initial estimate of the quantity's value. Be specific: name the quantity, give a point estimate or range, and explain your reasoning. Set an appropriately low epistemic status — these are Fermi-style first guesses, not researched figures.
+
+2. **A subquestion** asking about the value of that quantity, linked to the parent question. This creates a research target for later calls to refine the estimate.
+
+## How to Proceed
+
+1. Read the parent question and consider what quantities, if known, would most constrain or resolve the answer. Think about: magnitudes, rates, proportions, costs, timelines, thresholds, population sizes, frequencies.
+2. For each quantity, create a claim with your initial estimate using `create_claim`, then `link_consideration` to the parent question.
+3. Create a corresponding subquestion using `create_question` and `link_child_question` to the parent.
+
+## Quality Bar
+
+- **Informative quantities over comprehensive enumeration.** Two numbers that would materially change the answer beat five that are merely tangentially relevant.
+- **Be specific.** "The cost is probably high" is not an estimate. "Annual US spending on X is likely $5–15B" is.
+- **Show your reasoning.** Even rough Fermi reasoning in the claim content helps later calls evaluate and refine the estimate.
+- **Appropriate uncertainty.** Use epistemic status 1–2 for rough guesses, 2–3 for estimates grounded in some reasoning, higher only if you have genuine basis for confidence.
+- **Do not duplicate** quantities or estimates already present in the workspace.

--- a/prompts/scout_hypotheses.md
+++ b/prompts/scout_hypotheses.md
@@ -1,0 +1,35 @@
+# Scout Hypotheses Call Instructions
+
+## Your Task
+
+You are performing a **Scout Hypotheses** call — an initial exploration focused on identifying **hypotheses** that should be explored as potential answers to the parent question. Each hypothesis is a specific, substantive view that, if true, would substantially shape the answer.
+
+## What to Produce
+
+For each hypothesis (aim for 2–4):
+
+1. **A hypothesis subquestion** of the form "What should we make of the hypothesis that [X]?", linked as a child of the parent question. This frames the hypothesis as a research target: later calls will gather evidence for and against it, assess its plausibility, and extract whatever partial truth it contains.
+
+2. Optionally, **a claim** summarising the core assertion of the hypothesis and your initial assessment of its plausibility, linked as a consideration to the parent question or to the hypothesis subquestion.
+
+Use `propose_hypothesis` when the hypothesis is a compelling candidate answer to the parent question. Use `create_question` + `link_child_question` when framing it as a subquestion for further exploration.
+
+## How to Proceed
+
+1. Read the parent question and existing context carefully.
+2. Identify candidate answers, paradigms, or explanatory frameworks — not just pieces of evidence, but specific views about what the answer to the parent question looks like.
+3. For each, create a hypothesis subquestion and link it to the parent.
+4. Where you have an initial view on plausibility, state it as a claim with appropriate epistemic status.
+
+## What Makes a Good Hypothesis
+
+- **Specific and substantive.** "Economic factors are important" is not a hypothesis. "The primary driver of X is Y, because Z" is.
+- **Would shape the answer if true.** A hypothesis should be something that, if you became convinced of it, would substantially change how you respond to the parent question.
+- **Worth engaging with seriously.** Either it is plausibly correct, or engaging with it would yield useful insights — clarifying why it fails, surfacing adjacent territory, or extracting partial truth.
+- **Not already well-represented** in the existing consideration set.
+
+## Quality Bar
+
+- **One strong hypothesis beats several thin ones.** Do not pad with obvious or uninteresting options.
+- **Diversity of perspective.** Aim for hypotheses that represent genuinely different views, not minor variations on the same theme.
+- **Do not duplicate** hypotheses already present in the workspace.

--- a/prompts/scout_subquestions.md
+++ b/prompts/scout_subquestions.md
@@ -1,0 +1,25 @@
+# Scout Subquestions Call Instructions
+
+## Your Task
+
+You are performing a **Scout Subquestions** call — an initial exploration of a newly-generated question. Your job is to identify **subquestions whose answers would be highly informative** about the parent question, and to produce initial considerations that bear on it.
+
+## What to Produce
+
+1. **Subquestions (2–4).** Each should decompose the parent question into a piece that, if answered well, would substantially advance understanding of the whole. Avoid subquestions that merely restate the parent in different words, or that address marginal aspects. Think about what you would *most want to know* if you were trying to answer the parent question — those are your subquestions.
+
+2. **Initial considerations (1–3).** Claims that bear directly on the parent question. These may be tentative — the point is to plant stakes that later investigation can refine or refute. Where you have a provisional answer to one of the subquestions you are posing, state it as a claim with an appropriately low epistemic status.
+
+## How to Proceed
+
+1. Read the parent question and existing context carefully.
+2. Identify the most informative axes of decomposition — the subquestions whose answers would do the most to resolve the parent.
+3. For each subquestion, use `create_question` and then `link_child_question` to connect it to the parent.
+4. Where you can offer even a tentative answer or relevant consideration, use `create_claim` and `link_consideration` to attach it to the parent question (or to a subquestion, if it bears more directly there).
+
+## Quality Bar
+
+- **Informative decomposition over exhaustive coverage.** Two subquestions that cut to the heart of the matter beat five that nibble at the edges.
+- **Subquestions should be substantially independent.** If answering one would largely answer another, merge them or drop the weaker one.
+- **Tentative claims are valuable.** A provisional answer with epistemic status 1–2 gives later calls something concrete to evaluate. Do not shy away from stating a view just because you are uncertain — flag the uncertainty in the epistemic status and type.
+- **Do not duplicate** subquestions or considerations already present in the workspace.

--- a/src/rumil/calls/__init__.py
+++ b/src/rumil/calls/__init__.py
@@ -5,11 +5,19 @@ from rumil.calls.base import BaseCall, SimpleCall
 from rumil.calls.call_registry import (
     ASSESS_CALL_CLASSES,
     INGEST_CALL_CLASSES,
+    SCOUT_ANALOGIES_CALL_CLASSES,
     SCOUT_CALL_CLASSES,
+    SCOUT_ESTIMATES_CALL_CLASSES,
+    SCOUT_HYPOTHESES_CALL_CLASSES,
+    SCOUT_SUBQUESTIONS_CALL_CLASSES,
 )
 from rumil.calls.ingest import EmbeddingIngestCall, IngestCall
 from rumil.calls.prioritization import run_prioritization
 from rumil.calls.scout import EmbeddingScoutCall, ScoutCall
+from rumil.calls.scout_analogies import ScoutAnalogiesCall
+from rumil.calls.scout_estimates import ScoutEstimatesCall
+from rumil.calls.scout_hypotheses import ScoutHypothesesCall
+from rumil.calls.scout_subquestions import ScoutSubquestionsCall
 
 __all__ = [
     "BaseCall",
@@ -20,8 +28,16 @@ __all__ = [
     "EmbeddingIngestCall",
     "ScoutCall",
     "EmbeddingScoutCall",
+    "ScoutSubquestionsCall",
+    "ScoutEstimatesCall",
+    "ScoutHypothesesCall",
+    "ScoutAnalogiesCall",
     "SCOUT_CALL_CLASSES",
     "ASSESS_CALL_CLASSES",
     "INGEST_CALL_CLASSES",
+    "SCOUT_SUBQUESTIONS_CALL_CLASSES",
+    "SCOUT_ESTIMATES_CALL_CLASSES",
+    "SCOUT_HYPOTHESES_CALL_CLASSES",
+    "SCOUT_ANALOGIES_CALL_CLASSES",
     "run_prioritization",
 ]

--- a/src/rumil/calls/call_registry.py
+++ b/src/rumil/calls/call_registry.py
@@ -8,7 +8,11 @@ from rumil.calls.assess import AssessCall, EmbeddingAssessCall
 from rumil.calls.assess_concept import AssessConceptCall
 from rumil.calls.ingest import EmbeddingIngestCall, IngestCall
 from rumil.calls.scout import EmbeddingScoutCall, ScoutCall
+from rumil.calls.scout_analogies import ScoutAnalogiesCall
 from rumil.calls.scout_concepts import ScoutConceptsCall
+from rumil.calls.scout_estimates import ScoutEstimatesCall
+from rumil.calls.scout_hypotheses import ScoutHypothesesCall
+from rumil.calls.scout_subquestions import ScoutSubquestionsCall
 
 SCOUT_CALL_CLASSES: dict[str, type[ScoutCall]] = {
     "default": ScoutCall,
@@ -31,4 +35,20 @@ SCOUT_CONCEPTS_CALL_CLASSES: dict[str, type[ScoutConceptsCall]] = {
 
 ASSESS_CONCEPT_CALL_CLASSES: dict[str, type[AssessConceptCall]] = {
     "default": AssessConceptCall,
+}
+
+SCOUT_SUBQUESTIONS_CALL_CLASSES: dict[str, type[ScoutSubquestionsCall]] = {
+    "default": ScoutSubquestionsCall,
+}
+
+SCOUT_ESTIMATES_CALL_CLASSES: dict[str, type[ScoutEstimatesCall]] = {
+    "default": ScoutEstimatesCall,
+}
+
+SCOUT_HYPOTHESES_CALL_CLASSES: dict[str, type[ScoutHypothesesCall]] = {
+    "default": ScoutHypothesesCall,
+}
+
+SCOUT_ANALOGIES_CALL_CLASSES: dict[str, type[ScoutAnalogiesCall]] = {
+    "default": ScoutAnalogiesCall,
 }

--- a/src/rumil/calls/scout_analogies.py
+++ b/src/rumil/calls/scout_analogies.py
@@ -1,0 +1,55 @@
+"""Scout Analogies call: identify informative analogies for the question."""
+
+import logging
+
+from rumil.calls.base import SimpleCall
+from rumil.context import build_call_context
+from rumil.models import CallType, MoveType
+from rumil.page_graph import PageGraph
+
+log = logging.getLogger(__name__)
+
+
+class ScoutAnalogiesCall(SimpleCall):
+    """Identify analogies that may be informative about the question."""
+
+    def call_type(self) -> CallType:
+        return CallType.SCOUT_ANALOGIES
+
+    def task_description(self) -> str:
+        return (
+            'Identify analogies that may be informative about the parent '
+            'question. For each analogy, create claims describing it and its '
+            'relevance, and generate subquestions asking about the details '
+            'and limits of the analogy.\n\n'
+            f'Question ID: `{self.question_id}`'
+        )
+
+    def result_summary(self) -> str:
+        return (
+            f'Scout analogies complete. '
+            f'Created {len(self.result.created_page_ids)} pages.'
+        )
+
+    async def build_context(self) -> None:
+        graph = await PageGraph.load(self.db)
+        self.context_text, _, self.working_page_ids = await build_call_context(
+            self.question_id, self.db, extra_page_ids=self.preloaded_ids,
+            graph=graph,
+        )
+        await self._record_context_built()
+        await self._load_phase1_pages()
+
+    def _get_available_moves(self) -> list[MoveType]:
+        return [
+            MoveType.CREATE_CLAIM,
+            MoveType.CREATE_QUESTION,
+            MoveType.LINK_CONSIDERATION,
+            MoveType.LINK_CHILD_QUESTION,
+            MoveType.LINK_RELATED,
+            MoveType.LOAD_PAGE,
+        ]
+
+    async def create_pages(self) -> None:
+        self.available_moves = self._get_available_moves()
+        await super().create_pages()

--- a/src/rumil/calls/scout_estimates.py
+++ b/src/rumil/calls/scout_estimates.py
@@ -1,0 +1,54 @@
+"""Scout Estimates call: identify informative quantities and make initial guesses."""
+
+import logging
+
+from rumil.calls.base import SimpleCall
+from rumil.context import build_call_context
+from rumil.models import CallType, MoveType
+from rumil.page_graph import PageGraph
+
+log = logging.getLogger(__name__)
+
+
+class ScoutEstimatesCall(SimpleCall):
+    """Identify quantities whose estimates would be informative about the parent question."""
+
+    def call_type(self) -> CallType:
+        return CallType.SCOUT_ESTIMATES
+
+    def task_description(self) -> str:
+        return (
+            'Identify quantities whose estimates would be highly informative '
+            'about the parent question. Make initial guesses about their '
+            'values as claims, and generate subquestions asking about those '
+            'values so estimates can be refined.\n\n'
+            f'Question ID: `{self.question_id}`'
+        )
+
+    def result_summary(self) -> str:
+        return (
+            f'Scout estimates complete. '
+            f'Created {len(self.result.created_page_ids)} pages.'
+        )
+
+    async def build_context(self) -> None:
+        graph = await PageGraph.load(self.db)
+        self.context_text, _, self.working_page_ids = await build_call_context(
+            self.question_id, self.db, extra_page_ids=self.preloaded_ids,
+            graph=graph,
+        )
+        await self._record_context_built()
+        await self._load_phase1_pages()
+
+    def _get_available_moves(self) -> list[MoveType]:
+        return [
+            MoveType.CREATE_CLAIM,
+            MoveType.CREATE_QUESTION,
+            MoveType.LINK_CONSIDERATION,
+            MoveType.LINK_CHILD_QUESTION,
+            MoveType.LOAD_PAGE,
+        ]
+
+    async def create_pages(self) -> None:
+        self.available_moves = self._get_available_moves()
+        await super().create_pages()

--- a/src/rumil/calls/scout_hypotheses.py
+++ b/src/rumil/calls/scout_hypotheses.py
@@ -1,0 +1,55 @@
+"""Scout Hypotheses call: identify hypotheses to explore as potential answers."""
+
+import logging
+
+from rumil.calls.base import SimpleCall
+from rumil.context import build_call_context
+from rumil.models import CallType, MoveType
+from rumil.page_graph import PageGraph
+
+log = logging.getLogger(__name__)
+
+
+class ScoutHypothesesCall(SimpleCall):
+    """Identify hypotheses that should be explored as potential answers."""
+
+    def call_type(self) -> CallType:
+        return CallType.SCOUT_HYPOTHESES
+
+    def task_description(self) -> str:
+        return (
+            'Identify hypotheses that should be explored as potential answers '
+            'to the parent question. For each hypothesis, create a subquestion '
+            'of the form "What should we make of the hypothesis that ...?" '
+            'and link it to the parent.\n\n'
+            f'Question ID: `{self.question_id}`'
+        )
+
+    def result_summary(self) -> str:
+        return (
+            f'Scout hypotheses complete. '
+            f'Created {len(self.result.created_page_ids)} pages.'
+        )
+
+    async def build_context(self) -> None:
+        graph = await PageGraph.load(self.db)
+        self.context_text, _, self.working_page_ids = await build_call_context(
+            self.question_id, self.db, extra_page_ids=self.preloaded_ids,
+            graph=graph,
+        )
+        await self._record_context_built()
+        await self._load_phase1_pages()
+
+    def _get_available_moves(self) -> list[MoveType]:
+        return [
+            MoveType.CREATE_CLAIM,
+            MoveType.CREATE_QUESTION,
+            MoveType.PROPOSE_HYPOTHESIS,
+            MoveType.LINK_CONSIDERATION,
+            MoveType.LINK_CHILD_QUESTION,
+            MoveType.LOAD_PAGE,
+        ]
+
+    async def create_pages(self) -> None:
+        self.available_moves = self._get_available_moves()
+        await super().create_pages()

--- a/src/rumil/calls/scout_subquestions.py
+++ b/src/rumil/calls/scout_subquestions.py
@@ -1,0 +1,53 @@
+"""Scout Subquestions call: identify informative subquestions and initial considerations."""
+
+import logging
+
+from rumil.calls.base import SimpleCall
+from rumil.context import build_call_context
+from rumil.models import CallType, MoveType
+from rumil.page_graph import PageGraph
+
+log = logging.getLogger(__name__)
+
+
+class ScoutSubquestionsCall(SimpleCall):
+    """Identify subquestions whose answers would be highly informative about the parent."""
+
+    def call_type(self) -> CallType:
+        return CallType.SCOUT_SUBQUESTIONS
+
+    def task_description(self) -> str:
+        return (
+            'Identify subquestions whose answers would be highly informative '
+            'about the parent question, and generate initial considerations '
+            'that bear on the question.\n\n'
+            f'Question ID: `{self.question_id}`'
+        )
+
+    def result_summary(self) -> str:
+        return (
+            f'Scout subquestions complete. '
+            f'Created {len(self.result.created_page_ids)} pages.'
+        )
+
+    async def build_context(self) -> None:
+        graph = await PageGraph.load(self.db)
+        self.context_text, _, self.working_page_ids = await build_call_context(
+            self.question_id, self.db, extra_page_ids=self.preloaded_ids,
+            graph=graph,
+        )
+        await self._record_context_built()
+        await self._load_phase1_pages()
+
+    def _get_available_moves(self) -> list[MoveType]:
+        return [
+            MoveType.CREATE_CLAIM,
+            MoveType.CREATE_QUESTION,
+            MoveType.LINK_CONSIDERATION,
+            MoveType.LINK_CHILD_QUESTION,
+            MoveType.LOAD_PAGE,
+        ]
+
+    async def create_pages(self) -> None:
+        self.available_moves = self._get_available_moves()
+        await super().create_pages()

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -58,6 +58,10 @@ class CallType(str, Enum):
     SUMMARIZE = "summarize"
     SCOUT_CONCEPTS = "scout_concepts"
     ASSESS_CONCEPT = "assess_concept"
+    SCOUT_SUBQUESTIONS = "scout_subquestions"
+    SCOUT_ESTIMATES = "scout_estimates"
+    SCOUT_HYPOTHESES = "scout_hypotheses"
+    SCOUT_ANALOGIES = "scout_analogies"
 
 
 # The subset of CallTypes that prioritization can dispatch.


### PR DESCRIPTION
## Summary

- Add `scout_subquestions`, `scout_estimates`, `scout_hypotheses`, and `scout_analogies` call types, each subclassing `SimpleCall` with a dedicated prompt and restricted move set
- Each call targets a different angle for exploring newly-generated questions: decomposition into subquestions, identifying key quantities, proposing candidate answers, and finding structural parallels
- New `CallType` enum values, call classes, prompt files, and registry entries added — not yet wired into orchestrator or prioritization dispatch

## Test plan

- [x] All 55 existing tests pass
- [x] Import check confirms all four new classes load correctly
- [ ] Smoke-test each call type once wired up to verify prompt loading and move execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)