### PR TITLE
Add inline citations with auto-linking and frontend rendering

### DIFF
--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -58,6 +58,37 @@ function pageHref(page: Page): string {
   return `/pages/${page.id}`;
 }
 
+function buildCitationMap(
+  links_from: LinkedPageOut[],
+  links_to: LinkedPageOut[],
+): Map<string, { fullId: string; pageType: string }> {
+  const map = new Map<string, { fullId: string; pageType: string }>();
+  for (const lp of [...links_from, ...links_to]) {
+    const short = lp.page.id.slice(0, 8);
+    map.set(short, { fullId: lp.page.id, pageType: lp.page.page_type });
+  }
+  return map;
+}
+
+const CITATION_RE = /\[([a-f0-9]{8})\]/g;
+
+function injectCitationLinks(
+  content: string,
+  citationMap: Map<string, { fullId: string; pageType: string }>,
+): string {
+  const orderMap = new Map<string, number>();
+  let nextNum = 1;
+  return content.replace(CITATION_RE, (_match, shortId: string) => {
+    const entry = citationMap.get(shortId);
+    if (!entry) return `[${shortId}]`;
+    if (!orderMap.has(shortId)) {
+      orderMap.set(shortId, nextNum++);
+    }
+    const num = orderMap.get(shortId)!;
+    return `[${num}](/pages/${entry.fullId}?cite=${entry.pageType})`;
+  });
+}
+
 async function getPageRun(pageId: string): Promise<RunSummaryOut | null> {
   const res = await fetch(
     `${API_BASE}/api/pages/${pageId}/run`,
@@ -181,6 +212,8 @@ export default async function PageDetailPage({
 
   const { page, links_from, links_to } = detail;
   const cfg = TYPE_CONFIG[page.page_type] || TYPE_CONFIG.source;
+  const citationMap = buildCitationMap(links_from, links_to);
+  const processedContent = injectCitationLinks(page.content, citationMap);
 
   return (
     <main className="page-detail">
@@ -217,7 +250,30 @@ export default async function PageDetailPage({
         </header>
 
         <div className="page-content">
-          <Markdown>{page.content}</Markdown>
+          <Markdown
+            components={{
+              a: ({ href, children }) => {
+                if (href && href.startsWith("/pages/") && href.includes("?cite=")) {
+                  const url = new URL(href, "http://x");
+                  const pageType = url.searchParams.get("cite") || "claim";
+                  const typeCfg = TYPE_CONFIG[pageType] || TYPE_CONFIG.source;
+                  const cleanHref = url.pathname;
+                  return (
+                    <Link href={cleanHref} className="citation-chip" style={{
+                      color: typeCfg.accent,
+                      borderColor: typeCfg.border,
+                      background: typeCfg.bg,
+                    }}>
+                      {children}
+                    </Link>
+                  );
+                }
+                return <a href={href}>{children}</a>;
+              },
+            }}
+          >
+            {processedContent}
+          </Markdown>
         </div>
 
         <div className="page-meta-row">
@@ -418,6 +474,28 @@ const styles = `
   .page-content a {
     color: var(--color-accent);
     text-decoration: underline;
+  }
+  .page-content .citation-chip {
+    display: inline;
+    font-size: 0.78em;
+    font-family: var(--font-geist-mono), monospace;
+    font-weight: 500;
+    padding: 0.1em 0.4em;
+    border: 1px solid;
+    text-decoration: none;
+    letter-spacing: 0.01em;
+    transition: background 0.12s ease, border-color 0.12s ease;
+    cursor: pointer;
+    vertical-align: baseline;
+  }
+  .page-content .citation-chip:hover {
+    filter: brightness(0.92);
+    text-decoration: none;
+  }
+  @media (prefers-color-scheme: dark) {
+    .page-content .citation-chip:hover {
+      filter: brightness(1.3);
+    }
   }
 
   .page-meta-row {

--- a/prompts/citations.md
+++ b/prompts/citations.md
@@ -1,0 +1,16 @@
+# Inline Citations
+
+When your page content draws on information from another page in the workspace, **cite it inline** using the page's short ID in square brackets: `[shortid]`.
+
+## Format
+
+Write the 8-character short ID inside square brackets wherever you reference another page's content:
+
+> According to [a1b2c3d4], solar payback periods have fallen below 7 years. This contradicts the earlier estimate in [e5f6a7b8], which assumed a 12-year horizon.
+
+## Rules
+
+- **Only cite pages whose IDs appear in your context.** Never fabricate or guess a page ID.
+- **Cite in the `content` field** of page-creation tools, not in headlines.
+- **Cite whenever you draw on another page's substance** — paraphrasing a claim, referencing a finding, building on a judgement, or using a concept's definition.
+- Multiple citations in a single page are encouraged when the content synthesises several sources.

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -53,10 +53,11 @@ def _load_file(name: str) -> str:
 
 
 def build_system_prompt(call_type: str) -> str:
-    """Combine preamble + call-type instructions into one system prompt."""
+    """Combine preamble + call-type instructions + citations into one system prompt."""
     preamble = _load_file("preamble.md")
     instructions = _load_file(f"{call_type}.md")
-    return f"{preamble}\n\n---\n\n{instructions}"
+    citations = _load_file("citations.md")
+    return f"{preamble}\n\n---\n\n{instructions}\n\n---\n\n{citations}"
 
 
 def build_user_message(context_text: str, task_description: str) -> str:

--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -1,6 +1,7 @@
 """Base types and shared helpers for moves."""
 
 import logging
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -242,12 +243,88 @@ async def create_page(
         page_type.value, page.id[:8], page.headline[:70],
     )
 
+    try:
+        cited_ids = await extract_and_link_citations(
+            page.id, page.content, db, citing_page_type=page_type,
+        )
+        if cited_ids:
+            log.info(
+                "Auto-linked %d citations from page %s",
+                len(cited_ids), page.id[:8],
+            )
+    except Exception:
+        log.warning(
+            "Citation extraction failed for page %s", page.id[:8], exc_info=True,
+        )
+
     message = (
         f"Created [{page.id[:8]}]: {payload.headline}"
         if payload.headline
         else f"Created [{page.id[:8]}]"
     )
     return MoveResult(message=message, created_page_id=page.id)
+
+
+_CITATION_RE = re.compile(r'\[([a-f0-9]{8})\]')
+
+
+async def extract_and_link_citations(
+    page_id: str,
+    content: str,
+    db: DB,
+    citing_page_type: PageType | None = None,
+) -> set[str]:
+    """Extract [shortid] citations from content and create page links.
+
+    Link type depends on both citing and cited page types:
+    - Cited SOURCE → CITES
+    - Citing QUESTION/JUDGEMENT + cited CLAIM → CONSIDERATION (direction flipped:
+      from=cited claim, to=citing page, since "claim bears on question/judgement")
+    - Otherwise → RELATED
+
+    Returns the set of full UUIDs that were successfully linked.
+    """
+    matches = set(_CITATION_RE.findall(content))
+    own_short_id = page_id[:8]
+    matches.discard(own_short_id)
+    if not matches:
+        return set()
+
+    linked: set[str] = set()
+    for short_id in matches:
+        resolved = await db.resolve_page_id(short_id)
+        if not resolved:
+            log.debug("Citation [%s] did not resolve to a page", short_id)
+            continue
+
+        cited_page = await db.get_page(resolved)
+        if not cited_page:
+            continue
+
+        from_id, to_id = page_id, resolved
+        if cited_page.page_type == PageType.SOURCE:
+            link_type = LinkType.CITES
+        elif (
+            citing_page_type in (PageType.QUESTION, PageType.JUDGEMENT)
+            and cited_page.page_type == PageType.CLAIM
+        ):
+            link_type = LinkType.CONSIDERATION
+            from_id, to_id = resolved, page_id
+        else:
+            link_type = LinkType.RELATED
+
+        await db.save_link(PageLink(
+            from_page_id=from_id,
+            to_page_id=to_id,
+            link_type=link_type,
+        ))
+        log.info(
+            "Citation linked: %s -> %s (%s)",
+            from_id[:8], to_id[:8], link_type.value,
+        )
+        linked.add(resolved)
+
+    return linked
 
 
 async def link_pages(

--- a/src/rumil/moves/promote_concept.py
+++ b/src/rumil/moves/promote_concept.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 
 from rumil.database import DB
 from rumil.models import Call, MoveType, Page, PageLayer, PageType, Workspace
-from rumil.moves.base import MoveDef, MoveResult, write_page_file
+from rumil.moves.base import MoveDef, MoveResult, extract_and_link_citations, write_page_file
 
 log = logging.getLogger(__name__)
 
@@ -56,6 +56,15 @@ async def execute(payload: PromoteConceptPayload, call: Call, db: DB) -> MoveRes
     )
     await db.save_page(research_page)
     write_page_file(research_page)
+    try:
+        await extract_and_link_citations(
+            research_page.id, research_page.content, db,
+            citing_page_type=PageType.CONCEPT,
+        )
+    except Exception:
+        log.warning(
+            "Citation extraction failed for page %s", research_page.id[:8], exc_info=True,
+        )
     await db.supersede_page(resolved, research_page.id)
 
     log.info(

--- a/src/rumil/moves/propose_concept.py
+++ b/src/rumil/moves/propose_concept.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 
 from rumil.database import DB
 from rumil.models import Call, MoveType, Page, PageLayer, PageType, Workspace
-from rumil.moves.base import MoveDef, MoveResult, write_page_file
+from rumil.moves.base import MoveDef, MoveResult, extract_and_link_citations, write_page_file
 
 
 class ProposeConceptPayload(BaseModel):
@@ -47,6 +47,12 @@ async def execute(payload: ProposeConceptPayload, call: Call, db: DB) -> MoveRes
     )
     await db.save_page(page)
     write_page_file(page)
+    try:
+        await extract_and_link_citations(
+            page.id, page.content, db, citing_page_type=PageType.CONCEPT,
+        )
+    except Exception:
+        pass
     return MoveResult(
         message=f"Proposed concept [{page.id[:8]}]: {payload.headline}",
         created_page_id=page.id,

--- a/src/rumil/moves/propose_hypothesis.py
+++ b/src/rumil/moves/propose_hypothesis.py
@@ -15,7 +15,7 @@ from rumil.models import (
     PageType,
     Workspace,
 )
-from rumil.moves.base import MoveDef, MoveResult, write_page_file
+from rumil.moves.base import MoveDef, MoveResult, extract_and_link_citations, write_page_file
 
 log = logging.getLogger(__name__)
 
@@ -63,6 +63,12 @@ async def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> Move
     )
     await db.save_page(claim)
     write_page_file(claim)
+    try:
+        await extract_and_link_citations(
+            claim.id, claim.content, db, citing_page_type=PageType.CLAIM,
+        )
+    except Exception:
+        log.warning("Citation extraction failed for page %s", claim.id[:8], exc_info=True)
     log.info("Hypothesis claim created: %s", claim.id[:8])
 
     await db.save_link(
@@ -96,6 +102,12 @@ async def execute(payload: ProposeHypothesisPayload, call: Call, db: DB) -> Move
     )
     await db.save_page(question)
     write_page_file(question)
+    try:
+        await extract_and_link_citations(
+            question.id, question.content, db, citing_page_type=PageType.QUESTION,
+        )
+    except Exception:
+        log.warning("Citation extraction failed for page %s", question.id[:8], exc_info=True)
     log.info("Hypothesis question created: %s", question.id[:8])
 
     await db.save_link(

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -1,0 +1,317 @@
+"""Tests for inline citation extraction and auto-linking."""
+
+import re
+
+import pytest
+import pytest_asyncio
+
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.moves.base import _CITATION_RE, extract_and_link_citations
+
+
+@pytest_asyncio.fixture
+async def source_page(tmp_db):
+    page = Page(
+        page_type=PageType.SOURCE,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="The sky appears blue due to Rayleigh scattering of sunlight.",
+        headline="Rayleigh scattering explains blue sky",
+        extra={"filename": "sky-science.txt", "char_count": 58},
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def claim_page(tmp_db):
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Shorter wavelengths scatter more, making the sky blue.",
+        headline="Short-wavelength scattering produces blue sky",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def second_claim_page(tmp_db):
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Sunset colors result from longer path lengths through the atmosphere.",
+        headline="Longer atmospheric path lengths produce sunset colors",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+async def test_inline_citation_of_source_creates_cites_link(
+    tmp_db, source_page,
+):
+    """An inline [shortid] citing a SOURCE page should produce a CITES link."""
+    citing_page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"According to [{source_page.id[:8]}], scattering causes blue sky.",
+        headline="Scattering causes blue sky",
+    )
+    await tmp_db.save_page(citing_page)
+
+    linked = await extract_and_link_citations(citing_page.id, citing_page.content, tmp_db)
+
+    assert linked == {source_page.id}
+    links = await tmp_db.get_links_from(citing_page.id)
+    cites = [l for l in links if l.link_type == LinkType.CITES]
+    assert len(cites) == 1
+    assert cites[0].to_page_id == source_page.id
+
+
+async def test_inline_citation_of_claim_creates_related_link(
+    tmp_db, claim_page,
+):
+    """An inline [shortid] citing a CLAIM page should produce a RELATED link."""
+    citing_page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Building on [{claim_page.id[:8]}], the effect is strongest at noon.",
+        headline="Scattering effect strongest at noon",
+    )
+    await tmp_db.save_page(citing_page)
+
+    linked = await extract_and_link_citations(citing_page.id, citing_page.content, tmp_db)
+
+    assert linked == {claim_page.id}
+    links = await tmp_db.get_links_from(citing_page.id)
+    related = [l for l in links if l.link_type == LinkType.RELATED]
+    assert len(related) == 1
+    assert related[0].to_page_id == claim_page.id
+
+
+async def test_multiple_inline_citations(
+    tmp_db, claim_page, second_claim_page,
+):
+    """Content with multiple [shortid] citations creates one link per cited page."""
+    citing_page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=(
+            f"Combining [{claim_page.id[:8]}] and [{second_claim_page.id[:8]}], "
+            "we see a coherent picture of atmospheric optics."
+        ),
+        headline="Atmospheric optics coherent picture",
+    )
+    await tmp_db.save_page(citing_page)
+
+    linked = await extract_and_link_citations(citing_page.id, citing_page.content, tmp_db)
+
+    assert linked == {claim_page.id, second_claim_page.id}
+    links = await tmp_db.get_links_from(citing_page.id)
+    related = [l for l in links if l.link_type == LinkType.RELATED]
+    assert len(related) == 2
+    assert {l.to_page_id for l in related} == {claim_page.id, second_claim_page.id}
+
+
+async def test_judgement_citing_claim_creates_consideration_link(
+    tmp_db, claim_page,
+):
+    """A JUDGEMENT citing a CLAIM should produce a CONSIDERATION link (claim → judgement)."""
+    judgement = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Weighing [{claim_page.id[:8]}], the evidence is strong.",
+        headline="Evidence for blue sky is strong",
+    )
+    await tmp_db.save_page(judgement)
+
+    linked = await extract_and_link_citations(
+        judgement.id, judgement.content, tmp_db,
+        citing_page_type=PageType.JUDGEMENT,
+    )
+
+    assert linked == {claim_page.id}
+    consideration_links = await tmp_db.get_links_to(judgement.id)
+    cons = [l for l in consideration_links if l.link_type == LinkType.CONSIDERATION]
+    assert len(cons) == 1
+    assert cons[0].from_page_id == claim_page.id
+    assert cons[0].to_page_id == judgement.id
+
+
+async def test_question_citing_claim_creates_consideration_link(
+    tmp_db, claim_page,
+):
+    """A QUESTION citing a CLAIM should produce a CONSIDERATION link (claim → question)."""
+    question = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Given [{claim_page.id[:8]}], what are the implications for sunset colors?",
+        headline="What are the implications for sunset colors?",
+    )
+    await tmp_db.save_page(question)
+
+    linked = await extract_and_link_citations(
+        question.id, question.content, tmp_db,
+        citing_page_type=PageType.QUESTION,
+    )
+
+    assert linked == {claim_page.id}
+    consideration_links = await tmp_db.get_links_to(question.id)
+    cons = [l for l in consideration_links if l.link_type == LinkType.CONSIDERATION]
+    assert len(cons) == 1
+    assert cons[0].from_page_id == claim_page.id
+    assert cons[0].to_page_id == question.id
+
+
+async def test_unresolvable_short_ids_skipped(tmp_db):
+    """Citations referencing nonexistent pages are silently skipped."""
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="This references [deadbeef] which does not exist.",
+        headline="References nonexistent page",
+    )
+    await tmp_db.save_page(page)
+
+    linked = await extract_and_link_citations(page.id, page.content, tmp_db)
+
+    assert linked == set()
+    links = await tmp_db.get_links_from(page.id)
+    assert len(links) == 0
+
+
+def test_regex_ignores_non_hex_and_wrong_length():
+    """The citation regex should only match exactly 8 lowercase hex chars in brackets."""
+    assert _CITATION_RE.findall("[abcdef01]") == ["abcdef01"]
+    assert _CITATION_RE.findall("[12345678]") == ["12345678"]
+
+    assert _CITATION_RE.findall("[abc]") == []
+    assert _CITATION_RE.findall("[not-hex!]") == []
+    assert _CITATION_RE.findall("[ABCDEF01]") == []
+    assert _CITATION_RE.findall("[abcdef012]") == []
+    assert _CITATION_RE.findall("[link text](http://example.com)") == []
+
+
+async def test_page_does_not_cite_itself(tmp_db):
+    """A page whose content contains its own short ID should not self-link."""
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="placeholder",
+        headline="Self-referencing page",
+    )
+    await tmp_db.save_page(page)
+
+    content_with_self = f"As noted earlier in [{page.id[:8]}], this is recursive."
+    linked = await extract_and_link_citations(page.id, content_with_self, tmp_db)
+
+    assert linked == set()
+    links = await tmp_db.get_links_from(page.id)
+    assert len(links) == 0
+
+
+@pytest.mark.llm
+async def test_assess_produces_inline_citations(tmp_db, question_page):
+    """An assess call should produce a judgement with inline citations that get auto-linked."""
+    claims = []
+    for headline, content, direction in [
+        (
+            "Rayleigh scattering is the dominant blue-sky mechanism",
+            "Rayleigh scattering of shorter wavelengths of light by molecules "
+            "in Earth's atmosphere is the dominant mechanism for blue sky.",
+            "supports",
+        ),
+        (
+            "Mie scattering from aerosols shifts sky toward white or grey",
+            "In polluted or humid conditions, larger particles cause Mie scattering "
+            "which is wavelength-independent, shifting the sky toward white or grey.",
+            "opposes",
+        ),
+        (
+            "Human color perception adapts to ambient lighting conditions",
+            "Chromatic adaptation in the human visual system means the perceived "
+            "color of the sky depends on adaptation state, not just the spectrum.",
+            "neutral",
+        ),
+    ]:
+        claim = Page(
+            page_type=PageType.CLAIM,
+            layer=PageLayer.SQUIDGY,
+            workspace=Workspace.RESEARCH,
+            content=content,
+            headline=headline,
+            epistemic_status=3.5,
+            epistemic_type="empirical",
+        )
+        await tmp_db.save_page(claim)
+        await tmp_db.save_link(PageLink(
+            from_page_id=claim.id,
+            to_page_id=question_page.id,
+            link_type=LinkType.CONSIDERATION,
+            strength=3.5,
+            reasoning=headline,
+            direction=direction,
+        ))
+        claims.append(claim)
+
+    call = Call(
+        call_type=CallType.ASSESS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    from rumil.calls.assess import AssessCall
+
+    runner = AssessCall(question_page.id, call, tmp_db)
+    await runner.run()
+
+    refreshed = await tmp_db.get_call(call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+
+    citation_pattern = re.compile(r'\[([a-f0-9]{8})\]')
+
+    created_pages = []
+    for pid in runner.infra.state.created_page_ids:
+        p = await tmp_db.get_page(pid)
+        if p:
+            created_pages.append(p)
+
+    pages_with_citations = [
+        p for p in created_pages
+        if citation_pattern.search(p.content)
+    ]
+    assert len(pages_with_citations) >= 1, (
+        "At least one created page should contain an inline [shortid] citation"
+    )
+
+    for p in pages_with_citations:
+        cited_short_ids = citation_pattern.findall(p.content)
+        links_from_page = await tmp_db.get_links_from(p.id)
+        auto_link_targets = {l.to_page_id for l in links_from_page}
+        for sid in cited_short_ids:
+            resolved = await tmp_db.resolve_page_id(sid)
+            if resolved:
+                assert resolved in auto_link_targets, (
+                    f"Citation [{sid}] in page {p.id[:8]} should have a corresponding link"
+                )

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -307,11 +307,15 @@ async def test_assess_produces_inline_citations(tmp_db, question_page):
 
     for p in pages_with_citations:
         cited_short_ids = citation_pattern.findall(p.content)
-        links_from_page = await tmp_db.get_links_from(p.id)
-        auto_link_targets = {l.to_page_id for l in links_from_page}
+        links_from = await tmp_db.get_links_from(p.id)
+        links_to = await tmp_db.get_links_to(p.id)
+        linked_ids = (
+            {l.to_page_id for l in links_from}
+            | {l.from_page_id for l in links_to}
+        )
         for sid in cited_short_ids:
             resolved = await tmp_db.resolve_page_id(sid)
             if resolved:
-                assert resolved in auto_link_targets, (
+                assert resolved in linked_ids, (
                     f"Citation [{sid}] in page {p.id[:8]} should have a corresponding link"
                 )


### PR DESCRIPTION
## Summary

- **Prompt**: New `prompts/citations.md` appended to all system prompts, instructing the LLM to cite pages with `[shortid]` in content fields
- **Auto-linking**: `extract_and_link_citations()` in `moves/base.py` extracts `[shortid]` patterns from page content after creation and generates typed links:
  - Cited SOURCE → `CITES`
  - QUESTION/JUDGEMENT citing CLAIM → `CONSIDERATION` (flipped: claim bears on the citing page)
  - Otherwise → `RELATED`
- **Frontend**: Citations render as numbered chips `[1]`, `[2]` (ascending by appearance order), colored by cited page type, clickable to navigate to the cited page
- **Coverage**: All page creation paths handled, including outlier moves (`propose_hypothesis`, `propose_concept`, `promote_concept`)

## Test plan

- [x] 8 unit tests for citation extraction (link types, self-citation, unresolvable IDs, regex edge cases)
- [x] 1 LLM test: assess call produces inline citations that get auto-linked
- [x] Full test suite passes (71 passed, 35 skipped)
- [x] TypeScript compiles clean
- [x] Manual: run a smoke test and verify citation chips appear and link correctly in the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)