### PR TITLE
Fix .gitignore to ignore data symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,4 +227,4 @@ __marimo__/
 .a.env
 .b.env
 
-data/
+data


### PR DESCRIPTION
## Summary
- Remove trailing slash from `data/` pattern in `.gitignore` so it matches both directories and symlinks to directories

## Test plan
- [x] Verify `data` symlink no longer appears in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)