### PR TITLE
Use CONSIDERATION links for claim-to-claim citations

### DIFF
--- a/prompts/ingest.md
+++ b/prompts/ingest.md
@@ -25,7 +25,7 @@ Calibrate your `epistemic_status` and `epistemic_type` accordingly. A well-evide
 
 Extract **3–5 considerations** that bear on the primary question. Quality over quantity — if only 2 genuinely matter, produce 2.
 
-For each consideration, create the claim and link it to the primary question. Set the `source_ids` field on each claim to include the source page ID.
+For each consideration, create the claim and link it to the primary question. Cite the source inline using its `[shortid]` so the link is auto-created.
 
 ### Cross-question extraction
 

--- a/prompts/web_research.md
+++ b/prompts/web_research.md
@@ -7,11 +7,11 @@ You are performing a **Web Research** call — your job is to search the web for
 ## Workflow
 
 1. **Search**: Use `web_search` to find relevant sources for the question. Try multiple search queries to cover different angles.
-2. **Create claims**: For each substantive finding, use `create_claim` to record it. Every claim must cite its source(s) via the `source_ids` field using the **URL** of the page.
+2. **Create claims**: For each substantive finding, use `create_claim` to record it. Every claim must cite its source(s) via the `source_urls` field using the **URL** of the page.
 
 ## Rules
 
-- **Every claim must have at least one source_ids entry.** Use the full URL of the page you fetched (e.g. `https://example.com/article`).
+- **Every claim must have at least one source_urls entry.** Use the full URL of the page you fetched (e.g. `https://example.com/article`).
 - **Claims should be specific, falsifiable assertions** — not summaries of pages. Extract the most important finding from each source.
 - **Link claims to the target question** using the `links` field on `create_claim`. Every claim should be linked as a consideration.
 - **Epistemic status should reflect source reliability**: peer-reviewed research (3.5-4.5) > established news outlets (2.5-3.5) > blogs and opinion pieces (1.5-2.5) > forums and social media (0.5-1.5).

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -27,7 +27,15 @@ from rumil.llm import (
     call_api,
     structured_call,
 )
-from rumil.models import CallType, MoveType, FindConsiderationsMode, Page, PageLayer, PageType, Workspace
+from rumil.models import (
+    CallType,
+    MoveType,
+    FindConsiderationsMode,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
 from rumil.moves.registry import MOVES
 from rumil.settings import get_settings
 from rumil.moves.base import write_page_file
@@ -52,7 +60,9 @@ class SimpleAgentLoop(PageCreator):
         self._max_rounds = max_rounds
 
     async def create_pages(
-        self, infra: CallInfra, context: ContextResult,
+        self,
+        infra: CallInfra,
+        context: ContextResult,
     ) -> CreationResult:
         settings = get_settings()
         max_rounds = self._max_rounds
@@ -60,17 +70,21 @@ class SimpleAgentLoop(PageCreator):
             max_rounds = 1 if settings.is_smoke_test else 3
 
         moves_list = (
-            list(self._available_moves) if self._available_moves is not None
+            list(self._available_moves)
+            if self._available_moves is not None
             else list(MoveType)
         )
         tools = [MOVES[mt].bind(infra.state) for mt in moves_list]
         system_prompt = build_system_prompt(self._call_type.value)
         user_message = build_user_message(
-            context.context_text, self._task_description,
+            context.context_text,
+            self._task_description,
         )
 
         agent_result = await run_agent_loop(
-            system_prompt, user_message, tools,
+            system_prompt,
+            user_message,
+            tools,
             call_id=infra.call.id,
             db=infra.db,
             state=infra.state,
@@ -79,10 +93,11 @@ class SimpleAgentLoop(PageCreator):
         )
 
         log.info(
-            'create_pages complete: type=%s, pages_created=%d, '
-            'dispatches=%d, moves=%d',
-            self._call_type.value, len(infra.state.created_page_ids),
-            len(infra.state.dispatches), len(infra.state.moves),
+            "create_pages complete: type=%s, pages_created=%d, dispatches=%d, moves=%d",
+            self._call_type.value,
+            len(infra.state.created_page_ids),
+            len(infra.state.dispatches),
+            len(infra.state.moves),
         )
 
         result = RunCallResult(
@@ -95,9 +110,7 @@ class SimpleAgentLoop(PageCreator):
 
         phase2_loaded = await extract_loaded_page_ids(result, infra.db)
         all_loaded_ids = list(
-            dict.fromkeys(
-                [*context.preloaded_ids, *context.phase1_ids, *phase2_loaded]
-            )
+            dict.fromkeys([*context.preloaded_ids, *context.phase1_ids, *phase2_loaded])
         )
 
         return CreationResult(
@@ -110,47 +123,53 @@ class SimpleAgentLoop(PageCreator):
 
 
 _CONCRETE_INSTRUCTION = (
-    '\n\n**Mode: CONCRETE**\n\n'
-    'Your goal is considerations, sub-questions, and hypotheses that are as specific '
-    'and falsifiable as possible. Concreteness means: named actors, specific timeframes, '
-    'quantitative claims, named mechanisms, particular cases. A concrete claim should be '
-    'possible to be clearly wrong about — that is what makes it valuable.\n\n'
-    'Concrete scouts are expected to produce claims that subsequent investigation may '
-    'refute. That is a feature, not a failure. Do not hedge your way back to vagueness.'
+    "\n\n**Mode: CONCRETE**\n\n"
+    "Your goal is considerations, sub-questions, and hypotheses that are as specific "
+    "and falsifiable as possible. Concreteness means: named actors, specific timeframes, "
+    "quantitative claims, named mechanisms, particular cases. A concrete claim should be "
+    "possible to be clearly wrong about — that is what makes it valuable.\n\n"
+    "Concrete scouts are expected to produce claims that subsequent investigation may "
+    "refute. That is a feature, not a failure. Do not hedge your way back to vagueness."
 )
 
 _CONTINUE_TEMPLATE = (
-    'Continue scouting this question. You have already made contributions in '
-    'prior rounds (visible above). Focus on NEW angles, evidence, or '
-    'sub-questions you have not yet covered.{mode_instruction}\n\n'
-    'Question ID: `{question_id}`'
+    "Continue scouting this question. You have already made contributions in "
+    "prior rounds (visible above). Focus on NEW angles, evidence, or "
+    "sub-questions you have not yet covered.{mode_instruction}\n\n"
+    "Question ID: `{question_id}`"
 )
 
 _FRUIT_CHECK_MESSAGE = (
-    'Before continuing, rate how much useful scouting work remains on this '
-    'scope question. Consider what you have already contributed and what '
-    'angles are left unexplored. Respond with remaining_fruit (0-10) and '
-    'brief_reasoning. Do not call any tools — they will have no effect here.'
+    "Before continuing, rate how much useful scouting work remains on this "
+    "scope question. Consider what you have already contributed and what "
+    "angles are left unexplored. Respond with remaining_fruit (0-10) and "
+    "brief_reasoning. Do not call any tools — they will have no effect here."
 )
 
 
-def _resolve_round_mode(mode: FindConsiderationsMode, round_index: int) -> FindConsiderationsMode:
+def _resolve_round_mode(
+    mode: FindConsiderationsMode, round_index: int
+) -> FindConsiderationsMode:
     if mode == FindConsiderationsMode.ALTERNATE:
-        return FindConsiderationsMode.ABSTRACT if round_index % 2 == 0 else FindConsiderationsMode.CONCRETE
+        return (
+            FindConsiderationsMode.ABSTRACT
+            if round_index % 2 == 0
+            else FindConsiderationsMode.CONCRETE
+        )
     return mode
 
 
 class _FruitCheck(BaseModel):
     remaining_fruit: int = Field(
         description=(
-            '0-10 integer: how much useful work remains on this scope. '
-            '0 = nothing more to add; 1-2 = close to exhausted; '
-            '3-4 = most angles covered; 5-6 = diminishing but real returns; '
-            '7-8 = substantial work remains; 9-10 = barely started'
+            "0-10 integer: how much useful work remains on this scope. "
+            "0 = nothing more to add; 1-2 = close to exhausted; "
+            "3-4 = most angles covered; 5-6 = diminishing but real returns; "
+            "7-8 = substantial work remains; 9-10 = barely started"
         )
     )
     brief_reasoning: str = Field(
-        description='One sentence explaining why you chose this score'
+        description="One sentence explaining why you chose this score"
     )
 
 
@@ -168,7 +187,9 @@ class MultiRoundLoop(PageCreator):
         self._mode = mode
 
     async def create_pages(
-        self, infra: CallInfra, context: ContextResult,
+        self,
+        infra: CallInfra,
+        context: ContextResult,
     ) -> CreationResult:
         tools = [MOVES[mt].bind(infra.state) for mt in MoveType]
         tool_defs, _ = prepare_tools(tools)
@@ -176,12 +197,14 @@ class MultiRoundLoop(PageCreator):
 
         round_mode = _resolve_round_mode(self._mode, 0)
         mode_instruction = (
-            _CONCRETE_INSTRUCTION if round_mode == FindConsiderationsMode.CONCRETE else ''
+            _CONCRETE_INSTRUCTION
+            if round_mode == FindConsiderationsMode.CONCRETE
+            else ""
         )
         task = (
-            f'Scout for missing considerations on this question.{mode_instruction}\n\n'
-            'Question ID (use this when linking considerations): '
-            f'`{infra.question_id}`'
+            f"Scout for missing considerations on this question.{mode_instruction}\n\n"
+            "Question ID (use this when linking considerations): "
+            f"`{infra.question_id}`"
         )
         user_message = build_user_message(context.context_text, task)
 
@@ -192,7 +215,8 @@ class MultiRoundLoop(PageCreator):
         for i in range(self._max_rounds):
             if not await infra.db.consume_budget(1):
                 log.info(
-                    'Budget exhausted, stopping scout session at round %d', i,
+                    "Budget exhausted, stopping scout session at round %d",
+                    i,
                 )
                 break
 
@@ -212,15 +236,14 @@ class MultiRoundLoop(PageCreator):
             else:
                 mi = (
                     _CONCRETE_INSTRUCTION
-                    if round_mode == FindConsiderationsMode.CONCRETE else ''
+                    if round_mode == FindConsiderationsMode.CONCRETE
+                    else ""
                 )
                 continue_msg = _CONTINUE_TEMPLATE.format(
                     mode_instruction=mi,
                     question_id=infra.question_id,
                 )
-                resume_messages.append(
-                    {'role': 'user', 'content': continue_msg}
-                )
+                resume_messages.append({"role": "user", "content": continue_msg})
                 agent_result = await run_agent_loop(
                     system_prompt,
                     tools=tools,
@@ -236,12 +259,18 @@ class MultiRoundLoop(PageCreator):
             resume_messages = list(agent_result.messages)
 
             last_fruit_score = await self._run_fruit_check(
-                infra, system_prompt, resume_messages, tool_defs, _FruitCheck,
+                infra,
+                system_prompt,
+                resume_messages,
+                tool_defs,
+                _FruitCheck,
             )
             if last_fruit_score <= self._fruit_threshold:
                 log.info(
-                    'Scout fruit (%d) <= threshold (%d), stopping after round %d',
-                    last_fruit_score, self._fruit_threshold, i + 1,
+                    "Scout fruit (%d) <= threshold (%d), stopping after round %d",
+                    last_fruit_score,
+                    self._fruit_threshold,
+                    i + 1,
                 )
                 break
 
@@ -264,10 +293,12 @@ class MultiRoundLoop(PageCreator):
         fruit_check_model: type,
     ) -> int:
         check_messages = list(resume_messages) + [
-            {'role': 'user', 'content': _FRUIT_CHECK_MESSAGE},
+            {"role": "user", "content": _FRUIT_CHECK_MESSAGE},
         ]
         meta = LLMExchangeMetadata(
-            call_id=infra.call.id, phase='fruit_check', trace=infra.trace,
+            call_id=infra.call.id,
+            phase="fruit_check",
+            trace=infra.trace,
             user_message=_FRUIT_CHECK_MESSAGE,
         )
         result = await structured_call(
@@ -280,13 +311,14 @@ class MultiRoundLoop(PageCreator):
             cache=True,
         )
         if result.data:
-            score = result.data.get('remaining_fruit', 5)
+            score = result.data.get("remaining_fruit", 5)
             log.info(
-                'Fruit check: score=%d, reasoning=%s',
-                score, result.data.get('brief_reasoning', ''),
+                "Fruit check: score=%d, reasoning=%s",
+                score,
+                result.data.get("brief_reasoning", ""),
             )
             return score
-        log.warning('Fruit check returned empty data, defaulting to 5')
+        log.warning("Fruit check returned empty data, defaulting to 5")
         return 5
 
 
@@ -298,7 +330,9 @@ class WebResearchLoop(PageCreator):
         self.source_page_ids: dict[str, str] = {}
 
     async def create_pages(
-        self, infra: CallInfra, context: ContextResult,
+        self,
+        infra: CallInfra,
+        context: ContextResult,
     ) -> CreationResult:
         settings = get_settings()
         max_rounds = 2 if settings.is_smoke_test else 5
@@ -310,46 +344,57 @@ class WebResearchLoop(PageCreator):
         custom_tool_defs, custom_tool_fns = prepare_tools(custom_tools)
         all_tool_defs: list = server_tools + custom_tool_defs
 
-        system_prompt = build_system_prompt('web_research')
+        system_prompt = build_system_prompt("web_research")
         task = (
-            'Search the web for evidence relevant to this question and create '
-            'source-grounded claims.\n\n'
-            'Question ID (use this when linking considerations): '
-            f'`{infra.question_id}`'
+            "Search the web for evidence relevant to this question and create "
+            "source-grounded claims.\n\n"
+            "Question ID (use this when linking considerations): "
+            f"`{infra.question_id}`"
         )
         user_message = build_user_message(context.context_text, task)
-        messages: list[dict] = [{'role': 'user', 'content': user_message}]
+        messages: list[dict] = [{"role": "user", "content": user_message}]
 
         log.debug(
-            'Web research create_pages starting: '
-            'system_prompt=%d chars, user_message=%d chars, '
-            'server_tools=%d, custom_tools=%d, all_tool_defs=%d',
-            len(system_prompt), len(user_message),
-            len(server_tools), len(custom_tool_defs), len(all_tool_defs),
+            "Web research create_pages starting: "
+            "system_prompt=%d chars, user_message=%d chars, "
+            "server_tools=%d, custom_tools=%d, all_tool_defs=%d",
+            len(system_prompt),
+            len(user_message),
+            len(server_tools),
+            len(custom_tool_defs),
+            len(all_tool_defs),
         )
         tool_defs_chars = len(json.dumps(all_tool_defs))
         log.debug(
-            'Tool definitions total: %d chars (%d tokens approx)',
-            tool_defs_chars, tool_defs_chars // 4,
+            "Tool definitions total: %d chars (%d tokens approx)",
+            tool_defs_chars,
+            tool_defs_chars // 4,
         )
 
         for round_num in range(max_rounds):
-            total_msg_chars = sum(
-                len(str(m.get('content', ''))) for m in messages
-            )
+            total_msg_chars = sum(len(str(m.get("content", ""))) for m in messages)
             log.debug(
-                'Round %d: %d messages, ~%d chars in messages',
-                round_num, len(messages), total_msg_chars,
+                "Round %d: %d messages, ~%d chars in messages",
+                round_num,
+                len(messages),
+                total_msg_chars,
             )
             meta = LLMExchangeMetadata(
-                call_id=infra.call.id, phase='web_research_loop',
-                trace=infra.trace, round_num=round_num,
+                call_id=infra.call.id,
+                phase="web_research_loop",
+                trace=infra.trace,
+                round_num=round_num,
                 user_message=user_message if round_num == 0 else None,
             )
             api_resp = await call_api(
-                client, settings.model, system_prompt, messages,
+                client,
+                settings.model,
+                system_prompt,
+                messages,
                 all_tool_defs,
-                metadata=meta, db=infra.db, cache=True,
+                metadata=meta,
+                db=infra.db,
+                cache=True,
             )
             response = api_resp.message
 
@@ -358,28 +403,30 @@ class WebResearchLoop(PageCreator):
                 if isinstance(block, ToolUseBlock):
                     custom_tool_uses.append(block)
 
-            messages.append({'role': 'assistant', 'content': response.content})
+            messages.append({"role": "assistant", "content": response.content})
 
             if custom_tool_uses:
                 _, tool_results = await execute_tool_uses(
-                    custom_tool_uses, custom_tool_fns,
+                    custom_tool_uses,
+                    custom_tool_fns,
                 )
                 await record_round_moves(
-                    trace=infra.trace, state=infra.state, db=infra.db,
+                    trace=infra.trace,
+                    state=infra.state,
+                    db=infra.db,
                 )
-                messages.append({'role': 'user', 'content': tool_results})
+                messages.append({"role": "user", "content": tool_results})
 
-            if response.stop_reason == 'end_turn' or not (
+            if response.stop_reason == "end_turn" or not (
                 custom_tool_uses
-                or any(
-                    isinstance(b, ServerToolUseBlock) for b in response.content
-                )
+                or any(isinstance(b, ServerToolUseBlock) for b in response.content)
             ):
                 break
 
         log.info(
-            'Web research create_pages complete: %d pages created, %d sources',
-            len(infra.state.created_page_ids), len(self.source_page_ids),
+            "Web research create_pages complete: %d pages created, %d sources",
+            len(infra.state.created_page_ids),
+            len(self.source_page_ids),
         )
 
         return CreationResult(
@@ -392,12 +439,12 @@ class WebResearchLoop(PageCreator):
 
     def _build_server_tools(self) -> list[dict]:
         web_search: dict = {
-            'type': 'web_search_20250305',
-            'name': 'web_search',
-            'max_uses': 5,
+            "type": "web_search_20250305",
+            "name": "web_search",
+            "max_uses": 5,
         }
         if self._allowed_domains:
-            web_search['allowed_domains'] = list(self._allowed_domains)
+            web_search["allowed_domains"] = list(self._allowed_domains)
 
         return [web_search]
 
@@ -405,10 +452,9 @@ class WebResearchLoop(PageCreator):
         if url in self.source_page_ids:
             return self.source_page_ids[url]
 
-
         scraped = await scrape_url(url)
         if scraped is None:
-            log.warning('Scrape failed for URL: %s, skipping citation', url)
+            log.warning("Scrape failed for URL: %s, skipping citation", url)
             return None
 
         page = Page(
@@ -418,14 +464,14 @@ class WebResearchLoop(PageCreator):
             content=scraped.content,
             headline=scraped.title[:120],
             epistemic_status=2.5,
-            epistemic_type='web source',
-            provenance_model='scraper',
+            epistemic_type="web source",
+            provenance_model="scraper",
             provenance_call_type=CallType.WEB_RESEARCH.value,
             provenance_call_id=infra.call.id,
             extra={
-                'url': url,
-                'fetched_at': scraped.fetched_at,
-                'char_count': len(scraped.content),
+                "url": url,
+                "fetched_at": scraped.fetched_at,
+                "char_count": len(scraped.content),
             },
         )
         await infra.db.save_page(page)
@@ -434,43 +480,52 @@ class WebResearchLoop(PageCreator):
         self.source_page_ids[url] = page.id
         infra.state.created_page_ids.append(page.id)
         log.info(
-            'Source page created: %s -> %s (%s)',
-            url[:60], page.id[:8], scraped.title[:60],
+            "Source page created: %s -> %s (%s)",
+            url[:60],
+            page.id[:8],
+            scraped.title[:60],
         )
         return page.id
 
     def _wrap_create_claim(
-        self, tools: list[Tool], infra: CallInfra,
+        self,
+        tools: list[Tool],
+        infra: CallInfra,
     ) -> list[Tool]:
         wrapped: list[Tool] = []
         for tool in tools:
-            if tool.name == 'create_claim':
+            if tool.name == "create_claim":
                 original_fn = tool.fn
 
                 async def wrapped_fn(
-                    inp: dict, _orig=original_fn, _infra=infra,
+                    inp: dict,
+                    _orig=original_fn,
+                    _infra=infra,
                 ) -> str:
-                    source_ids = inp.get('source_ids', [])
-                    if source_ids:
+                    source_urls = inp.get("source_urls", [])
+                    if source_urls:
                         resolved: list[str] = []
-                        for sid in source_ids:
-                            if isinstance(sid, str) and sid.startswith('http'):
+                        for sid in source_urls:
+                            if isinstance(sid, str) and sid.startswith("http"):
                                 page_id = await self._ensure_source_page(
-                                    _infra, sid,
+                                    _infra,
+                                    sid,
                                 )
                                 if page_id:
                                     resolved.append(page_id)
                             else:
                                 resolved.append(sid)
-                        inp = {**inp, 'source_ids': resolved}
+                        inp = {**inp, "source_urls": resolved}
                     return await _orig(inp)
 
-                wrapped.append(Tool(
-                    name=tool.name,
-                    description=tool.description,
-                    input_schema=tool.input_schema,
-                    fn=wrapped_fn,
-                ))
+                wrapped.append(
+                    Tool(
+                        name=tool.name,
+                        description=tool.description,
+                        input_schema=tool.input_schema,
+                        fn=wrapped_fn,
+                    )
+                )
             else:
                 wrapped.append(tool)
         return wrapped

--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -79,11 +79,13 @@ class MoveState:
             if error:
                 log.warning("Dispatch rejected: %s", error)
 
-    def take_new_moves(self) -> tuple[list[Move], list[list[str]], list[dict[str, Any]]]:
+    def take_new_moves(
+        self,
+    ) -> tuple[list[Move], list[list[str]], list[dict[str, Any]]]:
         """Return moves, created-ID lists, and trace extras added since the last call."""
-        new_moves = self.moves[self._move_cursor:]
-        new_created = self.move_created_ids[self._move_cursor:]
-        new_extras = self.move_trace_extras[self._move_cursor:]
+        new_moves = self.moves[self._move_cursor :]
+        new_created = self.move_created_ids[self._move_cursor :]
+        new_extras = self.move_trace_extras[self._move_cursor :]
         self._move_cursor = len(self.moves)
         return new_moves, new_created, new_extras
 
@@ -132,7 +134,8 @@ class MoveDef(Generic[S]):
                 move_page_ids.append(result.created_page_id)
                 log.debug(
                     "Move %s created page: %s",
-                    self.name, result.created_page_id[:8],
+                    self.name,
+                    result.created_page_id[:8],
                 )
             if result.extra_created_ids:
                 move_page_ids.extend(result.extra_created_ids)
@@ -257,24 +260,34 @@ async def create_page(
     try:
         await embed_and_store_page(db, page, field_name="abstract")
     except Exception:
-        log.warning("Failed to create embedding for page %s", page.id[:8], exc_info=True)
+        log.warning(
+            "Failed to create embedding for page %s", page.id[:8], exc_info=True
+        )
     log.info(
         "Page created: type=%s, id=%s, headline=%s",
-        page_type.value, page.id[:8], page.headline[:70],
+        page_type.value,
+        page.id[:8],
+        page.headline[:70],
     )
 
     try:
         cited_ids = await extract_and_link_citations(
-            page.id, page.content, db, citing_page_type=page_type,
+            page.id,
+            page.content,
+            db,
+            citing_page_type=page_type,
         )
         if cited_ids:
             log.info(
                 "Auto-linked %d citations from page %s",
-                len(cited_ids), page.id[:8],
+                len(cited_ids),
+                page.id[:8],
             )
     except Exception:
         log.warning(
-            "Citation extraction failed for page %s", page.id[:8], exc_info=True,
+            "Citation extraction failed for page %s",
+            page.id[:8],
+            exc_info=True,
         )
 
     message = (
@@ -285,7 +298,7 @@ async def create_page(
     return MoveResult(message=message, created_page_id=page.id)
 
 
-_CITATION_RE = re.compile(r'\[([a-f0-9]{8})\]')
+_CITATION_RE = re.compile(r"\[([a-f0-9]{8})\]")
 
 
 async def extract_and_link_citations(
@@ -298,8 +311,8 @@ async def extract_and_link_citations(
 
     Link type depends on both citing and cited page types:
     - Cited SOURCE → CITES
-    - Citing QUESTION/JUDGEMENT + cited CLAIM → CONSIDERATION (direction flipped:
-      from=cited claim, to=citing page, since "claim bears on question/judgement")
+    - Cited CLAIM (from QUESTION/JUDGEMENT/CLAIM) → CONSIDERATION (direction flipped:
+      from=cited claim, to=citing page, since "claim bears on citing page")
     - Otherwise → RELATED
 
     Returns the set of full UUIDs that were successfully linked.
@@ -324,23 +337,28 @@ async def extract_and_link_citations(
         from_id, to_id = page_id, resolved
         if cited_page.page_type == PageType.SOURCE:
             link_type = LinkType.CITES
-        elif (
-            citing_page_type in (PageType.QUESTION, PageType.JUDGEMENT)
-            and cited_page.page_type == PageType.CLAIM
+        elif cited_page.page_type == PageType.CLAIM and citing_page_type in (
+            PageType.QUESTION,
+            PageType.JUDGEMENT,
+            PageType.CLAIM,
         ):
             link_type = LinkType.CONSIDERATION
             from_id, to_id = resolved, page_id
         else:
             link_type = LinkType.RELATED
 
-        await db.save_link(PageLink(
-            from_page_id=from_id,
-            to_page_id=to_id,
-            link_type=link_type,
-        ))
+        await db.save_link(
+            PageLink(
+                from_page_id=from_id,
+                to_page_id=to_id,
+                link_type=link_type,
+            )
+        )
         log.info(
             "Citation linked: %s -> %s (%s)",
-            from_id[:8], to_id[:8], link_type.value,
+            from_id[:8],
+            to_id[:8],
+            link_type.value,
         )
         linked.add(resolved)
 
@@ -361,7 +379,9 @@ async def link_pages(
     if not resolved_from or not resolved_to:
         log.warning(
             "Link %s skipped: from_id=%s, to_id=%s — one or both not found",
-            link_type.value, resolved_from, resolved_to,
+            link_type.value,
+            resolved_from,
+            resolved_to,
         )
         return MoveResult("Link skipped — page IDs not found.")
 
@@ -375,6 +395,8 @@ async def link_pages(
     await db.save_link(link)
     log.info(
         "Link created: %s %s -> %s",
-        link_type.value, resolved_from[:8], resolved_to[:8],
+        link_type.value,
+        resolved_from[:8],
+        resolved_to[:8],
     )
     return MoveResult("Done.")

--- a/src/rumil/moves/create_claim.py
+++ b/src/rumil/moves/create_claim.py
@@ -21,9 +21,13 @@ log = logging.getLogger(__name__)
 
 
 class CreateClaimPayload(CreatePagePayload):
-    source_ids: Sequence[str] = Field(
+    source_urls: Sequence[str] = Field(
         default_factory=list,
-        description="Source page IDs this claim cites. Creates citation links.",
+        description=(
+            "URLs of web pages this claim is based on. Only use during web "
+            "research after fetching or searching web pages. Each URL becomes "
+            "a source page with a CITES link to this claim."
+        ),
     )
     links: list[ConsiderationLinkFields] = Field(
         default_factory=list,
@@ -48,35 +52,43 @@ async def execute(payload: CreateClaimPayload, call: Call, db: DB) -> MoveResult
             )
             continue
 
-        await db.save_link(PageLink(
-            from_page_id=result.created_page_id,
-            to_page_id=resolved,
-            link_type=LinkType.CONSIDERATION,
-            strength=link_spec.strength,
-            reasoning=link_spec.reasoning,
-            role=link_spec.role,
-        ))
+        await db.save_link(
+            PageLink(
+                from_page_id=result.created_page_id,
+                to_page_id=resolved,
+                link_type=LinkType.CONSIDERATION,
+                strength=link_spec.strength,
+                reasoning=link_spec.reasoning,
+                role=link_spec.role,
+            )
+        )
         log.info(
             "Inline consideration linked: %s -> %s (%.1f)",
-            result.created_page_id[:8], resolved[:8], link_spec.strength,
+            result.created_page_id[:8],
+            resolved[:8],
+            link_spec.strength,
         )
 
-    for sid in payload.source_ids:
+    for sid in payload.source_urls:
         resolved = await db.resolve_page_id(sid)
         if not resolved:
             log.warning(
-                "Citation link skipped: source %s not found", sid,
+                "Citation link skipped: source %s not found",
+                sid,
             )
             continue
 
-        await db.save_link(PageLink(
-            from_page_id=result.created_page_id,
-            to_page_id=resolved,
-            link_type=LinkType.CITES,
-        ))
+        await db.save_link(
+            PageLink(
+                from_page_id=result.created_page_id,
+                to_page_id=resolved,
+                link_type=LinkType.CITES,
+            )
+        )
         log.info(
             "Citation linked: %s -> %s",
-            result.created_page_id[:8], resolved[:8],
+            result.created_page_id[:8],
+            resolved[:8],
         )
 
     return result

--- a/tests/test_cites_links.py
+++ b/tests/test_cites_links.py
@@ -48,13 +48,13 @@ async def second_source_page(tmp_db):
 
 
 async def test_cites_link_created_for_source(tmp_db, scout_call, source_page):
-    """A claim with source_ids should get a CITES link and no source_id in extra."""
+    """A claim with source_urls should get a CITES link and no source_id in extra."""
     state = MoveState(scout_call, tmp_db)
     tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
     await tool.fn({
         "headline": "Blue sky from scattering",
         "content": "Rayleigh scattering causes blue sky.",
-        "source_ids": [source_page.id[:8]],
+        "source_urls": [source_page.id[:8]],
     })
 
     assert len(state.created_page_ids) == 1
@@ -69,8 +69,8 @@ async def test_cites_link_created_for_source(tmp_db, scout_call, source_page):
     assert "source_id" not in page.extra
 
 
-async def test_no_cites_link_when_source_ids_empty(tmp_db, scout_call):
-    """A claim without source_ids should have no CITES links."""
+async def test_no_cites_link_when_source_urls_empty(tmp_db, scout_call):
+    """A claim without source_urls should have no CITES links."""
     state = MoveState(scout_call, tmp_db)
     tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
     await tool.fn({
@@ -94,7 +94,7 @@ async def test_multiple_cites_links(
     await tool.fn({
         "headline": "Combined scattering evidence",
         "content": "Multiple sources confirm scattering.",
-        "source_ids": [source_page.id[:8], second_source_page.id[:8]],
+        "source_urls": [source_page.id[:8], second_source_page.id[:8]],
     })
 
     assert len(state.created_page_ids) == 1
@@ -109,13 +109,13 @@ async def test_multiple_cites_links(
 async def test_cites_and_consideration_links_coexist(
     tmp_db, scout_call, question_page, source_page,
 ):
-    """A claim with both source_ids and links should create both link types."""
+    """A claim with both source_urls and links should create both link types."""
     state = MoveState(scout_call, tmp_db)
     tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
     await tool.fn({
         "headline": "Sourced and linked claim",
         "content": "This claim cites a source and bears on a question.",
-        "source_ids": [source_page.id[:8]],
+        "source_urls": [source_page.id[:8]],
         "links": [{
             "question_id": question_page.id[:8],
             "strength": 3.5,

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -82,10 +82,10 @@ async def test_inline_citation_of_source_creates_cites_link(
     assert cites[0].to_page_id == source_page.id
 
 
-async def test_inline_citation_of_claim_creates_related_link(
+async def test_inline_citation_of_claim_creates_consideration_link(
     tmp_db, claim_page,
 ):
-    """An inline [shortid] citing a CLAIM page should produce a RELATED link."""
+    """An inline [shortid] citing a CLAIM from a CLAIM should produce a CONSIDERATION link."""
     citing_page = Page(
         page_type=PageType.CLAIM,
         layer=PageLayer.SQUIDGY,
@@ -95,19 +95,23 @@ async def test_inline_citation_of_claim_creates_related_link(
     )
     await tmp_db.save_page(citing_page)
 
-    linked = await extract_and_link_citations(citing_page.id, citing_page.content, tmp_db)
+    linked = await extract_and_link_citations(
+        citing_page.id, citing_page.content, tmp_db,
+        citing_page_type=PageType.CLAIM,
+    )
 
     assert linked == {claim_page.id}
-    links = await tmp_db.get_links_from(citing_page.id)
-    related = [l for l in links if l.link_type == LinkType.RELATED]
-    assert len(related) == 1
-    assert related[0].to_page_id == claim_page.id
+    consideration_links = await tmp_db.get_links_to(citing_page.id)
+    cons = [l for l in consideration_links if l.link_type == LinkType.CONSIDERATION]
+    assert len(cons) == 1
+    assert cons[0].from_page_id == claim_page.id
+    assert cons[0].to_page_id == citing_page.id
 
 
 async def test_multiple_inline_citations(
     tmp_db, claim_page, second_claim_page,
 ):
-    """Content with multiple [shortid] citations creates one link per cited page."""
+    """Content with multiple [shortid] citations creates one CONSIDERATION link per cited claim."""
     citing_page = Page(
         page_type=PageType.CLAIM,
         layer=PageLayer.SQUIDGY,
@@ -120,13 +124,16 @@ async def test_multiple_inline_citations(
     )
     await tmp_db.save_page(citing_page)
 
-    linked = await extract_and_link_citations(citing_page.id, citing_page.content, tmp_db)
+    linked = await extract_and_link_citations(
+        citing_page.id, citing_page.content, tmp_db,
+        citing_page_type=PageType.CLAIM,
+    )
 
     assert linked == {claim_page.id, second_claim_page.id}
-    links = await tmp_db.get_links_from(citing_page.id)
-    related = [l for l in links if l.link_type == LinkType.RELATED]
-    assert len(related) == 2
-    assert {l.to_page_id for l in related} == {claim_page.id, second_claim_page.id}
+    consideration_links = await tmp_db.get_links_to(citing_page.id)
+    cons = [l for l in consideration_links if l.link_type == LinkType.CONSIDERATION]
+    assert len(cons) == 2
+    assert {l.from_page_id for l in cons} == {claim_page.id, second_claim_page.id}
 
 
 async def test_judgement_citing_claim_creates_consideration_link(


### PR DESCRIPTION
## Summary
- Inline `[shortid]` citations between claims now produce CONSIDERATION links (cited claim → citing claim) instead of RELATED links, matching the existing behavior for questions/judgements citing claims.
- Renamed `source_ids` to `source_urls` on `create_claim` with a description scoped to web research contexts, since that's the only call type that uses it.
- Updated ingest prompt to use inline `[shortid]` citations instead of the removed field.

## Test plan
- [x] All 77 non-LLM tests pass
- [x] Smoke test a web research call to verify `source_urls` works end-to-end
- [x] Smoke test an ingest call to verify inline citation CITES links still get created

🤖 Generated with [Claude Code](https://claude.com/claude-code)