### PR TITLE
Rename dispatch_web_research → dispatch_web_factcheck

### DIFF
--- a/prompts/two_phase_p2.md
+++ b/prompts/two_phase_p2.md
@@ -13,9 +13,9 @@ You must make all your dispatch calls now — this is your only turn.
 ### Dispatch tools
 
 - **dispatch_find_considerations**: Run general exploration on a question, based purely on trained knowledge without web research. Runs up to `max_rounds` rounds, stopping early when remaining fruit falls below `fruit_threshold`. Budget cost: between 1 and max_rounds (inclusive).
-- **Specialized scouts** (dispatch_scout_subquestions, dispatch_scout_estimates, dispatch_scout_hypotheses, dispatch_scout_analogies, dispatch_scout_paradigm_cases, dispatch_scout_facts_to_check, dispatch_scout_web_questions): Run additional scouting rounds on the **scope question** if more exploration is needed. Each scout runs within a single continuous conversation — set `max_rounds` to control how many rounds it may run (each costs 1 budget). Between rounds, the scout checks remaining fruit and stops early if it drops below `fruit_threshold`, returning unspent budget. Use these when it seems more useful to have further scouting on the top-level question (perhaps in light of recent investigations of subquestions). `dispatch_scout_web_questions` specifically identifies concrete factual questions answerable via web search — its output questions are good candidates for `dispatch_web_research`.
+- **Specialized scouts** (dispatch_scout_subquestions, dispatch_scout_estimates, dispatch_scout_hypotheses, dispatch_scout_analogies, dispatch_scout_paradigm_cases, dispatch_scout_facts_to_check, dispatch_scout_web_questions): Run additional scouting rounds on the **scope question** if more exploration is needed. Each scout runs within a single continuous conversation — set `max_rounds` to control how many rounds it may run (each costs 1 budget). Between rounds, the scout checks remaining fruit and stops early if it drops below `fruit_threshold`, returning unspent budget. Use these when it seems more useful to have further scouting on the top-level question (perhaps in light of recent investigations of subquestions). `dispatch_scout_web_questions` specifically identifies concrete factual questions answerable via web search — its output questions are good candidates for `dispatch_web_factcheck`.
 - **recurse_into_subquestion**: Launch a full two-phase prioritization cycle on a child question, with its own fan-out scouting and follow-up phases. Set `budget` to the number of units to allocate. Use this for subquestions that are substantial enough to warrant their own structured investigation. DO NOT use recurse_into_subquestion on the top-level scope question.
-- **dispatch_web_research**: Verify a factual claim via web search. Use only on questions that are specific, concrete fact-checks — verifying a particular claim ("Is it true that X?"), looking up a specific figure or date ("What is the actual value of Y?"), or searching for known examples of a well-defined category ("Are there known examples of Z?"). The question must be precise enough that a web search could answer it. Do not dispatch web research on broad analytical or interpretive questions. Budget cost: exactly 1.
+- **dispatch_web_factcheck**: Verify a specific factual claim via web search. Use only on questions that are concrete fact-checks — verifying a particular claim ("Is it true that X?"), looking up a specific figure or date ("What is the actual value of Y?"), or searching for known examples of a well-defined category ("Are there known examples of Z?"). The question must be precise enough that a web search could answer it. Do not dispatch web factchecks on broad, interpretive, hypothesis, or judgement questions. Budget cost: exactly 1.
 
 ## How to Decide
 
@@ -28,7 +28,7 @@ You will be shown scoring data from a preliminary assessment:
 
 - **Use the scores.** High-impact, high-fruit subquestions should get the most budget. Low-fruit questions may not need further investigation regardless of impact.
 - **Do not create subquestions directly.** Subquestion creation happens inside scouts. Use only the dispatch tools.
-- **Web research is for concrete fact-checks only.** Only dispatch `dispatch_web_research` on questions that target a specific, searchable factual claim — verification of an assertion, lookup of a figure or date, or search for known examples. Do not use it on broad or interpretive questions.
+- **Web research is for concrete fact-checks only.** Only dispatch `dispatch_web_factcheck` on questions that target a specific, searchable factual claim — verification of an assertion, lookup of a figure or date, or search for known examples. Do not use it on broad or interpretive questions.
 
 ### Guidance on how much budget to use
 Generally budgets of 5-20 mean "try to answer this question quickly", and budgets of 40-80 mean "this is worth a significant investigation to cover all the major angles", and budgets of 100+ mean "this is a major question which will involve deep dives into subquestions of its own".
@@ -65,4 +65,4 @@ The guidelines for scouts ranking fruit goes as:
 Your total dispatched budget (worst case) must not exceed your allocated budget:
 - Specialized scouts and find_considerations cost up to `max_rounds` (may stop early, but budget for the worst case)
 - `recurse_into_subquestion` costs exactly the `budget` you assign
-- `dispatch_web_research` costs exactly 1
+- `dispatch_web_factcheck` costs exactly 1

--- a/src/rumil/calls/dispatches.py
+++ b/src/rumil/calls/dispatches.py
@@ -269,10 +269,14 @@ DISPATCH_DEFS: dict[CallType, DispatchDef] = {
     ),
     CallType.WEB_RESEARCH: DispatchDef(
         call_type=CallType.WEB_RESEARCH,
-        name="dispatch_web_research",
+        name="dispatch_web_factcheck",
         description=(
-            "Dispatch web research for a question. Searches the web and extracts "
-            "relevant claims. Budget cost: exactly 1."
+            "Verify a specific factual claim via web search. Use ONLY on "
+            "questions that target a concrete, searchable fact — verifying "
+            "an assertion, looking up a figure or date, or finding known "
+            "examples of a well-defined category. Do NOT use on broad, "
+            "interpretive, hypothesis, or judgement questions. "
+            "Budget cost: exactly 1."
         ),
         schema=WebResearchDispatchPayload,
     ),


### PR DESCRIPTION
## Summary
- Renamed the web research dispatch tool from `dispatch_web_research` to `dispatch_web_factcheck` so the name itself signals factual-only scope
- Rewrote the tool description to explicitly prohibit use on broad, interpretive, hypothesis, or judgement questions
- Updated all references in the `two_phase_p2.md` prompt to match

## Motivation
The prioritizer was dispatching web research against question types it shouldn't (e.g. hypothesis questions). The old tool name and description were too permissive — the description just said "Searches the web and extracts relevant claims" with no constraints. While the prompt text already had guidance, the tool description is the most immediate context at the point of tool selection.

## Test plan
- [x] All existing tests pass (99 passed)
- [ ] Run a smoke test and verify web research is not dispatched against non-factual questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)