### PR TITLE
Fix trace event time hydration mismatch

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -431,7 +431,7 @@ function EventSection({ event }: { event: TraceEvent }) {
             )}
           </span>
         )}
-        <span className="trace-event-time">{formatTime(event.ts)}</span>
+        <span className="trace-event-time" suppressHydrationWarning>{formatTime(event.ts)}</span>
       </div>
 
       {isExchange && exchangeOpen && exchangeDetail && (


### PR DESCRIPTION
## Summary
- Add `suppressHydrationWarning` to the trace event timestamp span to fix React hydration errors caused by `toLocaleTimeString` producing different output on server (UTC) vs client (local timezone)

## Test plan
- [ ] Open a trace page and confirm no hydration warning in console
- [ ] Verify timestamps display in the user's local timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)