### PR TITLE
Fix stale descriptions from headline removal

### DIFF
--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -1,5 +1,5 @@
 """
-Backfill summary_short and summary_medium for existing pages that don't have them.
+Backfill abstracts for existing pages that don't have them.
 
 Usage:
     uv run python scripts/backfill_summaries.py [--prod] [--dry-run] [--limit N] [--concurrency N]

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -431,7 +431,7 @@ class ReviewResponse(BaseModel):
     page_summaries: list[PageSummaryItem] = Field(
         default_factory=list,
         description=(
-            "Short and medium summaries for each page you created during this call. "
+            "Abstract for each page you created during this call. "
             "Provide one entry per created page."
         ),
     )


### PR DESCRIPTION
## Summary

- Update `ReviewResponse.page_summaries` field description from "Short and medium summaries" to "Abstract" — this text is included in the LLM's structured output schema
- Update `backfill_summaries.py` module docstring to reflect that it now backfills abstracts only

Follow-up to #121.

## Test plan

- [ ] Verify pyright passes
- [ ] Verify field description change propagates correctly to LLM schema

🤖 Generated with [Claude Code](https://claude.ai/code)