### PR TITLE
Skip auto-assess for scope-question dispatches in phase 2

### DIFF
--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -1421,6 +1421,8 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                     'Queued recursive investigation: question=%s, budget=%d — %s',
                     resolved[:8], d.payload.budget, d.payload.reason,
                 )
+            elif d.payload.question_id == question_id:
+                sequences.append([d])
             else:
                 assess = Dispatch(
                     call_type=CallType.ASSESS,


### PR DESCRIPTION
## Summary
- In the two-phase orchestrator's phase 2, we were appending an assess call after every non-recurse dispatch
- Now we only append the trailing assess when the dispatch targets a child question, not the scope question itself
- This avoids unnecessary assess calls after scouts (which target the scope question) without coupling the logic to call-type names

## Test plan
- [ ] Run a two-phase investigation and verify scouts don't get trailing assess calls
- [ ] Verify dispatches to child questions still get trailing assess calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)