### PR TITLE
Style markdown headings in page detail view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,10 @@ To add a new call type: subclass `CallRunner`. Set `call_type`, override `_make_
 
 **Frontend** (`frontend/`): Next.js TypeScript app with Tailwind. Uses pnpm. Run with `cd frontend && pnpm dev`. The frontend port mirrors the API port: if the API is on `localhost:800X`, the frontend will be on `localhost:300X` (Next.js auto-increments when the default port is taken). Use this to find and stop the frontend process. TypeScript types in `frontend/src/api/` are auto-generated from the API's OpenAPI schema — **never create or edit these files by hand**. When API schemas change, theese need to be regenerated with `./scripts/generate-api-types.sh` (or `cd frontend && pnpm generate-api`). This is the only mechanism for sharing types between backend and frontend; do not manually duplicate type definitions. When `schemas.py` or `models.py` is edited, `./scripts/generate-api-types.sh` is automaticaly run via a hook.
 
+## Worktrees and localhost URLs
+
+When the user pastes a `localhost:<port>` URL, do NOT use that port literally. Instead, map it to this worktree's port. The frontend port is derived from `frontend/.env.local`: if the API URL there is `localhost:800X`, the frontend is on `localhost:300X`. Always read `frontend/.env.local` to determine the correct port and rewrite any user-provided localhost URL accordingly. Edits must go into the current worktree, not the main repo or other worktrees.
+
 ## Key Conventions
 
 - **NEVER pass `--prod` when running `main.py` unless the user explicitly asks you to.** The production database contains real research data. Default to the local database for all testing, development, and exploratory runs.

--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -542,7 +542,12 @@ const styles = `
   .page-content h4, .page-content h5, .page-content h6 {
     margin: 1em 0 0.5em;
     line-height: 1.3;
+    font-weight: 600;
   }
+  .page-content h1 { font-size: 1.4em; }
+  .page-content h2 { font-size: 1.2em; }
+  .page-content h3 { font-size: 1.05em; }
+  .page-content h4 { font-size: 1em; }
   .page-content h1:first-child, .page-content h2:first-child,
   .page-content h3:first-child {
     margin-top: 0;


### PR DESCRIPTION
## Summary
- Add `font-weight: 600` and explicit `font-size` rules (h1: 1.4em, h2: 1.2em, h3: 1.05em, h4: 1em) to `.page-content` headings so they render as visually distinct section headers instead of inheriting the base body text size
- Add CLAUDE.md guidance on remapping user-provided localhost URLs to the current worktree's port

## Test plan
- [x] Verified headings render correctly on a page with h2 and h3 content via Playwright screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)