### PR TITLE
Fix hydration mismatch in HashTargetProvider

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -973,9 +973,7 @@ function treeContainsAnchor(tree: TreeNode, hash: string): boolean {
 const HashTargetContext = createContext("");
 
 export function HashTargetProvider({ children }: { children: React.ReactNode }) {
-  const [hash, setHash] = useState(() =>
-    typeof window !== "undefined" ? window.location.hash.slice(1) : "",
-  );
+  const [hash, setHash] = useState("");
 
   useEffect(() => {
     setHash(window.location.hash.slice(1));


### PR DESCRIPTION
## Summary
- Initialize `HashTargetProvider` hash state as `""` on both server and client instead of reading `window.location.hash` during SSR
- The hash is read in `useEffect` after hydration, avoiding the server/client class name divergence on `trace-call-targeted`

## Test plan
- [x] Navigate to a trace URL with a `#call-xxx` fragment — no hydration warning in console, call still scrolls into view and highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)