### PR TITLE
Record caught exceptions as trace events

### DIFF
--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -357,25 +357,44 @@ async def call_api(
                         )
                 if metadata.user_messages is None and len(messages) > 1:
                     metadata.user_messages = _serialize_messages(messages)
-                await _save_exchange(
-                    metadata,
-                    db=db,
-                    model=model,
-                    system_prompt=system_prompt,
-                    response_text="\n".join(text_parts) or None,
-                    tool_calls=tool_call_data,
-                    input_tokens=response.usage.input_tokens,
-                    output_tokens=response.usage.output_tokens,
-                    duration_ms=elapsed_ms,
-                    cache_creation_input_tokens=getattr(
-                        response.usage, "cache_creation_input_tokens", 0
+                try:
+                    await _save_exchange(
+                        metadata,
+                        db=db,
+                        model=model,
+                        system_prompt=system_prompt,
+                        response_text="\n".join(text_parts) or None,
+                        tool_calls=tool_call_data,
+                        input_tokens=response.usage.input_tokens,
+                        output_tokens=response.usage.output_tokens,
+                        duration_ms=elapsed_ms,
+                        cache_creation_input_tokens=getattr(
+                            response.usage, "cache_creation_input_tokens", 0
+                        )
+                        or 0,
+                        cache_read_input_tokens=getattr(
+                            response.usage, "cache_read_input_tokens", 0
+                        )
+                        or 0,
                     )
-                    or 0,
-                    cache_read_input_tokens=getattr(
-                        response.usage, "cache_read_input_tokens", 0
+                except Exception as exc:
+                    log.error(
+                        "Failed to save exchange for call %s: %s",
+                        metadata.call_id[:8],
+                        exc,
+                        exc_info=True,
                     )
-                    or 0,
-                )
+                    trace = get_trace()
+                    if trace:
+                        await trace.record(
+                            ErrorEvent(
+                                message=(
+                                    f"Failed to save exchange: "
+                                    f"{type(exc).__name__}: {exc}"
+                                ),
+                                phase=metadata.phase,
+                            )
+                        )
             return APIResponse(message=response, duration_ms=elapsed_ms)
         except Exception as e:
             status = getattr(e, "status_code", None)

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -89,6 +89,7 @@ from rumil.tracing.trace_events import (
     DispatchExecutedEvent,
     DispatchesPlannedEvent,
     DispatchTraceItem,
+    ErrorEvent,
     ScoringCompletedEvent,
     SubquestionScoreItem,
 )
@@ -1140,6 +1141,18 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 for r in results:
                     if isinstance(r, Exception):
                         log.error('Concurrent dispatch failed: %s', r, exc_info=r)
+                        if result.call_id:
+                            trace = CallTrace(
+                                result.call_id, self.db,
+                                broadcaster=self.broadcaster,
+                            )
+                            await trace.record(ErrorEvent(
+                                message=(
+                                    f"Concurrent dispatch failed: "
+                                    f"{type(r).__name__}: {r}"
+                                ),
+                                phase="dispatch",
+                            ))
 
                 if not any(not isinstance(r, Exception) for r in results):
                     break

--- a/src/rumil/tracing/tracer.py
+++ b/src/rumil/tracing/tracer.py
@@ -44,7 +44,15 @@ class CallTrace:
         dumped = event_data.model_dump()
         dumped["ts"] = datetime.now(timezone.utc).isoformat()
         dumped["call_id"] = self.call_id
-        await self.db.save_call_trace(self.call_id, [dumped])
+        try:
+            await self.db.save_call_trace(self.call_id, [dumped])
+        except Exception as e:
+            log.error(
+                "Failed to persist trace event %s for call %s: %s",
+                dumped.get("event"),
+                self.call_id[:8],
+                e,
+            )
         if self._broadcaster:
             try:
                 await self._broadcaster.send(dumped["event"], dumped)

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 
+from rumil.database import DB
 from rumil.models import (
     AssessDispatchPayload,
     CallType,
@@ -11,7 +12,11 @@ from rumil.models import (
     FindConsiderationsMode,
     ScoutDispatchPayload,
 )
-from rumil.orchestrator import BaseOrchestrator
+from rumil.orchestrator import (
+    BaseOrchestrator,
+    PrioritizationResult,
+    TwoPhaseOrchestrator,
+)
 from rumil.tracing.tracer import CallTrace
 
 
@@ -224,3 +229,50 @@ async def test_dispatch_executed_events_recorded(tmp_db, question_page):
     assert evt["child_call_type"] == "assess"
     assert evt["question_id"] == question_page.id
     assert evt["child_call_id"] is not None
+
+
+async def test_concurrent_dispatch_failure_recorded_in_trace(
+    tmp_db, question_page, mocker,
+):
+    """When a dispatch raises during the TwoPhaseOrchestrator's concurrent
+    gather, an ErrorEvent should be recorded on the prioritization call's trace.
+    """
+    p_call = await tmp_db.create_call(
+        CallType.PRIORITIZATION,
+        scope_page_id=question_page.id,
+    )
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    orch._call_id = p_call.id
+
+    dispatches = [[_assess_dispatch(question_page.id)]]
+    call_count = 0
+
+    async def fake_get_next_batch(question_id, budget, parent_call_id=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return PrioritizationResult(
+                dispatch_sequences=dispatches,
+                call_id=p_call.id,
+            )
+        return PrioritizationResult(dispatch_sequences=[])
+
+    mocker.patch.object(orch, "_get_next_batch", side_effect=fake_get_next_batch)
+    mocker.patch.object(
+        DB, "resolve_page_id",
+        side_effect=ConnectionError("Simulated connection failure"),
+    )
+
+    await orch.run(question_page.id)
+
+    rows = (
+        await tmp_db.client.table("calls")
+        .select("trace_json")
+        .eq("id", p_call.id)
+        .execute()
+    )
+    trace_json = rows.data[0]["trace_json"]
+    error_events = [e for e in trace_json if e.get("event") == "error"]
+    assert len(error_events) >= 1
+    assert "Simulated connection failure" in error_events[0]["message"]


### PR DESCRIPTION
## Summary
- **Orchestrator gather failures**: Exceptions caught via `return_exceptions=True` in `TwoPhaseOrchestrator.run()` are now recorded as `ErrorEvent`s on the parent prioritization call's trace, not just logged to stderr
- **`_save_exchange` DB failures**: When persisting an LLM exchange fails (e.g. DB client closed), the error is now caught separately from API failures, logged, and traced — previously it was misidentified as a non-retryable API error
- **`CallTrace.record()` resilience**: DB write failures during trace persistence are now caught and logged instead of propagating, preventing cascading failures when the DB connection is dead

## Test plan
- [x] New test `test_concurrent_dispatch_failure_recorded_in_trace` verifies ErrorEvent appears in trace when a dispatch raises during the TwoPhaseOrchestrator gather
- [x] All existing tests pass (`99 passed, 37 skipped`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)