### PR TITLE
Replace scraper with Jina Reader API, show source URLs

### DIFF
--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -283,6 +283,17 @@ export default async function PageDetailPage({
             )}
           </div>
           <h1 className="page-summary">{page.headline}</h1>
+          {page.page_type === "source" && typeof page.extra?.url === "string" && (
+            <a
+              href={page.extra.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="source-url"
+            >
+              <span className="source-url-text">{page.extra.url}</span>
+              <span className="source-url-arrow">{"\u2197"}</span>
+            </a>
+          )}
           {page.abstract && (
             <div className="page-abstract">{page.abstract}</div>
           )}
@@ -453,6 +464,39 @@ const styles = `
     letter-spacing: -0.02em;
     line-height: 1.3;
     margin: 0;
+  }
+
+  .source-url {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-top: 0.5rem;
+    max-width: 100%;
+    font-size: 0.72rem;
+    font-family: var(--font-geist-mono), monospace;
+    color: var(--color-muted);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .source-url:hover {
+    color: var(--color-foreground);
+  }
+  .source-url-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .source-url-arrow {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    font-size: 0.8em;
+    opacity: 0.5;
+    transition: opacity 0.15s, transform 0.15s;
+  }
+  .source-url:hover .source-url-arrow {
+    opacity: 1;
+    transform: translate(1px, -1px);
   }
 
   .page-abstract {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ dependencies = [
     "supabase>=2.0.0",
     "uvicorn[standard]>=0.41.0",
     "voyageai>=0.3.2",
-    "beautifulsoup4>=4.12.0",
-    "fake-useragent>=2.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -471,7 +471,7 @@ class WebResearchLoop(PageCreator):
 
         scraped = await scrape_url(url)
         if scraped is None:
-            log.warning("Scrape failed for URL: %s, skipping citation", url)
+            log.warning("Scrape failed for URL: %s", url)
             return None
 
         page = Page(

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -522,6 +522,7 @@ class WebResearchLoop(PageCreator):
                     source_urls = inp.get("source_urls", [])
                     if source_urls:
                         resolved: list[str] = []
+                        failed_urls: list[str] = []
                         for sid in source_urls:
                             if isinstance(sid, str) and sid.startswith("http"):
                                 page_id = await self._ensure_source_page(
@@ -530,8 +531,18 @@ class WebResearchLoop(PageCreator):
                                 )
                                 if page_id:
                                     resolved.append(page_id)
+                                else:
+                                    failed_urls.append(sid)
                             else:
                                 resolved.append(sid)
+                        if failed_urls:
+                            urls = ", ".join(failed_urls)
+                            raise RuntimeError(
+                                f"Could not fetch the following source(s): {urls}. "
+                                "Find a different, accessible source that supports "
+                                "the same information, or modify the claim so it "
+                                "does not rely on the inaccessible source(s)."
+                            )
                         inp = {**inp, "source_urls": resolved}
                     return await _orig(inp)
 

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -633,7 +633,7 @@ class DB:
         query = self.client.table("page_links").select("*")
         query = self._ab_filter(query, table="page_links")
         if self.project_id:
-            page_ids_query = (
+            page_ids_query = self._ab_filter(
                 self.client.table("pages")
                 .select("id")
                 .eq("project_id", self.project_id)

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -629,13 +629,23 @@ class DB:
         return [_row_to_link(r) for r in rows]
 
     async def get_all_links(self) -> list[PageLink]:
-        """Bulk-fetch all links, optionally scoped by project via page membership."""
-        rows = _rows(
-            await self.client.table("page_links")
-            .select("*")
-            .limit(50000)
-            .execute()
-        )
+        """Bulk-fetch all links, scoped by project and AB run."""
+        query = self.client.table("page_links").select("*")
+        query = self._ab_filter(query, table="page_links")
+        if self.project_id:
+            page_ids_query = (
+                self.client.table("pages")
+                .select("id")
+                .eq("project_id", self.project_id)
+            )
+            page_ids_rows = _rows(await page_ids_query.limit(50000).execute())
+            page_ids = {r["id"] for r in page_ids_rows}
+            rows = _rows(await query.limit(50000).execute())
+            return [
+                _row_to_link(r) for r in rows
+                if r["from_page_id"] in page_ids or r["to_page_id"] in page_ids
+            ]
+        rows = _rows(await query.limit(50000).execute())
         return [_row_to_link(r) for r in rows]
 
     async def delete_link(self, link_id: str) -> None:

--- a/src/rumil/scraper.py
+++ b/src/rumil/scraper.py
@@ -1,18 +1,18 @@
-"""Lightweight URL scraper using httpx + BeautifulSoup."""
+"""URL scraper using Jina Reader API (https://r.jina.ai/)."""
 
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
 import httpx
-from bs4 import BeautifulSoup
-from fake_useragent import UserAgent
+
+from rumil.settings import get_settings
 
 log = logging.getLogger(__name__)
 
+JINA_READER_BASE = "https://r.jina.ai/"
 MAX_CONTENT_CHARS = 50_000
-TIMEOUT_SECONDS = 15
-_ua = UserAgent(browsers=['Chrome', 'Firefox'], min_version=120.0)
+TIMEOUT_SECONDS = 30
 
 
 @dataclass
@@ -24,34 +24,36 @@ class ScrapedPage:
 
 
 async def scrape_url(url: str) -> ScrapedPage | None:
-    """Fetch and extract text content from a URL.
+    """Fetch and extract text content from a URL via Jina Reader.
 
     Returns a ScrapedPage on success, or None on any failure.
     """
     try:
-        async with httpx.AsyncClient(
-            timeout=TIMEOUT_SECONDS,
-            follow_redirects=True,
-            headers={'User-Agent': _ua.random},
-        ) as client:
-            response = await client.get(url)
+        headers: dict[str, str] = {"Accept": "application/json"}
+        api_key = get_settings().jina_api_key
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                f"{JINA_READER_BASE}{url}",
+                headers=headers,
+            )
             response.raise_for_status()
 
-        soup = BeautifulSoup(response.text, 'html.parser')
+        data = response.json().get("data")
+        if not data or not data.get("content"):
+            log.warning("Jina Reader returned no content for URL: %s", url)
+            return None
 
-        for tag in soup.find_all(['script', 'style', 'nav', 'footer']):
-            tag.decompose()
-
-        title = soup.title.get_text(strip=True) if soup.title else url
-        content = soup.get_text(separator='\n', strip=True)
-        content = content[:MAX_CONTENT_CHARS]
+        content = data["content"][:MAX_CONTENT_CHARS]
+        title = data.get("title") or url
 
         return ScrapedPage(
-            url=url,
+            url=data.get("url", url),
             title=title,
             content=content,
             fetched_at=datetime.now(UTC).isoformat(),
         )
     except Exception:
-        log.warning('Failed to scrape URL: %s', url, exc_info=True)
+        log.warning("Failed to scrape URL: %s", url, exc_info=True)
         return None

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
     supabase_prod_url: str = ""
     supabase_prod_key: str = ""
     voyage_ai_api_key: str = ""
+    jina_api_key: str = ""
     frontend_url: str = "http://127.0.0.1:3000"
 
     find_considerations_call_variant: str = _capture_field(default="embedding")

--- a/tests/test_scrape_failure.py
+++ b/tests/test_scrape_failure.py
@@ -1,0 +1,123 @@
+"""Test that create_claim fails with an instructive error when a source URL cannot be scraped."""
+
+from anthropic.types import ToolUseBlock
+
+from rumil.calls.common import execute_tool_uses
+from rumil.calls.page_creators import WebResearchLoop
+from rumil.calls.stages import CallInfra
+from rumil.llm import Tool
+from rumil.moves.base import MoveState
+from rumil.tracing.tracer import CallTrace
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    Workspace,
+)
+
+import pytest
+
+
+@pytest.fixture
+def fake_create_claim_tool():
+    async def create_claim(inp: dict) -> str:
+        return "claim created"
+
+    return Tool(
+        name="create_claim",
+        description="Create a claim",
+        input_schema={"type": "object", "properties": {}},
+        fn=create_claim,
+    )
+
+
+def _make_infra(call: Call, db, question_id: str) -> CallInfra:
+    return CallInfra(
+        question_id=question_id,
+        call=call,
+        db=db,
+        trace=CallTrace(call_id=call.id, db=db),
+        state=MoveState(call=call, db=db),
+    )
+
+
+async def test_create_claim_errors_when_source_url_unscrapable(
+    tmp_db,
+    question_page,
+    fake_create_claim_tool,
+    mocker,
+):
+    call = Call(
+        call_type=CallType.WEB_RESEARCH,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    loop = WebResearchLoop()
+    infra = _make_infra(call, tmp_db, question_page.id)
+
+    mocker.patch(
+        "rumil.calls.page_creators.scrape_url",
+        return_value=None,
+    )
+
+    wrapped_tools = loop._wrap_create_claim([fake_create_claim_tool], infra)
+    tool_fns = {t.name: t.fn for t in wrapped_tools}
+
+    tool_use = ToolUseBlock(
+        id="test_tool_use_1",
+        type="tool_use",
+        name="create_claim",
+        input={
+            "headline": "Some claim",
+            "content": "Claim content",
+            "source_urls": ["https://unreachable.example.com/article"],
+        },
+    )
+
+    _, tool_results = await execute_tool_uses([tool_use], tool_fns)
+
+    assert len(tool_results) == 1
+    result = tool_results[0]
+    assert result["is_error"] is True
+    assert "unreachable.example.com" in result["content"]
+    assert "different" in result["content"].lower()
+
+
+async def test_create_claim_succeeds_when_no_source_urls(
+    tmp_db,
+    question_page,
+    fake_create_claim_tool,
+):
+    call = Call(
+        call_type=CallType.WEB_RESEARCH,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    loop = WebResearchLoop()
+    infra = _make_infra(call, tmp_db, question_page.id)
+
+    wrapped_tools = loop._wrap_create_claim([fake_create_claim_tool], infra)
+    tool_fns = {t.name: t.fn for t in wrapped_tools}
+
+    tool_use = ToolUseBlock(
+        id="test_tool_use_2",
+        type="tool_use",
+        name="create_claim",
+        input={
+            "headline": "Some claim",
+            "content": "Claim content",
+        },
+    )
+
+    _, tool_results = await execute_tool_uses([tool_use], tool_fns)
+
+    assert len(tool_results) == 1
+    result = tool_results[0]
+    assert "is_error" not in result
+    assert result["content"] == "claim created"

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -90,18 +90,14 @@ async def two_workspaces():
     claim_alpha = await _make_claim(
         db_alpha, "The sky is blue due to Rayleigh scattering"
     )
-    await _link_consideration(
-        db_alpha, claim_alpha, q_alpha
-    )
+    await _link_consideration(db_alpha, claim_alpha, q_alpha)
     source_alpha = await _make_source(db_alpha, "sky-paper.pdf")
 
     q_beta = await _make_question(db_beta, "Why is the ocean salty?")
     claim_beta = await _make_claim(
         db_beta, "Rivers carry dissolved salts into the ocean"
     )
-    await _link_consideration(
-        db_beta, claim_beta, q_beta
-    )
+    await _link_consideration(db_beta, claim_beta, q_beta)
 
     yield {
         "db_alpha": db_alpha,
@@ -190,12 +186,8 @@ async def test_call_context_isolated(two_workspaces):
 
 async def test_prioritization_context_isolated(two_workspaces):
     w = two_workspaces
-    ctx_alpha, _ = await build_prioritization_context(
-        w["db_alpha"], w["q_alpha"].id
-    )
-    ctx_beta, _ = await build_prioritization_context(
-        w["db_beta"], w["q_beta"].id
-    )
+    ctx_alpha, _ = await build_prioritization_context(w["db_alpha"], w["q_alpha"].id)
+    ctx_beta, _ = await build_prioritization_context(w["db_beta"], w["q_beta"].id)
 
     assert "sky" in ctx_alpha.lower()
     assert "ocean" not in ctx_alpha.lower()
@@ -203,14 +195,65 @@ async def test_prioritization_context_isolated(two_workspaces):
     assert "sky" not in ctx_beta.lower()
 
 
+async def test_get_all_links_isolated(two_workspaces):
+    w = two_workspaces
+    alpha_links = await w["db_alpha"].get_all_links()
+    beta_links = await w["db_beta"].get_all_links()
+
+    alpha_page_ids = {w["q_alpha"].id, w["claim_alpha"].id, w["source_alpha"].id}
+    beta_page_ids = {w["q_beta"].id, w["claim_beta"].id}
+
+    for link in alpha_links:
+        assert link.from_page_id in alpha_page_ids or link.to_page_id in alpha_page_ids
+        assert (
+            link.from_page_id not in beta_page_ids
+            and link.to_page_id not in beta_page_ids
+        )
+
+    for link in beta_links:
+        assert link.from_page_id in beta_page_ids or link.to_page_id in beta_page_ids
+        assert (
+            link.from_page_id not in alpha_page_ids
+            and link.to_page_id not in alpha_page_ids
+        )
+
+
+async def test_get_pages_slim_isolated(two_workspaces):
+    w = two_workspaces
+    alpha_pages = await w["db_alpha"].get_pages_slim()
+    beta_pages = await w["db_beta"].get_pages_slim()
+
+    alpha_ids = {p.id for p in alpha_pages}
+    beta_ids = {p.id for p in beta_pages}
+
+    assert w["q_alpha"].id in alpha_ids
+    assert w["q_alpha"].id not in beta_ids
+    assert w["q_beta"].id in beta_ids
+    assert w["q_beta"].id not in alpha_ids
+
+
+async def test_page_graph_isolated(two_workspaces):
+    from rumil.page_graph import PageGraph
+
+    w = two_workspaces
+    graph_alpha = await PageGraph.load(w["db_alpha"])
+    graph_beta = await PageGraph.load(w["db_beta"])
+
+    alpha_page = await graph_alpha.get_page(w["q_alpha"].id)
+    beta_leak = await graph_alpha.get_page(w["q_beta"].id)
+    assert alpha_page is not None
+    assert beta_leak is None
+
+    beta_page = await graph_beta.get_page(w["q_beta"].id)
+    alpha_leak = await graph_beta.get_page(w["q_alpha"].id)
+    assert beta_page is not None
+    assert alpha_leak is None
+
+
 async def test_source_in_prioritization_context_isolated(two_workspaces):
     w = two_workspaces
-    ctx_alpha, _ = await build_prioritization_context(
-        w["db_alpha"], w["q_alpha"].id
-    )
-    ctx_beta, _ = await build_prioritization_context(
-        w["db_beta"], w["q_beta"].id
-    )
+    ctx_alpha, _ = await build_prioritization_context(w["db_alpha"], w["q_alpha"].id)
+    ctx_beta, _ = await build_prioritization_context(w["db_beta"], w["q_beta"].id)
 
     assert "sky-paper.pdf" in ctx_alpha
     assert "sky-paper.pdf" not in ctx_beta

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -19,6 +19,7 @@ from rumil.models import (
     PageType,
     Workspace,
 )
+from rumil.page_graph import PageGraph
 from rumil.workspace_map import build_workspace_map
 
 
@@ -233,7 +234,6 @@ async def test_get_pages_slim_isolated(two_workspaces):
 
 
 async def test_page_graph_isolated(two_workspaces):
-    from rumil.page_graph import PageGraph
 
     w = two_workspaces
     graph_alpha = await PageGraph.load(w["db_alpha"])

--- a/uv.lock
+++ b/uv.lock
@@ -183,19 +183,6 @@ wheels = [
 ]
 
 [[package]]
-name = "beautifulsoup4"
-version = "4.14.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
-]
-
-[[package]]
 name = "cachetools"
 version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -429,15 +416,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
-]
-
-[[package]]
-name = "fake-useragent"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/43/948d10bf42735709edb5ae51e23297d034086f17fc7279fef385a7acb473/fake_useragent-2.2.0.tar.gz", hash = "sha256:4e6ab6571e40cc086d788523cf9e018f618d07f9050f822ff409a4dfe17c16b2", size = 158898, upload-time = "2025-04-14T15:32:19.238Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/37/b3ea9cd5558ff4cb51957caca2193981c6b0ff30bd0d2630ac62505d99d0/fake_useragent-2.2.0-py3-none-any.whl", hash = "sha256:67f35ca4d847b0d298187443aaf020413746e56acd985a611908c73dba2daa24", size = 161695, upload-time = "2025-04-14T15:32:17.732Z" },
 ]
 
 [[package]]
@@ -1835,8 +1813,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
-    { name = "beautifulsoup4" },
-    { name = "fake-useragent" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pydantic" },
@@ -1863,8 +1839,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.84.0" },
-    { name = "beautifulsoup4", specifier = ">=4.12.0" },
-    { name = "fake-useragent", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -1910,15 +1884,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "soupsieve"
-version = "2.8.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Jina Reader API**: Replace httpx + BeautifulSoup + fake-useragent scraper with Jina Reader (`r.jina.ai`), which handles paywalled sites, JS-rendered content, and returns clean markdown. Removes `beautifulsoup4`, `fake-useragent` dependencies. Supports optional `JINA_API_KEY` for higher rate limits.
- **Scrape failure handling**: When a source URL can't be fetched, `create_claim` now returns an error instructing the agent to find an alternative source or modify the claim, instead of silently dropping the citation.
- **Source URL in frontend**: Source pages now display a clickable link to the original URL below the headline, visible only when `extra.url` is set.
- **Workspace isolation**: `get_all_links()` now scopes results by project, and new tests verify link/page/graph isolation across workspaces.

## Test plan
- [x] `test_scrape_failure.py` — verifies create_claim errors on failed scrape, succeeds without source URLs
- [x] `test_workspace_isolation.py` — new tests for link, page, and graph isolation
- [x] Manual: visit a source page in the frontend and confirm the URL is clickable and opens in a new tab
- [x] Manual: run a web research call against a paywalled URL and confirm Jina successfully scrapes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)