### PR TITLE
Cap web_fetch at 20K tokens to reduce web research costs ~10x

### DIFF
--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -37,7 +37,11 @@ import asyncio
 import logging
 import uuid
 
-from rumil.calls.call_registry import ASSESS_CALL_CLASSES, FIND_CONSIDERATIONS_CALL_CLASSES
+from rumil.calls.call_registry import (
+    ASSESS_CALL_CLASSES,
+    FIND_CONSIDERATIONS_CALL_CLASSES,
+    WEB_RESEARCH_CALL_CLASSES,
+)
 from rumil.calls.prioritization import run_prioritization
 from rumil.database import DB
 from rumil.models import CallStage, CallType, ScoutMode
@@ -75,6 +79,14 @@ async def run_call(args: argparse.Namespace, db: DB, question_id: str) -> None:
         cls = ASSESS_CALL_CLASSES[settings.assess_call_variant]
         assess = cls(question_id, call, db, up_to_stage=up_to_stage)
         await assess.run()
+
+    elif call_type == "web-research":
+        call = await db.create_call(
+            CallType.WEB_RESEARCH, scope_page_id=question_id,
+        )
+        cls = WEB_RESEARCH_CALL_CLASSES[settings.web_research_call_variant]
+        web_research = cls(question_id, call, db)
+        await web_research.run()
 
     elif call_type == "prioritize":
         if up_to_stage:
@@ -202,7 +214,7 @@ async def _run_ab(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run a single call end-to-end.")
     parser.add_argument(
-        "call_type", choices=["find-considerations", "assess", "prioritize"],
+        "call_type", choices=["find-considerations", "assess", "prioritize", "web-research"],
         help="Type of call to run",
     )
     parser.add_argument(

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -85,7 +85,9 @@ async def run_call(args: argparse.Namespace, db: DB, question_id: str) -> None:
             CallType.WEB_RESEARCH, scope_page_id=question_id,
         )
         cls = WEB_RESEARCH_CALL_CLASSES[settings.web_research_call_variant]
-        web_research = cls(question_id, call, db)
+        web_research = cls(
+            question_id, call, db, up_to_stage=up_to_stage,
+        )
         await web_research.run()
 
     elif call_type == "prioritize":

--- a/src/rumil/calls/web_research.py
+++ b/src/rumil/calls/web_research.py
@@ -1,5 +1,6 @@
 """Web research call: search the web and create source-grounded claims."""
 
+import json
 import logging
 from collections.abc import Sequence
 
@@ -16,7 +17,7 @@ from rumil.calls.common import (
     resolve_page_refs,
     run_closing_review,
 )
-from rumil.context import build_call_context, build_embedding_based_context
+from rumil.context import build_embedding_based_context
 from rumil.database import DB
 from rumil.llm import (
     LLMExchangeMetadata,
@@ -37,7 +38,6 @@ from rumil.models import (
 )
 from rumil.moves.base import write_page_file
 from rumil.moves.registry import MOVES
-from rumil.page_graph import PageGraph
 from rumil.settings import get_settings
 from rumil.tracing.trace_events import ContextBuiltEvent, ReviewCompleteEvent
 
@@ -81,7 +81,7 @@ class WebResearchCall(BaseCall):
 
         system_prompt = build_system_prompt('web_research')
         user_message = build_user_message(self.context_text, '(diagnostic)')
-        log.info(
+        log.debug(
             'Web research context diagnostic: '
             'context_text=%d chars, system_prompt=%d chars, '
             'user_message=%d chars, total_prompt=%d chars, '
@@ -123,16 +123,15 @@ class WebResearchCall(BaseCall):
         user_message = build_user_message(self.context_text, task)
         messages: list[dict] = [{'role': 'user', 'content': user_message}]
 
-        log.info(
+        log.debug(
             'Web research create_pages starting: '
             'system_prompt=%d chars, user_message=%d chars, '
             'server_tools=%d, custom_tools=%d, all_tool_defs=%d',
             len(system_prompt), len(user_message),
             len(server_tools), len(custom_tool_defs), len(all_tool_defs),
         )
-        import json as _json
-        tool_defs_chars = len(_json.dumps(all_tool_defs))
-        log.info(
+        tool_defs_chars = len(json.dumps(all_tool_defs))
+        log.debug(
             'Tool definitions total: %d chars (%d tokens approx)',
             tool_defs_chars, tool_defs_chars // 4,
         )
@@ -141,7 +140,7 @@ class WebResearchCall(BaseCall):
             total_msg_chars = sum(
                 len(str(m.get('content', ''))) for m in messages
             )
-            log.info(
+            log.debug(
                 'Round %d: %d messages, ~%d chars in messages',
                 round_num, len(messages), total_msg_chars,
             )
@@ -226,6 +225,7 @@ class WebResearchCall(BaseCall):
         web_fetch: dict = {
             'type': 'web_fetch_20250910',
             'name': 'web_fetch',
+            'max_content_tokens': 20000,
         }
         if self.allowed_domains:
             web_fetch['allowed_domains'] = list(self.allowed_domains)

--- a/src/rumil/calls/web_research.py
+++ b/src/rumil/calls/web_research.py
@@ -27,6 +27,7 @@ from rumil.llm import (
 )
 from rumil.models import (
     Call,
+    CallStage,
     CallType,
     MoveType,
     Page,
@@ -60,8 +61,12 @@ class WebResearchCall(BaseCall):
         *,
         allowed_domains: Sequence[str] | None = None,
         broadcaster=None,
+        up_to_stage: CallStage | None = None,
     ):
-        super().__init__(question_id, call, db, broadcaster=broadcaster)
+        super().__init__(
+            question_id, call, db,
+            broadcaster=broadcaster, up_to_stage=up_to_stage,
+        )
         self.allowed_domains = allowed_domains
         self.source_page_ids: dict[str, str] = {}
 
@@ -73,6 +78,23 @@ class WebResearchCall(BaseCall):
         )
         self.working_page_ids = emb_result.page_ids
         self.context_text = emb_result.context_text
+
+        system_prompt = build_system_prompt('web_research')
+        user_message = build_user_message(self.context_text, '(diagnostic)')
+        log.info(
+            'Web research context diagnostic: '
+            'context_text=%d chars, system_prompt=%d chars, '
+            'user_message=%d chars, total_prompt=%d chars, '
+            'full_pages=%d, abstract_pages=%d, summary_pages=%d, '
+            'distillation_pages=%d, '
+            'budget_usage=%s',
+            len(self.context_text), len(system_prompt),
+            len(user_message), len(system_prompt) + len(user_message),
+            len(emb_result.full_page_ids), len(emb_result.abstract_page_ids),
+            len(emb_result.summary_page_ids), len(emb_result.distillation_page_ids),
+            emb_result.budget_usage,
+        )
+
         await self.trace.record(ContextBuiltEvent(
             working_context_page_ids=await resolve_page_refs(
                 self.working_page_ids, self.db,
@@ -101,7 +123,28 @@ class WebResearchCall(BaseCall):
         user_message = build_user_message(self.context_text, task)
         messages: list[dict] = [{'role': 'user', 'content': user_message}]
 
+        log.info(
+            'Web research create_pages starting: '
+            'system_prompt=%d chars, user_message=%d chars, '
+            'server_tools=%d, custom_tools=%d, all_tool_defs=%d',
+            len(system_prompt), len(user_message),
+            len(server_tools), len(custom_tool_defs), len(all_tool_defs),
+        )
+        import json as _json
+        tool_defs_chars = len(_json.dumps(all_tool_defs))
+        log.info(
+            'Tool definitions total: %d chars (%d tokens approx)',
+            tool_defs_chars, tool_defs_chars // 4,
+        )
+
         for round_num in range(max_rounds):
+            total_msg_chars = sum(
+                len(str(m.get('content', ''))) for m in messages
+            )
+            log.info(
+                'Round %d: %d messages, ~%d chars in messages',
+                round_num, len(messages), total_msg_chars,
+            )
             meta = LLMExchangeMetadata(
                 call_id=self.call.id, phase='web_research_loop',
                 trace=self.trace, round_num=round_num,

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -304,11 +304,13 @@ async def call_api(
             response = await client.messages.create(**kwargs)
             elapsed_ms = int((time.monotonic() - start) * 1000)
             log.debug(
-                "API response: stop_reason=%s, usage=%d/%d tokens, duration=%dms",
+                "API response: stop_reason=%s, usage=%d/%d tokens, duration=%dms, "
+                "full_usage=%s",
                 response.stop_reason,
                 response.usage.input_tokens,
                 response.usage.output_tokens,
                 elapsed_ms,
+                response.usage,
             )
             if metadata and db:
                 text_parts = []


### PR DESCRIPTION
## Summary
- Add `max_content_tokens: 20000` to the `web_fetch` server tool to prevent unbounded page content from accumulating across rounds
- Unbounded fetches were causing prompts to exceed 200K tokens and costing $3-10 per call; capped fetches bring costs to ~$0.25
- Add `web-research` call type to `run_call.py` for easier testing
- Add `up_to_stage` support to `WebResearchCall`
- Add debug-level diagnostic logging for context sizes and per-round message growth
- Enhanced API response logging with full usage details

## Test plan
- [x] Ran web research call with `max_content_tokens: 5000` — $0.16 total (40-60x reduction)
- [x] Ran web research call with `max_content_tokens: 20000` — $0.24 total (~15-40x reduction)
- [x] Both runs completed successfully with 6-7 claims created
- [ ] Verify on a non-smoke-test run (5 rounds) that costs stay reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)