### PR TITLE
Remove max_tokens parameter, use high default

### DIFF
--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -97,7 +97,7 @@ async def _process_page(
         try:
             response = await client.messages.create(
                 model=MODEL,
-                max_tokens=600,
+                max_tokens=50_000,
                 system=SYSTEM,
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/src/rumil/calls/assess_concept.py
+++ b/src/rumil/calls/assess_concept.py
@@ -189,7 +189,6 @@ class AssessConceptCall(SimpleCall):
                 system_prompt=REVIEW_SYSTEM_PROMPT,
                 user_message=user_message,
                 response_model=ConceptAssessmentReview,
-                max_tokens=2048,
                 metadata=meta,
                 db=self.db,
             )

--- a/src/rumil/calls/base.py
+++ b/src/rumil/calls/base.py
@@ -150,7 +150,6 @@ class SimpleCall(BaseCall):
             db=self.db,
             state=self.state,
             trace=self.trace,
-            max_tokens=4096,
             max_rounds=max_rounds,
         )
 

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -148,7 +148,6 @@ async def run_single_call(
     db: DB,
     state: MoveState,
     trace: "CallTrace | None" = None,
-    max_tokens: int = 4096,
     messages: list[dict] | None = None,
     cache: bool = False,
 ) -> AgentResult:
@@ -171,8 +170,8 @@ async def run_single_call(
         tool_fns = {}
 
     log.debug(
-        "run_single_call: phase=%s, max_tokens=%d, tools=%d, resuming=%s",
-        phase, max_tokens, len(tool_defs), messages is not None,
+        "run_single_call: phase=%s, tools=%d, resuming=%s",
+        phase, len(tool_defs), messages is not None,
     )
 
     msg_list: list[dict] = (
@@ -186,7 +185,7 @@ async def run_single_call(
     )
     api_resp = await call_api(
         client, settings.model, system_prompt, msg_list,
-        tool_defs or None, max_tokens, warnings=all_warnings,
+        tool_defs or None, warnings=all_warnings,
         metadata=meta, db=db, cache=cache,
     )
     response = api_resp.message
@@ -244,7 +243,6 @@ async def run_agent_loop(
     db: DB,
     state: MoveState,
     trace: "CallTrace | None" = None,
-    max_tokens: int = 4096,
     max_rounds: int | None = None,
     messages: list[dict] | None = None,
     cache: bool = False,
@@ -270,8 +268,8 @@ async def run_agent_loop(
         tool_defs = []
         tool_fns = {}
     log.debug(
-        "run_agent_loop starting: max_rounds=%d, max_tokens=%d, resuming=%s",
-        effective_rounds, max_tokens, messages is not None,
+        "run_agent_loop starting: max_rounds=%d, resuming=%s",
+        effective_rounds, messages is not None,
     )
 
     msg_list: list[dict] = (
@@ -293,7 +291,7 @@ async def run_agent_loop(
         )
         api_resp = await call_api(
             client, settings.model, system_prompt, msg_list,
-            tool_defs or None, max_tokens, warnings=all_warnings,
+            tool_defs or None, warnings=all_warnings,
             metadata=meta, db=db, cache=cache,
         )
         response = api_resp.message
@@ -491,7 +489,6 @@ async def _run_phase1(
             db=db,
             state=state,
             trace=trace,
-            max_tokens=2048,
         )
         loaded_ids = []
         for tc in result.tool_calls:
@@ -518,7 +515,6 @@ async def run_call(
     db: DB,
     *,
     available_moves: list[MoveType] | None = None,
-    max_tokens: int = 4096,
     max_rounds: int | None = None,
     trace: "CallTrace | None" = None,
     state: MoveState | None = None,
@@ -564,7 +560,6 @@ async def run_call(
         db=db,
         state=state,
         trace=trace,
-        max_tokens=max_tokens,
         max_rounds=max_rounds,
     )
 
@@ -745,7 +740,6 @@ async def run_closing_review(
             system_prompt=REVIEW_SYSTEM_PROMPT,
             user_message=user_message,
             response_model=ReviewResponse,
-            max_tokens=8192,
             metadata=meta,
             db=db,
         )

--- a/src/rumil/calls/find_considerations.py
+++ b/src/rumil/calls/find_considerations.py
@@ -150,7 +150,6 @@ async def link_new_pages(
         db=db,
         state=state,
         trace=trace,
-        max_tokens=2048,
     )
 
 
@@ -406,7 +405,6 @@ class ScoutCall(BaseCall):
             response_model=FruitCheck,
             messages=check_messages,
             tools=self.tool_defs,
-            max_tokens=256,
             metadata=meta,
             db=self.db,
             cache=True,
@@ -522,7 +520,6 @@ class ScoutCall(BaseCall):
             response_model=ReviewResponse,
             messages=assessment_messages,
             tools=self.tool_defs,
-            max_tokens=8192,
             metadata=meta,
             db=self.db,
             cache=True,

--- a/src/rumil/calls/prioritization.py
+++ b/src/rumil/calls/prioritization.py
@@ -31,7 +31,6 @@ async def run_prioritization_call(
     db: DB,
     *,
     available_moves: list[MoveType] | None = None,
-    max_tokens: int = 4096,
     subtree_ids: set[str] | None = None,
     short_id_map: dict[str, str] | None = None,
     trace: CallTrace | None = None,
@@ -82,7 +81,6 @@ async def run_prioritization_call(
         db=db,
         state=state,
         trace=trace,
-        max_tokens=max_tokens,
     )
 
     log.info(

--- a/src/rumil/calls/summarize.py
+++ b/src/rumil/calls/summarize.py
@@ -245,7 +245,6 @@ async def summarize_question(
             system_prompt=SYSTEM_PROMPT,
             user_message=user_message,
             response_model=SummaryOutput,
-            max_tokens=4096,
             metadata=meta,
             db=db,
         )

--- a/src/rumil/calls/web_research.py
+++ b/src/rumil/calls/web_research.py
@@ -109,7 +109,7 @@ class WebResearchCall(BaseCall):
             )
             api_resp = await call_api(
                 client, settings.model, system_prompt, messages,
-                all_tool_defs, max_tokens=4096,
+                all_tool_defs,
                 metadata=meta, db=self.db,
             )
             response = api_resp.message

--- a/src/rumil/chat.py
+++ b/src/rumil/chat.py
@@ -210,7 +210,6 @@ async def run_chat(question_id: str, db: DB) -> None:
             response = await text_call(
                 system_prompt=system_prompt,
                 messages=history,
-                max_tokens=1024,
             )
         except Exception as e:
             log.error("Chat LLM call failed: %s", e, exc_info=True)

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -29,13 +29,14 @@ from pydantic import BaseModel, ValidationError
 
 from rumil.pricing import compute_cost
 
-DEFAULT_MAX_TOKENS = 50_000
 from rumil.settings import get_settings
 from rumil.tracing.trace_events import LLMExchangeEvent
 
 if TYPE_CHECKING:
     from rumil.database import DB
     from rumil.tracing.tracer import CallTrace
+
+DEFAULT_MAX_TOKENS = 20_000
 
 PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
 

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -28,6 +28,8 @@ from anthropic.types import MessageParam, ServerToolUseBlock, TextBlock, ToolUse
 from pydantic import BaseModel, ValidationError
 
 from rumil.pricing import compute_cost
+
+DEFAULT_MAX_TOKENS = 50_000
 from rumil.settings import get_settings
 from rumil.tracing.trace_events import LLMExchangeEvent
 
@@ -270,7 +272,6 @@ async def call_api(
     system_prompt: str,
     messages: list[dict],
     tools: list[dict] | None = None,
-    max_tokens: int = 4096,
     warnings: list[str] | None = None,
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
@@ -285,7 +286,7 @@ async def call_api(
         raise ValueError("metadata and db must be provided together")
     kwargs: dict = {
         "model": model,
-        "max_tokens": max_tokens,
+        "max_tokens": DEFAULT_MAX_TOKENS,
         "system": system_prompt,
         "messages": _add_cache_breakpoint(messages) if cache else messages,
     }
@@ -294,8 +295,8 @@ async def call_api(
 
     n_tools = len(tools) if tools else 0
     log.debug(
-        "API call: model=%s, max_tokens=%d, tools=%d, system_prompt_len=%d, messages=%d",
-        model, max_tokens, n_tools, len(system_prompt), len(messages),
+        "API call: model=%s, tools=%d, system_prompt_len=%d, messages=%d",
+        model, n_tools, len(system_prompt), len(messages),
     )
 
     for attempt in range(MAX_API_RETRIES):
@@ -368,7 +369,6 @@ async def text_call(
     user_message: str = "",
     *,
     messages: list[dict] | None = None,
-    max_tokens: int = 4096,
 ) -> str:
     """Make a plain text LLM call. Returns the raw text response.
 
@@ -383,8 +383,8 @@ async def text_call(
         if messages is not None
         else [{"role": "user", "content": user_message}]
     )
-    log.debug("text_call: max_tokens=%d, messages=%d", max_tokens, len(msg_list))
-    api_resp = await call_api(client, model, system_prompt, msg_list, max_tokens=max_tokens)
+    log.debug("text_call: messages=%d", len(msg_list))
+    api_resp = await call_api(client, model, system_prompt, msg_list)
     for block in api_resp.message.content:
         if isinstance(block, TextBlock):
             log.debug("text_call returned %d chars", len(block.text))
@@ -410,7 +410,6 @@ async def _structured_call_cached(
     msg_list: list[dict],
     *,
     tools: list[dict] | None = None,
-    max_tokens: int = 1024,
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
 ) -> StructuredCallResult:
@@ -429,7 +428,7 @@ async def _structured_call_cached(
     for parse_attempt in range(max_parse_attempts):
         api_resp = await call_api(
             client, settings.model, system_prompt, inject_msgs,
-            tools=tools, max_tokens=max_tokens,
+            tools=tools,
             metadata=metadata, db=db, cache=True,
         )
         response_text = ''
@@ -516,7 +515,6 @@ async def _structured_call_parse(
     *,
     tools: list[dict] | None = None,
     tool_choice: dict | None = None,
-    max_tokens: int = 1024,
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
 ) -> StructuredCallResult:
@@ -530,7 +528,7 @@ async def _structured_call_parse(
             t0 = time.monotonic()
             parse_kwargs: dict = {
                 'model': model,
-                'max_tokens': max_tokens,
+                'max_tokens': DEFAULT_MAX_TOKENS,
                 'system': system_prompt,
                 'messages': msg_list,
             }
@@ -575,8 +573,8 @@ async def _structured_call_parse(
                     duration_ms=elapsed_ms,
                 )
             log.warning(
-                'Structured output was empty (stop_reason=%s, usage=%d/%d tokens)',
-                response.stop_reason, response.usage.output_tokens, max_tokens,
+                'Structured output was empty (stop_reason=%s, usage=%d tokens)',
+                response.stop_reason, response.usage.output_tokens,
             )
             return StructuredCallResult(
                 response_text=response_text or None,
@@ -619,7 +617,6 @@ async def structured_call(
     messages: list[dict] | None = None,
     tools: list[dict] | None = None,
     tool_choice: dict | None = None,
-    max_tokens: int = 1024,
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     cache: bool = False,
@@ -644,18 +641,18 @@ async def structured_call(
     )
     model_name = response_model.__name__ if response_model else 'None'
     log.debug(
-        'structured_call: response_model=%s, max_tokens=%d, cache=%s',
-        model_name, max_tokens, cache,
+        'structured_call: response_model=%s, cache=%s',
+        model_name, cache,
     )
 
     if cache and response_model is not None:
         return await _structured_call_cached(
             system_prompt, response_model, raw_msgs,
-            tools=tools, max_tokens=max_tokens,
+            tools=tools,
             metadata=metadata, db=db,
         )
     return await _structured_call_parse(
         system_prompt, response_model, raw_msgs,
-        tools=tools, tool_choice=tool_choice, max_tokens=max_tokens,
+        tools=tools, tool_choice=tool_choice,
         metadata=metadata, db=db,
     )

--- a/src/rumil/prioritizer.py
+++ b/src/rumil/prioritizer.py
@@ -503,7 +503,6 @@ class TwoPhasePrioritizer(Prioritizer):
                 scoring_system,
                 user_message=subq_user_msg,
                 response_model=SubquestionScoringResult,
-                max_tokens=2048,
                 metadata=LLMExchangeMetadata(
                     call_id=p_call.id,
                     phase='score_subquestions',
@@ -526,7 +525,6 @@ class TwoPhasePrioritizer(Prioritizer):
             scoring_system,
             user_message=fruit_user_msg,
             response_model=FruitResult,
-            max_tokens=512,
             metadata=LLMExchangeMetadata(
                 call_id=p_call.id,
                 phase='score_parent_fruit',

--- a/src/rumil/sources.py
+++ b/src/rumil/sources.py
@@ -45,7 +45,6 @@ async def generate_source_summary(content: str, filename: str) -> str:
                 f'Filename: {filename}\n\n'
                 f'{excerpt}'
             ),
-            max_tokens=256,
         )
         return result.strip()
     except Exception as e:

--- a/src/rumil/summary.py
+++ b/src/rumil/summary.py
@@ -146,7 +146,7 @@ async def generate_summary(
     )
 
     return await text_call(
-        system_prompt=system_prompt, user_message=user_message, max_tokens=8192
+        system_prompt=system_prompt, user_message=user_message
     )
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -53,7 +53,6 @@ async def test_text_only_returns_nonempty_text(tmp_db, scout_call):
         call_id=scout_call.id,
         db=tmp_db,
         state=state,
-        max_tokens=64,
     )
     assert result.text.strip()
     assert result.tool_calls == []
@@ -70,7 +69,6 @@ async def test_tool_is_called_and_result_recorded(tmp_db, scout_call):
         call_id=scout_call.id,
         db=tmp_db,
         state=state,
-        max_tokens=256,
         max_rounds=2,
     )
     assert len(result.tool_calls) >= 1
@@ -90,7 +88,6 @@ async def test_tool_error_does_not_crash_loop(tmp_db, scout_call):
         call_id=scout_call.id,
         db=tmp_db,
         state=state,
-        max_tokens=256,
         max_rounds=2,
     )
     assert len(result.tool_calls) >= 1
@@ -121,7 +118,6 @@ async def test_max_rounds_limits_tool_calls(tmp_db, scout_call):
         call_id=scout_call.id,
         db=tmp_db,
         state=state,
-        max_tokens=128,
         max_rounds=2,
     )
     # max_rounds=2 means at most 3 rounds (0, 1, 2), so tool calls are bounded
@@ -134,7 +130,6 @@ async def test_text_call_returns_string():
     result = await text_call(
         "You are a helpful assistant.",
         "Say 'yes' and nothing else.",
-        max_tokens=16,
     )
     assert isinstance(result, str)
     assert result.strip()
@@ -152,7 +147,6 @@ async def test_structured_call_returns_parsed_dict():
         "You are a rating bot.",
         "Rate the color blue on a scale of 1-5.",
         response_model=Rating,
-        max_tokens=256,
     )
     assert result.data is not None
     assert isinstance(result.data["score"], int)

--- a/tests/test_embedding_context.py
+++ b/tests/test_embedding_context.py
@@ -62,9 +62,8 @@ async def test_basic_budget_split(mock_embeddings, mock_db):
     result = await build_embedding_based_context(
         'test query',
         mock_db,
-        context_char_budget=10_000,
-        full_page_char_fraction=0.6,
-        summary_para_char_fraction=0.3,
+        full_page_char_budget=6_000,
+        summary_page_char_budget=3_000,
     )
 
     assert isinstance(result, EmbeddingBasedContextResult)
@@ -81,7 +80,7 @@ async def test_similarity_ordering(mock_embeddings, mock_db):
     result = await build_embedding_based_context(
         'test query',
         mock_db,
-        context_char_budget=10_000,
+        full_page_char_budget=10_000,
     )
 
     if len(result.full_page_ids) >= 2:
@@ -91,17 +90,17 @@ async def test_similarity_ordering(mock_embeddings, mock_db):
             assert page_order.index(full_ids[i]) < page_order.index(full_ids[i + 1])
 
 
-async def test_small_budget_forces_summaries(mock_embeddings, mock_db):
-    """With a tiny full budget, pages overflow to summary tier."""
+async def test_small_budget_forces_lower_tiers(mock_embeddings, mock_db):
+    """With a tiny full budget, pages overflow to abstract/summary tiers."""
     result = await build_embedding_based_context(
         'test query',
         mock_db,
-        context_char_budget=1_000,
-        full_page_char_fraction=0.1,
-        summary_para_char_fraction=0.8,
+        full_page_char_budget=100,
+        abstract_page_char_budget=800,
+        summary_page_char_budget=800,
     )
 
-    assert len(result.summary_page_ids) > 0
+    assert len(result.abstract_page_ids) + len(result.summary_page_ids) > 0
 
 
 async def test_section_headers_present(mock_embeddings, mock_db):
@@ -109,7 +108,7 @@ async def test_section_headers_present(mock_embeddings, mock_db):
     result = await build_embedding_based_context(
         'test query',
         mock_db,
-        context_char_budget=10_000,
+        full_page_char_budget=10_000,
     )
 
     assert '## Relevant Pages (Full)' in result.context_text
@@ -131,7 +130,10 @@ async def test_zero_budget_returns_empty(mock_embeddings, mock_db):
     result = await build_embedding_based_context(
         'test query',
         mock_db,
-        context_char_budget=0,
+        full_page_char_budget=0,
+        abstract_page_char_budget=0,
+        summary_page_char_budget=0,
+        distillation_page_char_budget=0,
     )
     assert result.page_ids == []
     assert result.full_page_ids == []


### PR DESCRIPTION
## Summary
- Remove `max_tokens` as a parameter from all LLM wrapper functions (`call_api`, `text_call`, `structured_call`, `run_agent_loop`, `run_single_call`, `run_call`, `run_prioritization_call`)
- Use a single `DEFAULT_MAX_TOKENS = 50_000` constant in `llm.py` instead
- Fix stale `test_embedding_context.py` tests to match current `build_embedding_based_context` API (per-tier budgets instead of total + fractions)

## Test plan
- [x] All non-LLM tests pass (55 passed, including the previously-broken embedding context tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)