### PR TITLE
Scope get_all_links to known page IDs

### DIFF
--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -628,8 +628,17 @@ class DB:
         rows = _rows(await query.execute())
         return [_row_to_link(r) for r in rows]
 
-    async def get_all_links(self) -> list[PageLink]:
-        """Bulk-fetch all links, scoped by project and AB run."""
+    async def get_all_links(
+        self, page_ids: set[str] | None = None,
+    ) -> list[PageLink]:
+        """Bulk-fetch links, scoped to a set of page IDs if provided.
+
+        When *page_ids* is given, only links where at least one endpoint is in
+        the set are returned. This avoids fetching every link in the DB when the
+        caller already knows which pages matter.
+        """
+        if page_ids is not None:
+            return await self._get_links_for_pages(page_ids)
         query = self.client.table("page_links").select("*")
         query = self._ab_filter(query, table="page_links")
         if self.project_id:
@@ -639,14 +648,35 @@ class DB:
                 .eq("project_id", self.project_id)
             )
             page_ids_rows = _rows(await page_ids_query.limit(50000).execute())
-            page_ids = {r["id"] for r in page_ids_rows}
+            proj_page_ids = {r["id"] for r in page_ids_rows}
             rows = _rows(await query.limit(50000).execute())
             return [
                 _row_to_link(r) for r in rows
-                if r["from_page_id"] in page_ids or r["to_page_id"] in page_ids
+                if r["from_page_id"] in proj_page_ids or r["to_page_id"] in proj_page_ids
             ]
         rows = _rows(await query.limit(50000).execute())
         return [_row_to_link(r) for r in rows]
+
+    async def _get_links_for_pages(
+        self, page_ids: set[str],
+    ) -> list[PageLink]:
+        """Fetch links where at least one endpoint is in *page_ids*.
+
+        Batches into chunks to stay within URL-length limits.
+        """
+        all_links: dict[str, PageLink] = {}
+        id_list = list(page_ids)
+        batch_size = 200
+        for start in range(0, len(id_list), batch_size):
+            batch = id_list[start:start + batch_size]
+            for col in ('from_page_id', 'to_page_id'):
+                query = self.client.table("page_links").select("*").in_(col, batch)
+                query = self._ab_filter(query, table="page_links")
+                rows = _rows(await query.limit(50000).execute())
+                for r in rows:
+                    link = _row_to_link(r)
+                    all_links[link.id] = link
+        return list(all_links.values())
 
     async def delete_link(self, link_id: str) -> None:
         """Delete a page link by ID."""

--- a/src/rumil/page_graph.py
+++ b/src/rumil/page_graph.py
@@ -50,9 +50,12 @@ class PageGraph:
     @classmethod
     async def load(cls, db: "PageSource") -> "PageGraph":
         pages = await db.get_pages_slim(active_only=True)
-        links = await db.get_all_links()
+        page_ids = {p.id for p in pages}
+        links = await db.get_all_links(page_ids=page_ids)
         log.debug(
-            'PageGraph.load: %d pages, %d links', len(pages), len(links),
+            "PageGraph.load: %d pages, %d links",
+            len(pages),
+            len(links),
         )
         return cls(pages, links)
 
@@ -82,7 +85,8 @@ class PageGraph:
         return list(self._links_from.get(page_id, []))
 
     async def get_considerations_for_question(
-        self, question_id: str,
+        self,
+        question_id: str,
     ) -> list[tuple[Page, PageLink]]:
         links = self._links_to.get(question_id, [])
         result = []
@@ -95,7 +99,8 @@ class PageGraph:
         return result
 
     async def get_judgements_for_question(
-        self, question_id: str,
+        self,
+        question_id: str,
     ) -> list[Page]:
         links = self._links_to.get(question_id, [])
         result = []
@@ -128,7 +133,8 @@ class PageGraph:
         return result
 
     async def get_child_questions_with_links(
-        self, parent_id: str,
+        self,
+        parent_id: str,
     ) -> list[tuple[Page, PageLink]]:
         links = self._links_from.get(parent_id, [])
         result = []
@@ -141,7 +147,8 @@ class PageGraph:
         return result
 
     async def get_root_questions(
-        self, workspace: Workspace = Workspace.RESEARCH,
+        self,
+        workspace: Workspace = Workspace.RESEARCH,
     ) -> list[Page]:
         child_ids: set[str] = set()
         for links in self._links_from.values():
@@ -149,7 +156,8 @@ class PageGraph:
                 if link.link_type == LinkType.CHILD_QUESTION:
                     child_ids.add(link.to_page_id)
         return [
-            p for p in self._pages.values()
+            p
+            for p in self._pages.values()
             if p.page_type == PageType.QUESTION
             and p.workspace == workspace
             and p.is_active()
@@ -157,7 +165,8 @@ class PageGraph:
         ]
 
     async def get_last_find_considerations_info(
-        self, question_id: str,
+        self,
+        question_id: str,
     ) -> tuple[str, int | None] | None:
         return None
 


### PR DESCRIPTION
## Summary
- Add optional `page_ids` parameter to `DB.get_all_links()` that uses batched `IN` queries to fetch only links touching the given pages, instead of fetching all links and filtering client-side
- `PageGraph.load` now passes its page ID set through, avoiding row-limit issues on large databases
- Ported from the stale `two-phase-prioritizer` branch

## Test plan
- [x] All 98 existing tests pass
- [ ] Verify on prod-sized DB that PageGraph loads correctly with scoped queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)