### PR TITLE
Record errors in trace via contextvar-based CallTrace

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1449,6 +1449,11 @@
           "message": {
             "type": "string",
             "title": "Message"
+          },
+          "phase": {
+            "type": "string",
+            "title": "Phase",
+            "default": ""
           }
         },
         "type": "object",
@@ -1456,7 +1461,8 @@
           "ts",
           "call_id",
           "event",
-          "message"
+          "message",
+          "phase"
         ],
         "title": "ErrorEventOut"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -320,6 +320,10 @@ export type ErrorEventOut = {
      * Message
      */
     message: string;
+    /**
+     * Phase
+     */
+    phase: string;
 };
 
 /**

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -796,6 +796,9 @@ function EventSection({ event }: { event: TraceEvent }) {
 
       {event.event === "error" && (
         <div className="trace-event-body trace-error-text">
+          {event.phase && (
+            <span className="trace-error-phase">{event.phase}</span>
+          )}
           {event.message}
         </div>
       )}

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -519,6 +519,18 @@
   font-size: 13px;
 }
 
+.trace-error-phase {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  color: #944;
+  background: #fde8e8;
+  border-radius: 3px;
+  padding: 1px 5px;
+  margin-right: 6px;
+  vertical-align: baseline;
+}
+
 /* Dispatches section */
 
 .trace-dispatches {
@@ -1222,6 +1234,7 @@
   .trace-duration { color: #666; }
   .trace-warning-text { color: #d4a017; }
   .trace-error-text { color: #e55; }
+  .trace-error-phase { background: #3a1c1c; color: #e88; }
 
   .trace-score-headline { color: #ccc; }
   .trace-score-reasoning { color: #777; }

--- a/src/rumil/calls/closing_reviewers.py
+++ b/src/rumil/calls/closing_reviewers.py
@@ -31,7 +31,8 @@ from rumil.models import CallType, MoveType
 from rumil.move_presets import get_moves_for_call
 from rumil.moves.load_page import LoadPagePayload
 from rumil.moves.registry import MOVES
-from rumil.tracing.trace_events import ReviewCompleteEvent
+from rumil.tracing.trace_events import ErrorEvent, ReviewCompleteEvent
+from rumil.tracing.tracer import get_trace
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +57,6 @@ class StandardClosingReview(ClosingReviewer):
             creation.all_loaded_ids,
             creation.created_page_ids,
             infra.db,
-            infra.trace,
         )
         if review:
             log.info(
@@ -214,7 +214,6 @@ async def _self_assessment(
     meta = LLMExchangeMetadata(
         call_id=infra.call.id,
         phase="closing_review",
-        trace=infra.trace,
         user_message=assessment_msg,
     )
     review_result = await structured_call(
@@ -346,7 +345,6 @@ class TwoPhaseScoutReview(ClosingReviewer):
             phase="link_review",
             db=infra.db,
             state=infra.state,
-            trace=infra.trace,
             messages=link_messages,
             cache=True,
         )
@@ -451,7 +449,6 @@ class ConceptAssessReview(ClosingReviewer):
         meta = LLMExchangeMetadata(
             call_id=infra.call.id,
             phase="closing_review",
-            trace=infra.trace,
             user_message=user_message,
         )
         try:
@@ -470,6 +467,14 @@ class ConceptAssessReview(ClosingReviewer):
                 e,
                 exc_info=True,
             )
+            trace = get_trace()
+            if trace:
+                await trace.record(
+                    ErrorEvent(
+                        message=f"Concept closing review failed: {e}",
+                        phase="closing_review",
+                    )
+                )
             infra.call.review_json = {}
             await mark_call_completed(
                 infra.call,

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -40,12 +40,13 @@ from rumil.moves.base import MoveState
 from rumil.moves.load_page import LoadPagePayload
 from rumil.moves.registry import MOVES
 from rumil.tracing.trace_events import (
+    ErrorEvent,
     MoveTraceItem,
     MovesExecutedEvent,
     PageRef,
     WarningEvent,
 )
-from rumil.tracing.tracer import CallTrace
+from rumil.tracing.tracer import get_trace
 
 log = logging.getLogger(__name__)
 
@@ -109,6 +110,14 @@ async def execute_tool_uses(
                         "is_error": True,
                     }
                 )
+                trace = get_trace()
+                if trace:
+                    await trace.record(
+                        ErrorEvent(
+                            message=f"Tool {tu.name} error: {e}",
+                            phase="tool_execution",
+                        )
+                    )
             else:
                 log.debug(
                     "Tool %s returned: %s",
@@ -128,13 +137,13 @@ async def execute_tool_uses(
 
 async def record_round_moves(
     *,
-    trace: CallTrace,
     state: MoveState,
     db: DB,
 ) -> None:
     """Record a trace event for any moves added since the last call."""
+    trace = get_trace()
     round_moves, round_created, round_extras = state.take_new_moves()
-    if round_moves:
+    if round_moves and trace:
         await trace.record(
             await moves_to_trace_event(round_moves, round_created, db, round_extras)
         )
@@ -159,7 +168,6 @@ async def run_single_call(
     phase: str,
     db: DB,
     state: MoveState,
-    trace: "CallTrace | None" = None,
     messages: list[dict] | None = None,
     cache: bool = False,
 ) -> AgentResult:
@@ -197,7 +205,6 @@ async def run_single_call(
     meta = LLMExchangeMetadata(
         call_id=call_id,
         phase=phase,
-        trace=trace,
         user_message=user_message if user_message else None,
     )
     api_resp = await call_api(
@@ -232,8 +239,8 @@ async def run_single_call(
         duration_ms=api_resp.duration_ms,
     )
 
-    if trace:
-        await record_round_moves(trace=trace, state=state, db=db)
+    await record_round_moves(state=state, db=db)
+    trace = get_trace()
     for w in all_warnings:
         if trace:
             await trace.record(WarningEvent(message=w))
@@ -266,7 +273,6 @@ async def run_agent_loop(
     call_id: str,
     db: DB,
     state: MoveState,
-    trace: "CallTrace | None" = None,
     max_rounds: int | None = None,
     messages: list[dict] | None = None,
     cache: bool = False,
@@ -313,7 +319,6 @@ async def run_agent_loop(
         meta = LLMExchangeMetadata(
             call_id=call_id,
             phase="inner_loop",
-            trace=trace,
             round_num=round_num,
             user_message=user_message if round_num == 0 else None,
         )
@@ -377,8 +382,7 @@ async def run_agent_loop(
             duration_ms=api_resp.duration_ms,
         )
         all_rounds.append(rr)
-        if trace:
-            await record_round_moves(trace=trace, state=state, db=db)
+        await record_round_moves(state=state, db=db)
 
         remaining = effective_rounds - round_num
         if remaining == 1:
@@ -398,6 +402,7 @@ async def run_agent_loop(
         msg_list.append({"role": "assistant", "content": response.content})
         msg_list.append({"role": "user", "content": tool_results + [budget_note]})
 
+    trace = get_trace()
     for w in all_warnings:
         if trace:
             await trace.record(WarningEvent(message=w))
@@ -505,7 +510,6 @@ async def _run_phase1(
     call_id: str,
     state: MoveState,
     db: DB,
-    trace: "CallTrace | None" = None,
 ) -> list[str]:
     """Preliminary page loading via single LLM call with load_page tool.
 
@@ -523,7 +527,6 @@ async def _run_phase1(
             phase="initial_page_loads",
             db=db,
             state=state,
-            trace=trace,
         )
         loaded_ids = []
         for tc in result.tool_calls:
@@ -539,6 +542,14 @@ async def _run_phase1(
         return loaded_ids
     except Exception as e:
         log.warning("Phase 1 skipped due to error: %s", e, exc_info=True)
+        trace = get_trace()
+        if trace:
+            await trace.record(
+                ErrorEvent(
+                    message=f"Phase 1 skipped: {e}",
+                    phase="initial_page_loads",
+                )
+            )
         return []
 
 
@@ -551,7 +562,6 @@ async def run_call(
     *,
     available_moves: list[MoveType] | None = None,
     max_rounds: int | None = None,
-    trace: "CallTrace | None" = None,
     state: MoveState | None = None,
 ) -> RunCallResult:
     """Run a workspace call (assess/ingest) with tool use.
@@ -586,7 +596,6 @@ async def run_call(
         call.id,
         state,
         db,
-        trace=trace,
     )
     if phase1_ids:
         extra_text = await _format_loaded_pages(phase1_ids, db)
@@ -602,7 +611,6 @@ async def run_call(
         call_id=call.id,
         db=db,
         state=state,
-        trace=trace,
         max_rounds=max_rounds,
     )
 
@@ -727,7 +735,6 @@ async def run_closing_review(
     loaded_page_ids: list[str] | None = None,
     created_page_ids: list[str] | None = None,
     db: DB | None = None,
-    trace: CallTrace | None = None,
 ) -> dict | None:
     """Run the closing review as a separate call. Free (not counted against budget)."""
     page_rating_note = ""
@@ -785,7 +792,6 @@ async def run_closing_review(
             LLMExchangeMetadata(
                 call_id=call.id,
                 phase="closing_review",
-                trace=trace,
                 user_message=user_message,
             )
             if db
@@ -837,6 +843,14 @@ async def run_closing_review(
                                         pid[:8],
                                         exc_info=True,
                                     )
+                                    trace = get_trace()
+                                    if trace:
+                                        await trace.record(
+                                            ErrorEvent(
+                                                message=f"Failed to re-embed page {pid[:8]}",
+                                                phase="closing_review",
+                                            )
+                                        )
         else:
             log.warning("Closing review returned None for call=%s", call.id[:8])
         return review
@@ -847,6 +861,14 @@ async def run_closing_review(
             e,
             exc_info=True,
         )
+        trace = get_trace()
+        if trace:
+            await trace.record(
+                ErrorEvent(
+                    message=f"Closing review failed: {e}",
+                    phase="closing_review",
+                )
+            )
         return None
 
 

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -21,12 +21,18 @@ from rumil.context import (
 )
 from rumil.database import DB
 from rumil.llm import build_system_prompt, build_user_message
-from rumil.models import Call, CallType, MoveType, Page, PageDetail, FindConsiderationsMode
+from rumil.models import (
+    Call,
+    CallType,
+    MoveType,
+    Page,
+    PageDetail,
+    FindConsiderationsMode,
+)
 from rumil.moves.base import MoveState
 from rumil.moves.registry import MOVES
 from rumil.page_graph import PageGraph
 from rumil.tracing.trace_events import ContextBuiltEvent
-from rumil.tracing.tracer import CallTrace
 from rumil.workspace_map import build_workspace_map
 
 log = logging.getLogger(__name__)
@@ -40,12 +46,16 @@ async def _record_context_built(
     source_page_id: str | None = None,
     scout_mode: str | None = None,
 ) -> None:
-    await infra.trace.record(ContextBuiltEvent(
-        working_context_page_ids=await resolve_page_refs(working_page_ids, infra.db),
-        preloaded_page_ids=await resolve_page_refs(preloaded_ids, infra.db),
-        source_page_id=source_page_id,
-        scout_mode=scout_mode,
-    ))
+    await infra.trace.record(
+        ContextBuiltEvent(
+            working_context_page_ids=await resolve_page_refs(
+                working_page_ids, infra.db
+            ),
+            preloaded_page_ids=await resolve_page_refs(preloaded_ids, infra.db),
+            source_page_id=source_page_id,
+            scout_mode=scout_mode,
+        )
+    )
 
 
 async def _do_phase1(
@@ -56,12 +66,15 @@ async def _do_phase1(
     """Run phase1 page loading and return (updated context_text, phase1_ids)."""
     system_prompt = build_system_prompt(call_type.value)
     phase1_ids = await _run_phase1(
-        system_prompt, context_text, infra.call.id,
-        infra.state, infra.db, trace=infra.trace,
+        system_prompt,
+        context_text,
+        infra.call.id,
+        infra.state,
+        infra.db,
     )
     if phase1_ids:
         extra_text = await _format_loaded_pages(phase1_ids, infra.db)
-        context_text += '\n\n## Loaded Pages\n\n' + extra_text
+        context_text += "\n\n## Loaded Pages\n\n" + extra_text
     return context_text, phase1_ids
 
 
@@ -75,12 +88,16 @@ class GraphContextWithPhase1(ContextBuilder):
         preloaded_ids = infra.call.context_page_ids or []
         graph = await PageGraph.load(infra.db)
         context_text, _, working_page_ids = await build_call_context(
-            infra.question_id, infra.db, extra_page_ids=preloaded_ids,
+            infra.question_id,
+            infra.db,
+            extra_page_ids=preloaded_ids,
             graph=graph,
         )
         await _record_context_built(infra, working_page_ids, preloaded_ids)
         context_text, phase1_ids = await _do_phase1(
-            infra, self._call_type, context_text,
+            infra,
+            self._call_type,
+            context_text,
         )
         return ContextResult(
             context_text=context_text,
@@ -100,7 +117,9 @@ class EmbeddingContext(ContextBuilder):
         question = await infra.db.get_page(infra.question_id)
         query = question.headline if question else infra.question_id
         result = await build_embedding_based_context(
-            query, infra.db, scope_question_id=infra.question_id,
+            query,
+            infra.db,
+            scope_question_id=infra.question_id,
         )
         working_page_ids = result.page_ids
         await _record_context_built(infra, working_page_ids, [])
@@ -116,29 +135,35 @@ class IngestGraphContext(ContextBuilder):
     def __init__(self, source_page: Page) -> None:
         self._source_page = source_page
         extra = source_page.extra or {}
-        self._filename = extra.get('filename', source_page.id[:8])
+        self._filename = extra.get("filename", source_page.id[:8])
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
         preloaded_ids = infra.call.context_page_ids or []
         graph = await PageGraph.load(infra.db)
         question_context, _, working_page_ids = await build_call_context(
-            infra.question_id, infra.db, extra_page_ids=preloaded_ids,
+            infra.question_id,
+            infra.db,
+            extra_page_ids=preloaded_ids,
             graph=graph,
         )
         await _record_context_built(
-            infra, working_page_ids, preloaded_ids,
+            infra,
+            working_page_ids,
+            preloaded_ids,
             source_page_id=self._source_page.id,
         )
 
         source_section = (
-            '\n\n---\n\n## Source Document\n\n'
-            f'**File:** {self._filename}  \n'
-            f'**Source page ID:** `{self._source_page.id}`\n\n'
-            f'{self._source_page.content}'
+            "\n\n---\n\n## Source Document\n\n"
+            f"**File:** {self._filename}  \n"
+            f"**Source page ID:** `{self._source_page.id}`\n\n"
+            f"{self._source_page.content}"
         )
         context_text = question_context + source_section
         context_text, phase1_ids = await _do_phase1(
-            infra, CallType.INGEST, context_text,
+            infra,
+            CallType.INGEST,
+            context_text,
         )
         return ContextResult(
             context_text=context_text,
@@ -154,25 +179,29 @@ class IngestEmbeddingContext(ContextBuilder):
     def __init__(self, source_page: Page) -> None:
         self._source_page = source_page
         extra = source_page.extra or {}
-        self._filename = extra.get('filename', source_page.id[:8])
+        self._filename = extra.get("filename", source_page.id[:8])
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
         question = await infra.db.get_page(infra.question_id)
         query = question.headline if question else infra.question_id
         result = await build_embedding_based_context(
-            query, infra.db, scope_question_id=infra.question_id,
+            query,
+            infra.db,
+            scope_question_id=infra.question_id,
         )
         working_page_ids = result.page_ids
         await _record_context_built(
-            infra, working_page_ids, [],
+            infra,
+            working_page_ids,
+            [],
             source_page_id=self._source_page.id,
         )
 
         source_section = (
-            '\n\n---\n\n## Source Document\n\n'
-            f'**File:** {self._filename}  \n'
-            f'**Source page ID:** `{self._source_page.id}`\n\n'
-            f'{self._source_page.content}'
+            "\n\n---\n\n## Source Document\n\n"
+            f"**File:** {self._filename}  \n"
+            f"**Source page ID:** `{self._source_page.id}`\n\n"
+            f"{self._source_page.content}"
         )
         return ContextResult(
             context_text=result.context_text + source_section,
@@ -181,21 +210,21 @@ class IngestEmbeddingContext(ContextBuilder):
 
 
 _LINKING_TASK = (
-    'Review the workspace and link relevant existing pages to the scope question.\n\n'
-    'For each link, specify a role:\n'
+    "Review the workspace and link relevant existing pages to the scope question.\n\n"
+    "For each link, specify a role:\n"
     '- **direct**: "Now I know X, I can immediately update my answer." The page '
-    'directly bears on the answer to the scope question \u2014 it is evidence, a '
-    'counter-argument, or a partial answer.\n'
+    "directly bears on the answer to the scope question \u2014 it is evidence, a "
+    "counter-argument, or a partial answer.\n"
     '- **structural**: "Now I know X, I know better what evidence and angles to '
     'consider." The page frames the investigation \u2014 it indicates what to look '
-    'for, how to decompose the question, or what dimensions matter.\n\n'
-    'Link claims as considerations and sub-questions as child questions.\n\n'
-    'Be discerning. Only link pages that genuinely bear on this question \u2014 '
-    'tangential or weakly related pages should not be linked. '
-    'Do not duplicate any links already shown above. '
-    'Create no more than 6 new links, and fewer if fewer are warranted \u2014 '
-    'do not force links just to fill a quota.\n\n'
-    'Scope question ID: `{question_id}`'
+    "for, how to decompose the question, or what dimensions matter.\n\n"
+    "Link claims as considerations and sub-questions as child questions.\n\n"
+    "Be discerning. Only link pages that genuinely bear on this question \u2014 "
+    "tangential or weakly related pages should not be linked. "
+    "Do not duplicate any links already shown above. "
+    "Create no more than 6 new links, and fewer if fewer are warranted \u2014 "
+    "do not force links just to fill a quota.\n\n"
+    "Scope question ID: `{question_id}`"
 )
 
 
@@ -204,7 +233,6 @@ async def link_new_pages(
     call: Call,
     db: DB,
     state: MoveState,
-    trace: CallTrace,
     context_page_ids: Sequence[str] | None = None,
     graph: PageGraph | None = None,
 ) -> None:
@@ -227,16 +255,15 @@ async def link_new_pages(
             page = await source.get_page(pid)
             if page and page.id != question_id:
                 page_lines.append(await format_page(page, PageDetail.HEADLINE))
-        pages_text = '# Nearby Pages\n\n' + '\n'.join(page_lines)
+        pages_text = "# Nearby Pages\n\n" + "\n".join(page_lines)
     else:
         pages_text, _ = await build_workspace_map(db, graph=graph)
 
     question_text = await format_page(question, PageDetail.HEADLINE)
     existing_links = await _build_link_inventory(question_id, db, graph=graph)
     working_context = (
-        pages_text + '\n\n---\n\n'
-        '# Scope Question\n\n' + question_text
-        + '\n\n' + existing_links
+        pages_text + "\n\n---\n\n"
+        "# Scope Question\n\n" + question_text + "\n\n" + existing_links
     )
 
     linking_tools = [
@@ -252,10 +279,9 @@ async def link_new_pages(
         user_message=user_message,
         tools=linking_tools,
         call_id=call.id,
-        phase='link_new_pages',
+        phase="link_new_pages",
         db=db,
         state=state,
-        trace=trace,
     )
 
 
@@ -269,22 +295,22 @@ async def _build_link_inventory(
     children_with_links = await source.get_child_questions_with_links(question_id)
 
     if not considerations and not children_with_links:
-        return 'No existing links on the scope question.'
+        return "No existing links on the scope question."
 
-    lines = ['### Current Links']
+    lines = ["### Current Links"]
     for page, link in considerations:
         lines.append(
-            f'- [{link.role.value}] consideration: '
+            f"- [{link.role.value}] consideration: "
             f'"{page.headline}" '
-            f'(strength {link.strength:.1f}, link_id: `{link.id}`)'
+            f"(strength {link.strength:.1f}, link_id: `{link.id}`)"
         )
     for page, link in children_with_links:
         lines.append(
-            f'- [{link.role.value}] child_question: '
+            f"- [{link.role.value}] child_question: "
             f'"{page.headline}" '
-            f'(link_id: `{link.id}`)'
+            f"(link_id: `{link.id}`)"
         )
-    return '\n'.join(lines)
+    return "\n".join(lines)
 
 
 class FindConsiderationsGraphContext(ContextBuilder):
@@ -302,11 +328,16 @@ class FindConsiderationsGraphContext(ContextBuilder):
         preloaded_ids = self._context_page_ids or []
         graph = await PageGraph.load(infra.db)
         scout_ctx = await build_scout_context(
-            infra.question_id, infra.db, graph=graph,
+            infra.question_id,
+            infra.db,
+            graph=graph,
         )
 
         await link_new_pages(
-            infra.question_id, infra.call, infra.db, infra.state, infra.trace,
+            infra.question_id,
+            infra.call,
+            infra.db,
+            infra.state,
             context_page_ids=scout_ctx.page_ids,
             graph=graph,
         )
@@ -315,16 +346,21 @@ class FindConsiderationsGraphContext(ContextBuilder):
         context_text = scout_ctx.context_text
         if preloaded_ids:
             context_text += await format_preloaded_pages(
-                preloaded_ids, infra.db, graph=graph,
+                preloaded_ids,
+                infra.db,
+                graph=graph,
             )
 
-        await infra.trace.record(ContextBuiltEvent(
-            working_context_page_ids=await resolve_page_refs(
-                working_page_ids, infra.db,
-            ),
-            preloaded_page_ids=await resolve_page_refs(preloaded_ids, infra.db),
-            scout_mode=self._mode.value,
-        ))
+        await infra.trace.record(
+            ContextBuiltEvent(
+                working_context_page_ids=await resolve_page_refs(
+                    working_page_ids,
+                    infra.db,
+                ),
+                preloaded_page_ids=await resolve_page_refs(preloaded_ids, infra.db),
+                scout_mode=self._mode.value,
+            )
+        )
 
         return ContextResult(
             context_text=context_text,
@@ -342,17 +378,22 @@ class ScoutEmbeddingContext(ContextBuilder):
     async def build_context(self, infra: CallInfra) -> ContextResult:
         graph = await PageGraph.load(infra.db)
         scout_ctx = await build_scout_context(
-            infra.question_id, infra.db, graph=graph,
+            infra.question_id,
+            infra.db,
+            graph=graph,
         )
         working_page_ids = scout_ctx.page_ids
 
-        await infra.trace.record(ContextBuiltEvent(
-            working_context_page_ids=await resolve_page_refs(
-                working_page_ids, infra.db,
-            ),
-            preloaded_page_ids=[],
-            scout_mode=self._mode.value,
-        ))
+        await infra.trace.record(
+            ContextBuiltEvent(
+                working_context_page_ids=await resolve_page_refs(
+                    working_page_ids,
+                    infra.db,
+                ),
+                preloaded_page_ids=[],
+                scout_mode=self._mode.value,
+            )
+        )
 
         return ContextResult(
             context_text=scout_ctx.context_text,
@@ -370,33 +411,37 @@ class ConceptScoutContext(ContextBuilder):
         preloaded_ids = infra.call.context_page_ids or []
         graph = await PageGraph.load(infra.db)
         context_text, _, working_page_ids = await build_call_context(
-            infra.question_id, infra.db, extra_page_ids=preloaded_ids,
+            infra.question_id,
+            infra.db,
+            extra_page_ids=preloaded_ids,
             graph=graph,
         )
 
         registry = await infra.db.get_concept_registry()
         if registry:
-            lines = ['## Concept Registry', '']
+            lines = ["## Concept Registry", ""]
             lines.append(
-                'The following concepts have already been proposed (do not re-propose them):'
+                "The following concepts have already been proposed (do not re-propose them):"
             )
-            lines.append('')
+            lines.append("")
             for concept in registry:
                 extra = concept.extra or {}
-                stage = extra.get('stage', 'proposed')
-                score = extra.get('score')
-                promoted = extra.get('promoted', False)
-                status = 'promoted' if promoted else (
-                    f'score={score}' if score is not None else stage
+                stage = extra.get("stage", "proposed")
+                score = extra.get("score")
+                promoted = extra.get("promoted", False)
+                status = (
+                    "promoted"
+                    if promoted
+                    else (f"score={score}" if score is not None else stage)
                 )
-                lines.append(
-                    f'- [{status}] `{concept.id[:8]}` — {concept.headline}'
-                )
-            context_text += '\n\n' + '\n'.join(lines)
+                lines.append(f"- [{status}] `{concept.id[:8]}` — {concept.headline}")
+            context_text += "\n\n" + "\n".join(lines)
 
         await _record_context_built(infra, working_page_ids, preloaded_ids)
         context_text, phase1_ids = await _do_phase1(
-            infra, self._call_type, context_text,
+            infra,
+            self._call_type,
+            context_text,
         )
         return ContextResult(
             context_text=context_text,
@@ -418,7 +463,7 @@ class ConceptAssessContext(ContextBuilder):
         concept = await infra.db.get_page(infra.question_id)
         if not concept:
             return ContextResult(
-                context_text=f'[Concept page {infra.question_id} not found]',
+                context_text=f"[Concept page {infra.question_id} not found]",
                 working_page_ids=[],
             )
 
@@ -426,40 +471,50 @@ class ConceptAssessContext(ContextBuilder):
         concept_text = await format_page(concept, PageDetail.HEADLINE, db=infra.db)
 
         extra = concept.extra or {}
-        assessment_rounds = extra.get('assessment_rounds', [])
-        history_section = ''
+        assessment_rounds = extra.get("assessment_rounds", [])
+        history_section = ""
         if assessment_rounds:
-            lines = ['## Previous Assessment Rounds', '']
+            lines = ["## Previous Assessment Rounds", ""]
             for i, r in enumerate(assessment_rounds):
                 lines.append(
-                    f'Round {i + 1} ({r.get("phase", "?")}): '
-                    f'score={r.get("score", "?")}, '
-                    f'remaining_fruit={r.get("remaining_fruit", "?")}'
+                    f"Round {i + 1} ({r.get('phase', '?')}): "
+                    f"score={r.get('score', '?')}, "
+                    f"remaining_fruit={r.get('remaining_fruit', '?')}"
                 )
-                if r.get('what_worked'):
-                    lines.append(f'  Worked: {r["what_worked"]}')
-                if r.get('what_didnt'):
+                if r.get("what_worked"):
+                    lines.append(f"  Worked: {r['what_worked']}")
+                if r.get("what_didnt"):
                     lines.append(f"  Didn't: {r['what_didnt']}")
-            history_section = '\n\n' + '\n'.join(lines)
+            history_section = "\n\n" + "\n".join(lines)
 
-        context_text = '\n\n'.join([
-            map_text,
-            '---',
-            '## Concept Under Assessment',
-            '',
-            concept_text,
-        ]) + history_section
+        context_text = (
+            "\n\n".join(
+                [
+                    map_text,
+                    "---",
+                    "## Concept Under Assessment",
+                    "",
+                    concept_text,
+                ]
+            )
+            + history_section
+        )
 
         working_page_ids = [infra.question_id]
         preloaded_ids = infra.call.context_page_ids or []
-        await infra.trace.record(ContextBuiltEvent(
-            working_context_page_ids=await resolve_page_refs(
-                working_page_ids, infra.db,
-            ),
-            preloaded_page_ids=await resolve_page_refs(preloaded_ids, infra.db),
-        ))
+        await infra.trace.record(
+            ContextBuiltEvent(
+                working_context_page_ids=await resolve_page_refs(
+                    working_page_ids,
+                    infra.db,
+                ),
+                preloaded_page_ids=await resolve_page_refs(preloaded_ids, infra.db),
+            )
+        )
         context_text, phase1_ids = await _do_phase1(
-            infra, CallType.ASSESS_CONCEPT, context_text,
+            infra,
+            CallType.ASSESS_CONCEPT,
+            context_text,
         )
         return ContextResult(
             context_text=context_text,
@@ -476,33 +531,42 @@ class WebResearchEmbeddingContext(ContextBuilder):
         question = await infra.db.get_page(infra.question_id)
         query = question.headline if question else infra.question_id
         emb_result = await build_embedding_based_context(
-            query, infra.db, scope_question_id=infra.question_id,
+            query,
+            infra.db,
+            scope_question_id=infra.question_id,
         )
         working_page_ids = emb_result.page_ids
         context_text = emb_result.context_text
 
-        system_prompt = build_system_prompt('web_research')
-        user_message = build_user_message(context_text, '(diagnostic)')
+        system_prompt = build_system_prompt("web_research")
+        user_message = build_user_message(context_text, "(diagnostic)")
         log.debug(
-            'Web research context diagnostic: '
-            'context_text=%d chars, system_prompt=%d chars, '
-            'user_message=%d chars, total_prompt=%d chars, '
-            'full_pages=%d, abstract_pages=%d, summary_pages=%d, '
-            'distillation_pages=%d, '
-            'budget_usage=%s',
-            len(context_text), len(system_prompt),
-            len(user_message), len(system_prompt) + len(user_message),
-            len(emb_result.full_page_ids), len(emb_result.abstract_page_ids),
-            len(emb_result.summary_page_ids), len(emb_result.distillation_page_ids),
+            "Web research context diagnostic: "
+            "context_text=%d chars, system_prompt=%d chars, "
+            "user_message=%d chars, total_prompt=%d chars, "
+            "full_pages=%d, abstract_pages=%d, summary_pages=%d, "
+            "distillation_pages=%d, "
+            "budget_usage=%s",
+            len(context_text),
+            len(system_prompt),
+            len(user_message),
+            len(system_prompt) + len(user_message),
+            len(emb_result.full_page_ids),
+            len(emb_result.abstract_page_ids),
+            len(emb_result.summary_page_ids),
+            len(emb_result.distillation_page_ids),
             emb_result.budget_usage,
         )
 
-        await infra.trace.record(ContextBuiltEvent(
-            working_context_page_ids=await resolve_page_refs(
-                working_page_ids, infra.db,
-            ),
-            preloaded_page_ids=[],
-        ))
+        await infra.trace.record(
+            ContextBuiltEvent(
+                working_context_page_ids=await resolve_page_refs(
+                    working_page_ids,
+                    infra.db,
+                ),
+                preloaded_page_ids=[],
+            )
+        )
 
         return ContextResult(
             context_text=context_text,

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -91,7 +91,6 @@ class SimpleAgentLoop(PageCreator):
             call_id=infra.call.id,
             db=infra.db,
             state=infra.state,
-            trace=infra.trace,
             max_rounds=max_rounds,
         )
 
@@ -247,7 +246,6 @@ class MultiRoundLoop(PageCreator):
                     call_id=infra.call.id,
                     db=infra.db,
                     state=infra.state,
-                    trace=infra.trace,
                     cache=True,
                 )
             else:
@@ -271,7 +269,6 @@ class MultiRoundLoop(PageCreator):
                     call_id=infra.call.id,
                     db=infra.db,
                     state=infra.state,
-                    trace=infra.trace,
                     messages=resume_messages,
                     cache=True,
                 )
@@ -321,7 +318,6 @@ class MultiRoundLoop(PageCreator):
         meta = LLMExchangeMetadata(
             call_id=infra.call.id,
             phase="fruit_check",
-            trace=infra.trace,
             user_message=_FRUIT_CHECK_MESSAGE,
         )
         result = await structured_call(
@@ -415,7 +411,6 @@ class WebResearchLoop(PageCreator):
             meta = LLMExchangeMetadata(
                 call_id=infra.call.id,
                 phase="web_research_loop",
-                trace=infra.trace,
                 round_num=round_num,
                 user_message=user_message if round_num == 0 else None,
             )
@@ -444,7 +439,6 @@ class WebResearchLoop(PageCreator):
                     custom_tool_fns,
                 )
                 await record_round_moves(
-                    trace=infra.trace,
                     state=infra.state,
                     db=infra.db,
                 )

--- a/src/rumil/calls/prioritization.py
+++ b/src/rumil/calls/prioritization.py
@@ -29,7 +29,7 @@ from rumil.tracing.trace_events import (
     DispatchTraceItem,
     DispatchesPlannedEvent,
 )
-from rumil.tracing.tracer import CallTrace
+from rumil.tracing.tracer import CallTrace, set_trace
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +43,6 @@ async def run_prioritization_call(
     available_moves: list[MoveType] | None = None,
     subtree_ids: set[str] | None = None,
     short_id_map: dict[str, str] | None = None,
-    trace: CallTrace | None = None,
     dispatch_types: Sequence[CallType] | None = None,
     extra_dispatch_defs: Sequence[DispatchDef] | None = None,
     system_prompt_override: str | None = None,
@@ -106,7 +105,6 @@ async def run_prioritization_call(
         phase="prioritization",
         db=db,
         state=state,
-        trace=trace,
     )
 
     log.info(
@@ -135,6 +133,7 @@ async def run_prioritization(
     Returns a summary dict including the list of dispatches and trace.
     """
     trace = CallTrace(call.id, db, broadcaster=broadcaster)
+    set_trace(trace)
     log.info(
         "Prioritization starting: call=%s, question=%s, budget=%d",
         call.id[:8],
@@ -167,7 +166,6 @@ async def run_prioritization(
         db,
         subtree_ids=subtree_ids,
         short_id_map=short_id_map,
-        trace=trace,
     )
 
     await trace.record(

--- a/src/rumil/calls/stages.py
+++ b/src/rumil/calls/stages.py
@@ -13,7 +13,8 @@ from rumil.database import DB
 from rumil.models import Call, CallStage, CallStatus, CallType, Dispatch, Move, MoveType
 from rumil.move_presets import get_moves_for_call
 from rumil.moves.base import MoveState
-from rumil.tracing.tracer import CallTrace
+from rumil.tracing.trace_events import ErrorEvent
+from rumil.tracing.tracer import CallTrace, set_trace
 
 log = logging.getLogger(__name__)
 
@@ -151,35 +152,45 @@ class CallRunner(ABC):
     def task_description(self) -> str: ...
 
     async def run(self) -> None:
-        await self.infra.db.update_call_status(
-            self.infra.call.id,
-            CallStatus.RUNNING,
-            call_params=self.infra.call.call_params,
-        )
-
-        self.context_result = await self.context_builder.build_context(self.infra)
-        if self.up_to_stage == CallStage.BUILD_CONTEXT:
-            await mark_call_completed(
-                self.infra.call,
-                self.infra.db,
-                "Stopped after build_context",
+        set_trace(self.infra.trace)
+        try:
+            await self.infra.db.update_call_status(
+                self.infra.call.id,
+                CallStatus.RUNNING,
+                call_params=self.infra.call.call_params,
             )
-            return
 
-        self.creation_result = await self.page_creator.create_pages(
-            self.infra,
-            self.context_result,
-        )
-        if self.up_to_stage == CallStage.CREATE_PAGES:
-            await mark_call_completed(
-                self.infra.call,
-                self.infra.db,
-                "Stopped after create_pages",
+            self.context_result = await self.context_builder.build_context(self.infra)
+            if self.up_to_stage == CallStage.BUILD_CONTEXT:
+                await mark_call_completed(
+                    self.infra.call,
+                    self.infra.db,
+                    "Stopped after build_context",
+                )
+                return
+
+            self.creation_result = await self.page_creator.create_pages(
+                self.infra,
+                self.context_result,
             )
-            return
+            if self.up_to_stage == CallStage.CREATE_PAGES:
+                await mark_call_completed(
+                    self.infra.call,
+                    self.infra.db,
+                    "Stopped after create_pages",
+                )
+                return
 
-        await self.closing_reviewer.closing_review(
-            self.infra,
-            self.context_result,
-            self.creation_result,
-        )
+            await self.closing_reviewer.closing_review(
+                self.infra,
+                self.context_result,
+                self.creation_result,
+            )
+        except Exception as e:
+            await self.infra.trace.record(
+                ErrorEvent(
+                    message=f"Call failed: {type(e).__name__}: {e}",
+                    phase="run",
+                )
+            )
+            raise

--- a/src/rumil/calls/summarize.py
+++ b/src/rumil/calls/summarize.py
@@ -20,7 +20,7 @@ from rumil.models import (
 )
 from rumil.moves.base import write_page_file
 from rumil.tracing.trace_events import ContextBuiltEvent, PageRef
-from rumil.tracing.tracer import CallTrace
+from rumil.tracing.tracer import CallTrace, set_trace
 
 log = logging.getLogger(__name__)
 
@@ -123,19 +123,25 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
                 f"**Consideration{direction}** (strength {link.strength:.1f}): "
                 f"{page.headline}\n\n{page.content}"
             )
-        parts.append(_section("Direct Considerations (full)", "\n\n---\n\n".join(cons_parts)))
+        parts.append(
+            _section("Direct Considerations (full)", "\n\n---\n\n".join(cons_parts))
+        )
 
     if judgements:
         most_recent = max(judgements, key=lambda j: j.created_at)
-        parts.append(_section(
-            "Most Recent Judgement (full)",
-            f"Epistemic status: {most_recent.epistemic_status:.1f} — {most_recent.epistemic_type}\n\n"
-            f"{most_recent.content}",
-        ))
+        parts.append(
+            _section(
+                "Most Recent Judgement (full)",
+                f"Epistemic status: {most_recent.epistemic_status:.1f} — {most_recent.epistemic_type}\n\n"
+                f"{most_recent.content}",
+            )
+        )
         older = [j for j in judgements if j.id != most_recent.id]
         if older:
             older_lines = [f"- [{j.epistemic_status:.1f}] {j.headline}" for j in older]
-            parts.append(_section("Earlier Judgements (summaries)", "\n".join(older_lines)))
+            parts.append(
+                _section("Earlier Judgements (summaries)", "\n".join(older_lines))
+            )
 
     if children:
         child_parts = []
@@ -161,10 +167,7 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
             child_considerations = await db.get_considerations_for_question(child.id)
             if child_considerations:
                 page_refs.extend(ref(p) for p, _ in child_considerations)
-                con_lines = [
-                    f"  - {p.headline}"
-                    for p, _ in child_considerations
-                ]
+                con_lines = [f"  - {p.headline}" for p, _ in child_considerations]
                 child_section_parts.append(
                     "**Considerations (short):**\n" + "\n".join(con_lines)
                 )
@@ -183,7 +186,8 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
                         page_refs.extend(ref(j) for j in gc_judgements)
                     gc_short_j = (
                         max(gc_judgements, key=lambda j: j.created_at).headline
-                        if gc_judgements else None
+                        if gc_judgements
+                        else None
                     )
                     gc_lines.append(
                         f"  - **{gc.headline}**"
@@ -201,18 +205,30 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
     return "\n\n".join(parts), page_refs
 
 
-async def _supersede_old_summaries(question_id: str, new_summary_id: str, db: DB) -> None:
+async def _supersede_old_summaries(
+    question_id: str, new_summary_id: str, db: DB
+) -> None:
     """Mark any existing summary pages for this question as superseded."""
     links = await db.get_links_to(question_id)
     for link in links:
         if link.link_type != LinkType.SUMMARIZES:
             continue
         old = await db.get_page(link.from_page_id)
-        if old and old.is_active() and old.page_type == PageType.SUMMARY and old.id != new_summary_id:
-            await db.client.table("pages").update(
-                {"is_superseded": True, "superseded_by": new_summary_id}
-            ).eq("id", old.id).execute()
-            log.info("Superseded old summary %s with %s", old.id[:8], new_summary_id[:8])
+        if (
+            old
+            and old.is_active()
+            and old.page_type == PageType.SUMMARY
+            and old.id != new_summary_id
+        ):
+            await (
+                db.client.table("pages")
+                .update({"is_superseded": True, "superseded_by": new_summary_id})
+                .eq("id", old.id)
+                .execute()
+            )
+            log.info(
+                "Superseded old summary %s with %s", old.id[:8], new_summary_id[:8]
+            )
 
 
 async def summarize_question(
@@ -232,15 +248,18 @@ async def summarize_question(
         parent_call_id=parent_call_id,
     )
     trace = CallTrace(call.id, db)
+    set_trace(trace)
 
     try:
         context, context_page_ids = await _build_summary_context(question_id, db)
-        await trace.record(ContextBuiltEvent(
-            working_context_page_ids=context_page_ids,
-        ))
+        await trace.record(
+            ContextBuiltEvent(
+                working_context_page_ids=context_page_ids,
+            )
+        )
         user_message = build_user_message(context, TASK)
 
-        meta = LLMExchangeMetadata(call_id=call.id, phase="summarize", trace=trace)
+        meta = LLMExchangeMetadata(call_id=call.id, phase="summarize")
         result = await structured_call(
             system_prompt=SYSTEM_PROMPT,
             user_message=user_message,
@@ -250,7 +269,10 @@ async def summarize_question(
         )
 
         if not result.data:
-            log.warning("summarize_question: structured call returned no data for %s", question_id[:8])
+            log.warning(
+                "summarize_question: structured call returned no data for %s",
+                question_id[:8],
+            )
             await _fail_call(call, db)
             return None
 
@@ -296,7 +318,9 @@ async def summarize_question(
         return page.id
 
     except Exception as e:
-        log.error("summarize_question failed for %s: %s", question_id[:8], e, exc_info=True)
+        log.error(
+            "summarize_question failed for %s: %s", question_id[:8], e, exc_info=True
+        )
         await _fail_call(call, db)
         return None
 

--- a/src/rumil/calls/summarize.py
+++ b/src/rumil/calls/summarize.py
@@ -19,8 +19,8 @@ from rumil.models import (
     Workspace,
 )
 from rumil.moves.base import write_page_file
-from rumil.tracing.trace_events import ContextBuiltEvent, PageRef
-from rumil.tracing.tracer import CallTrace, set_trace
+from rumil.tracing.trace_events import ContextBuiltEvent, ErrorEvent, PageRef
+from rumil.tracing.tracer import CallTrace, get_trace, set_trace
 
 log = logging.getLogger(__name__)
 
@@ -321,6 +321,14 @@ async def summarize_question(
         log.error(
             "summarize_question failed for %s: %s", question_id[:8], e, exc_info=True
         )
+        trace = get_trace()
+        if trace:
+            await trace.record(
+                ErrorEvent(
+                    message=f"Summarize failed: {e}",
+                    phase="summarize",
+                )
+            )
         await _fail_call(call, db)
         return None
 

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -36,11 +36,11 @@ from pydantic import BaseModel, ValidationError
 from rumil.pricing import compute_cost
 
 from rumil.settings import get_settings
-from rumil.tracing.trace_events import LLMExchangeEvent
+from rumil.tracing.trace_events import ErrorEvent, LLMExchangeEvent
+from rumil.tracing.tracer import get_trace
 
 if TYPE_CHECKING:
     from rumil.database import DB
-    from rumil.tracing.tracer import CallTrace
 
 DEFAULT_MAX_TOKENS = 20_000
 
@@ -220,7 +220,6 @@ class LLMExchangeMetadata:
 
     call_id: str
     phase: str
-    trace: CallTrace | None = None
     round_num: int | None = None
     user_message: str | None = None
     user_messages: list[dict] | None = None
@@ -262,8 +261,9 @@ async def _save_exchange(
         cache_creation_input_tokens=cache_creation_input_tokens,
         cache_read_input_tokens=cache_read_input_tokens,
     )
-    if metadata.trace:
-        await metadata.trace.record(
+    trace = get_trace()
+    if trace:
+        await trace.record(
             LLMExchangeEvent(
                 exchange_id=exchange_id,
                 phase=metadata.phase,
@@ -380,6 +380,15 @@ async def call_api(
             )
             if not retryable or attempt == MAX_API_RETRIES - 1:
                 log.error("API call failed (non-retryable): %s", e, exc_info=True)
+                trace = get_trace()
+                if trace:
+                    phase = metadata.phase if metadata else "api_call"
+                    await trace.record(
+                        ErrorEvent(
+                            message=f"API call failed: {type(e).__name__}: {e}",
+                            phase=phase,
+                        )
+                    )
                 raise
             wait = 2**attempt
             label = f"HTTP {status}" if status else name
@@ -519,6 +528,15 @@ async def _structured_call_cached(
                 "returning empty result",
                 exc,
             )
+            trace = get_trace()
+            if trace:
+                phase = metadata.phase if metadata else "structured_call"
+                await trace.record(
+                    ErrorEvent(
+                        message=f"Structured call parse failed: {exc}",
+                        phase=phase,
+                    )
+                )
             return StructuredCallResult(
                 response_text=response_text or None,
                 input_tokens=api_resp.message.usage.input_tokens,

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -79,7 +79,7 @@ from rumil.models import (
 from rumil.page_graph import PageGraph
 from rumil.settings import get_settings
 from rumil.tracing.broadcast import Broadcaster
-from rumil.tracing.tracer import CallTrace
+from rumil.tracing.tracer import CallTrace, get_trace, set_trace
 from rumil.tracing.trace_events import (
     ContextBuiltEvent,
     DispatchExecutedEvent,
@@ -172,7 +172,6 @@ class FruitResult(BaseModel):
 class PrioritizationResult:
     dispatch_sequences: Sequence[Sequence[Dispatch]]
     call_id: str | None = None
-    trace: CallTrace | None = None
     children: Sequence[tuple['TwoPhaseOrchestrator', str]] = ()
 
 
@@ -610,7 +609,6 @@ class BaseOrchestrator(ABC):
         sequence: Sequence[Dispatch],
         scope_question_id: str,
         parent_call_id: str | None,
-        trace: CallTrace | None,
         base_index: int,
         position_in_batch: int = 0,
     ) -> bool:
@@ -644,6 +642,7 @@ class BaseOrchestrator(ABC):
             page = await self.db.get_page(resolved)
             headlines.append(page.headline if page else '')
 
+        trace = get_trace()
         if trace:
             for i, dispatch in enumerate(sequence):
                 await trace.record(DispatchExecutedEvent(
@@ -813,7 +812,6 @@ class BaseOrchestrator(ABC):
         sequences: Sequence[Sequence[Dispatch]],
         scope_question_id: str,
         call_id: str | None,
-        trace: CallTrace | None,
     ) -> bool:
         """Run multiple dispatch sequences concurrently. Returns True if any executed."""
         base_index = 0
@@ -821,7 +819,7 @@ class BaseOrchestrator(ABC):
         for batch_pos, seq in enumerate(sequences):
             tasks.append(self._run_dispatch_sequence(
                 seq, scope_question_id, call_id,
-                trace, base_index,
+                base_index,
                 position_in_batch=batch_pos,
             ))
             base_index += len(seq)
@@ -847,7 +845,7 @@ class LLMOrchestrator(BaseOrchestrator):
         self._plan: list[Dispatch] = []
         self._cursor: int = 0
         self._call_id: str | None = None
-        self._trace: CallTrace | None = None
+
         self._executed_since_last_plan: bool = False
         self._first_call: bool = True
 
@@ -865,7 +863,7 @@ class LLMOrchestrator(BaseOrchestrator):
 
                 executed = await self._run_sequences(
                     result.dispatch_sequences, root_question_id,
-                    result.call_id, result.trace,
+                    result.call_id,
                 )
                 if executed:
                     self._executed_since_last_plan = True
@@ -909,7 +907,6 @@ class LLMOrchestrator(BaseOrchestrator):
         return PrioritizationResult(
             dispatch_sequences=[batch] if batch else [],
             call_id=self._call_id,
-            trace=self._trace,
         )
 
     async def _run_prioritization(
@@ -937,7 +934,7 @@ class LLMOrchestrator(BaseOrchestrator):
         self._plan = list(plan.get('dispatches', []))
         self._cursor = 0
         self._call_id = p_call.id
-        self._trace = plan.get('trace')
+
 
         log.debug(
             'LLMOrchestrator: got %d dispatches for question=%s',
@@ -987,7 +984,7 @@ class LLMOrchestrator(BaseOrchestrator):
         sub_dispatches = list(plan.get('dispatches', []))
         self._plan[self._cursor:self._cursor + 1] = sub_dispatches
         self._call_id = p_call.id
-        self._trace = plan.get('trace')
+
 
         log.debug(
             'Sub-prioritization expanded to %d dispatches',
@@ -1021,7 +1018,6 @@ class LLMOrchestrator(BaseOrchestrator):
                 ),
             ]],
             call_id=self._call_id,
-            trace=self._trace,
         )
 
 
@@ -1042,7 +1038,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         super().__init__(db, broadcaster)
         self._invocation: int = 0
         self._call_id: str | None = None
-        self._trace: CallTrace | None = None
+
         self._executed_since_last_plan: bool = False
         self._budget_cap: int | None = budget_cap
         self._consumed: int = 0
@@ -1102,7 +1098,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 if result.dispatch_sequences:
                     tasks.append(self._run_sequences(
                         result.dispatch_sequences, root_question_id,
-                        result.call_id, result.trace,
+                        result.call_id,
                     ))
                 for child, child_qid in result.children:
                     tasks.append(child.run(child_qid))
@@ -1134,12 +1130,11 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         sequence: Sequence[Dispatch],
         scope_question_id: str,
         parent_call_id: str | None,
-        trace: CallTrace | None,
         base_index: int,
         position_in_batch: int = 0,
     ) -> bool:
         result = await super()._run_dispatch_sequence(
-            sequence, scope_question_id, parent_call_id, trace, base_index,
+            sequence, scope_question_id, parent_call_id, base_index,
             position_in_batch=position_in_batch,
         )
         if result:
@@ -1199,6 +1194,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 workspace=Workspace.PRIORITIZATION,
             )
         trace = CallTrace(p_call.id, self.db, broadcaster=self.broadcaster)
+        set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=phase1_budget))
 
         task = (
@@ -1219,7 +1215,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
 
             subtree_ids=subtree_ids,
             short_id_map=short_id_map,
-            trace=trace,
             dispatch_types=list(PHASE1_SCOUT_TYPES),
             system_prompt_override=build_system_prompt('two_phase_p1'),
         )
@@ -1257,7 +1252,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         )
 
         self._call_id = p_call.id
-        self._trace = trace
+
 
         log.info(
             'TwoPhaseOrchestrator phase1 complete: %d sequences',
@@ -1266,7 +1261,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         return PrioritizationResult(
             dispatch_sequences=sequences,
             call_id=p_call.id,
-            trace=trace,
         )
 
     async def _phase2(
@@ -1288,6 +1282,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             workspace=Workspace.PRIORITIZATION,
         )
         trace = CallTrace(p_call.id, self.db, broadcaster=self.broadcaster)
+        set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=budget))
 
         graph = await PageGraph.load(self.db)
@@ -1312,7 +1307,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 metadata=LLMExchangeMetadata(
                     call_id=p_call.id,
                     phase='score_subquestions',
-                    trace=trace,
                 ),
                 db=self.db,
             ))
@@ -1334,7 +1328,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             metadata=LLMExchangeMetadata(
                 call_id=p_call.id,
                 phase='score_parent_fruit',
-                trace=trace,
             ),
             db=self.db,
         ))
@@ -1400,7 +1393,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
 
             subtree_ids=subtree_ids,
             short_id_map=short_id_map,
-            trace=trace,
             dispatch_types=list(PHASE2_DISPATCH_TYPES),
             extra_dispatch_defs=extra_defs or None,
             system_prompt_override=build_system_prompt('two_phase_p2'),
@@ -1473,7 +1465,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         )
 
         self._call_id = p_call.id
-        self._trace = trace
+
 
         log.info(
             'TwoPhaseOrchestrator phase2 complete: %d sequences, %d children',
@@ -1482,7 +1474,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         return PrioritizationResult(
             dispatch_sequences=sequences,
             call_id=p_call.id,
-            trace=trace,
             children=children,
         )
 

--- a/src/rumil/tracing/trace_events.py
+++ b/src/rumil/tracing/trace_events.py
@@ -12,7 +12,11 @@ class PageRef(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _migrate_summary(cls, values: dict) -> dict:
-        if isinstance(values, dict) and "summary" in values and "headline" not in values:
+        if (
+            isinstance(values, dict)
+            and "summary" in values
+            and "headline" not in values
+        ):
             values["headline"] = values.pop("summary")
         return values
 
@@ -78,6 +82,7 @@ class WarningEvent(BaseModel):
 class ErrorEvent(BaseModel):
     event: Literal["error"] = "error"
     message: str
+    phase: str = ""
 
 
 class SubquestionScoreItem(BaseModel):

--- a/src/rumil/tracing/tracer.py
+++ b/src/rumil/tracing/tracer.py
@@ -1,5 +1,6 @@
 """Execution tracing: capture call events and persist them to the DB."""
 
+import contextvars
 import logging
 from datetime import datetime, timezone
 
@@ -9,6 +10,20 @@ from rumil.tracing.trace_events import TraceEvent
 from rumil.settings import get_settings
 
 log = logging.getLogger(__name__)
+
+_trace_var: contextvars.ContextVar["CallTrace | None"] = contextvars.ContextVar(
+    "rumil_call_trace", default=None
+)
+
+
+def get_trace() -> "CallTrace | None":
+    """Return the current task-local CallTrace, or None if not set."""
+    return _trace_var.get()
+
+
+def set_trace(trace: "CallTrace") -> contextvars.Token:
+    """Set the task-local CallTrace. Returns a token for optional reset."""
+    return _trace_var.set(trace)
 
 
 class CallTrace:

--- a/tests/test_call_sequences.py
+++ b/tests/test_call_sequences.py
@@ -18,11 +18,10 @@ from rumil.tracing.tracer import CallTrace
 class ScriptedOrchestrator(BaseOrchestrator):
     """Returns pre-scripted batches of dispatch sequences."""
 
-    def __init__(self, db, sequences, call_id=None, trace=None):
+    def __init__(self, db, sequences, call_id=None):
         super().__init__(db)
         self._sequences = list(sequences)
         self._call_id = call_id
-        self._trace = trace
 
     async def run(self, root_question_id):
         await self._setup()
@@ -34,7 +33,6 @@ class ScriptedOrchestrator(BaseOrchestrator):
                 self._sequences,
                 root_question_id,
                 self._call_id,
-                self._trace,
             )
         finally:
             await self._teardown()
@@ -178,7 +176,6 @@ async def test_single_element_sequences_skip_sequence_creation(tmp_db, question_
             [_assess(question_page.id)],
         ],
         call_id=p_call.id,
-        trace=trace,
     )
     await orch.run(question_page.id)
 
@@ -209,7 +206,6 @@ async def test_multi_step_sequence_creates_record_and_assigns_positions(
             [_scout(question_page.id), _assess(question_page.id)],
         ],
         call_id=p_call.id,
-        trace=trace,
     )
     await orch.run(question_page.id)
 
@@ -240,7 +236,6 @@ async def test_mixed_single_and_multi_step_sequences(tmp_db, question_page):
             [_scout(question_page.id), _assess(question_page.id)],
         ],
         call_id=p_call.id,
-        trace=trace,
     )
     await orch.run(question_page.id)
 

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -18,12 +18,11 @@ from rumil.tracing.tracer import CallTrace
 class ScriptedOrchestrator(BaseOrchestrator):
     """Returns pre-scripted batches of dispatches, one per loop iteration."""
 
-    def __init__(self, db, batches, call_id=None, trace=None):
+    def __init__(self, db, batches, call_id=None):
         super().__init__(db)
         self._batches = list(batches)
         self._index = 0
         self._call_id = call_id
-        self._trace = trace
         self.get_calls_count = 0
 
     async def run(self, root_question_id):
@@ -40,7 +39,6 @@ class ScriptedOrchestrator(BaseOrchestrator):
                     [batch],
                     root_question_id,
                     self._call_id,
-                    self._trace,
                 )
         finally:
             await self._teardown()
@@ -209,7 +207,6 @@ async def test_dispatch_executed_events_recorded(tmp_db, question_page):
         tmp_db,
         batches=[[_assess_dispatch(question_page.id)]],
         call_id=p_call.id,
-        trace=trace,
     )
     await orch.run(question_page.id)
 


### PR DESCRIPTION
## Summary
- Migrates `CallTrace` from explicit parameter threading (~15 functions) to a `ContextVar`, following the existing `_settings_var` pattern
- Records `ErrorEvent`s at every exception catch site so errors appear in the trace UI positioned precisely where they occurred (e.g. within a specific LLM exchange block)
- Adds a `phase` field to `ErrorEvent` (e.g. `tool_execution`, `api_call`, `closing_review`) so users can immediately see what was happening when the error occurred
- Frontend shows the phase as a styled badge on error events, with dark mode support

## Test plan
- [x] `uv run pyright` — 0 errors
- [x] `npx tsc --noEmit` — 0 errors  
- [x] `uv run pytest` — 98 passed
- [x] Smoke test passes clean
- [x] Injected deliberate tool error → confirmed error event appears in trace UI at correct position with `tool_execution` phase badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)