### PR TITLE
Handle comma-separated inline citations

### DIFF
--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -58,19 +58,49 @@ function pageHref(page: Page): string {
   return `/pages/${page.id}`;
 }
 
-function buildCitationMap(
+const ALL_CITATIONS_RE = /\[([a-f0-9]{8}(?:,\s*[a-f0-9]{8})*)\]/g;
+
+function extractCitedIds(content: string): Set<string> {
+  const ids = new Set<string>();
+  for (const match of content.matchAll(ALL_CITATIONS_RE)) {
+    for (const id of match[1].split(/,\s*/)) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}
+
+async function buildCitationMap(
   links_from: LinkedPageOut[],
   links_to: LinkedPageOut[],
-): Map<string, { fullId: string; pageType: string }> {
+  content: string,
+): Promise<Map<string, { fullId: string; pageType: string }>> {
   const map = new Map<string, { fullId: string; pageType: string }>();
   for (const lp of [...links_from, ...links_to]) {
     const short = lp.page.id.slice(0, 8);
     map.set(short, { fullId: lp.page.id, pageType: lp.page.page_type });
   }
+  const cited = extractCitedIds(content);
+  const missing = [...cited].filter((id) => !map.has(id));
+  if (missing.length > 0) {
+    const results = await Promise.all(
+      missing.map(async (shortId) => {
+        const res = await fetch(`${API_BASE}/api/pages/short/${shortId}`, {
+          cache: "no-store",
+        });
+        if (!res.ok) return null;
+        const page: Page = await res.json();
+        return { shortId, fullId: page.id, pageType: page.page_type };
+      }),
+    );
+    for (const r of results) {
+      if (r) map.set(r.shortId, { fullId: r.fullId, pageType: r.pageType });
+    }
+  }
   return map;
 }
 
-const CITATION_RE = /\[([a-f0-9]{8})\]/g;
+const CITATION_RE = /\[([a-f0-9]{8}(?:,\s*[a-f0-9]{8})*)\]/g;
 
 function injectCitationLinks(
   content: string,
@@ -78,14 +108,18 @@ function injectCitationLinks(
 ): string {
   const orderMap = new Map<string, number>();
   let nextNum = 1;
-  return content.replace(CITATION_RE, (_match, shortId: string) => {
-    const entry = citationMap.get(shortId);
-    if (!entry) return `[${shortId}]`;
-    if (!orderMap.has(shortId)) {
-      orderMap.set(shortId, nextNum++);
-    }
-    const num = orderMap.get(shortId)!;
-    return `[${num}](/pages/${entry.fullId}?cite=${entry.pageType})`;
+  return content.replace(CITATION_RE, (_match, group: string) => {
+    const ids = group.split(/,\s*/);
+    const parts = ids.map((shortId) => {
+      const entry = citationMap.get(shortId);
+      if (!entry) return `[${shortId}]`;
+      if (!orderMap.has(shortId)) {
+        orderMap.set(shortId, nextNum++);
+      }
+      const num = orderMap.get(shortId)!;
+      return `[${num}](/pages/${entry.fullId}?cite=${entry.pageType})`;
+    });
+    return parts.join(" ");
   });
 }
 
@@ -197,29 +231,31 @@ export default async function PageDetailPage({
 
   if (!detail) {
     return (
-      <main className="page-detail">
+      <>
         <style>{styles}</style>
-        <div className="not-found">
-          <span className="not-found-code">404</span>
-          <span className="not-found-msg">Page not found</span>
-          <Link href="/" className="back-link">
-            &larr; Home
-          </Link>
-        </div>
-      </main>
+        <main className="page-detail">
+          <div className="not-found">
+            <span className="not-found-code">404</span>
+            <span className="not-found-msg">Page not found</span>
+            <Link href="/" className="back-link">
+              &larr; Home
+            </Link>
+          </div>
+        </main>
+      </>
     );
   }
 
   const { page, links_from, links_to } = detail;
   const cfg = TYPE_CONFIG[page.page_type] || TYPE_CONFIG.source;
-  const citationMap = buildCitationMap(links_from, links_to);
+  const citationMap = await buildCitationMap(links_from, links_to, page.content);
   const processedContent = injectCitationLinks(page.content, citationMap);
 
   return (
-    <main className="page-detail">
+    <>
       <style>{styles}</style>
-
-      <Link href={`/projects/${page.project_id}`} className="back-link">
+      <main className="page-detail">
+        <Link href={`/projects/${page.project_id}`} className="back-link">
         &larr; Workspace
       </Link>
 
@@ -324,7 +360,8 @@ export default async function PageDetailPage({
           </>
         )}
       </footer>
-    </main>
+      </main>
+    </>
   );
 }
 

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -61,6 +61,7 @@ async def _get_db(project_id: str = "") -> DB:
 
 # --- Projects ---
 
+
 @app.get("/api/projects", response_model=list[Project])
 async def list_projects():
     db = await _get_db()
@@ -75,6 +76,7 @@ async def list_project_runs(project_id: str):
 
 # --- Pages ---
 
+
 @app.get("/api/projects/{project_id}/pages", response_model=list[Page])
 async def list_pages(
     project_id: str,
@@ -88,6 +90,18 @@ async def list_pages(
         page_type=page_type,
         active_only=active_only,
     )
+
+
+@app.get("/api/pages/short/{short_id}", response_model=Page)
+async def get_page_by_short_id(short_id: str):
+    db = await _get_db()
+    full_id = await db.resolve_page_id(short_id)
+    if not full_id:
+        raise HTTPException(status_code=404, detail="Page not found")
+    page = await db.get_page(full_id)
+    if not page:
+        raise HTTPException(status_code=404, detail="Page not found")
+    return page
 
 
 @app.get("/api/pages/{page_id}", response_model=Page)
@@ -141,6 +155,7 @@ async def get_page_counts(page_id: str):
 
 # --- Questions ---
 
+
 @app.get(
     "/api/projects/{project_id}/questions",
     response_model=list[Page],
@@ -155,6 +170,7 @@ async def list_root_questions(
 
 # --- Calls ---
 
+
 @app.get(
     "/api/projects/{project_id}/calls",
     response_model=list[Call],
@@ -167,6 +183,7 @@ async def list_calls(
     if question_id:
         return await db.get_root_calls_for_question(question_id)
     from rumil.database import _rows, _row_to_call
+
     rows = _rows(
         await db.client.table("calls")
         .select("*")
@@ -222,20 +239,18 @@ async def _build_call_trace(db: DB, call_id: str) -> CallTraceOut:
         for seq in db_sequences:
             seq_calls = await db.get_calls_for_sequence(seq.id)
             seq_traces = [await _build_call_trace(db, sc.id) for sc in seq_calls]
-            sequences_out.append(CallSequenceOut(
-                id=seq.id,
-                position_in_batch=seq.position_in_batch,
-                calls=seq_traces,
-            ))
+            sequences_out.append(
+                CallSequenceOut(
+                    id=seq.id,
+                    position_in_batch=seq.position_in_batch,
+                    calls=seq_traces,
+                )
+            )
 
     exchange_costs = [
-        e.cost_usd for e in events
-        if hasattr(e, "cost_usd") and e.cost_usd is not None
+        e.cost_usd for e in events if hasattr(e, "cost_usd") and e.cost_usd is not None
     ]
-    child_costs = [
-        ct.cost_usd for ct in child_traces
-        if ct.cost_usd is not None
-    ]
+    child_costs = [ct.cost_usd for ct in child_traces if ct.cost_usd is not None]
     total = sum(exchange_costs) + sum(child_costs)
     return CallTraceOut(
         call=call,
@@ -277,11 +292,9 @@ async def get_call_trace(call_id: str):
 async def get_ab_run_trace(ab_run_id: str):
     db = await _get_db()
     from rumil.database import _rows
+
     ab_rows = _rows(
-        await db.client.table("ab_runs")
-        .select("*")
-        .eq("id", ab_run_id)
-        .execute()
+        await db.client.table("ab_runs").select("*").eq("id", ab_run_id).execute()
     )
     if not ab_rows:
         raise HTTPException(status_code=404, detail="AB run not found")
@@ -315,12 +328,14 @@ async def get_ab_run_trace(ab_run_id: str):
             root_calls=root_traces,
             cost_usd=run_total if run_total > 0 else None,
         )
-        arms.append(ABRunArmOut(
-            run_id=run_id,
-            name=arm_row.get("name", ""),
-            config=arm_row.get("config", {}),
-            trace=trace,
-        ))
+        arms.append(
+            ABRunArmOut(
+                run_id=run_id,
+                name=arm_row.get("name", ""),
+                config=arm_row.get("config", {}),
+                trace=trace,
+            )
+        )
     return ABRunTraceOut(
         ab_run_id=ab_run_id,
         name=ab_row.get("name", ""),


### PR DESCRIPTION
## Summary
- Update citation regex to match comma-separated formats like `[4fad6abe, 6f67fb62]`, splitting each into individual citation chips
- Add `GET /api/pages/short/{short_id}` endpoint to resolve 8-char page ID prefixes, since multi-cited pages aren't always in the direct link graph
- Move `<style>` tag outside `<main>` to fix hydration mismatch caused by browser hoisting

## Test plan
- [x] Load a page with comma-separated citations (e.g. `/pages/1a02ddba-b737-48e3-9f74-60c6c879abb9`) and verify each ID renders as a clickable citation chip
- [x] Verify single citations still work as before
- [x] Confirm no hydration error in browser console
- [ ] Test `/api/pages/short/{short_id}` endpoint returns correct page data

🤖 Generated with [Claude Code](https://claude.com/claude-code)