### PR TITLE
Inject today's date into LLM system prompts

### DIFF
--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -28,4 +28,5 @@ To make this practical:
 - **Assert only on basic structural outcomes** that should hold as long as the LLM does something remotely reasonable: e.g. "at least one claim was created", "the call completed", "a judgement page exists". Don't assert on specific wording or exact counts.
 - **Keep budgets tiny** (1–2 calls) so tests stay fast.
 - **Mark LLM-calling tests** with `@pytest.mark.llm` so they can be skipped in CI or fast-feedback loops (`pytest -m "not llm"`).
+- **Time LLM tests when first written.** Run the test in isolation and check wall-clock time. If it takes longer than 15 seconds, mark it `@pytest.mark.integration` instead of `@pytest.mark.llm` (integration tests require `--integration` to run, which implies `--llm`).
 - If a test truly cannot call an LLM (e.g. testing pure parsing logic), mocking is fine — but mock at the highest boundary possible and use `mocker` from pytest-mock.

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING
 
 from collections.abc import Awaitable, Callable, Sequence
 
+from datetime import date
+
 import anthropic
 
 from anthropic.types import (
@@ -103,6 +105,12 @@ def _add_cache_breakpoint(messages: list[dict]) -> list[dict]:
         last["content"] = content
     msgs[-1] = last
     return msgs
+
+
+def _with_date_suffix(system_prompt: str) -> str:
+    """Append today's date to the system prompt."""
+    today = date.today().strftime("%Y-%m-%d")
+    return system_prompt + f"\n\nIMPORTANT: Today's date is {today}\n"
 
 
 _JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*\n(.*?)\n```", re.DOTALL)
@@ -296,6 +304,7 @@ async def call_api(
     """
     if bool(metadata) != bool(db):
         raise ValueError("metadata and db must be provided together")
+    system_prompt = _with_date_suffix(system_prompt)
     kwargs: dict = {
         "model": model,
         "max_tokens": DEFAULT_MAX_TOKENS,
@@ -583,6 +592,7 @@ async def _structured_call_parse(
     settings = get_settings()
     client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
     model = settings.model
+    system_prompt = _with_date_suffix(system_prompt)
 
     for attempt in range(MAX_API_RETRIES):
         try:

--- a/tests/test_date_suffix.py
+++ b/tests/test_date_suffix.py
@@ -1,0 +1,104 @@
+"""Tests for the date suffix injected into system prompts."""
+
+from datetime import date
+from unittest.mock import AsyncMock
+
+import anthropic.types
+import pytest
+
+from rumil.llm import _with_date_suffix, call_api, Tool
+from rumil.calls.common import run_agent_loop
+from rumil.moves.base import MoveState
+
+
+TODAY = date.today().strftime("%Y-%m-%d")
+DATE_MARKER = f"IMPORTANT: Today's date is {TODAY}"
+
+
+def test_with_date_suffix_appends_date():
+    result = _with_date_suffix("You are helpful.")
+    assert result.startswith("You are helpful.")
+    assert DATE_MARKER in result
+
+
+def test_with_date_suffix_does_not_double_when_called_twice():
+    """Calling _with_date_suffix on an already-suffixed string adds a second copy,
+    but call_api always receives the *original* prompt so this shouldn't happen
+    in practice. This test documents the raw function behavior."""
+    once = _with_date_suffix("Base prompt.")
+    twice = _with_date_suffix(once)
+    assert twice.count(DATE_MARKER) == 2
+
+
+async def test_call_api_sends_date_in_system_prompt(mocker):
+    """call_api should inject the date suffix into the system prompt it sends."""
+    fake_usage = anthropic.types.Usage(input_tokens=10, output_tokens=5)
+    fake_message = anthropic.types.Message(
+        id="msg_test",
+        type="message",
+        role="assistant",
+        content=[anthropic.types.TextBlock(type="text", text="hi")],
+        model="claude-haiku-4-5-20251001",
+        stop_reason="end_turn",
+        usage=fake_usage,
+    )
+    mock_create = AsyncMock(return_value=fake_message)
+    fake_client = mocker.MagicMock()
+    fake_client.messages.create = mock_create
+
+    await call_api(
+        fake_client,
+        "claude-haiku-4-5-20251001",
+        "You are helpful.",
+        [{"role": "user", "content": "hi"}],
+    )
+
+    call_kwargs = mock_create.call_args
+    sent_system = call_kwargs.kwargs.get("system") or call_kwargs[1].get("system")
+    assert DATE_MARKER in sent_system
+
+
+@pytest.mark.llm
+async def test_agent_loop_two_rounds_no_duplication(tmp_db, scout_call):
+    """A two-round agent loop should have the date suffix in the system prompt
+    exactly once per API call — never duplicated from round to round."""
+    call_count = []
+
+    async def ping(inp: dict) -> str:
+        call_count.append(1)
+        return "pong"
+
+    ping_tool = Tool(
+        name="ping",
+        description="Ping. Always call this tool every turn.",
+        input_schema={"type": "object", "properties": {}},
+        fn=ping,
+    )
+
+    state = MoveState(scout_call, tmp_db)
+    result = await run_agent_loop(
+        "You must call the ping tool every turn. Never stop calling it.",
+        "Start pinging.",
+        tools=[ping_tool],
+        call_id=scout_call.id,
+        db=tmp_db,
+        state=state,
+        max_rounds=2,
+    )
+
+    # The loop ran at least 2 rounds (tool was used)
+    assert len(call_count) >= 1
+
+    # Fetch full exchange records (get_llm_exchanges only returns summary columns,
+    # so retrieve each one individually to get system_prompt).
+    exchange_summaries = await tmp_db.get_llm_exchanges(scout_call.id)
+    assert len(exchange_summaries) >= 2, "Expected at least 2 exchanges for 2 rounds"
+
+    for summary in exchange_summaries:
+        full = await tmp_db.get_llm_exchange(summary["id"])
+        prompt = full["system_prompt"]
+        occurrences = prompt.count(DATE_MARKER)
+        assert occurrences == 1, (
+            f"Expected date marker exactly once, found {occurrences} "
+            f"in exchange round {summary.get('round')}"
+        )


### PR DESCRIPTION
## Summary
- Adds a global `IMPORTANT: Today's date is YYYY-MM-DD` suffix to every system prompt sent to the Anthropic API
- Applied at the `call_api` and `_structured_call_parse` boundaries so multi-round agent loops never duplicate it
- Adds tests covering the helper, the injection in `call_api`, and a real 2-round agent loop verifying no duplication

## Test plan
- [x] `uv run pytest tests/test_date_suffix.py -m "not llm"` — 3 non-LLM tests pass
- [x] `uv run pytest tests/test_date_suffix.py --llm` — agent loop duplication test passes (~2.4s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)