### PR TITLE
Rework context building for scout and prioritization calls

### DIFF
--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 
 from rumil.context import format_page
 from rumil.database import DB
+from rumil.embeddings import embed_and_store_page
 from rumil.settings import get_settings
 from rumil.llm import (
     AgentResult,
@@ -770,6 +771,19 @@ async def run_closing_review(
                             s.get("headline", ""),
                             s.get("abstract", ""),
                         )
+                        abstract_text = s.get("abstract", "")
+                        if abstract_text.strip():
+                            page = await db.get_page(pid)
+                            if page:
+                                try:
+                                    await embed_and_store_page(
+                                        db, page, field_name="abstract",
+                                    )
+                                except Exception:
+                                    log.warning(
+                                        "Failed to re-embed page %s", pid[:8],
+                                        exc_info=True,
+                                    )
         else:
             log.warning("Closing review returned None for call=%s", call.id[:8])
         return review

--- a/src/rumil/calls/find_considerations.py
+++ b/src/rumil/calls/find_considerations.py
@@ -17,11 +17,13 @@ from rumil.calls.common import (
 from rumil.context import (
     assemble_call_context,
     build_embedding_based_context,
+    build_scout_context,
     format_page,
     format_preloaded_pages,
     format_question_for_find_considerations,
 )
 from rumil.database import DB
+from rumil.embeddings import embed_and_store_page
 from rumil.llm import (
     build_system_prompt,
     build_user_message,
@@ -97,23 +99,36 @@ async def link_new_pages(
     db: DB,
     state: MoveState,
     trace: CallTrace,
+    context_page_ids: list[str] | None = None,
     graph: PageGraph | None = None,
 ) -> None:
-    """Single LLM call that reviews the workspace and creates direct/structural links.
+    """Single LLM call that reviews nearby pages and creates direct/structural links.
 
     Uses only LINK_CONSIDERATION and LINK_CHILD_QUESTION tools with role fields.
     Free (not counted against budget).
+
+    If *context_page_ids* is provided, those pages are shown as headlines
+    instead of the full workspace map.
     """
     source: DB | PageGraph = graph if graph is not None else db
     question = await source.get_page(question_id)
     if not question:
         return
 
-    workspace_map, _ = await build_workspace_map(db, graph=graph)
+    if context_page_ids:
+        page_lines: list[str] = []
+        for pid in context_page_ids:
+            page = await source.get_page(pid)
+            if page and page.id != question_id:
+                page_lines.append(await format_page(page, PageDetail.HEADLINE))
+        pages_text = '# Nearby Pages\n\n' + '\n'.join(page_lines)
+    else:
+        pages_text, _ = await build_workspace_map(db, graph=graph)
+
     question_text = await format_page(question, PageDetail.HEADLINE)
     existing_links = await _build_link_inventory(question_id, db, graph=graph)
     working_context = (
-        workspace_map + '\n\n---\n\n'
+        pages_text + '\n\n---\n\n'
         '# Scope Question\n\n' + question_text
         + '\n\n' + existing_links
     )
@@ -280,18 +295,21 @@ class ScoutCall(BaseCall):
 
     async def build_context(self) -> None:
         graph = await PageGraph.load(self.db)
-        await link_new_pages(
-            self.question_id, self.call, self.db, self.state, self.trace,
-            graph=graph,
-        )
-
-        graph = await PageGraph.load(self.db)
-        working_context, self.working_page_ids = await format_question_for_find_considerations(
+        scout_ctx = await build_scout_context(
             self.question_id, self.db, graph=graph,
         )
 
+        await link_new_pages(
+            self.question_id, self.call, self.db, self.state, self.trace,
+            context_page_ids=scout_ctx.page_ids,
+            graph=graph,
+        )
+
+        self.working_page_ids = scout_ctx.page_ids
+
+        context_text = scout_ctx.context_text
         if self.preloaded_ids:
-            working_context += await format_preloaded_pages(
+            context_text += await format_preloaded_pages(
                 self.preloaded_ids, self.db, graph=graph,
             )
 
@@ -302,11 +320,6 @@ class ScoutCall(BaseCall):
             preloaded_page_ids=await resolve_page_refs(self.preloaded_ids, self.db),
             scout_mode=self.mode.value,
         ))
-
-        workspace_map, _ = await build_workspace_map(self.db, graph=graph)
-        phase2_context = assemble_call_context(
-            working_context, workspace_map=workspace_map,
-        )
 
         self.tools = [MOVES[mt].bind(self.state) for mt in MoveType]
         self.tool_defs, _ = _prepare_tools(self.tools)
@@ -322,7 +335,7 @@ class ScoutCall(BaseCall):
             f"Question ID (use this when linking considerations): "
             f"`{self.question_id}`"
         )
-        self.user_message = build_user_message(phase2_context, task)
+        self.user_message = build_user_message(context_text, task)
 
     async def create_pages(self) -> None:
         for i in range(self.max_rounds):
@@ -538,6 +551,19 @@ class ScoutCall(BaseCall):
                         s.get("headline", ""),
                         s.get("abstract", ""),
                     )
+                    abstract_text = s.get("abstract", "")
+                    if abstract_text.strip():
+                        page = await self.db.get_page(pid)
+                        if page:
+                            try:
+                                await embed_and_store_page(
+                                    self.db, page, field_name="abstract",
+                                )
+                            except Exception:
+                                log.warning(
+                                    "Failed to re-embed page %s", pid[:8],
+                                    exc_info=True,
+                                )
 
         self.call.review_json = review_data
         return review_data
@@ -570,12 +596,11 @@ class EmbeddingScoutCall(ScoutCall):
         )
 
     async def build_context(self) -> None:
-        question = await self.db.get_page(self.question_id)
-        query = question.headline if question else self.question_id
-        emb_result = await build_embedding_based_context(
-            query, self.db, scope_question_id=self.question_id,
+        graph = await PageGraph.load(self.db)
+        scout_ctx = await build_scout_context(
+            self.question_id, self.db, graph=graph,
         )
-        self.working_page_ids = emb_result.page_ids
+        self.working_page_ids = scout_ctx.page_ids
 
         await self.trace.record(ContextBuiltEvent(
             working_context_page_ids=await resolve_page_refs(
@@ -585,7 +610,7 @@ class EmbeddingScoutCall(ScoutCall):
             scout_mode=self.mode.value,
         ))
 
-        self.context_text = emb_result.context_text
+        self.context_text = scout_ctx.context_text
 
         self.tools = [MOVES[mt].bind(self.state) for mt in MoveType]
         self.tool_defs, _ = _prepare_tools(self.tools)

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -71,6 +71,243 @@ async def collect_all_subtree_page_ids(
     return result
 
 
+async def _get_ancestry_chain(
+    question_id: str,
+    source: DB | PageGraph,
+) -> list[Page]:
+    """Walk up from question to root. Returns [parent, grandparent, ...] order."""
+    chain: list[Page] = []
+    current_id = question_id
+    visited = {question_id}
+    while True:
+        parent = await source.get_parent_question(current_id)
+        if not parent or parent.id in visited:
+            break
+        chain.append(parent)
+        visited.add(parent.id)
+        current_id = parent.id
+    return chain
+
+
+async def _render_subtree_headlines(
+    question_id: str,
+    source: DB | PageGraph,
+    db: DB,
+    indent: int = 0,
+    _visited: set[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Render a question subtree as headlines. Returns (lines, page_ids)."""
+    if _visited is None:
+        _visited = set()
+    if question_id in _visited:
+        return [], []
+    _visited = _visited | {question_id}
+
+    question = await source.get_page(question_id)
+    if not question:
+        return [], []
+
+    prefix = '  ' * indent
+    lines = [prefix + await format_page(question, PageDetail.HEADLINE)]
+    page_ids = [question_id]
+
+    judgements = await source.get_judgements_for_question(question_id)
+    if judgements:
+        latest = max(judgements, key=lambda j: j.created_at)
+        lines.append(
+            prefix + '  ' + await format_page(latest, PageDetail.HEADLINE)
+        )
+        page_ids.append(latest.id)
+
+    for child in await source.get_child_questions(question_id):
+        child_lines, child_ids = await _render_subtree_headlines(
+            child.id, source, db, indent + 1, _visited=_visited,
+        )
+        lines.extend(child_lines)
+        page_ids.extend(child_ids)
+
+    return lines, page_ids
+
+
+@dataclass
+class ScoutContextResult:
+    context_text: str
+    page_ids: list[str]
+    structural_page_ids: set[str]
+
+
+async def build_scout_context(
+    question_id: str,
+    db: DB,
+    graph: PageGraph | None = None,
+) -> ScoutContextResult:
+    """Build context for a find_considerations call.
+
+    Combines embedding search with structural context:
+    - Full text of scope question
+    - Abstract of parent/grandparent + direct child considerations/questions/judgements
+    - Headlines for ancestry chain, siblings, subtree, and judgements on each
+    """
+    source: DB | PageGraph = graph if graph is not None else db
+    question = await source.get_page(question_id)
+    if not question:
+        return ScoutContextResult(
+            context_text=f'[Question {question_id} not found]',
+            page_ids=[], structural_page_ids=set(),
+        )
+
+    all_page_ids: list[str] = []
+    structural_ids: set[str] = set()
+    parts: list[str] = []
+
+    parts.append('# Scope Question')
+    parts.append('')
+    parts.append(await format_page(question, PageDetail.CONTENT, db=db, linked_detail=None))
+    parts.append('')
+    all_page_ids.append(question_id)
+    structural_ids.add(question_id)
+
+    ancestry = await _get_ancestry_chain(question_id, source)
+    parent = ancestry[0] if len(ancestry) >= 1 else None
+    grandparent = ancestry[1] if len(ancestry) >= 2 else None
+
+    if parent or grandparent:
+        parts.append('# Parent Context')
+        parts.append('')
+        if parent:
+            parts.append('## Parent Question')
+            parts.append('')
+            parts.append(await format_page(parent, PageDetail.ABSTRACT, db=db, linked_detail=None))
+            parts.append('')
+            all_page_ids.append(parent.id)
+            structural_ids.add(parent.id)
+        if grandparent:
+            parts.append('## Grandparent Question')
+            parts.append('')
+            parts.append(await format_page(grandparent, PageDetail.ABSTRACT, db=db, linked_detail=None))
+            parts.append('')
+            all_page_ids.append(grandparent.id)
+            structural_ids.add(grandparent.id)
+
+    considerations = await source.get_considerations_for_question(question_id)
+    children = await source.get_child_questions(question_id)
+    child_judgements: list[tuple[Page, Page]] = []
+    for child in children:
+        for j in await source.get_judgements_for_question(child.id):
+            child_judgements.append((child, j))
+
+    if considerations or children or child_judgements:
+        parts.append('# Direct Context')
+        parts.append('')
+
+        if considerations:
+            parts.append('## Considerations on Scope Question')
+            parts.append('')
+            for claim, link in considerations:
+                direction = f' ({link.direction.value})' if link.direction else ''
+                parts.append(
+                    f'**[strength {link.strength:.1f}/5{direction}]**'
+                )
+                parts.append(await format_page(claim, PageDetail.ABSTRACT, db=db, linked_detail=None))
+                parts.append('')
+                all_page_ids.append(claim.id)
+                structural_ids.add(claim.id)
+
+        if children:
+            parts.append('## Direct Child Questions')
+            parts.append('')
+            for child in children:
+                parts.append(await format_page(child, PageDetail.ABSTRACT, db=db, linked_detail=None))
+                parts.append('')
+                all_page_ids.append(child.id)
+                structural_ids.add(child.id)
+
+        if child_judgements:
+            parts.append('## Judgements on Child Questions')
+            parts.append('')
+            for child, j in child_judgements:
+                parts.append(
+                    f'*On: {child.headline} (`{child.id[:8]}`)*'
+                )
+                parts.append(await format_page(j, PageDetail.ABSTRACT, db=db, linked_detail=None))
+                parts.append('')
+                all_page_ids.append(j.id)
+                structural_ids.add(j.id)
+
+    headline_lines: list[str] = []
+    headline_ids: list[str] = []
+
+    if ancestry:
+        headline_lines.append('## Ancestry & Siblings')
+        headline_lines.append('')
+        for ancestor in reversed(ancestry):
+            structural_ids.add(ancestor.id)
+            headline_lines.append(await format_page(ancestor, PageDetail.HEADLINE))
+            a_judgements = await source.get_judgements_for_question(ancestor.id)
+            if a_judgements:
+                latest = max(a_judgements, key=lambda j: j.created_at)
+                headline_lines.append(
+                    '  ' + await format_page(latest, PageDetail.HEADLINE)
+                )
+                headline_ids.append(latest.id)
+                structural_ids.add(latest.id)
+            siblings = await source.get_child_questions(ancestor.id)
+            for sib in siblings:
+                if sib.id == question_id or any(a.id == sib.id for a in ancestry):
+                    continue
+                headline_lines.append(
+                    '  ' + await format_page(sib, PageDetail.HEADLINE)
+                )
+                headline_ids.append(sib.id)
+                structural_ids.add(sib.id)
+                sib_judgements = await source.get_judgements_for_question(sib.id)
+                if sib_judgements:
+                    latest = max(sib_judgements, key=lambda j: j.created_at)
+                    headline_lines.append(
+                        '    ' + await format_page(latest, PageDetail.HEADLINE)
+                    )
+                    headline_ids.append(latest.id)
+                    structural_ids.add(latest.id)
+        headline_lines.append('')
+
+    subtree_lines, subtree_ids = await _render_subtree_headlines(
+        question_id, source, db,
+    )
+    if subtree_lines:
+        headline_lines.append('## Scope Subtree')
+        headline_lines.append('')
+        headline_lines.extend(subtree_lines)
+        headline_lines.append('')
+        headline_ids.extend(subtree_ids)
+        structural_ids.update(subtree_ids)
+
+    if headline_lines:
+        parts.append('# Wider Context (Headlines)')
+        parts.append('')
+        parts.extend(headline_lines)
+
+    all_page_ids.extend(headline_ids)
+
+    embedding_result = await build_embedding_based_context(
+        question.headline,
+        db,
+        scope_question_id=question_id,
+        headline_only_ids=structural_ids,
+    )
+    if embedding_result.context_text:
+        parts.append('# Embedding Search Results')
+        parts.append('')
+        parts.append(embedding_result.context_text)
+        parts.append('')
+    all_page_ids.extend(embedding_result.page_ids)
+
+    return ScoutContextResult(
+        context_text='\n'.join(parts),
+        page_ids=all_page_ids,
+        structural_page_ids=structural_ids,
+    )
+
+
 async def render_subtree(
     root_id: str,
     db: DB,
@@ -78,6 +315,7 @@ async def render_subtree(
     graph: PageGraph | None = None,
     detail: PageDetail = PageDetail.CONTENT,
     linked_detail: PageDetail | None = PageDetail.HEADLINE,
+    content_page_ids: set[str] | None = None,
 ) -> str:
     """Render a full subtree of pages starting from a root page.
 
@@ -86,6 +324,9 @@ async def render_subtree(
     question -> considerations, judgements, child questions (recurse).
 
     Non-question root pages are rendered standalone with their outgoing links.
+
+    Pages whose IDs appear in *content_page_ids* are rendered at CONTENT
+    detail regardless of the *detail* parameter.
     """
     if graph is None:
         graph = await PageGraph.load(db)
@@ -94,6 +335,7 @@ async def render_subtree(
     if not root:
         return f'[Page {root_id} not found]'
 
+    _content_ids = content_page_ids or set()
     parts: list[str] = []
     visited: set[str] = set()
 
@@ -103,9 +345,10 @@ async def render_subtree(
             return
         visited.add(question.id)
 
+        q_detail = PageDetail.CONTENT if question.id in _content_ids else detail
         indent = '  ' * depth
         parts.append(
-            indent + await format_page(question, detail, linked_detail=None, graph=graph)
+            indent + await format_page(question, q_detail, linked_detail=None, db=db, graph=graph)
         )
 
         considerations = await graph.get_considerations_for_question(question.id)
@@ -540,11 +783,14 @@ async def build_prioritization_context(
             parts.extend(index_lines)
             parts.append('')
 
+            direct_children = await source.get_child_questions(scope_question_id)
+            full_page_ids = {scope_question_id} | {c.id for c in direct_children}
             subtree_text = await render_subtree(
                 scope_question_id, db,
                 graph=graph,
                 detail=PageDetail.ABSTRACT,
                 linked_detail=PageDetail.ABSTRACT,
+                content_page_ids=full_page_ids,
             )
             parts.append('## Scope Subtree — Detail')
             parts.append('')
@@ -593,31 +839,41 @@ async def build_embedding_based_context(
     *,
     scope_question_id: str | None = None,
     headline_only_ids: set[str] | None = None,
-    context_char_budget: int | None = None,
-    distillation_page_char_fraction: float | None = None,
-    full_page_char_fraction: float | None = None,
-    abstract_page_char_fraction: float | None = None,
-    summary_para_char_fraction: float | None = None,
-    match_threshold: float = 0.01,
+    full_page_char_budget: int | None = None,
+    abstract_page_char_budget: int | None = None,
+    summary_page_char_budget: int | None = None,
+    distillation_page_char_budget: int | None = None,
+    full_page_similarity_floor: float | None = None,
+    abstract_page_similarity_floor: float | None = None,
+    summary_page_similarity_floor: float | None = None,
 ) -> EmbeddingBasedContextResult:
     """Build context by embedding-similarity search over the whole workspace.
 
     Pages are ranked by similarity and placed into tiers by descending detail:
     distillation (CONTENT) -> full (CONTENT) -> abstract (ABSTRACT) -> summary
-    (HEADLINE). Budget parameters default to values from settings when not
-    provided.
+    (HEADLINE). Each tier has its own char budget and similarity floor.
     """
     settings = get_settings()
-    if context_char_budget is None:
-        context_char_budget = settings.context_char_budget
-    if distillation_page_char_fraction is None:
-        distillation_page_char_fraction = settings.distillation_page_char_fraction
-    if full_page_char_fraction is None:
-        full_page_char_fraction = settings.full_page_char_fraction
-    if abstract_page_char_fraction is None:
-        abstract_page_char_fraction = settings.abstract_page_char_fraction
-    if summary_para_char_fraction is None:
-        summary_para_char_fraction = settings.summary_page_char_fraction
+    if full_page_char_budget is None:
+        full_page_char_budget = settings.full_page_char_budget
+    if abstract_page_char_budget is None:
+        abstract_page_char_budget = settings.abstract_page_char_budget
+    if summary_page_char_budget is None:
+        summary_page_char_budget = settings.summary_page_char_budget
+    if distillation_page_char_budget is None:
+        distillation_page_char_budget = settings.distillation_page_char_budget
+    if full_page_similarity_floor is None:
+        full_page_similarity_floor = settings.full_page_similarity_floor
+    if abstract_page_similarity_floor is None:
+        abstract_page_similarity_floor = settings.abstract_page_similarity_floor
+    if summary_page_similarity_floor is None:
+        summary_page_similarity_floor = settings.summary_page_similarity_floor
+
+    match_threshold = min(
+        full_page_similarity_floor,
+        abstract_page_similarity_floor,
+        summary_page_similarity_floor,
+    )
     query_embedding = await embed_query(question_text)
     ranked = await search_pages_by_vector(
         db,
@@ -640,10 +896,10 @@ async def build_embedding_based_context(
             scope_page_ids = [scope_question_id]
             ranked = [(p, s) for p, s in ranked if p.id != scope_question_id]
 
-    distillation_budget = int(context_char_budget * distillation_page_char_fraction)
-    full_budget = int(context_char_budget * full_page_char_fraction)
-    abstract_budget = int(context_char_budget * abstract_page_char_fraction)
-    summary_budget = int(context_char_budget * summary_para_char_fraction)
+    distillation_budget = distillation_page_char_budget
+    full_budget = full_page_char_budget
+    abstract_budget = abstract_page_char_budget
+    summary_budget = summary_page_char_budget
 
     distillation_pages = _filter_summary_pages(ranked)
     distillation_ids: list[str] = []
@@ -678,13 +934,13 @@ async def build_embedding_based_context(
             summary_chars += len(formatted)
             continue
 
-    for page, _sim in ranked:
+    for page, sim in ranked:
         if page.id in distillation_page_id_set:
             continue
         if page.id in _headline_only:
             continue
 
-        if full_chars < full_budget:
+        if sim >= full_page_similarity_floor and full_chars < full_budget:
             formatted = await format_page(page, PageDetail.CONTENT, db=db, linked_detail=None)
             if full_chars + len(formatted) <= full_budget:
                 full_parts.append(formatted)
@@ -692,7 +948,7 @@ async def build_embedding_based_context(
                 full_chars += len(formatted)
                 continue
 
-        if abstract_chars < abstract_budget:
+        if sim >= abstract_page_similarity_floor and abstract_chars < abstract_budget:
             formatted = await format_page(page, PageDetail.ABSTRACT, linked_detail=None)
             if abstract_chars + len(formatted) <= abstract_budget:
                 abstract_parts.append(formatted)
@@ -700,7 +956,7 @@ async def build_embedding_based_context(
                 abstract_chars += len(formatted)
                 continue
 
-        if summary_chars < summary_budget:
+        if sim >= summary_page_similarity_floor and summary_chars < summary_budget:
             formatted = await format_page(page, PageDetail.HEADLINE, linked_detail=None)
             if summary_chars + len(formatted) <= summary_budget:
                 summary_parts.append(formatted)
@@ -708,7 +964,8 @@ async def build_embedding_based_context(
                 summary_chars += len(formatted)
                 continue
 
-        break
+        if sim < summary_page_similarity_floor:
+            break
 
     sections: list[str] = []
     if scope_section:

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -405,6 +405,16 @@ class DB:
                 result.append((page, link))
         return result
 
+    async def get_parent_question(self, question_id: str) -> Page | None:
+        """Return the parent question, or None if this is a root question."""
+        links = await self.get_links_to(question_id)
+        for link in links:
+            if link.link_type == LinkType.CHILD_QUESTION:
+                page = await self.get_page(link.from_page_id)
+                if page and page.is_active():
+                    return page
+        return None
+
     async def get_child_questions(self, parent_id: str) -> list[Page]:
         """Return sub-questions of a question."""
         links = await self.get_links_from(parent_id)

--- a/src/rumil/embeddings.py
+++ b/src/rumil/embeddings.py
@@ -52,11 +52,17 @@ async def embed_query(text: str) -> Sequence[float]:
 
 
 def page_text_for_field(page: Page, field_name: str) -> str:
-    """Return the text to embed for a given page field."""
+    """Return the text to embed for a given page field.
+
+    For the 'abstract' field, falls back to headline+content when abstract is
+    empty (pages that haven't been through closing review yet).
+    """
     if field_name == "content":
         return f"{page.headline}\n\n{page.content}"
     if field_name == "abstract":
-        return page.abstract
+        if page.abstract and page.abstract.strip():
+            return page.abstract
+        return f"{page.headline}\n\n{page.content}"
     raise ValueError(f"Unknown embedding field: {field_name}")
 
 

--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -9,6 +9,7 @@ from typing import Any, Generic, TypeVar
 from pydantic import BaseModel, Field
 
 from rumil.database import DB
+from rumil.embeddings import embed_and_store_page
 from rumil.llm import Tool
 from rumil.models import (
     Call,
@@ -232,6 +233,10 @@ async def create_page(
 
     await db.save_page(page)
     write_page_file(page)
+    try:
+        await embed_and_store_page(db, page, field_name="abstract")
+    except Exception:
+        log.warning("Failed to create embedding for page %s", page.id[:8], exc_info=True)
     log.info(
         "Page created: type=%s, id=%s, headline=%s",
         page_type.value, page.id[:8], page.headline[:70],

--- a/src/rumil/moves/link_related.py
+++ b/src/rumil/moves/link_related.py
@@ -1,10 +1,14 @@
 """LINK_RELATED move: create a general relation between two pages."""
 
+import logging
+
 from pydantic import BaseModel, Field
 
 from rumil.database import DB
-from rumil.models import Call, LinkType, MoveType
+from rumil.models import Call, LinkType, MoveType, PageType
 from rumil.moves.base import MoveDef, MoveResult, link_pages
+
+log = logging.getLogger(__name__)
 
 
 class LinkRelatedPayload(BaseModel):
@@ -13,14 +17,42 @@ class LinkRelatedPayload(BaseModel):
     reasoning: str = Field("", description="Nature of the relation")
 
 
+async def _supersede_old_judgements(
+    new_judgement_id: str, question_id: str, db: DB,
+) -> None:
+    """Supersede any existing judgements on a question when a new one is linked."""
+    old_judgements = await db.get_judgements_for_question(question_id)
+    for old in old_judgements:
+        if old.id == new_judgement_id:
+            continue
+        await db.supersede_page(old.id, new_judgement_id)
+        log.info(
+            'Superseded old judgement %s with %s on question %s',
+            old.id[:8], new_judgement_id[:8], question_id[:8],
+        )
+
+
 async def execute(payload: LinkRelatedPayload, call: Call, db: DB) -> MoveResult:
-    return await link_pages(
+    result = await link_pages(
         payload.from_page_id,
         payload.to_page_id,
         payload.reasoning,
         db,
         LinkType.RELATED,
     )
+
+    from_id = await db.resolve_page_id(payload.from_page_id)
+    to_id = await db.resolve_page_id(payload.to_page_id)
+    if from_id and to_id:
+        from_page = await db.get_page(from_id)
+        to_page = await db.get_page(to_id)
+        if (
+            from_page and from_page.page_type == PageType.JUDGEMENT
+            and to_page and to_page.page_type == PageType.QUESTION
+        ):
+            await _supersede_old_judgements(from_id, to_id, db)
+
+    return result
 
 
 MOVE = MoveDef(

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -17,6 +17,7 @@ from rumil.calls.call_registry import (
     WEB_RESEARCH_CALL_CLASSES,
 )
 from rumil.database import DB
+from rumil.embeddings import embed_and_store_page
 from rumil.settings import get_settings
 from rumil.models import (
     AssessDispatchPayload,
@@ -59,6 +60,10 @@ async def create_root_question(question_text: str, db: DB) -> str:
         extra={"status": "open"},
     )
     await db.save_page(page)
+    try:
+        await embed_and_store_page(db, page, field_name="abstract")
+    except Exception:
+        log.warning("Failed to create embedding for root question %s", page.id[:8], exc_info=True)
     return page.id
 
 

--- a/src/rumil/page_graph.py
+++ b/src/rumil/page_graph.py
@@ -107,6 +107,15 @@ class PageGraph:
                 result.append(page)
         return result
 
+    async def get_parent_question(self, question_id: str) -> Page | None:
+        """Return the parent question, or None if this is a root question."""
+        for link in self._links_to.get(question_id, []):
+            if link.link_type == LinkType.CHILD_QUESTION:
+                page = self._pages.get(link.from_page_id)
+                if page and page.is_active():
+                    return page
+        return None
+
     async def get_child_questions(self, parent_id: str) -> list[Page]:
         links = self._links_from.get(parent_id, [])
         result = []

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -44,11 +44,13 @@ class Settings(BaseSettings):
     ingest_call_variant: str = _capture_field(default="default")
     web_research_call_variant: str = _capture_field(default="default")
 
-    context_char_budget: int = _capture_field(default=10_000)
-    full_page_char_fraction: float = _capture_field(default=0.4)
-    abstract_page_char_fraction: float = _capture_field(default=0.3)
-    summary_page_char_fraction: float = _capture_field(default=0.2)
-    distillation_page_char_fraction: float = _capture_field(default=0.0)
+    full_page_char_budget: int = _capture_field(default=10_000)
+    abstract_page_char_budget: int = _capture_field(default=10_000)
+    summary_page_char_budget: int = _capture_field(default=5_000)
+    distillation_page_char_budget: int = _capture_field(default=3_000)
+    full_page_similarity_floor: float = _capture_field(default=0.3)
+    abstract_page_similarity_floor: float = _capture_field(default=0.2)
+    summary_page_similarity_floor: float = _capture_field(default=0.1)
 
     @property
     def is_test_mode(self) -> bool:


### PR DESCRIPTION
Scout context now combines embedding search with structural context:
- Full text of scope question
- Abstract of parent/grandparent + direct child considerations/questions
- Headlines for ancestry chain, siblings, subtree, and judgements
- Embedding similarity search (with per-tier similarity floors)

Prioritization context now renders scope question and direct children at full content detail, with most-recent-only judgements.

Embedding infrastructure wired into page lifecycle:
- Pages get abstract-field embeddings on creation (headline+content fallback)
- Closing review re-embeds with real abstract once generated
- page_text_for_field falls back to headline+content when abstract is empty

Other changes:
- Per-tier char budgets (10k/10k/5k/3k) replace fraction-based system
- Per-tier similarity floors (0.3/0.2/0.1) prevent low-quality matches
- Aggressive break in tier loop replaced with similarity-based cutoff
- link_new_pages uses embedding-sourced page IDs instead of workspace map
- New judgements supersede old ones via link_related
- get_parent_question added to DB and PageGraph