### PR TITLE
Use realistic browser user agents for scraping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "uvicorn[standard]>=0.41.0",
     "voyageai>=0.3.2",
     "beautifulsoup4>=4.12.0",
+    "fake-useragent>=2.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/rumil/scraper.py
+++ b/src/rumil/scraper.py
@@ -6,14 +6,13 @@ from datetime import UTC, datetime
 
 import httpx
 from bs4 import BeautifulSoup
+from fake_useragent import UserAgent
 
 log = logging.getLogger(__name__)
 
 MAX_CONTENT_CHARS = 50_000
 TIMEOUT_SECONDS = 15
-USER_AGENT = (
-    'Mozilla/5.0 (compatible; Rumil/0.1; +https://github.com/chaosGuppy/differential)'
-)
+_ua = UserAgent(browsers=['Chrome', 'Firefox'], min_version=120.0)
 
 
 @dataclass
@@ -33,7 +32,7 @@ async def scrape_url(url: str) -> ScrapedPage | None:
         async with httpx.AsyncClient(
             timeout=TIMEOUT_SECONDS,
             follow_redirects=True,
-            headers={'User-Agent': USER_AGENT},
+            headers={'User-Agent': _ua.random},
         ) as client:
             response = await client.get(url)
             response.raise_for_status()

--- a/uv.lock
+++ b/uv.lock
@@ -432,6 +432,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fake-useragent"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/43/948d10bf42735709edb5ae51e23297d034086f17fc7279fef385a7acb473/fake_useragent-2.2.0.tar.gz", hash = "sha256:4e6ab6571e40cc086d788523cf9e018f618d07f9050f822ff409a4dfe17c16b2", size = 158898, upload-time = "2025-04-14T15:32:19.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/37/b3ea9cd5558ff4cb51957caca2193981c6b0ff30bd0d2630ac62505d99d0/fake_useragent-2.2.0-py3-none-any.whl", hash = "sha256:67f35ca4d847b0d298187443aaf020413746e56acd985a611908c73dba2daa24", size = 161695, upload-time = "2025-04-14T15:32:17.732Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1827,6 +1836,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "beautifulsoup4" },
+    { name = "fake-useragent" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pydantic" },
@@ -1854,6 +1864,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.84.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "fake-useragent", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary
- Replace the static bot-identifying `User-Agent` header in `scraper.py` with randomized Chrome/Firefox user agents via `fake-useragent`
- Pin minimum browser version to 120.0 to ensure only modern user agents are generated
- Fixes 403 errors when scraping source URLs for claim linking

## Test plan
- [ ] Run a scrape against a site that was previously returning 403
- [ ] Verify `_ua.random` produces recent Chrome/Firefox strings (`>= 120.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)