### PR TITLE
Tracing improvements: eager dispatch IDs, headlines, UI polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,5 @@ To add a new call type: subclass `SimpleCall` (for single-pass calls) or `BaseCa
 - Multiline strings use parenthesized concatenation of single-quoted lines (`"line 1 " "line 2"`), not triple-quoted strings (`"""`). Only use `f""` on lines that actually contain `{placeholder}` expressions.
 - Do not add section divider comments (e.g. `# ----------` banners). Use blank lines between logical sections; the code should speak for itself.
 - When adding new user-facing CLI flags or commands to `main.py`, always update `README.md` with corresponding documentation.
+
+Whenever you run a script that prints a trace url, please report that trace url to the user immediately so they can follow along.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1127,6 +1127,8 @@
           "scout_estimates",
           "scout_hypotheses",
           "scout_analogies",
+          "scout_paradigm_cases",
+          "scout_facts_to_check",
           "web_research"
         ],
         "title": "CallType"
@@ -1239,6 +1241,11 @@
           "question_id": {
             "type": "string",
             "title": "Question Id"
+          },
+          "question_headline": {
+            "type": "string",
+            "title": "Question Headline",
+            "default": ""
           },
           "child_call_id": {
             "anyOf": [

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -154,7 +154,7 @@ export type CallTraceOut = {
 /**
  * CallType
  */
-export type CallType = 'find_considerations' | 'assess' | 'prioritization' | 'ingest' | 'reframe' | 'maintain' | 'summarize' | 'scout_concepts' | 'assess_concept' | 'scout_subquestions' | 'scout_estimates' | 'scout_hypotheses' | 'scout_analogies' | 'web_research';
+export type CallType = 'find_considerations' | 'assess' | 'prioritization' | 'ingest' | 'reframe' | 'maintain' | 'summarize' | 'scout_concepts' | 'assess_concept' | 'scout_subquestions' | 'scout_estimates' | 'scout_hypotheses' | 'scout_analogies' | 'scout_paradigm_cases' | 'scout_facts_to_check' | 'web_research';
 
 /**
  * ConsiderationDirection
@@ -227,6 +227,10 @@ export type DispatchExecutedEventOut = {
      * Question Id
      */
     question_id: string;
+    /**
+     * Question Headline
+     */
+    question_headline?: string;
     /**
      * Child Call Id
      */

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -21,6 +21,16 @@ const CALL_TYPE_ACCENT: Record<string, string> = {
   ingest: "#4dab6f",
   reframe: "#c46b6b",
   maintain: "#7a8a9e",
+  summarize: "#8a9e7a",
+  scout_concepts: "#4a9ec4",
+  assess_concept: "#b48ad4",
+  scout_subquestions: "#3d8cb5",
+  scout_estimates: "#6b9fd4",
+  scout_hypotheses: "#4d8fba",
+  scout_analogies: "#5498c8",
+  scout_paradigm_cases: "#3b7fa8",
+  scout_facts_to_check: "#4793bf",
+  web_research: "#c4884d",
 };
 
 function compactTokens(n: number): string {
@@ -658,6 +668,8 @@ export function CallNode({
                   const isRecurse = d.call_type === "recurse";
                   const accent = CALL_TYPE_ACCENT[d.call_type] || "#7a8a9e";
                   const budget = (d as Record<string, unknown>).budget as number | undefined;
+                  const questionHeadline = ex?.question_headline || null;
+                  const questionId = (ex?.question_id ?? (d as Record<string, unknown>).question_id) as string | undefined;
                   return (
                     <div key={i} className={`trace-dispatch-item${isRecurse ? " trace-dispatch-recurse" : ""}`}>
                       <span className="trace-dispatch-index">{i + 1}</span>
@@ -687,6 +699,11 @@ export function CallNode({
                       )}
                       {isRecurse && budget != null && (
                         <span className="trace-dispatch-budget">budget {budget}</span>
+                      )}
+                      {(questionHeadline || questionId) && (
+                        <span className="trace-dispatch-question">
+                          {questionHeadline || questionId?.slice(0, 8)}
+                        </span>
                       )}
                       {d.reason ? (
                         <span className="trace-dispatch-reason">

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -608,6 +608,17 @@
   flex-shrink: 0;
 }
 
+.trace-dispatch-question {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+  color: #7a8a9e;
+  background: rgba(122, 138, 158, 0.08);
+  padding: 1px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
 /* Toggle exchanges button */
 
 .trace-toggle-exchanges {

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from rumil.database import DB
 from rumil.models import Page, PageLayer, PageLink, PageType, LinkType, Workspace
+from rumil.constants import MIN_TWOPHASE_BUDGET
 from rumil.orchestrator import Orchestrator, create_root_question, run_concept_session
 from rumil.sources import create_source_page, run_ingest_calls
 from rumil.chat import run_chat
@@ -27,6 +28,19 @@ from rumil.summary import generate_summary, save_summary
 from rumil.settings import Settings, get_settings, _settings_var
 
 PAGES_DIR = Path(__file__).parent / "pages"
+
+NORMAL_BUDGET_DEFAULT = 10
+
+
+def _default_budget(budget: int | None, fallback: int = NORMAL_BUDGET_DEFAULT) -> int:
+    if budget is not None:
+        return budget
+    settings = get_settings()
+    if settings.is_smoke_test:
+        if settings.prioritizer_variant == 'two_phase':
+            return MIN_TWOPHASE_BUDGET
+        return 1
+    return fallback
 
 
 async def cmd_add_question(
@@ -66,8 +80,7 @@ async def cmd_add_question(
     print(f"\nQuestion added: {page.id}")
     print(f"Text:           {question_text}")
 
-    smoke = get_settings().is_smoke_test
-    effective_budget = budget if budget is not None else (1 if smoke else 5)
+    effective_budget = _default_budget(budget, fallback=5)
     if effective_budget > 0:
         print(
             f"Budget:         {effective_budget} research call{'s' if effective_budget != 1 else ''}\n"
@@ -201,7 +214,7 @@ async def cmd_new(
     ingest_files: list[str] | None = None,
     name: str = "",
 ) -> None:
-    budget = budget if budget is not None else (1 if get_settings().is_smoke_test else 10)
+    budget = _default_budget(budget)
     await db.init_budget(budget)
     question_id = await create_root_question(question_text, db)
     await db.create_run(
@@ -309,7 +322,7 @@ async def cmd_ab(
 ) -> None:
     """Run an A/B test: two concurrent investigations with different configs."""
     ab_run_id = str(uuid.uuid4())
-    budget = budget if budget is not None else (1 if get_settings().is_smoke_test else 10)
+    budget = _default_budget(budget)
 
     question_id = await create_root_question(question_text, db)
     await db.create_ab_run(ab_run_id, name or question_text[:120], question_id)
@@ -563,6 +576,12 @@ async def async_main():
         help="Smoke-test mode: use Haiku, fewer rounds, lower budget defaults",
     )
     parser.add_argument(
+        "--force-twophase-recurse",
+        dest="force_twophase_recurse",
+        action="store_true",
+        help="Force the two-phase orchestrator to dispatch two recurse calls",
+    )
+    parser.add_argument(
         "--prod",
         dest="prod_db",
         action="store_true",
@@ -600,6 +619,8 @@ async def async_main():
         get_settings().use_prod_db = "1"
     if args.no_trace:
         get_settings().tracing_enabled = False
+    if args.force_twophase_recurse:
+        get_settings().force_twophase_recurse = True
 
     PAGES_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -109,6 +109,8 @@ async def run(args: argparse.Namespace) -> None:
     settings = get_settings()
     if args.smoke_test:
         settings.rumil_smoke_test = "1"
+    if args.force_twophase_recurse:
+        settings.force_twophase_recurse = True
 
     logging.basicConfig(
         level=logging.INFO,
@@ -240,6 +242,11 @@ def main() -> None:
     parser.add_argument(
         "--smoke-test", action="store_true",
         help="Use smoke-test settings (haiku model, reduced rounds)",
+    )
+    parser.add_argument(
+        "--force-twophase-recurse", action="store_true",
+        dest="force_twophase_recurse",
+        help="Force the two-phase orchestrator to dispatch two recurse calls",
     )
     parser.add_argument(
         "--ab", action="store_true",

--- a/src/rumil/calls/prioritization.py
+++ b/src/rumil/calls/prioritization.py
@@ -14,7 +14,7 @@ from rumil.context import build_prioritization_context, collect_subtree_ids
 from rumil.database import DB
 from rumil.page_graph import PageGraph
 from rumil.llm import build_system_prompt, build_user_message
-from rumil.models import Call, CallType, MoveType
+from rumil.models import Call, CallStatus, CallType, MoveType
 from rumil.moves.base import MoveState
 from rumil.moves.create_question import PRIORITIZATION_MOVE
 from rumil.moves.registry import MOVES
@@ -48,6 +48,7 @@ async def run_prioritization_call(
         call.id[:8],
         call.scope_page_id[:8] if call.scope_page_id else None,
     )
+    await db.update_call_status(call.id, CallStatus.RUNNING)
 
     if available_moves is None:
         available_moves = list(MoveType)

--- a/src/rumil/constants.py
+++ b/src/rumil/constants.py
@@ -1,0 +1,16 @@
+"""
+Domain constants for the research workspace.
+
+Centralises numeric thresholds and defaults that govern orchestration,
+call loops, and budget allocation so they can be tuned in one place.
+"""
+
+MIN_TWOPHASE_BUDGET = 4
+
+DEFAULT_FRUIT_THRESHOLD = 4
+DEFAULT_MAX_ROUNDS = 5
+DEFAULT_INGEST_FRUIT_THRESHOLD = 5
+DEFAULT_INGEST_MAX_ROUNDS = 5
+
+SMOKE_TEST_MAX_ROUNDS = 1
+SMOKE_TEST_INGEST_MAX_ROUNDS = 1

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -459,6 +459,7 @@ class DB:
         budget_allocated: int | None = None,
         workspace: Workspace = Workspace.RESEARCH,
         context_page_ids: list | None = None,
+        call_id: str | None = None,
     ) -> Call:
         log.debug(
             "create_call: type=%s, scope=%s, parent=%s, budget=%s",
@@ -476,6 +477,8 @@ class DB:
             status=CallStatus.PENDING,
             context_page_ids=context_page_ids or [],
         )
+        if call_id is not None:
+            call.id = call_id
         await self.save_call(call)
         return call
 

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -10,6 +10,8 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field
 
+from rumil.constants import MIN_TWOPHASE_BUDGET
+
 
 def _all_fields_required(schema: dict) -> None:
     """Mark all fields as required in JSON schema.
@@ -217,7 +219,10 @@ class WebResearchDispatchPayload(BaseDispatchPayload):
 
 
 class RecurseDispatchPayload(BaseDispatchPayload, _PrioritizationFields):
-    budget: int = Field(ge=4, description="Budget to allocate for the sub-investigation (minimum 4)")
+    budget: int = Field(
+        ge=MIN_TWOPHASE_BUDGET,
+        description=f'Budget to allocate for the sub-investigation (minimum {MIN_TWOPHASE_BUDGET})',
+    )
 
 
 class InlineScoutDispatch(_DispatchBase, _ScoutFields):

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -6,6 +6,7 @@ Budget is tracked here; prioritization and review calls are free.
 import asyncio
 import logging
 import os
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -35,6 +36,15 @@ from rumil.context import build_prioritization_context, collect_subtree_ids
 from rumil.database import DB
 from rumil.embeddings import embed_and_store_page
 from rumil.llm import LLMExchangeMetadata, build_system_prompt, build_user_message, structured_call
+from rumil.constants import (
+    DEFAULT_FRUIT_THRESHOLD,
+    DEFAULT_INGEST_FRUIT_THRESHOLD,
+    DEFAULT_INGEST_MAX_ROUNDS,
+    DEFAULT_MAX_ROUNDS,
+    MIN_TWOPHASE_BUDGET,
+    SMOKE_TEST_INGEST_MAX_ROUNDS,
+    SMOKE_TEST_MAX_ROUNDS,
+)
 from rumil.models import (
     AssessDispatchPayload,
     Call,
@@ -74,13 +84,6 @@ from rumil.tracing.trace_events import (
 
 log = logging.getLogger(__name__)
 
-DEFAULT_FRUIT_THRESHOLD = 4
-DEFAULT_MAX_ROUNDS = 5
-DEFAULT_INGEST_FRUIT_THRESHOLD = 5
-DEFAULT_INGEST_MAX_ROUNDS = 5
-
-SMOKE_TEST_MAX_ROUNDS = 1
-SMOKE_TEST_INGEST_MAX_ROUNDS = 1
 
 PRIORITIZATION_MOVES: list[MoveType] = [
     MoveType.CREATE_QUESTION,
@@ -184,6 +187,7 @@ async def find_considerations_until_done(
     mode: ScoutMode = ScoutMode.ALTERNATE,
     broadcaster=None,
     force: bool = False,
+    call_id: str | None = None,
 ) -> tuple[int, list[str]]:
     """Run a cache-aware find-considerations session.
 
@@ -211,6 +215,7 @@ async def find_considerations_until_done(
         scope_page_id=question_id,
         parent_call_id=parent_call_id,
         context_page_ids=context_page_ids,
+        call_id=call_id,
     )
 
     cls = FIND_CONSIDERATIONS_CALL_CLASSES[get_settings().find_considerations_call_variant]
@@ -295,6 +300,7 @@ async def assess_question(
     context_page_ids: list | None = None,
     broadcaster=None,
     force: bool = False,
+    call_id: str | None = None,
 ) -> str | None:
     """Run one Assess call on a question. Returns call ID, or None if no budget."""
     log.info("assess_question: question=%s", question_id[:8])
@@ -308,6 +314,7 @@ async def assess_question(
         scope_page_id=question_id,
         parent_call_id=parent_call_id,
         context_page_ids=context_page_ids,
+        call_id=call_id,
     )
     cls = ASSESS_CALL_CLASSES[get_settings().assess_call_variant]
     assess = cls(question_id, call, db, broadcaster=broadcaster)
@@ -448,6 +455,7 @@ async def web_research_question(
     parent_call_id: str | None = None,
     broadcaster=None,
     force: bool = False,
+    call_id: str | None = None,
 ) -> str | None:
     """Run one web research call on a question. Returns call ID, or None if no budget."""
     log.info('web_research_question: question=%s', question_id[:8])
@@ -458,6 +466,7 @@ async def web_research_question(
         CallType.WEB_RESEARCH,
         scope_page_id=question_id,
         parent_call_id=parent_call_id,
+        call_id=call_id,
     )
     cls = WEB_RESEARCH_CALL_CLASSES[get_settings().web_research_call_variant]
     web_research = cls(
@@ -508,6 +517,7 @@ class BaseOrchestrator(ABC):
         registry: dict,
         parent_call_id: str | None,
         force: bool = False,
+        call_id: str | None = None,
     ) -> str | None:
         """Run a simple (single-pass) call dispatch. Consumes 1 budget."""
         if not await _consume_budget(self.db, force=force):
@@ -517,6 +527,7 @@ class BaseOrchestrator(ABC):
             call_type,
             scope_page_id=question_id,
             parent_call_id=parent_call_id,
+            call_id=call_id,
         )
         cls = registry['default']
         instance = cls(question_id, call, self.db, broadcaster=self.broadcaster)
@@ -536,21 +547,39 @@ class BaseOrchestrator(ABC):
         All dispatches in the sequence are guaranteed to run: if budget
         is exhausted mid-sequence, subsequent dispatches force-consume
         so that trailing calls (e.g. auto-assess) are never skipped.
+
+        Child call IDs are pre-generated so that DispatchExecutedEvents
+        can be recorded before execution begins, making dispatch links
+        clickable in the trace frontend immediately.
         """
-        executed = False
-        for i, dispatch in enumerate(sequence):
-            force = i > 0 and await self.db.budget_remaining() <= 0
-            resolved, child_call_id = await self._execute_dispatch(
-                dispatch, scope_question_id, parent_call_id, force=force,
-            )
-            executed = True
-            if trace:
+        pre_ids = [str(uuid.uuid4()) for _ in sequence]
+        resolves = []
+        headlines = []
+        for dispatch in sequence:
+            resolved = await self.db.resolve_page_id(dispatch.payload.question_id)
+            resolved = resolved or scope_question_id
+            resolves.append(resolved)
+            page = await self.db.get_page(resolved)
+            headlines.append(page.headline if page else '')
+
+        if trace:
+            for i, dispatch in enumerate(sequence):
                 await trace.record(DispatchExecutedEvent(
                     index=base_index + i,
                     child_call_type=dispatch.call_type.value,
-                    question_id=resolved,
-                    child_call_id=child_call_id,
+                    question_id=resolves[i],
+                    question_headline=headlines[i],
+                    child_call_id=pre_ids[i],
                 ))
+
+        executed = False
+        for i, dispatch in enumerate(sequence):
+            force = i > 0 and await self.db.budget_remaining() <= 0
+            await self._execute_dispatch(
+                dispatch, scope_question_id, parent_call_id,
+                force=force, call_id=pre_ids[i],
+            )
+            executed = True
         return executed
 
     async def _execute_dispatch(
@@ -560,11 +589,15 @@ class BaseOrchestrator(ABC):
         parent_call_id: str | None,
         *,
         force: bool = False,
+        call_id: str | None = None,
     ) -> tuple[str, str | None]:
         """Execute a single dispatch.
 
         When *force* is True, budget is expanded if needed so the call
         always proceeds (used for trailing dispatches in a committed batch).
+
+        When *call_id* is provided, the child call will be created with
+        that ID (for eager link creation in traces).
 
         Returns (resolved_question_id, child_call_id).
         """
@@ -596,6 +629,7 @@ class BaseOrchestrator(ABC):
                 mode=p.mode,
                 broadcaster=self.broadcaster,
                 force=force,
+                call_id=call_id,
             )
             child_call_id = child_ids[0] if child_ids else None
 
@@ -608,6 +642,7 @@ class BaseOrchestrator(ABC):
                 context_page_ids=p.context_page_ids,
                 broadcaster=self.broadcaster,
                 force=force,
+                call_id=call_id,
             )
 
         elif isinstance(p, ScoutSubquestionsDispatchPayload):
@@ -615,7 +650,7 @@ class BaseOrchestrator(ABC):
             child_call_id = await self._run_simple_call_dispatch(
                 resolved, CallType.SCOUT_SUBQUESTIONS,
                 SCOUT_SUBQUESTIONS_CALL_CLASSES, parent_call_id,
-                force=force,
+                force=force, call_id=call_id,
             )
 
         elif isinstance(p, ScoutEstimatesDispatchPayload):
@@ -623,7 +658,7 @@ class BaseOrchestrator(ABC):
             child_call_id = await self._run_simple_call_dispatch(
                 resolved, CallType.SCOUT_ESTIMATES,
                 SCOUT_ESTIMATES_CALL_CLASSES, parent_call_id,
-                force=force,
+                force=force, call_id=call_id,
             )
 
         elif isinstance(p, ScoutHypothesesDispatchPayload):
@@ -631,7 +666,7 @@ class BaseOrchestrator(ABC):
             child_call_id = await self._run_simple_call_dispatch(
                 resolved, CallType.SCOUT_HYPOTHESES,
                 SCOUT_HYPOTHESES_CALL_CLASSES, parent_call_id,
-                force=force,
+                force=force, call_id=call_id,
             )
 
         elif isinstance(p, ScoutAnalogiesDispatchPayload):
@@ -639,7 +674,7 @@ class BaseOrchestrator(ABC):
             child_call_id = await self._run_simple_call_dispatch(
                 resolved, CallType.SCOUT_ANALOGIES,
                 SCOUT_ANALOGIES_CALL_CLASSES, parent_call_id,
-                force=force,
+                force=force, call_id=call_id,
             )
 
         elif isinstance(p, ScoutParadigmCasesDispatchPayload):
@@ -647,7 +682,7 @@ class BaseOrchestrator(ABC):
             child_call_id = await self._run_simple_call_dispatch(
                 resolved, CallType.SCOUT_PARADIGM_CASES,
                 SCOUT_PARADIGM_CASES_CALL_CLASSES, parent_call_id,
-                force=force,
+                force=force, call_id=call_id,
             )
 
         elif isinstance(p, ScoutFactsToCheckDispatchPayload):
@@ -655,7 +690,7 @@ class BaseOrchestrator(ABC):
             child_call_id = await self._run_simple_call_dispatch(
                 resolved, CallType.SCOUT_FACTS_TO_CHECK,
                 SCOUT_FACTS_TO_CHECK_CALL_CLASSES, parent_call_id,
-                force=force,
+                force=force, call_id=call_id,
             )
 
         elif isinstance(p, WebResearchDispatchPayload):
@@ -665,6 +700,7 @@ class BaseOrchestrator(ABC):
                 parent_call_id=parent_call_id,
                 broadcaster=self.broadcaster,
                 force=force,
+                call_id=call_id,
             )
 
         return resolved, child_call_id
@@ -907,6 +943,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         self._budget_cap: int | None = budget_cap
         self._consumed: int = 0
         self._initial_call: Call | None = None
+        self._parent_call_id: str | None = None
 
     def _effective_budget(self, global_remaining: int) -> int:
         if self._budget_cap is not None:
@@ -924,7 +961,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         before ``run()`` begins. ``_phase1`` reuses the pre-created call.
         """
         budget = self._effective_budget(await self.db.budget_remaining())
-        phase1_budget = min(budget - 3, 4)
+        phase1_budget = min(budget - 3, MIN_TWOPHASE_BUDGET)
         p_call = await self.db.create_call(
             CallType.PRIORITIZATION,
             scope_page_id=question_id,
@@ -934,10 +971,18 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         )
         self._call_id = p_call.id
         self._initial_call = p_call
+        self._parent_call_id = parent_call_id
         return p_call.id
 
     async def run(self, root_question_id: str) -> None:
         await self._setup()
+        remaining = await self.db.budget_remaining()
+        effective = self._effective_budget(remaining)
+        if effective < MIN_TWOPHASE_BUDGET:
+            raise ValueError(
+                f'TwoPhaseOrchestrator requires a budget of at least '
+                f'{MIN_TWOPHASE_BUDGET}, got {effective}'
+            )
         try:
             while True:
                 remaining = await self.db.budget_remaining()
@@ -1016,7 +1061,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
 
         self._executed_since_last_plan = False
         self._invocation += 1
-        return await self._phase2(question_id, budget, parent_call_id)
+        return await self._phase2(question_id, budget, self._parent_call_id)
 
     async def _phase1(
         self,
@@ -1024,7 +1069,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         budget: int,
         parent_call_id: str | None,
     ) -> PrioritizationResult:
-        phase1_budget = min(budget - 3, 4)
+        phase1_budget = min(budget - 3, MIN_TWOPHASE_BUDGET)
         log.info(
             'TwoPhaseOrchestrator phase1: question=%s, budget=%d, phase1_budget=%d',
             question_id[:8], budget, phase1_budget,
@@ -1242,12 +1287,17 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             'exploration that can be based purely on your trained knowledge and does not require web research, '
             'dispatch_web_research for web-based evidence, or '
             'recurse_into_subquestion to recursively investigate a child '
-            'question with its own prioritization cycle (minimum budget: 4). '
+            f'question with its own prioritization cycle (minimum budget: {MIN_TWOPHASE_BUDGET}). '
             'You can target the parent question or any child question.\n\n'
             'You may create subquestions before dispatching. '
             'You must make all your dispatch calls now — this is your only turn. '
-            'Each recurse call must have a budget of at least 4.'
+            f'Each recurse call must have a budget of at least {MIN_TWOPHASE_BUDGET}.'
         )
+        if get_settings().force_twophase_recurse:
+            task += (
+                '\n\nCRITICAL: You MUST dispatch two recurse calls '
+                'if you have enough budget to do so.'
+            )
 
         result = await run_prioritization_call(
             task, context_text, p_call, self.db,
@@ -1309,10 +1359,12 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             child_call_id = await child.create_initial_call(
                 child_qid, parent_call_id=p_call.id,
             )
+            child_page = await self.db.get_page(child_qid)
             await trace.record(DispatchExecutedEvent(
                 index=recurse_base + ci,
                 child_call_type='recurse',
                 question_id=child_qid,
+                question_headline=child_page.headline if child_page else '',
                 child_call_id=child_call_id,
             ))
 

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     rumil_test_mode: str = ""
     rumil_smoke_test: str = ""
+    force_twophase_recurse: bool = False
     use_prod_db: str = ""
     tracing_enabled: bool = True
 

--- a/src/rumil/tracing/trace_events.py
+++ b/src/rumil/tracing/trace_events.py
@@ -105,6 +105,7 @@ class DispatchExecutedEvent(BaseModel):
     index: int
     child_call_type: str
     question_id: str
+    question_headline: str = ""
     child_call_id: str | None = None
 
 

--- a/src/rumil/tracing/tracer.py
+++ b/src/rumil/tracing/tracer.py
@@ -31,4 +31,4 @@ class CallTrace:
             try:
                 await self._broadcaster.send(dumped["event"], dumped)
             except Exception as e:
-                log.debug("Broadcast failed for event %s: %s", dumped["event"], e)
+                log.warning("Broadcast failed for event %s: %s", dumped["event"], e)


### PR DESCRIPTION
## Summary
- Pre-generate child call IDs so dispatch links in the trace frontend are clickable immediately, before the child call finishes executing
- Add question headlines to dispatch events so the UI shows meaningful names instead of short UUIDs
- Fix phase-2 `parent_call_id` not being threaded through in `TwoPhaseOrchestrator`, causing phase-2 calls to appear as disconnected roots
- Set prioritization calls to RUNNING status (previously stuck on PENDING until completion)
- Add `--force-twophase-recurse` CLI flag for testing the recurse dispatch code path
- Extract `constants.py` for orchestration tuning knobs (`MIN_TWOPHASE_BUDGET`, fruit thresholds, round limits)
- Validate minimum budget in `TwoPhaseOrchestrator.run()` and raise smoke-test default budget to 4 when using `two_phase` orchestrator
- Add accent colours for all remaining call types in the trace frontend

## Test plan
- [x] All existing tests pass (`uv run pytest`)
- [x] Smoke test with `--smoke-test --force-twophase-recurse --budget 12` to verify eager IDs, headlines, and recurse dispatches render correctly in the trace UI
- [x] Verify prioritization calls show as "running" during execution in the trace frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)