### PR TITLE
Show page abstract in detail view

### DIFF
--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -214,6 +214,9 @@ export default async function PageDetailPage({
             )}
           </div>
           <h1 className="page-summary">{page.headline}</h1>
+          {page.abstract && (
+            <div className="page-abstract">{page.abstract}</div>
+          )}
         </header>
 
         <div className="page-content">
@@ -357,6 +360,17 @@ const styles = `
     letter-spacing: -0.02em;
     line-height: 1.3;
     margin: 0;
+  }
+
+  .page-abstract {
+    max-width: 36rem;
+    margin: 0.75rem auto 0;
+    padding: 0 1.5rem;
+    font-size: 0.82rem;
+    font-style: italic;
+    line-height: 1.55;
+    color: var(--color-foreground);
+    opacity: 0.65;
   }
 
   .page-content {


### PR DESCRIPTION
## Summary
- Display the page abstract beneath the headline on the page detail view
- Styled like an academic paper abstract: smaller italic text, narrower column width (36rem), reduced opacity
- Only rendered when the abstract field is present

## Test plan
- [x] Open a page that has an abstract — verify it appears between headline and content
- [ ] Open a page without an abstract — verify no extra whitespace or empty element
- [ ] Check light and dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)