### PR TITLE
Add expand-to-overlay for prompt/response text in trace UI

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -249,6 +249,36 @@ function MoveRow({
 
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
 
+function TextOverlay({
+  label,
+  content,
+  onClose,
+}: {
+  label: string;
+  content: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className="trace-overlay-backdrop" onClick={onClose}>
+      <div
+        className="trace-overlay-panel"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="trace-overlay-header">
+          <span className="trace-overlay-label">{label}</span>
+          <span className="trace-overlay-meta">
+            {content.length.toLocaleString()} chars
+          </span>
+          <button className="trace-overlay-close" onClick={onClose}>
+            {"\u2715"}
+          </button>
+        </div>
+        <pre className="trace-overlay-content">{content}</pre>
+      </div>
+    </div>
+  );
+}
+
 function CollapsiblePre({
   label,
   content,
@@ -257,6 +287,7 @@ function CollapsiblePre({
   content: string | null;
 }) {
   const [open, setOpen] = useState(false);
+  const [overlayOpen, setOverlayOpen] = useState(false);
   if (!content) return null;
 
   return (
@@ -270,6 +301,19 @@ function CollapsiblePre({
         <span className="trace-collapsible-meta">
           {content.length.toLocaleString()} chars
         </span>
+        {open && (
+          <span
+            className="trace-expand-btn"
+            role="button"
+            title="Expand to full view"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOverlayOpen(true);
+            }}
+          >
+            {"\u2922"}
+          </span>
+        )}
       </button>
       {open && (
         <pre className="trace-collapsible-content">{content}</pre>
@@ -278,6 +322,13 @@ function CollapsiblePre({
         <pre className="trace-collapsible-preview">
           {content.slice(0, 200)}...
         </pre>
+      )}
+      {overlayOpen && (
+        <TextOverlay
+          label={label}
+          content={content}
+          onClose={() => setOverlayOpen(false)}
+        />
       )}
     </div>
   );
@@ -302,24 +353,48 @@ function formatMessageContent(content: unknown): string {
   return String(content ?? "");
 }
 
+function MessageTurn({ msg, index }: { msg: Record<string, unknown>; index: number }) {
+  const [overlayOpen, setOverlayOpen] = useState(false);
+  const role = String(msg.role ?? "unknown");
+  const text = formatMessageContent(msg.content);
+  return (
+    <details key={index} className="trace-message-turn">
+      <summary className={`trace-message-role trace-role-${role}`}>
+        {role}
+        <span className="trace-collapsible-meta">
+          {" "}{text.length.toLocaleString()} chars
+        </span>
+        <span
+          className="trace-expand-btn"
+          role="button"
+          title="Expand to full view"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setOverlayOpen(true);
+          }}
+        >
+          {"\u2922"}
+        </span>
+      </summary>
+      <pre className="trace-collapsible-content">{text}</pre>
+      {overlayOpen && (
+        <TextOverlay
+          label={`${role} message`}
+          content={text}
+          onClose={() => setOverlayOpen(false)}
+        />
+      )}
+    </details>
+  );
+}
+
 function MessageThread({ messages }: { messages: Array<Record<string, unknown>> }) {
   return (
     <div className="trace-message-thread">
-      {messages.map((msg, i) => {
-        const role = String(msg.role ?? "unknown");
-        const text = formatMessageContent(msg.content);
-        return (
-          <details key={i} className="trace-message-turn">
-            <summary className={`trace-message-role trace-role-${role}`}>
-              {role}
-              <span className="trace-collapsible-meta">
-                {" "}{text.length.toLocaleString()} chars
-              </span>
-            </summary>
-            <pre className="trace-collapsible-content">{text}</pre>
-          </details>
-        );
-      })}
+      {messages.map((msg, i) => (
+        <MessageTurn key={i} msg={msg} index={i} />
+      ))}
     </div>
   );
 }

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -937,6 +937,110 @@
   margin-top: 4px;
 }
 
+/* Expand button */
+
+.trace-expand-btn {
+  font-size: 14px;
+  color: #aaa;
+  cursor: pointer;
+  margin-left: auto;
+  padding: 0 4px;
+  transition: color 0.15s;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.trace-expand-btn:hover {
+  color: #444;
+}
+
+/* Full-viewport text overlay */
+
+.trace-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: trace-overlay-fade-in 0.12s ease-out;
+}
+
+@keyframes trace-overlay-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.trace-overlay-panel {
+  background: #fff;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 960px;
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  animation: trace-overlay-slide-up 0.15s ease-out;
+}
+
+@keyframes trace-overlay-slide-up {
+  from { transform: translateY(12px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.trace-overlay-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid #e8e8e8;
+  flex-shrink: 0;
+}
+
+.trace-overlay-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  letter-spacing: -0.01em;
+}
+
+.trace-overlay-meta {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+  color: #999;
+}
+
+.trace-overlay-close {
+  margin-left: auto;
+  background: none;
+  border: none;
+  font-size: 16px;
+  color: #999;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background-color 0.1s, color 0.1s;
+  line-height: 1;
+}
+.trace-overlay-close:hover {
+  background: #f0f0f0;
+  color: #333;
+}
+
+.trace-overlay-content {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #333;
+  padding: 18px 22px;
+  margin: 0;
+  overflow: auto;
+  white-space: pre-wrap;
+  flex: 1;
+  min-height: 0;
+}
+
 @media (prefers-color-scheme: dark) {
   .trace-back-link { color: #888; }
   .trace-back-link:hover { color: #ccc; }
@@ -1078,4 +1182,19 @@
     color: #5cb8a5;
     background: rgba(92, 184, 165, 0.08);
   }
+
+  .trace-expand-btn { color: #555; }
+  .trace-expand-btn:hover { color: #ccc; }
+
+  .trace-overlay-backdrop { background: rgba(0, 0, 0, 0.7); }
+  .trace-overlay-panel {
+    background: #1a1a1a;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  }
+  .trace-overlay-header { border-bottom-color: #2a2a2a; }
+  .trace-overlay-label { color: #e0e0e0; }
+  .trace-overlay-meta { color: #666; }
+  .trace-overlay-close { color: #666; }
+  .trace-overlay-close:hover { background: #2a2a2a; color: #ccc; }
+  .trace-overlay-content { color: #ccc; }
 }


### PR DESCRIPTION
## Summary
- Adds a full-viewport overlay modal for reading long prompt/response text in the trace viewer
- Expand button (⤢) appears on `CollapsiblePre` blocks (system prompt, user message, response) and on each message turn in multi-turn `MessageThread` conversations
- Light and dark mode support with fade-in/slide-up animations

## Test plan
- [x] Open a trace with LLM exchanges, expand an exchange, verify ⤢ button appears on system prompt / user message / response blocks
- [x] Click ⤢ to open the overlay, verify text is readable and scrollable
- [x] Close overlay via ✕ button and via backdrop click
- [x] Test with multi-turn message threads — each turn should have its own expand button
- [ ] Verify dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)