### PR TITLE
Stop closing review from overwriting page headlines

### DIFF
--- a/prompts/preamble.md
+++ b/prompts/preamble.md
@@ -39,6 +39,15 @@ Always express epistemic status as a 0–5 float (subjective confidence, not a p
 
 Accompany every epistemic_status with an epistemic_type: a brief description of the nature of the uncertainty (e.g. "empirical, depends on data we don't have", "conceptual, contested definition", "value-laden").
 
+## Headlines
+
+Every page has a headline — the primary label seen throughout the workspace. Write headlines that are **self-contained**: a reader with no prior context should understand what the page is about.
+
+- **10–15 words** (20-word ceiling). Sharp label, not a truncated sentence.
+- **Questions must be phrased as questions.** e.g. "How sensitive is the 2028 timeline to regulatory delays?"
+- **Claims and judgements should name the actual position**, e.g. "Solar payback periods have fallen below 7 years in most climates". Avoid vague openings like "There are several factors…".
+- **Include the key finding or main caveat** if space allows.
+
 ## Key Principles
 
 - **Use tools for all output.** The only way to modify the workspace is through tool calls. Non-tool-call text is not recorded and serves no purpose. Keep text output to an absolute minimum — ideally empty. Never narrate, summarize, or explain what you are about to do or just did. Just make tool calls.

--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -35,30 +35,22 @@ SYSTEM = (
 )
 
 PROMPT_TEMPLATE = (
-    'Produce two summaries of the research page below.\n\n'
-    'SHORT (~30 words): State the core topic and conclusion in a single self-contained '
-    'sentence or two. Include the highest-priority finding and the main caveat. '
-    'Must make sense with zero prior context.\n\n'
-    'MEDIUM (~200 words): Include the core conclusion, the main supporting reasoning or '
+    'Produce an abstract (~200 words) of the research page below.\n\n'
+    'Include the core conclusion, the main supporting reasoning or '
     'evidence, key counter-arguments and why they were discounted, and the critical '
     'uncertainties or dependencies. Preserve epistemic qualifications and confidence levels. '
     'Must be self-contained.\n\n'
     'Format your response exactly as:\n'
-    'SHORT: <text>\n\n'
-    'MEDIUM: <text>\n\n'
+    'ABSTRACT: <text>\n\n'
     'Research page:\n'
     '{content}'
 )
 
 
-def _parse_response(text: str) -> tuple[str, str]:
-    if "SHORT:" in text and "MEDIUM:" in text:
-        short_start = text.index("SHORT:") + len("SHORT:")
-        medium_start = text.index("MEDIUM:")
-        short = text[short_start:medium_start].strip()
-        medium = text[medium_start + len("MEDIUM:"):].strip()
-        return short, medium
-    return "", ""
+def _parse_response(text: str) -> str:
+    if "ABSTRACT:" in text:
+        return text[text.index("ABSTRACT:") + len("ABSTRACT:"):].strip()
+    return ""
 
 
 async def _fetch_all_needing_summaries(db: DB) -> list[dict]:
@@ -69,7 +61,7 @@ async def _fetch_all_needing_summaries(db: DB) -> list[dict]:
         rows = (
             await db.client.table("pages")
             .select("id, page_type, headline, content")
-            .or_("headline.eq.,abstract.eq.")
+            .eq("abstract", "")
             .eq("is_superseded", False)
             .order("created_at", desc=False)
             .range(offset, offset + CHUNK_SIZE - 1)
@@ -107,16 +99,16 @@ async def _process_page(
                 log.warning("[%d/%d] Non-text response for %s", idx, total, page_id[:8])
                 counters["failed"] += 1
                 return
-            short, medium = _parse_response(block.text.strip())
-            if not short or not medium:
+            abstract = _parse_response(block.text.strip())
+            if not abstract:
                 log.warning(
                     "[%d/%d] Parse failed for %s — raw: %s",
                     idx, total, page_id[:8], block.text[:120],
                 )
                 counters["failed"] += 1
                 return
-            await db.update_page_summaries(page_id, short, medium)
-            log.info("[%d/%d] %s: %s", idx, total, page_id[:8], short[:80])
+            await db.update_page_abstract(page_id, abstract)
+            log.info("[%d/%d] %s: %s", idx, total, page_id[:8], abstract[:80])
             counters["ok"] += 1
         except Exception as e:
             log.error("[%d/%d] Failed for %s: %s", idx, total, page_id[:8], e)

--- a/src/rumil/calls/closing_reviewers.py
+++ b/src/rumil/calls/closing_reviewers.py
@@ -189,8 +189,8 @@ async def _self_assessment(
             page_summary_note = (
                 '\n\nYou created the following pages during this call:\n'
                 + '\n'.join(created_lines)
-                + '\n\nFor each, provide a headline (~30 words, fully self-contained) '
-                'and an abstract (~200 words, fully self-contained) in your page_summaries. '
+                + '\n\nFor each, provide an abstract (~200 words, fully self-contained) '
+                'in your page_summaries. '
                 'These will be read by other LLM instances with no prior context, so do not '
                 'assume any background knowledge.'
             )
@@ -233,9 +233,8 @@ async def _self_assessment(
         for s in review_data.get('page_summaries', []):
             pid = await infra.db.resolve_page_id(s.get('page_id', ''))
             if pid:
-                await infra.db.update_page_summaries(
+                await infra.db.update_page_abstract(
                     pid,
-                    s.get('headline', ''),
                     s.get('abstract', ''),
                 )
                 abstract_text = s.get('abstract', '')

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -382,13 +382,6 @@ async def run_agent_loop(
 
 class PageSummaryItem(BaseModel):
     page_id: str = Field(description="Full or short ID of the page")
-    headline: str = Field(
-        description=(
-            "Self-contained summary of ~30 words. State the core topic and conclusion "
-            "so a reader with no prior context understands what the page is about and "
-            "what it concludes. Include the key finding and main caveat if space allows."
-        )
-    )
     abstract: str = Field(
         description=(
             "Self-contained summary of ~200 words. Include: the core conclusion, "
@@ -712,8 +705,8 @@ async def run_closing_review(
             page_summary_note = (
                 '\n\nYou created the following pages during this call:\n'
                 + '\n'.join(created_lines)
-                + '\n\nFor each, provide a headline (~30 words, fully self-contained) '
-                'and an abstract (~200 words, fully self-contained) in your page_summaries. '
+                + '\n\nFor each, provide an abstract (~200 words, fully self-contained) '
+                'in your page_summaries. '
                 'These will be read by other LLM instances with no prior context, so do not '
                 'assume any background knowledge.'
             )
@@ -761,9 +754,8 @@ async def run_closing_review(
                 for s in review.get("page_summaries", []):
                     pid = await db.resolve_page_id(s.get("page_id", ""))
                     if pid:
-                        await db.update_page_summaries(
+                        await db.update_page_abstract(
                             pid,
-                            s.get("headline", ""),
                             s.get("abstract", ""),
                         )
                         abstract_text = s.get("abstract", "")

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -55,7 +55,7 @@ def _row_to_page(row: dict[str, Any]) -> Page:
         layer=PageLayer(row["layer"]),
         workspace=Workspace(row["workspace"]),
         content=row.get("content") or "",
-        headline=row.get("headline") or "",
+        headline=row["headline"],
         project_id=row.get("project_id") or "",
         epistemic_status=row.get("epistemic_status") or 0.0,
         epistemic_type=row.get("epistemic_type") or "",
@@ -244,11 +244,11 @@ class DB:
             active_only=False,
         )
 
-    async def update_page_summaries(
-        self, page_id: str, headline: str, abstract: str
+    async def update_page_abstract(
+        self, page_id: str, abstract: str
     ) -> None:
         await self.client.table("pages").update(
-            {"headline": headline, "abstract": abstract}
+            {"abstract": abstract}
         ).eq("id", page_id).execute()
 
     async def get_page(self, page_id: str) -> Page | None:

--- a/supabase/migrations/20260323161618_headline_not_null.sql
+++ b/supabase/migrations/20260323161618_headline_not_null.sql
@@ -1,0 +1,4 @@
+-- Backfill any NULL headlines to empty string, then make the column NOT NULL.
+UPDATE pages SET headline = '' WHERE headline IS NULL;
+ALTER TABLE pages ALTER COLUMN headline SET DEFAULT '';
+ALTER TABLE pages ALTER COLUMN headline SET NOT NULL;


### PR DESCRIPTION
## Summary
- The closing review was rewriting page headlines with summary-style text, causing questions to lose their question phrasing (e.g. "Which Republican candidates..." became "Identifying plausible 2028 Republican nominees...")
- Closing review now only generates abstracts; `headline` field removed from `PageSummaryItem`
- Headline writing guidance ported to the preamble prompt so it applies at page creation time
- `headline` column made `NOT NULL DEFAULT ''` in the database, matching the existing application-level assumption
- Backfill script updated to only backfill abstracts

## Test plan
- [x] All 63 tests pass
- [x] Run a smoke test and verify question headlines remain as questions after closing review
- [x] Verify trace view link text matches the page detail headline

🤖 Generated with [Claude Code](https://claude.com/claude-code)