### PR TITLE
Fix stale trace events and group recursive calls as sequences

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import type {
   CallNodeOut,
@@ -1072,7 +1072,16 @@ export const CallNode = memo(function CallNode({
   const [isOpen, setIsOpen] = useState(depth === 0 || isHashTarget || hasTargetDescendant);
   const nodeRef = useRef<HTMLDivElement>(null);
   const isComplete = call.status === "complete" || call.status === "failed";
+  const queryClient = useQueryClient();
+  const prevCompleteRef = useRef(isComplete);
   const { data: events } = useCallEvents(call.id, isOpen, isComplete);
+
+  useEffect(() => {
+    if (isComplete && !prevCompleteRef.current) {
+      queryClient.invalidateQueries({ queryKey: traceKeys.callEvents(call.id) });
+    }
+    prevCompleteRef.current = isComplete;
+  }, [isComplete, call.id, queryClient]);
 
   useEffect(() => {
     if (hasTargetDescendant) {

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -356,7 +356,12 @@ async def assess_question(
     sequence_id: str | None = None,
     sequence_position: int | None = None,
 ) -> str | None:
-    """Run one Assess call on a question. Returns call ID, or None if no budget."""
+    """Run one Assess call on a question. Returns call ID, or None if no budget.
+
+    When ``sequence_id`` is provided, the summarise call is placed at
+    ``sequence_position`` and the assess call at ``sequence_position + 1``.
+    Callers should account for two positions being consumed.
+    """
     log.info("assess_question: question=%s", question_id[:8])
     if not await _consume_budget(db, force=force):
         return None
@@ -368,6 +373,9 @@ async def assess_question(
         sequence_position=sequence_position,
     )
 
+    assess_position = (
+        sequence_position + 1 if sequence_position is not None else None
+    )
     call = await db.create_call(
         CallType.ASSESS,
         scope_page_id=question_id,
@@ -375,7 +383,7 @@ async def assess_question(
         context_page_ids=context_page_ids,
         call_id=call_id,
         sequence_id=sequence_id,
-        sequence_position=sequence_position,
+        sequence_position=assess_position,
     )
     cls = ASSESS_CALL_CLASSES[get_settings().assess_call_variant]
     assess = cls(question_id, call, db, broadcaster=broadcaster)
@@ -1049,6 +1057,8 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         self._consumed: int = 0
         self._initial_call: Call | None = None
         self._parent_call_id: str | None = None
+        self._sequence_id: str | None = None
+        self._seq_position: int = 0
 
     def _effective_budget(self, global_remaining: int) -> int:
         if self._budget_cap is not None:
@@ -1090,6 +1100,13 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 f'TwoPhaseOrchestrator requires a budget of at least '
                 f'{MIN_TWOPHASE_BUDGET}, got {effective}'
             )
+        if self._parent_call_id:
+            seq = await self.db.create_call_sequence(
+                parent_call_id=self._parent_call_id,
+                scope_question_id=root_question_id,
+            )
+            self._sequence_id = seq.id
+            self._seq_position = 0
         try:
             while True:
                 remaining = await self.db.budget_remaining()
@@ -1128,7 +1145,11 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                         root_question_id, self.db,
                         parent_call_id=self._parent_call_id,
                         broadcaster=self.broadcaster, force=True,
+                        sequence_id=self._sequence_id,
+                        sequence_position=self._seq_position,
                     )
+                    if self._sequence_id is not None:
+                        self._seq_position += 2
         finally:
             await self._teardown()
             await own_db.close()
@@ -1193,6 +1214,11 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         if self._initial_call is not None:
             p_call = self._initial_call
             self._initial_call = None
+            if self._sequence_id is not None:
+                p_call.sequence_id = self._sequence_id
+                p_call.sequence_position = self._seq_position
+                await self.db.save_call(p_call)
+                self._seq_position += 1
         else:
             p_call = await self.db.create_call(
                 CallType.PRIORITIZATION,
@@ -1200,7 +1226,11 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 parent_call_id=parent_call_id,
                 budget_allocated=phase1_budget,
                 workspace=Workspace.PRIORITIZATION,
+                sequence_id=self._sequence_id,
+                sequence_position=self._seq_position if self._sequence_id else None,
             )
+            if self._sequence_id is not None:
+                self._seq_position += 1
         trace = CallTrace(p_call.id, self.db, broadcaster=self.broadcaster)
         set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=phase1_budget))
@@ -1288,7 +1318,11 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             parent_call_id=parent_call_id,
             budget_allocated=budget,
             workspace=Workspace.PRIORITIZATION,
+            sequence_id=self._sequence_id,
+            sequence_position=self._seq_position if self._sequence_id else None,
         )
+        if self._sequence_id is not None:
+            self._seq_position += 1
         trace = CallTrace(p_call.id, self.db, broadcaster=self.broadcaster)
         set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=budget))


### PR DESCRIPTION
## Summary
- **Fix missing trace events**: When a call completes, the tree query (3s poll) could mark it complete before the events query (5s poll) fetched the final events — freezing stale data via `staleTime: Infinity`. Added a `useEffect` that invalidates the events query when `isComplete` transitions to `true`.
- **Sequence grouping for recursive orchestrator calls**: Recursive `TwoPhaseOrchestrator` children (phase-1 → phase-2 → summarise → assess) now render as an ordered sequence lane instead of flat unordered children under the parent call.
- **Separate sequence positions for summarise/assess**: `assess_question` now places summarise at position N and assess at position N+1 when part of a sequence.

## Test plan
- [x] All 99 existing tests pass
- [x] Pyright and TSC type checks pass
- [x] Smoke test with `--force-twophase-recurse` confirms correct sequence structure in DB: `prioritization(0) → prioritization(1) → summarize(2) → assess(3)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)