### PR TITLE
Display trace sequences vertically instead of in columns

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -583,10 +583,8 @@ function SequenceGroup({
   const sorted = [...sequences].sort(
     (a, b) => a.position_in_batch - b.position_in_batch,
   );
-  const isMulti = sorted.length > 1;
-
   return (
-    <div className={`trace-sequences${isMulti ? " trace-sequences-multi" : ""}`}>
+    <div className="trace-sequences">
       {sorted.map((seq, si) => {
         const seqColor = SEQUENCE_COLORS[si % SEQUENCE_COLORS.length];
         return (
@@ -599,7 +597,7 @@ function SequenceGroup({
           >
             <div className="trace-sequence-header" style={{ color: seqColor }}>
               <span className="trace-sequence-label">
-                sequence{isMulti ? ` ${si + 1}` : ""}
+                sequence {si + 1}
               </span>
               <span className="trace-sequence-meta">
                 {seq.calls.length} call{seq.calls.length !== 1 ? "s" : ""}

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -663,20 +663,14 @@
   margin-top: 12px;
 }
 
-.trace-sequences-multi {
-  display: flex;
-  gap: 8px;
-  overflow-x: auto;
-}
-
-.trace-sequences-multi > .trace-sequence-lane {
-  flex: 1;
-  min-width: 280px;
-}
-
 .trace-sequence-lane {
   border-left: 2px solid #d0d0d0;
   padding-left: 8px;
+  margin-bottom: 8px;
+}
+
+.trace-sequence-lane:last-child {
+  margin-bottom: 0;
 }
 
 .trace-sequence-header {


### PR DESCRIPTION
## Summary
- Removed multi-column flexbox layout for concurrent sequences in the trace view
- Sequences now stack vertically one after the other, improving readability
- Always show sequence numbers in labels for clarity

## Test plan
- [x] Open a trace with concurrent sequences (e.g. `/traces/868e3374-cfff-4685-a1de-0ddbdf7d3d47`)
- [x] Verify sequences display vertically with colored left borders
- [x] Verify single-sequence traces still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)