### PR TITLE
Fix cycle bugs in mapper and summary graph traversals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 An LLM-powered research workspace. Users pose questions, and the system investigates them by making structured LLM calls (find_considerations, assess, prioritize, ingest) that produce "pages" (claims, questions, judgements, concepts). Pages link together into a research graph with considerations bearing on questions. The codebase is optimised for experimentation, containing multiple implementations of pluggable abstractions, rather than being a monolithic application where there's only one way of achieving things.
 
+**The page graph can be cyclic.** Any code that traverses page links (parent/child questions, considerations, etc.) must track visited nodes to avoid infinite recursion. Use a `_visited: set[str]` parameter — see `context.py` for the standard pattern.
+
 ## Running
 
 Environment managed with `uv`.

--- a/src/rumil/mapper.py
+++ b/src/rumil/mapper.py
@@ -123,7 +123,18 @@ def _render_judgement(j: Page, index: int, total: int) -> str:
 </div>"""
 
 
-async def _render_question(question_id: str, db: DB, depth: int = 0) -> str:
+async def _render_question(
+    question_id: str,
+    db: DB,
+    depth: int = 0,
+    _visited: set[str] | None = None,
+) -> str:
+    if _visited is None:
+        _visited = set()
+    if question_id in _visited:
+        return ""
+    _visited = _visited | {question_id}
+
     question = await db.get_page(question_id)
     if not question:
         return ""
@@ -173,7 +184,7 @@ async def _render_question(question_id: str, db: DB, depth: int = 0) -> str:
     if children:
         ch_html = '<div class="section"><h4>Sub-questions</h4>'
         for child in children:
-            ch_html += await _render_question(child.id, db, depth=depth + 1)
+            ch_html += await _render_question(child.id, db, depth=depth + 1, _visited=_visited)
         ch_html += "</div>"
 
     q_sel_id = f"qb-{question_id[:8]}"

--- a/src/rumil/summary.py
+++ b/src/rumil/summary.py
@@ -23,6 +23,7 @@ async def build_research_tree(
     depth: int = 0,
     max_depth: int = 4,
     summary_cutoff: int | None = None,
+    _visited: set[str] | None = None,
 ) -> str:
     """
     Recursively build a full picture of the research on a question.
@@ -31,6 +32,12 @@ async def build_research_tree(
     reasoning, judgement bodies). Deeper levels render only page summaries
     to keep total context size manageable. Defaults to max_depth // 2.
     """
+    if _visited is None:
+        _visited = set()
+    if question_id in _visited:
+        return ""
+    _visited = _visited | {question_id}
+
     question = await db.get_page(question_id)
     if not question:
         return ""
@@ -109,6 +116,7 @@ async def build_research_tree(
                         depth=depth + 1,
                         max_depth=max_depth,
                         summary_cutoff=summary_cutoff,
+                        _visited=_visited,
                     )
                 )
 


### PR DESCRIPTION
## Summary
- `_render_question()` in `mapper.py` and `build_research_tree()` in `summary.py` recurse into child questions without tracking visited nodes, causing infinite recursion or exponential blowup on cyclic page graphs
- Added `_visited: set[str]` cycle protection to both, matching the standard pattern used in `context.py`
- Documented the cyclic-graph invariant in `CLAUDE.md`

## Test plan
- [ ] Create a cyclic question graph (Q1→Q2→Q1) in a scratch workspace
- [ ] Run `--summary` on Q1 and verify it completes without error
- [ ] Generate an HTML map and verify it renders without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)