### PR TITLE
Fix dispatch question headlines overflowing in trace view

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -720,43 +720,48 @@ export function CallNode({
                   const questionId = (ex?.question_id ?? (d as Record<string, unknown>).question_id) as string | undefined;
                   return (
                     <div key={i} className={`trace-dispatch-item${isRecurse ? " trace-dispatch-recurse" : ""}`}>
-                      <span className="trace-dispatch-index">{i + 1}</span>
-                      {childCallId ? (
-                        <a
-                          href={`#call-${childCallId.slice(0, 8)}`}
-                          className="trace-dispatch-link"
-                          style={{ color: accent }}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            document
-                              .getElementById(
-                                `call-${childCallId.slice(0, 8)}`,
-                              )
-                              ?.scrollIntoView({ behavior: "smooth" });
-                          }}
-                        >
-                          {isRecurse ? "recurse" : d.call_type}
-                        </a>
-                      ) : (
-                        <span
-                          className={isRecurse ? "trace-dispatch-type" : "trace-dispatch-skipped"}
-                          style={{ color: accent }}
-                        >
-                          {isRecurse ? "recurse" : d.call_type}
-                        </span>
-                      )}
-                      {isRecurse && budget != null && (
-                        <span className="trace-dispatch-budget">budget {budget}</span>
-                      )}
-                      {(questionHeadline || questionId) && (
-                        <span className="trace-dispatch-question">
-                          {questionHeadline || questionId?.slice(0, 8)}
-                        </span>
-                      )}
+                      <div className="trace-dispatch-header">
+                        <span className="trace-dispatch-index">{i + 1}</span>
+                        {childCallId ? (
+                          <a
+                            href={`#call-${childCallId.slice(0, 8)}`}
+                            className="trace-dispatch-link"
+                            style={{ color: accent }}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              document
+                                .getElementById(
+                                  `call-${childCallId.slice(0, 8)}`,
+                                )
+                                ?.scrollIntoView({ behavior: "smooth" });
+                            }}
+                          >
+                            {isRecurse ? "recurse" : d.call_type}
+                          </a>
+                        ) : (
+                          <span
+                            className={isRecurse ? "trace-dispatch-type" : "trace-dispatch-skipped"}
+                            style={{ color: accent }}
+                          >
+                            {isRecurse ? "recurse" : d.call_type}
+                          </span>
+                        )}
+                        {isRecurse && budget != null && (
+                          <span className="trace-dispatch-budget">budget {budget}</span>
+                        )}
+                        {(questionHeadline || questionId) && (
+                          <span
+                            className="trace-dispatch-question"
+                            title={questionHeadline || questionId}
+                          >
+                            {questionHeadline || questionId?.slice(0, 8)}
+                          </span>
+                        )}
+                      </div>
                       {d.reason ? (
-                        <span className="trace-dispatch-reason">
+                        <div className="trace-dispatch-reason">
                           {String(d.reason)}
-                        </span>
+                        </div>
                       ) : null}
                     </div>
                   );

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -539,10 +539,22 @@
 .trace-dispatch-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
-.trace-dispatch-item,
+.trace-dispatch-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.trace-dispatch-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
 .trace-dispatch-row {
   display: flex;
   align-items: baseline;
@@ -588,9 +600,10 @@
 }
 
 .trace-dispatch-reason {
-  font-size: 13px;
-  color: #666;
-  min-width: 0;
+  font-size: 12px;
+  color: #888;
+  line-height: 1.4;
+  margin-left: 22px;
 }
 
 .trace-dispatch-recurse {
@@ -616,7 +629,10 @@
   padding: 1px 6px;
   border-radius: 3px;
   letter-spacing: 0.02em;
-  flex-shrink: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Toggle exchanges button */


### PR DESCRIPTION
## Summary
- Switch dispatch items from single-row to two-line layout: header (index, call type, badges, question) on top, reason text indented below
- Question headlines now truncate with ellipsis instead of pushing reason off-screen; full text available on hover via title attribute
- Slightly increased vertical spacing between dispatch items to accommodate the new layout

## Test plan
- [x] Open a trace view with a prioritize call that has long question headlines
- [x] Verify question headlines truncate cleanly with ellipsis
- [x] Hover over truncated headlines to confirm full text tooltip appears
- [x] Verify reason text displays on its own line, indented under the header
- [x] Check dispatches with short headlines still look clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)