### PR TITLE
Prevent ruff from auto-removing unused imports

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | { read -r f; [[ \"$f\" != *.py ]] && exit 0; uv run ruff check --fix \"$f\" && uv run ruff format \"$f\"; }"
+            "command": "jq -r '.tool_input.file_path' | { read -r f; [[ \"$f\" != *.py ]] && exit 0; uv run ruff check --fix --unfixable F401 \"$f\" && uv run ruff format \"$f\"; }"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Adds `--unfixable F401` to the ruff check PostToolUse hook so unused imports are flagged but not auto-deleted
- Prevents a race condition where ruff removes an import added in one edit before the usage is added in a subsequent edit

## Test plan
- [ ] Edit a Python file to add an import, verify ruff doesn't remove it
- [ ] Verify ruff still flags other lint issues and auto-fixes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)