### PR TITLE
Add inline citations to web research claims

### DIFF
--- a/prompts/web_research.md
+++ b/prompts/web_research.md
@@ -12,6 +12,7 @@ You are performing a **Web Research** call — your job is to search the web for
 ## Rules
 
 - **Every claim must have at least one source_urls entry.** Use the full URL of the page you fetched (e.g. `https://example.com/article`).
+- **Cite sources inline in claim content using `[url]` syntax.** Wherever the content draws on a source, embed the full URL in square brackets — e.g. `According to [https://example.com/article], the rate has doubled.` Every URL cited inline must also appear in `source_urls`. **Do NOT use `<cite>` tags** — only square-bracket URL citations.
 - **Claims should be specific, falsifiable assertions** — not summaries of pages. Extract the most important finding from each source.
 - **Link claims to the target question** using the `links` field on `create_claim`. Every claim should be linked as a consideration.
 - **Epistemic status should reflect source reliability**: peer-reviewed research (3.5-4.5) > established news outlets (2.5-3.5) > blogs and opinion pieces (1.5-2.5) > forums and social media (0.5-1.5).
@@ -23,4 +24,5 @@ You are performing a **Web Research** call — your job is to search the web for
 
 - Do not summarise entire articles as single claims. Extract specific findings.
 - Do not create claims without source citations.
+- Do not use `<cite>` tags in claim content. Use `[url]` square-bracket citations only.
 - Do not duplicate information already present in the workspace context.

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import Sequence
 
 import anthropic
@@ -42,6 +43,8 @@ from rumil.moves.base import write_page_file
 from rumil.scraper import scrape_url
 
 log = logging.getLogger(__name__)
+
+_URL_CITATION_RE = re.compile(r"\[(https?://[^\]\s]+)\]")
 
 
 class SimpleAgentLoop(PageCreator):
@@ -504,6 +507,40 @@ class WebResearchLoop(PageCreator):
         )
         return page.id
 
+    def _rewrite_url_citations(self, content: str) -> str:
+        """Replace [url] inline citations with [shortid] using source_page_ids.
+
+        Uses slightly-forgiving matching: a trailing slash difference is
+        tolerated (e.g. [https://x.com/foo] matches https://x.com/foo/).
+        Raises ValueError for URLs that don't match any scraped source page.
+        """
+
+        def _normalize(url: str) -> str:
+            return url.rstrip("/")
+
+        normalized_lookup: dict[str, str] = {
+            _normalize(url): page_id for url, page_id in self.source_page_ids.items()
+        }
+
+        unmatched: list[str] = []
+
+        def _replace(m: re.Match) -> str:
+            url = m.group(1)
+            page_id = normalized_lookup.get(_normalize(url))
+            if page_id is not None:
+                return f"[{page_id[:8]}]"
+            unmatched.append(url)
+            return m.group(0)
+
+        rewritten = _URL_CITATION_RE.sub(_replace, content)
+        if unmatched:
+            raise ValueError(
+                "Inline citation URLs do not match any scraped source page: "
+                + ", ".join(unmatched)
+                + ". Only cite URLs that are also listed in source_urls."
+            )
+        return rewritten
+
     def _wrap_create_claim(
         self,
         tools: list[Tool],
@@ -530,9 +567,24 @@ class WebResearchLoop(PageCreator):
                                 )
                                 if page_id:
                                     resolved.append(page_id)
+                                else:
+                                    return (
+                                        f"ERROR: Failed to fetch {sid} — "
+                                        "remove it from source_urls and "
+                                        "inline citations, then retry."
+                                    )
                             else:
                                 resolved.append(sid)
                         inp = {**inp, "source_urls": resolved}
+                    content = inp.get("content", "")
+                    if content:
+                        try:
+                            inp = {
+                                **inp,
+                                "content": self._rewrite_url_citations(content),
+                            }
+                        except ValueError as exc:
+                            return f"ERROR: {exc}"
                     return await _orig(inp)
 
                 wrapped.append(

--- a/tests/test_url_citations.py
+++ b/tests/test_url_citations.py
@@ -1,0 +1,80 @@
+"""Unit tests for URL citation rewriting in WebResearchLoop."""
+
+import uuid
+
+import pytest
+
+from rumil.calls.page_creators import WebResearchLoop
+
+
+def _make_loop(url_map: dict[str, str]) -> WebResearchLoop:
+    loop = WebResearchLoop()
+    loop.source_page_ids = url_map
+    return loop
+
+
+def _fake_id() -> str:
+    return str(uuid.uuid4())
+
+
+class TestRewriteUrlCitations:
+    def test_basic_replacement(self):
+        pid = _fake_id()
+        loop = _make_loop({"https://example.com/article": pid})
+        result = loop._rewrite_url_citations(
+            "According to [https://example.com/article], rates doubled."
+        )
+        assert result == f"According to [{pid[:8]}], rates doubled."
+
+    def test_trailing_slash_tolerance(self):
+        pid = _fake_id()
+        loop = _make_loop({"https://example.com/article/": pid})
+        result = loop._rewrite_url_citations(
+            "See [https://example.com/article] for details."
+        )
+        assert result == f"See [{pid[:8]}] for details."
+
+    def test_trailing_slash_tolerance_reverse(self):
+        pid = _fake_id()
+        loop = _make_loop({"https://example.com/article": pid})
+        result = loop._rewrite_url_citations(
+            "See [https://example.com/article/] for details."
+        )
+        assert result == f"See [{pid[:8]}] for details."
+
+    def test_multiple_citations(self):
+        pid1 = _fake_id()
+        pid2 = _fake_id()
+        loop = _make_loop(
+            {
+                "https://a.com/1": pid1,
+                "https://b.com/2": pid2,
+            }
+        )
+        result = loop._rewrite_url_citations(
+            "[https://a.com/1] agrees with [https://b.com/2]."
+        )
+        assert result == f"[{pid1[:8]}] agrees with [{pid2[:8]}]."
+
+    def test_no_citations_passthrough(self):
+        loop = _make_loop({"https://example.com": _fake_id()})
+        text = "No citations here."
+        assert loop._rewrite_url_citations(text) == text
+
+    def test_unmatched_url_raises(self):
+        loop = _make_loop({"https://example.com/known": _fake_id()})
+        with pytest.raises(ValueError, match="do not match any scraped source"):
+            loop._rewrite_url_citations("See [https://unknown.com/page] for details.")
+
+    def test_unmatched_error_lists_urls(self):
+        loop = _make_loop({})
+        with pytest.raises(ValueError, match="https://bad.com/x"):
+            loop._rewrite_url_citations("See [https://bad.com/x].")
+
+    def test_non_url_brackets_ignored(self):
+        pid = _fake_id()
+        loop = _make_loop({"https://example.com": pid})
+        result = loop._rewrite_url_citations(
+            "The value [42] and [https://example.com] are different."
+        )
+        assert result == f"The value [42] and [{pid[:8]}] are different."


### PR DESCRIPTION
## Summary
- Web research claims now cite sources inline with `[url]` syntax, which is post-processed into `[shortid]` references matching existing workspace citation style
- Scrape failures return tool errors so the model retries without inaccessible URLs, rather than silently dropping citations
- Prompt explicitly steers the model away from `<cite>` tags (native web search tool format) toward `[url]` brackets

## Test plan
- [x] Unit tests for URL citation rewriting (trailing slash tolerance, unmatched URL errors, non-URL brackets ignored)
- [x] 5 concurrent smoke test runs: 14/14 claims had proper `[shortid]` inline citations, 0 `<cite>` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)