### PR TITLE
Reconcile two-phase prioritizer prompts

### DIFF
--- a/prompts/two_phase_p1.md
+++ b/prompts/two_phase_p1.md
@@ -4,29 +4,44 @@
 
 You are performing the **first phase** of a two-phase research prioritization. Your sole job is to distribute a small budget among the **scouting dispatch tools** provided to you.
 
-Each scouting dispatch costs exactly 1 budget unit. You must call at least one dispatch tool. You will not get another turn — all dispatching must happen now.
+You must call at least one dispatch tool. You will not get another turn — all dispatching must happen now.
 
 ## What the Scout Types Do
 
 All scout dispatches automatically target the scope question — you do not need to specify a question ID for them.
 
-- **Scout subquestions**: Decompose the question into informative sub-questions.
-- **Scout estimates**: Identify key quantities and make initial guesses.
-- **Scout hypotheses**: Generate candidate answers to explore.
-- **Scout analogies**: Find analogies that might illuminate the question.
-- **Scout paradigm cases**: Identify concrete, real-world cases or examples that illuminate the question.
-- **Scout facts-to-check**: Surface uncertain factual claims whose truth value could materially affect the answer.
+* **Scout subquestions**: Decompose the question into informative sub-questions.
+* **Scout estimates**: Identify key quantities and make initial guesses.
+* **Scout facts-to-check**: Identify key factual information to look up.
+* **Scout hypotheses**: Generate candidate answers to explore.
+* **Scout analogies**: Find analogies that might illuminate the question.
+* **Scout paradigm cases**: Identify concrete, real-world cases or examples that illuminate the question.
+
+## How Scouts Work
+
+Each scout dispatch runs as a single call that can execute multiple rounds of work within a continuous conversation. The `max_rounds` parameter controls how many rounds the scout may run (each round costs 1 budget). Between rounds, the scout checks how much useful work remains ("fruit"); if fruit drops below `fruit_threshold`, it stops early and returns unspent budget.
+
+This means setting `max_rounds: 3` does not necessarily cost 3 budget — it costs between 1 and 3 depending on how much the scout finds to do. Each round builds on the conversation from prior rounds, so later rounds focus on angles not yet covered.
+
+## How this work will be used
+
+* Following the fan-out scouting, there will be a second-phase prioritization step, in which budget will be allocated for investigation between the different lines of research that the scouting has identified.
+* After that research has been pursued for a while, judgements will be integrated at the top level for re-prioritization.
 
 ## How to Decide
 
-- Weight your budget toward scout types that seem most informative for this particular question.
-- Skip scout types that are clearly irrelevant (e.g., scout_estimates on a purely conceptual question).
-- If in doubt, prefer scout_subquestions — it is the most generally useful.
+* Fan-out scouting will help the research process orient to the question; subquestions, analogies, and paradigm cases can help assessments a little even without further research, whereas the other scouts are crucial mostly for what they unlock in terms of future work.
+
+Be conscious of the total budget available for the research. As a rule of thumb:
+
+* If you have a total budget of 10, you might spend 3-5 on fan-out scouting
+* If you have a total budget of 100, you might spend 10-15 on fan-out scouting
+* If you have a total budget of 1,000, you might spend 20-30 on fan-out scouting
+* If you have a total budget of 10,000, you might spend 30-40 on fan-out scouting
+
+Weight your budget toward scout types that seem most informative for this particular question. It's normal for one type of scout to get more than half the budget. Skip scout types that are clearly irrelevant (e.g., scout_estimates on a purely conceptual question). If you're unsure how much budget to allocate to a certain type of scout, you can use fruit_threshold as an extra limiter.
 
 ## What NOT to Do
 
-- Do not try to load pages or do any object-level research.
-- Do not assess or plan follow-up — that happens in phase 2.
-- Do not leave budget unspent unless you have a strong reason.
-
-You may optionally create subquestions before dispatching, but this is secondary to dispatching.
+* Do not try to load pages or do any object-level research.
+* Do not assess or plan follow-up — that happens later.

--- a/prompts/two_phase_p2.md
+++ b/prompts/two_phase_p2.md
@@ -1,0 +1,68 @@
+# Phase 2: Targeted Follow-Up
+
+## Your Task
+
+You are performing prioritization on a research question that has already had some investigation. At minimum, phase 1 has already run fan-out scouting (subquestions, estimates, hypotheses, analogies, paradigm cases, facts-to-check) on the scope question. You now have scoring data on each subquestion (impact and remaining fruit) and on the parent question itself. There may also be further investigation of subquestions.
+
+Your job is to allocate your remaining budget to targeted follow-up, based on what the scouting discovered. You are **not** doing object-level research yourself — you are deciding what to dispatch.
+
+You must make all your dispatch calls now — this is your only turn.
+
+## Available Tools
+
+### Dispatch tools
+
+- **dispatch_find_considerations**: Run general exploration on a question, based purely on trained knowledge without web research. Runs up to `max_rounds` rounds, stopping early when remaining fruit falls below `fruit_threshold`. Budget cost: between 1 and max_rounds (inclusive).
+- **Specialized scouts** (dispatch_scout_subquestions, dispatch_scout_estimates, dispatch_scout_hypotheses, dispatch_scout_analogies, dispatch_scout_paradigm_cases, dispatch_scout_facts_to_check): Run additional scouting rounds on the **scope question** if more exploration is needed. Each scout runs within a single continuous conversation — set `max_rounds` to control how many rounds it may run (each costs 1 budget). Between rounds, the scout checks remaining fruit and stops early if it drops below `fruit_threshold`, returning unspent budget. Use these when it seems more useful to have further scouting on the top-level question (perhaps in light of recent investigations of subquestions).
+- **recurse_into_subquestion**: Launch a full two-phase prioritization cycle on a child question, with its own fan-out scouting and follow-up phases. Set `budget` to the number of units to allocate. Use this for subquestions that are substantial enough to warrant their own structured investigation. DO NOT use recurse_into_subquestion on the top-level scope question.
+- **dispatch_web_research**: Verify a fact-check question via web search. Use **only** on questions identified by scout_facts_to_check. Budget cost: exactly 1.
+
+## How to Decide
+
+You will be shown scoring data from a preliminary assessment:
+
+- **Subquestion scores**: Each subquestion has an `impact` (0-10: how much answering it helps the parent) and `fruit` (0-10: how much useful investigation remains). Each subquestion also shows research stats: how many considerations, judgements, and sub-subquestions it already has.
+- **Parent question fruit**: How much useful investigation remains on the parent question directly (as opposed to through subquestions).
+
+### Allocation principles
+
+- **Use the scores.** High-impact, high-fruit subquestions should get the most budget. Low-fruit questions may not need further investigation regardless of impact.
+- **Do not create subquestions directly.** Subquestion creation happens inside scouts. Use only the dispatch tools.
+- **Web research is for fact-checks only.** Only dispatch `dispatch_web_research` on questions that were created by the facts-to-check scout.
+
+### Guidance on how much budget to use
+Generally budgets of 5-20 mean "try to answer this question quickly", and budgets of 40-80 mean "this is worth a significant investigation to cover all the major angles", and budgets of 100+ mean "this is a major question which will involve deep dives into subquestions of its own".
+
+If none of the subquestions have been investigated yet, how much budget to allocate will depend on your total budget:
+- If you have <50 budget, it's fine to allocate your whole budget
+- With 500 budget, suggest starting by allocating 100-200 budget
+- With 5000 budget, suggested starting by allocating 200-500 budget
+- With 50000 budget, suggested starting by allocating 500-1000 budget
+
+If a subquestion has been investigated before, you should generally avoid allocating more than twice the total number of subquestions and considerations it has as budget.
+
+These limits are to ensure that there's enough opportunity for initial findings to be consolidated and considered at the top level before further targeted investigations.
+
+If you are allocating >50 budget, most of that should typically be recursing into subquestions. You should normally split the budget between several questions, although it's OK if some questions get a much larger slice of the budget than others.
+
+## Scout Parameters
+
+When dispatching any specialized scout or find_considerations:
+
+- `max_rounds` controls maximum budget investment (each round costs 1). The scout maintains a continuous conversation across rounds — later rounds build on earlier ones and focus on new angles. The scout stops early if remaining fruit drops below `fruit_threshold`, so setting a high `max_rounds` does not guarantee all rounds will run.
+- `fruit_threshold` controls when to stop. Lower values squeeze harder; higher values stop earlier. Default is 4.
+
+The guidelines for scouts ranking fruit goes as:
+0 = nothing more to add
+1-2 = close to exhausted
+3-4 = most angles covered
+5-6 = diminishing but real returns
+7-8 = substantial work remains
+9-10 = barely started
+
+## Budget Accounting
+
+Your total dispatched budget (worst case) must not exceed your allocated budget:
+- Specialized scouts and find_considerations cost up to `max_rounds` (may stop early, but budget for the worst case)
+- `recurse_into_subquestion` costs exactly the `budget` you assign
+- `dispatch_web_research` costs exactly 1

--- a/src/rumil/move_presets.py
+++ b/src/rumil/move_presets.py
@@ -9,52 +9,58 @@ MovePreset = dict[CallType, Sequence[MoveType]]
 
 _ALL_MOVES_EXCEPT_JUDGEMENT = [m for m in MoveType if m != MoveType.CREATE_JUDGEMENT]
 
+_SCOUT_SUBQUESTIONS_MOVES = [
+    MoveType.CREATE_CLAIM,
+    MoveType.CREATE_QUESTION,
+    MoveType.LINK_CONSIDERATION,
+    MoveType.LOAD_PAGE,
+]
+
+_SCOUT_HYPOTHESES_MOVES = [
+    MoveType.CREATE_CLAIM,
+    MoveType.CREATE_QUESTION,
+    MoveType.PROPOSE_HYPOTHESIS,
+    MoveType.LINK_CONSIDERATION,
+    MoveType.LOAD_PAGE,
+]
+
+_SCOUT_ESTIMATES_MOVES = [
+    MoveType.CREATE_CLAIM,
+    MoveType.CREATE_QUESTION,
+    MoveType.LINK_CONSIDERATION,
+    MoveType.LOAD_PAGE,
+]
+
+_SCOUT_ANALOGIES_MOVES = [
+    MoveType.CREATE_CLAIM,
+    MoveType.CREATE_QUESTION,
+    MoveType.LINK_CONSIDERATION,
+    MoveType.LINK_RELATED,
+    MoveType.LOAD_PAGE,
+]
+
+_SCOUT_PARADIGM_CASES_MOVES = [
+    MoveType.CREATE_CLAIM,
+    MoveType.CREATE_QUESTION,
+    MoveType.LINK_CONSIDERATION,
+    MoveType.LOAD_PAGE,
+]
+
+_SCOUT_FACTS_TO_CHECK_MOVES = [
+    MoveType.CREATE_CLAIM,
+    MoveType.CREATE_QUESTION,
+    MoveType.LINK_CONSIDERATION,
+    MoveType.LOAD_PAGE,
+]
+
 PRESETS: dict[str, MovePreset] = {
     "default": {
-        CallType.SCOUT_SUBQUESTIONS: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_HYPOTHESES: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.PROPOSE_HYPOTHESIS,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_ESTIMATES: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_ANALOGIES: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LINK_RELATED,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_PARADIGM_CASES: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_FACTS_TO_CHECK: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
+        CallType.SCOUT_SUBQUESTIONS: _SCOUT_SUBQUESTIONS_MOVES,
+        CallType.SCOUT_HYPOTHESES: _SCOUT_HYPOTHESES_MOVES,
+        CallType.SCOUT_ESTIMATES: _SCOUT_ESTIMATES_MOVES,
+        CallType.SCOUT_ANALOGIES: _SCOUT_ANALOGIES_MOVES,
+        CallType.SCOUT_PARADIGM_CASES: _SCOUT_PARADIGM_CASES_MOVES,
+        CallType.SCOUT_FACTS_TO_CHECK: _SCOUT_FACTS_TO_CHECK_MOVES,
         CallType.SCOUT_CONCEPTS: [
             MoveType.PROPOSE_CONCEPT,
             MoveType.LOAD_PAGE,
@@ -69,50 +75,12 @@ PRESETS: dict[str, MovePreset] = {
         CallType.FIND_CONSIDERATIONS: _ALL_MOVES_EXCEPT_JUDGEMENT,
         CallType.INGEST: _ALL_MOVES_EXCEPT_JUDGEMENT,
         CallType.PRIORITIZATION: _ALL_MOVES_EXCEPT_JUDGEMENT,
-        CallType.SCOUT_SUBQUESTIONS: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_HYPOTHESES: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.PROPOSE_HYPOTHESIS,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_ESTIMATES: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_ANALOGIES: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LINK_RELATED,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_PARADIGM_CASES: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
-        CallType.SCOUT_FACTS_TO_CHECK: [
-            MoveType.CREATE_CLAIM,
-            MoveType.CREATE_QUESTION,
-            MoveType.LINK_CONSIDERATION,
-            MoveType.LINK_CHILD_QUESTION,
-            MoveType.LOAD_PAGE,
-        ],
+        CallType.SCOUT_SUBQUESTIONS: _SCOUT_SUBQUESTIONS_MOVES,
+        CallType.SCOUT_HYPOTHESES: _SCOUT_HYPOTHESES_MOVES,
+        CallType.SCOUT_ESTIMATES: _SCOUT_ESTIMATES_MOVES,
+        CallType.SCOUT_ANALOGIES: _SCOUT_ANALOGIES_MOVES,
+        CallType.SCOUT_PARADIGM_CASES: _SCOUT_PARADIGM_CASES_MOVES,
+        CallType.SCOUT_FACTS_TO_CHECK: _SCOUT_FACTS_TO_CHECK_MOVES,
         CallType.SCOUT_CONCEPTS: [
             MoveType.PROPOSE_CONCEPT,
             MoveType.LOAD_PAGE,

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -40,7 +40,7 @@ from rumil.calls.call_registry import (
     SCOUT_SUBQUESTIONS_CALL_CLASSES,
     WEB_RESEARCH_CALL_CLASSES,
 )
-from rumil.context import build_prioritization_context, collect_subtree_ids
+from rumil.context import build_prioritization_context
 from rumil.database import DB
 from rumil.embeddings import embed_and_store_page
 from rumil.llm import LLMExchangeMetadata, build_system_prompt, build_user_message, structured_call
@@ -91,6 +91,37 @@ from rumil.tracing.trace_events import (
 
 
 log = logging.getLogger(__name__)
+
+
+async def _count_subtree_questions(question_id: str, graph: PageGraph) -> int:
+    """Count all descendant questions (not including the question itself)."""
+    children = await graph.get_child_questions(question_id)
+    count = len(children)
+    for child in children:
+        count += await _count_subtree_questions(child.id, graph)
+    return count
+
+
+async def _describe_child_questions(
+    children: Sequence[Page], graph: PageGraph,
+) -> str:
+    """Build enriched descriptions of child questions with research stats."""
+    lines = []
+    for c in children:
+        considerations = await graph.get_considerations_for_question(c.id)
+        judgements = await graph.get_judgements_for_question(c.id)
+        subtree_count = await _count_subtree_questions(c.id, graph)
+
+        parts = []
+        parts.append(f'{len(considerations)} considerations')
+        if judgements:
+            parts.append(f'{len(judgements)} judgement{"s" if len(judgements) != 1 else ""}')
+        if subtree_count:
+            parts.append(f'{subtree_count} subquestion{"s" if subtree_count != 1 else ""}')
+
+        stats = ', '.join(parts) if parts else 'no research yet'
+        lines.append(f'- `{c.id}` — {c.headline} ({stats})')
+    return '\n'.join(lines)
 
 
 PRIORITIZATION_MOVES: list[MoveType] = [
@@ -1148,8 +1179,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         context_text, short_id_map = await build_prioritization_context(
             self.db, scope_question_id=question_id, graph=graph,
         )
-        subtree_ids = await collect_subtree_ids(question_id, self.db, graph=graph)
-
         if self._initial_call is not None:
             p_call = self._initial_call
             self._initial_call = None
@@ -1182,7 +1211,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         result = await run_prioritization_call(
             task, context_text, p_call, self.db,
             available_moves=PRIORITIZATION_MOVES,
-            subtree_ids=subtree_ids,
             short_id_map=short_id_map,
             trace=trace,
             dispatch_types=list(PHASE1_SCOUT_TYPES),
@@ -1255,18 +1283,16 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         trace = CallTrace(p_call.id, self.db, broadcaster=self.broadcaster)
         await trace.record(ContextBuiltEvent(budget=budget))
 
-        child_questions = await self.db.get_child_questions(question_id)
-        parent_question = await self.db.get_page(question_id)
+        graph = await PageGraph.load(self.db)
+        child_questions = await graph.get_child_questions(question_id)
+        parent_question = await graph.get_page(question_id)
         parent_headline = parent_question.headline if parent_question else question_id[:8]
 
         scoring_system = build_system_prompt('score_subquestions')
 
         scoring_tasks = []
         if child_questions:
-            child_descriptions = '\n'.join(
-                f'- `{c.id}` — {c.headline}'
-                for c in child_questions
-            )
+            child_descriptions = await _describe_child_questions(child_questions, graph)
             subq_user_msg = build_user_message(
                 f'Parent question: {parent_headline}\n\n'
                 f'Subquestions to score:\n{child_descriptions}',
@@ -1328,7 +1354,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             lines = ['## Subquestion Scores', '']
             for s in subq_scores:
                 lines.append(
-                    f'- `{s["question_id"][:8]}` — {s["headline"]}: '
+                    f'- `{s["question_id"]}` — {s["headline"]}: '
                     f'impact={s["impact"]}, fruit={s["fruit"]} '
                     f'({s["reasoning"]})'
                 )
@@ -1340,27 +1366,14 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             f'Remaining fruit on parent: {parent_fruit}/10\n'
         )
 
-        graph = await PageGraph.load(self.db)
         context_text, short_id_map = await build_prioritization_context(
             self.db, scope_question_id=question_id, graph=graph,
         )
-        subtree_ids = await collect_subtree_ids(question_id, self.db, graph=graph)
 
         task = (
-            f'You have a budget of **{budget} research calls** to allocate during this rollout.\n\n'
-            'You do not need to allocate your entire budget during this call (although you can, especially if it seems low). '
+            f'You have a budget of **{budget} budget units** to allocate.\n\n'
             f'Scope question ID: `{question_id}`\n\n'
-            'Phase 1 (specialized scouts + assess) is complete. Now plan '
-            'targeted follow-up based on what was discovered.\n\n'
             f'{scores_text}\n\n'
-            'Dispatch further investigation: use dispatch_find_considerations for general '
-            'exploration that can be based purely on your trained knowledge and does not require web research, '
-            'dispatch_web_research for web-based evidence, or '
-            'recurse_into_subquestion to recursively investigate a child '
-            f'question with its own prioritization cycle (minimum budget: {MIN_TWOPHASE_BUDGET}). '
-            'For find_considerations, web_research, and recurse you can target the parent question '
-            'or any child question. Scout dispatches always target the scope question automatically.\n\n'
-            'You may create subquestions before dispatching. '
             'You must make all your dispatch calls now — this is your only turn. '
             f'Each recurse call must have a budget of at least {MIN_TWOPHASE_BUDGET}.'
         )
@@ -1372,12 +1385,12 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
 
         result = await run_prioritization_call(
             task, context_text, p_call, self.db,
-            available_moves=PRIORITIZATION_MOVES,
-            subtree_ids=subtree_ids,
+            available_moves=[],
             short_id_map=short_id_map,
             trace=trace,
             dispatch_types=list(PHASE2_DISPATCH_TYPES),
             extra_dispatch_defs=[RECURSE_DISPATCH_DEF],
+            system_prompt_override=build_system_prompt('two_phase_p2'),
         )
 
         sequences: list[list[Dispatch]] = []

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -113,7 +113,8 @@ async def _describe_child_questions(
         subtree_count = await _count_subtree_questions(c.id, graph)
 
         parts = []
-        parts.append(f'{len(considerations)} considerations')
+        if considerations:
+            parts.append(f'{len(considerations)} considerations')
         if judgements:
             parts.append(f'{len(judgements)} judgement{"s" if len(judgements) != 1 else ""}')
         if subtree_count:
@@ -1203,8 +1204,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             'your only turn and you will not get another chance. Distribute your budget '
             'among the scouting dispatch tools, weighting towards types that seem most '
             'useful for this question and skipping types that are clearly irrelevant. '
-            'Each dispatch costs 1 budget unit.\n\n'
-            'You may optionally create subquestions before dispatching. '
             'Do not do anything else — just dispatch.'
         )
 


### PR DESCRIPTION
## Summary
- Brings in prompt improvements from the stale `two-phase-prioritizer` branch, reconciled against current main
- **two_phase_p1.md**: adds multi-round scout mechanics docs, budget scaling guidance, and context on how scouting feeds into phase 2
- **New two_phase_p2.md**: dedicated phase-2 system prompt with allocation principles, scout parameters, and budget guidance — replaces use of the generic `prioritization.md` for phase-2 calls
- Enriches child question descriptions with research stats (considerations, judgements, subquestion counts) for better scoring context
- Uses full question IDs in score text; removes dead `subtree_ids` parameter; disables page-creation moves during phase-2 prioritization

## Test plan
- [ ] Smoke test a two-phase run: `uv run python main.py "test question" --workspace prompt-test --smoke-test`
- [ ] Verify phase-1 prompt loads correctly with scout mechanics section
- [ ] Verify phase-2 uses the new `two_phase_p2` system prompt (check trace)
- [ ] Confirm enriched child descriptions appear in scoring context

🤖 Generated with [Claude Code](https://claude.com/claude-code)