### PR TITLE
Staged runs: event-sourced mutations with run isolation

### DIFF
--- a/main.py
+++ b/main.py
@@ -289,7 +289,9 @@ async def cmd_report(
         sys.exit(1)
 
     print(f"\nGenerating report for: {question.headline[:80]}")
-    print("(This will use multiple LLM calls but does not count against research budget)\n")
+    print(
+        "(This will use multiple LLM calls but does not count against research budget)\n"
+    )
 
     report_text = await generate_report(question_id, db, max_depth=max_depth)
     path = save_report(report_text, question.headline)
@@ -480,6 +482,7 @@ async def cmd_ab(
             prod=arm_settings.is_prod_db,
             client=db.client,
             project_id=db.project_id,
+            staged=True,
             ab_run_id=ab_run_id,
         )
         config = arm_settings.capture_config()

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -254,6 +254,7 @@ async def _run_ab(
             run_id=str(uuid.uuid4()),
             client=db.client,
             project_id=db.project_id,
+            staged=True,
             ab_run_id=ab_run_id,
         )
         config = arm_settings.capture_config()

--- a/src/rumil/calls/summarize.py
+++ b/src/rumil/calls/summarize.py
@@ -220,12 +220,7 @@ async def _supersede_old_summaries(
             and old.page_type == PageType.SUMMARY
             and old.id != new_summary_id
         ):
-            await (
-                db.client.table("pages")
-                .update({"is_superseded": True, "superseded_by": new_summary_id})
-                .eq("id", old.id)
-                .execute()
-            )
+            await db.supersede_page(old.id, new_summary_id)
             log.info(
                 "Superseded old summary %s with %s", old.id[:8], new_summary_id[:8]
             )

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -399,12 +399,13 @@ class DB:
         )
 
     async def get_page(self, page_id: str) -> Page | None:
-        rows = _rows(
-            await self._execute(
-                self.client.table("pages").select("*").eq("id", page_id)
-            )
-        )
-        return _row_to_page(rows[0]) if rows else None
+        query = self.client.table("pages").select("*").eq("id", page_id)
+        query = self._staged_filter(query)
+        rows = _rows(await self._execute(query))
+        if not rows:
+            return None
+        pages = await self._apply_page_events([_row_to_page(rows[0])])
+        return pages[0] if pages else None
 
     async def get_pages_by_ids(self, page_ids: Sequence[str]) -> dict[str, Page]:
         """Bulk-fetch pages by ID. Returns {id: Page} for pages that exist."""
@@ -566,14 +567,13 @@ class DB:
         )
 
     async def get_link(self, link_id: str) -> PageLink | None:
-        rows = _rows(
-            await self._execute(
-                self.client.table("page_links")
-                .select("*")
-                .eq("id", link_id)
-            )
-        )
-        return _row_to_link(rows[0]) if rows else None
+        query = self.client.table("page_links").select("*").eq("id", link_id)
+        query = self._staged_filter(query)
+        rows = _rows(await self._execute(query))
+        if not rows:
+            return None
+        links = await self._apply_link_events([_row_to_link(rows[0])])
+        return links[0] if links else None
 
     async def get_links_to(self, page_id: str) -> list[PageLink]:
         query = self.client.table("page_links").select("*").eq("to_page_id", page_id)

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -123,22 +123,36 @@ def _row_to_call_sequence(row: dict[str, Any]) -> CallSequence:
     )
 
 
+class MutationState:
+    """Cached mutation events for a staged run, keyed by target_id."""
+
+    __slots__ = ("superseded_pages", "deleted_links", "link_role_overrides")
+
+    def __init__(self) -> None:
+        self.superseded_pages: dict[str, str] = {}
+        self.deleted_links: set[str] = set()
+        self.link_role_overrides: dict[str, LinkRole] = {}
+
+
 class DB:
     def __init__(
         self,
         run_id: str,
         client: AsyncClient,
         project_id: str = "",
+        staged: bool = False,
         ab_run_id: str | None = None,
     ):
         self.run_id = run_id
         self.client = client
         self.project_id = project_id
+        self.staged = staged
         self.ab_run_id = ab_run_id
         self._semaphore = asyncio.Semaphore(
             get_settings().db_max_concurrent_queries
         )
         self._prod: bool = False
+        self._mutation_cache: MutationState | None = None
 
     @classmethod
     async def create(
@@ -147,6 +161,7 @@ class DB:
         prod: bool = False,
         project_id: str = "",
         client: AsyncClient | None = None,
+        staged: bool = False,
         ab_run_id: str | None = None,
     ) -> "DB":
         if client is None:
@@ -156,7 +171,7 @@ class DB:
             )
         db = cls(
             run_id=run_id, client=client, project_id=project_id,
-            ab_run_id=ab_run_id,
+            staged=staged, ab_run_id=ab_run_id,
         )
         db._prod = prod
         return db
@@ -164,7 +179,7 @@ class DB:
     async def fork(self) -> "DB":
         """Create a new DB instance with a fresh Supabase client.
 
-        Shares run_id, project_id, and ab_run_id with the parent but gets
+        Shares run_id, project_id, and staged flag with the parent but gets
         its own HTTP connection. Use this to scope connections to a single
         call, avoiding HTTP/2 stream exhaustion on long-running jobs.
         """
@@ -176,6 +191,7 @@ class DB:
             run_id=self.run_id,
             client=client,
             project_id=self.project_id,
+            staged=self.staged,
             ab_run_id=self.ab_run_id,
         )
         db._prod = self._prod
@@ -193,11 +209,93 @@ class DB:
         async with self._semaphore:
             return await query.execute()
 
-    def _ab_filter(self, query: Any, table: str = "pages") -> Any:
-        """Apply AB run isolation filter to a query."""
-        if self.ab_run_id:
-            return query.or_(f"ab_run_id.is.null,ab_run_id.eq.{self.ab_run_id}")
-        return query.is_("ab_run_id", "null")
+    def _staged_filter(self, query: Any) -> Any:
+        """Apply staged-run visibility filter to a query.
+
+        Staged runs see baseline (staged=false) + their own rows.
+        Non-staged runs see only baseline rows.
+        """
+        if self.staged:
+            return query.or_(f"staged.eq.false,run_id.eq.{self.run_id}")
+        return query.eq("staged", False)
+
+    async def _load_mutation_state(self) -> MutationState:
+        """Fetch and cache mutation events for this staged run."""
+        if self._mutation_cache is not None:
+            return self._mutation_cache
+        if not self.staged:
+            self._mutation_cache = MutationState()
+            return self._mutation_cache
+        rows = _rows(
+            await self._execute(
+                self.client.table("mutation_events")
+                .select("event_type, target_id, payload")
+                .eq("run_id", self.run_id)
+                .order("created_at")
+            )
+        )
+        state = MutationState()
+        for row in rows:
+            et = row["event_type"]
+            tid = row["target_id"]
+            payload = row.get("payload") or {}
+            if et == "supersede_page":
+                state.superseded_pages[tid] = payload.get("new_page_id", "")
+            elif et == "delete_link":
+                state.deleted_links.add(tid)
+            elif et == "change_link_role":
+                state.link_role_overrides[tid] = LinkRole(payload["new_role"])
+        self._mutation_cache = state
+        return state
+
+    def _invalidate_mutation_cache(self) -> None:
+        self._mutation_cache = None
+
+    async def _apply_page_events(self, pages: Sequence[Page]) -> list[Page]:
+        """Overlay mutation events onto a batch of pages."""
+        state = await self._load_mutation_state()
+        if not state.superseded_pages:
+            return list(pages)
+        result: list[Page] = []
+        for p in pages:
+            if p.id in state.superseded_pages:
+                p = p.model_copy(update={
+                    "is_superseded": True,
+                    "superseded_by": state.superseded_pages[p.id],
+                })
+            result.append(p)
+        return result
+
+    async def _apply_link_events(self, links: Sequence[PageLink]) -> list[PageLink]:
+        """Overlay mutation events onto a batch of links."""
+        state = await self._load_mutation_state()
+        if not state.deleted_links and not state.link_role_overrides:
+            return list(links)
+        result: list[PageLink] = []
+        for link in links:
+            if link.id in state.deleted_links:
+                continue
+            if link.id in state.link_role_overrides:
+                link = link.model_copy(update={
+                    "role": state.link_role_overrides[link.id],
+                })
+            result.append(link)
+        return result
+
+    async def record_mutation_event(
+        self, event_type: str, target_id: str, payload: dict,
+    ) -> None:
+        """Record a mutation event (staged runs only)."""
+        await self._execute(
+            self.client.table("mutation_events").insert({
+                "id": str(uuid.uuid4()),
+                "run_id": self.run_id,
+                "event_type": event_type,
+                "target_id": target_id,
+                "payload": payload,
+            })
+        )
+        self._invalidate_mutation_cache()
 
     async def get_or_create_project(self, name: str) -> Project:
         rows = _rows(
@@ -269,7 +367,7 @@ class DB:
                     "is_superseded": page.is_superseded,
                     "extra": page.extra,
                     "run_id": self.run_id,
-                    "ab_run_id": self.ab_run_id,
+                    "staged": self.staged,
                     "abstract": page.abstract,
                 }
             )
@@ -319,7 +417,7 @@ class DB:
             batch = id_list[start:start + batch_size]
             rows = _rows(
                 await self._execute(
-                    self._ab_filter(
+                    self._staged_filter(
                         self.client.table("pages").select("*").in_("id", batch)
                     )
                 )
@@ -327,7 +425,8 @@ class DB:
             for r in rows:
                 page = _row_to_page(r)
                 result[page.id] = page
-        return result
+        pages = await self._apply_page_events(list(result.values()))
+        return {p.id: p for p in pages}
 
     async def resolve_page_id(self, page_id: str) -> str | None:
         """Resolve a page ID to a full UUID. Handles both full UUIDs and
@@ -383,8 +482,8 @@ class DB:
             query = query.eq("project_id", self.project_id)
         if active_only:
             query = query.eq("is_superseded", False)
-        query = self._ab_filter(query)
-        return [
+        query = self._staged_filter(query)
+        pages = [
             _row_to_page(r)
             for r in _rows(
                 await self._execute(
@@ -392,6 +491,10 @@ class DB:
                 )
             )
         ]
+        pages = await self._apply_page_events(pages)
+        if active_only:
+            pages = [p for p in pages if p.is_active()]
+        return pages
 
     async def get_pages(
         self,
@@ -408,8 +511,8 @@ class DB:
             query = query.eq("page_type", page_type.value)
         if active_only:
             query = query.eq("is_superseded", False)
-        query = self._ab_filter(query)
-        return [
+        query = self._staged_filter(query)
+        pages = [
             _row_to_page(r)
             for r in _rows(
                 await self._execute(
@@ -417,8 +520,17 @@ class DB:
                 )
             )
         ]
+        pages = await self._apply_page_events(pages)
+        if active_only:
+            pages = [p for p in pages if p.is_active()]
+        return pages
 
     async def supersede_page(self, old_id: str, new_id: str) -> None:
+        if self.staged:
+            await self.record_mutation_event(
+                "supersede_page", old_id, {"new_page_id": new_id},
+            )
+            return
         await self._execute(
             self.client.table("pages").update(
                 {
@@ -448,7 +560,7 @@ class DB:
                     "role": link.role.value,
                     "created_at": link.created_at.isoformat(),
                     "run_id": self.run_id,
-                    "ab_run_id": self.ab_run_id,
+                    "staged": self.staged,
                 }
             )
         )
@@ -465,15 +577,15 @@ class DB:
 
     async def get_links_to(self, page_id: str) -> list[PageLink]:
         query = self.client.table("page_links").select("*").eq("to_page_id", page_id)
-        query = self._ab_filter(query, table="page_links")
+        query = self._staged_filter(query)
         rows = _rows(await self._execute(query))
-        return [_row_to_link(r) for r in rows]
+        return await self._apply_link_events([_row_to_link(r) for r in rows])
 
     async def get_links_from(self, page_id: str) -> list[PageLink]:
         query = self.client.table("page_links").select("*").eq("from_page_id", page_id)
-        query = self._ab_filter(query, table="page_links")
+        query = self._staged_filter(query)
         rows = _rows(await self._execute(query))
-        return [_row_to_link(r) for r in rows]
+        return await self._apply_link_events([_row_to_link(r) for r in rows])
 
     async def get_latest_summary_for_question(self, question_id: str) -> "Page | None":
         """Return the most recent active SUMMARY page linked to a question."""
@@ -749,9 +861,9 @@ class DB:
             .eq("from_page_id", from_page_id)
             .eq("to_page_id", to_page_id)
         )
-        query = self._ab_filter(query, table="page_links")
+        query = self._staged_filter(query)
         rows = _rows(await self._execute(query))
-        return [_row_to_link(r) for r in rows]
+        return await self._apply_link_events([_row_to_link(r) for r in rows])
 
     async def get_all_links(
         self, page_ids: set[str] | None = None,
@@ -765,9 +877,9 @@ class DB:
         if page_ids is not None:
             return await self._get_links_for_pages(page_ids)
         query = self.client.table("page_links").select("*")
-        query = self._ab_filter(query, table="page_links")
+        query = self._staged_filter(query)
         if self.project_id:
-            page_ids_query = self._ab_filter(
+            page_ids_query = self._staged_filter(
                 self.client.table("pages")
                 .select("id")
                 .eq("project_id", self.project_id)
@@ -775,12 +887,14 @@ class DB:
             page_ids_rows = _rows(await self._execute(page_ids_query.limit(50000)))
             proj_page_ids = {r["id"] for r in page_ids_rows}
             rows = _rows(await self._execute(query.limit(50000)))
-            return [
+            links = [
                 _row_to_link(r) for r in rows
                 if r["from_page_id"] in proj_page_ids or r["to_page_id"] in proj_page_ids
             ]
-        rows = _rows(await self._execute(query.limit(50000)))
-        return [_row_to_link(r) for r in rows]
+        else:
+            rows = _rows(await self._execute(query.limit(50000)))
+            links = [_row_to_link(r) for r in rows]
+        return await self._apply_link_events(links)
 
     async def _get_links_for_pages(
         self, page_ids: set[str],
@@ -796,21 +910,31 @@ class DB:
             batch = id_list[start:start + batch_size]
             for col in ('from_page_id', 'to_page_id'):
                 query = self.client.table("page_links").select("*").in_(col, batch)
-                query = self._ab_filter(query, table="page_links")
+                query = self._staged_filter(query)
                 rows = _rows(await self._execute(query.limit(50000)))
                 for r in rows:
                     link = _row_to_link(r)
                     all_links[link.id] = link
-        return list(all_links.values())
+        return await self._apply_link_events(list(all_links.values()))
 
     async def delete_link(self, link_id: str) -> None:
         """Delete a page link by ID."""
+        if self.staged:
+            await self.record_mutation_event(
+                "delete_link", link_id, {},
+            )
+            return
         await self._execute(
             self.client.table("page_links").delete().eq("id", link_id)
         )
 
     async def update_link_role(self, link_id: str, role: LinkRole) -> None:
         """Update a link's role."""
+        if self.staged:
+            await self.record_mutation_event(
+                "change_link_role", link_id, {"new_role": role.value},
+            )
+            return
         await self._execute(
             self.client.table("page_links").update(
                 {"role": role.value}
@@ -1042,8 +1166,8 @@ class DB:
         params: dict[str, Any] = {"ws": workspace.value}
         if self.project_id:
             params["pid"] = self.project_id
-        if self.ab_run_id:
-            params["p_ab_run_id"] = self.ab_run_id
+        if self.staged:
+            params["p_staged_run_id"] = self.run_id
         rows = _rows(
             await self._execute(self.client.rpc("get_root_questions", params))
         )
@@ -1211,6 +1335,7 @@ class DB:
                     "project_id": self.project_id,
                     "question_id": question_id,
                     "config": config or {},
+                    "staged": self.staged,
                     "ab_run_id": self.ab_run_id,
                     "ab_arm": ab_arm,
                 }
@@ -1331,6 +1456,11 @@ class DB:
 
     async def delete_run_data(self, delete_project: bool = False) -> None:
         """Delete all data for this run_id. Used by test teardown."""
+        await self._execute(
+            self.client.table("mutation_events").delete().eq(
+                "run_id", self.run_id
+            )
+        )
         await self._execute(
             self.client.table("call_llm_exchanges").delete().eq(
                 "run_id", self.run_id

--- a/src/rumil/embeddings.py
+++ b/src/rumil/embeddings.py
@@ -165,8 +165,8 @@ async def search_pages_by_vector(
         results.append((page, similarity))
     if db.staged:
         pages = await db._apply_page_events([p for p, _ in results])
-        active_ids = {p.id for p in pages if p.is_active()}
-        results = [(p, s) for p, s in results if p.id in active_ids]
+        scores = {p.id: s for p, s in results}
+        results = [(p, scores[p.id]) for p in pages if p.is_active()]
     return results
 
 

--- a/src/rumil/embeddings.py
+++ b/src/rumil/embeddings.py
@@ -80,15 +80,19 @@ async def store_embedding(
     embedding: Sequence[float],
 ) -> None:
     """Store an embedding vector for a page field (upsert)."""
-    embedding_str = '[' + ','.join(str(x) for x in embedding) + ']'
-    await db.client.table("page_embeddings").upsert(
-        {
-            "page_id": page_id,
-            "field_name": field_name,
-            "embedding": embedding_str,
-        },
-        on_conflict="page_id,field_name",
-    ).execute()
+    embedding_str = "[" + ",".join(str(x) for x in embedding) + "]"
+    await (
+        db.client.table("page_embeddings")
+        .upsert(
+            {
+                "page_id": page_id,
+                "field_name": field_name,
+                "embedding": embedding_str,
+            },
+            on_conflict="page_id,field_name",
+        )
+        .execute()
+    )
     log.debug("Stored %s embedding for page %s", field_name, page_id[:8])
 
 
@@ -139,7 +143,7 @@ async def search_pages_by_vector(
     Returns (page, similarity_score) pairs sorted by descending similarity.
     Optionally filter to embeddings of a specific field_name.
     """
-    embedding_str = '[' + ','.join(str(x) for x in query_embedding) + ']'
+    embedding_str = "[" + ",".join(str(x) for x in query_embedding) + "]"
     params: dict[str, Any] = {
         "query_embedding": embedding_str,
         "match_threshold": match_threshold,
@@ -151,14 +155,18 @@ async def search_pages_by_vector(
         params["filter_project_id"] = db.project_id
     if field_name:
         params["filter_field_name"] = field_name
-    if db.ab_run_id:
-        params["filter_ab_run_id"] = db.ab_run_id
+    if db.staged:
+        params["filter_staged_run_id"] = db.run_id
     rows: _Rows = _rows(await db.client.rpc("match_pages", params).execute())
-    results = []
+    results: list[tuple[Page, float]] = []
     for row in rows:
         page = _row_to_page(row)
         similarity = row["similarity"]
         results.append((page, similarity))
+    if db.staged:
+        pages = await db._apply_page_events([p for p, _ in results])
+        active_ids = {p.id for p in pages if p.is_active()}
+        results = [(p, s) for p, s in results if p.id in active_ids]
     return results
 
 

--- a/src/rumil/orchestrator.py
+++ b/src/rumil/orchestrator.py
@@ -745,13 +745,19 @@ class BaseOrchestrator(ABC):
                 ))
 
         executed = False
+        seq_pos = 0
         for i, dispatch in enumerate(sequence):
             force = i > 0 and await self.db.budget_remaining() <= 0
             await self._execute_dispatch(
                 dispatch, scope_question_id, parent_call_id,
                 force=force, call_id=pre_ids[i],
-                sequence_id=seq_id, sequence_position=i if is_multi_step else None,
+                sequence_id=seq_id,
+                sequence_position=seq_pos if is_multi_step else None,
             )
+            if isinstance(dispatch.payload, AssessDispatchPayload):
+                seq_pos += 2
+            else:
+                seq_pos += 1
             executed = True
         return executed
 

--- a/supabase/migrations/20260328102907_staged_runs.sql
+++ b/supabase/migrations/20260328102907_staged_runs.sql
@@ -1,0 +1,129 @@
+-- Staged runs: event-sourced mutations + staged visibility
+
+-- 1. mutation_events table for event-sourced superseding and link mutations
+CREATE TABLE mutation_events (
+    id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    run_id TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('supersede_page', 'delete_link', 'change_link_role')),
+    target_id TEXT NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX idx_mutation_events_target ON mutation_events(target_id);
+CREATE INDEX idx_mutation_events_run ON mutation_events(run_id);
+
+ALTER TABLE mutation_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "allow all" ON mutation_events FOR ALL USING (true) WITH CHECK (true);
+
+-- 2. staged column on pages and page_links (replaces ab_run_id for visibility)
+ALTER TABLE pages ADD COLUMN staged BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE page_links ADD COLUMN staged BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE INDEX idx_pages_staged ON pages(staged) WHERE staged = TRUE;
+CREATE INDEX idx_page_links_staged ON page_links(staged) WHERE staged = TRUE;
+
+-- 3. staged column on runs
+ALTER TABLE runs ADD COLUMN staged BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- 4. Backfill: existing AB arm data becomes staged
+UPDATE pages SET staged = TRUE WHERE ab_run_id IS NOT NULL;
+UPDATE page_links SET staged = TRUE WHERE ab_run_id IS NOT NULL;
+UPDATE runs SET staged = TRUE WHERE ab_run_id IS NOT NULL;
+
+-- 5. Update match_pages RPC: replace ab_run_id filter with staged visibility
+DROP FUNCTION IF EXISTS match_pages(
+    extensions.vector, DOUBLE PRECISION, INTEGER, TEXT, UUID, TEXT, TEXT
+);
+
+CREATE OR REPLACE FUNCTION match_pages(
+    query_embedding extensions.vector(1024),
+    match_threshold DOUBLE PRECISION DEFAULT 0.5,
+    match_count INTEGER DEFAULT 10,
+    filter_workspace TEXT DEFAULT NULL,
+    filter_project_id UUID DEFAULT NULL,
+    filter_field_name TEXT DEFAULT NULL,
+    filter_staged_run_id TEXT DEFAULT NULL
+)
+RETURNS TABLE(
+    id TEXT,
+    page_type TEXT,
+    layer TEXT,
+    workspace TEXT,
+    content TEXT,
+    headline TEXT,
+    abstract TEXT,
+    project_id UUID,
+    epistemic_status DOUBLE PRECISION,
+    epistemic_type TEXT,
+    provenance_model TEXT,
+    provenance_call_type TEXT,
+    provenance_call_id TEXT,
+    created_at TIMESTAMPTZ,
+    superseded_by TEXT,
+    is_superseded BOOLEAN,
+    extra JSONB,
+    run_id TEXT,
+    field_name TEXT,
+    similarity DOUBLE PRECISION
+)
+LANGUAGE sql STABLE
+SET search_path = public, extensions
+AS $$
+    SELECT
+        p.id,
+        p.page_type,
+        p.layer,
+        p.workspace,
+        p.content,
+        p.headline,
+        p.abstract,
+        p.project_id,
+        p.epistemic_status,
+        p.epistemic_type,
+        p.provenance_model,
+        p.provenance_call_type,
+        p.provenance_call_id,
+        p.created_at,
+        p.superseded_by,
+        p.is_superseded,
+        p.extra,
+        p.run_id,
+        pe.field_name,
+        1 - (pe.embedding <=> query_embedding) AS similarity
+    FROM page_embeddings pe
+    JOIN pages p ON p.id = pe.page_id
+    WHERE p.is_superseded = FALSE
+      AND 1 - (pe.embedding <=> query_embedding) > match_threshold
+      AND (filter_workspace IS NULL OR p.workspace = filter_workspace)
+      AND (filter_project_id IS NULL OR p.project_id = filter_project_id)
+      AND (filter_field_name IS NULL OR pe.field_name = filter_field_name)
+      AND (filter_staged_run_id IS NULL
+           OR p.staged = FALSE
+           OR p.run_id = filter_staged_run_id)
+    ORDER BY pe.embedding <=> query_embedding
+    LIMIT match_count;
+$$;
+
+-- 6. Update get_root_questions RPC: replace ab_run_id filter with staged visibility
+DROP FUNCTION IF EXISTS get_root_questions(TEXT);
+DROP FUNCTION IF EXISTS get_root_questions(TEXT, UUID, TEXT);
+
+CREATE OR REPLACE FUNCTION get_root_questions(
+    ws TEXT,
+    pid UUID DEFAULT NULL,
+    p_staged_run_id TEXT DEFAULT NULL
+)
+RETURNS SETOF pages
+LANGUAGE sql STABLE AS $$
+    SELECT p.* FROM pages p
+    WHERE p.page_type = 'question'
+      AND p.workspace = ws
+      AND p.is_superseded = FALSE
+      AND (pid IS NULL OR p.project_id = pid)
+      AND (p_staged_run_id IS NULL
+           OR p.staged = FALSE
+           OR p.run_id = p_staged_run_id)
+      AND p.id NOT IN (
+          SELECT to_page_id FROM page_links WHERE link_type = 'child_question'
+      )
+    ORDER BY p.created_at DESC;
+$$;

--- a/tests/test_call_sequences.py
+++ b/tests/test_call_sequences.py
@@ -210,11 +210,14 @@ async def test_multi_step_sequence_creates_record_and_assigns_positions(
     db_seqs = await tmp_db.get_sequences_for_call(p_call.id)
     assert len(db_seqs) == 1
     seq_calls = await tmp_db.get_calls_for_sequence(db_seqs[0].id)
-    assert len(seq_calls) == 2
+    # assess_question creates 2 calls (summarize + assess), so 3 total
+    assert len(seq_calls) == 3
     assert seq_calls[0].sequence_position == 0
     assert seq_calls[1].sequence_position == 1
+    assert seq_calls[2].sequence_position == 2
     types = [c.call_type for c in seq_calls]
     assert CallType.FIND_CONSIDERATIONS in types
+    assert CallType.SUMMARIZE in types
     assert CallType.ASSESS in types
 
 
@@ -242,4 +245,5 @@ async def test_mixed_single_and_multi_step_sequences(tmp_db, question_page):
     assert db_seqs[0].position_in_batch == 1
 
     seq_calls = await tmp_db.get_calls_for_sequence(db_seqs[0].id)
-    assert len(seq_calls) == 2
+    # assess_question creates 2 calls (summarize + assess), so 3 total
+    assert len(seq_calls) == 3

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -10,6 +10,7 @@ from rumil.embeddings import (
     embed_texts,
     search_pages,
 )
+from rumil.database import DB
 from rumil.models import Page, PageLayer, PageType, Workspace
 
 
@@ -42,7 +43,9 @@ async def test_store_and_search_round_trip(tmp_db):
     await embed_and_store_page(tmp_db, page)
 
     results = await search_pages(
-        tmp_db, "how do plants use sunlight?", match_threshold=0.3,
+        tmp_db,
+        "how do plants use sunlight?",
+        match_threshold=0.3,
     )
     returned_ids = [p.id for p, _ in results]
     assert page.id in returned_ids
@@ -64,24 +67,27 @@ async def test_store_and_search_with_field_filter(tmp_db):
     await embed_and_store_page(tmp_db, page, field_name="abstract")
 
     results_with_filter = await search_pages(
-        tmp_db, "quantum particles", match_threshold=0.3,
+        tmp_db,
+        "quantum particles",
+        match_threshold=0.3,
         field_name="abstract",
     )
     returned_ids = [p.id for p, _ in results_with_filter]
     assert page.id in returned_ids
 
     results_wrong_field = await search_pages(
-        tmp_db, "quantum particles", match_threshold=0.3,
+        tmp_db,
+        "quantum particles",
+        match_threshold=0.3,
         field_name="content",
     )
     wrong_ids = [p.id for p, _ in results_wrong_field]
     assert page.id not in wrong_ids
 
 
-async def test_search_with_ab_run_id_filter(tmp_db):
-    """When db.ab_run_id is set, embedding search only returns pages from that AB arm."""
-    ab_run_id = str(uuid.uuid4())
-    tmp_db.ab_run_id = ab_run_id
+async def test_search_with_staged_run_filter(tmp_db):
+    """When db.staged is set, embedding search only returns pages from that staged run + baseline."""
+    tmp_db.staged = True
 
     page = Page(
         page_type=PageType.CLAIM,
@@ -94,14 +100,24 @@ async def test_search_with_ab_run_id_filter(tmp_db):
     await embed_and_store_page(tmp_db, page)
 
     results_matching = await search_pages(
-        tmp_db, "plate tectonics", match_threshold=0.3,
+        tmp_db,
+        "plate tectonics",
+        match_threshold=0.3,
     )
     matching_ids = [p.id for p, _ in results_matching]
     assert page.id in matching_ids
 
-    tmp_db.ab_run_id = "nonexistent-ab-run-id"
-    results_wrong_ab = await search_pages(
-        tmp_db, "plate tectonics", match_threshold=0.3,
+    # A different staged run should not see this page
+    other_db = await DB.create(
+        run_id=str(uuid.uuid4()),
+        client=tmp_db.client,
+        project_id=tmp_db.project_id,
+        staged=True,
     )
-    wrong_ids = [p.id for p, _ in results_wrong_ab]
-    assert page.id not in wrong_ids
+    results_other = await search_pages(
+        other_db,
+        "plate tectonics",
+        match_threshold=0.3,
+    )
+    other_ids = [p.id for p, _ in results_other]
+    assert page.id not in other_ids

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -17,7 +17,7 @@ from rumil.orchestrator import (
     PrioritizationResult,
     TwoPhaseOrchestrator,
 )
-from rumil.tracing.tracer import CallTrace
+from rumil.tracing.tracer import CallTrace, set_trace
 
 
 class ScriptedOrchestrator(BaseOrchestrator):
@@ -207,6 +207,7 @@ async def test_dispatch_executed_events_recorded(tmp_db, question_page):
         scope_page_id=question_page.id,
     )
     trace = CallTrace(p_call.id, tmp_db)
+    set_trace(trace)
 
     orch = ScriptedOrchestrator(
         tmp_db,
@@ -232,7 +233,9 @@ async def test_dispatch_executed_events_recorded(tmp_db, question_page):
 
 
 async def test_concurrent_dispatch_failure_recorded_in_trace(
-    tmp_db, question_page, mocker,
+    tmp_db,
+    question_page,
+    mocker,
 ):
     """When a dispatch raises during the TwoPhaseOrchestrator's concurrent
     gather, an ErrorEvent should be recorded on the prioritization call's trace.
@@ -260,7 +263,8 @@ async def test_concurrent_dispatch_failure_recorded_in_trace(
 
     mocker.patch.object(orch, "_get_next_batch", side_effect=fake_get_next_batch)
     mocker.patch.object(
-        DB, "resolve_page_id",
+        DB,
+        "resolve_page_id",
         side_effect=ConnectionError("Simulated connection failure"),
     )
 

--- a/tests/test_staged_runs.py
+++ b/tests/test_staged_runs.py
@@ -1,0 +1,213 @@
+"""Test staged run isolation: pages, links, superseding, and link mutations."""
+
+import uuid
+
+import pytest_asyncio
+
+from rumil.database import DB
+from rumil.models import (
+    LinkRole,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+
+
+async def _make_db(project_id: str, staged: bool = False) -> DB:
+    db = await DB.create(run_id=str(uuid.uuid4()), staged=staged)
+    db.project_id = project_id
+    return db
+
+
+async def _make_page(db: DB, headline: str, page_type: PageType = PageType.CLAIM) -> Page:
+    page = Page(
+        page_type=page_type,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Content for: {headline}",
+        headline=headline,
+    )
+    await db.save_page(page)
+    return page
+
+
+async def _link(db: DB, from_page: Page, to_page: Page) -> PageLink:
+    link = PageLink(
+        from_page_id=from_page.id,
+        to_page_id=to_page.id,
+        link_type=LinkType.CONSIDERATION,
+        strength=5.0,
+        reasoning="test link",
+    )
+    await db.save_link(link)
+    return link
+
+
+@pytest_asyncio.fixture
+async def project_id():
+    db = await DB.create(run_id=str(uuid.uuid4()))
+    project = await db.get_or_create_project(f"test-staged-{uuid.uuid4().hex[:8]}")
+    return project.id
+
+
+@pytest_asyncio.fixture
+async def baseline_db(project_id):
+    """A non-staged DB that creates baseline data."""
+    db = await _make_db(project_id, staged=False)
+    await db.init_budget(100)
+    yield db
+    await db.delete_run_data()
+
+
+@pytest_asyncio.fixture
+async def staged_db(project_id):
+    """A staged DB whose writes should be isolated."""
+    db = await _make_db(project_id, staged=True)
+    await db.init_budget(100)
+    yield db
+    await db.delete_run_data()
+
+
+@pytest_asyncio.fixture
+async def observer_db(project_id):
+    """A non-staged DB that observes — should never see staged data."""
+    db = await _make_db(project_id, staged=False)
+    yield db
+    await db.delete_run_data()
+
+
+async def test_staged_pages_invisible_to_observers(baseline_db, staged_db, observer_db):
+    """Pages created by a staged run are visible to that run but not to others."""
+    baseline_page = await _make_page(baseline_db, "baseline claim")
+    staged_page = await _make_page(staged_db, "staged claim")
+
+    # Staged run sees both
+    staged_pages = await staged_db.get_pages()
+    staged_ids = {p.id for p in staged_pages}
+    assert baseline_page.id in staged_ids
+    assert staged_page.id in staged_ids
+
+    # Observer sees only baseline
+    observer_pages = await observer_db.get_pages()
+    observer_ids = {p.id for p in observer_pages}
+    assert baseline_page.id in observer_ids
+    assert staged_page.id not in observer_ids
+
+
+async def test_staged_links_invisible_to_observers(baseline_db, staged_db, observer_db):
+    """Links created by a staged run are visible to that run but not to others."""
+    q = await _make_page(baseline_db, "question", PageType.QUESTION)
+    baseline_claim = await _make_page(baseline_db, "baseline claim")
+    await _link(baseline_db, baseline_claim, q)
+
+    staged_claim = await _make_page(staged_db, "staged claim")
+    await _link(staged_db, staged_claim, q)
+
+    # Staged run sees both links
+    staged_links = await staged_db.get_links_to(q.id)
+    staged_from_ids = {l.from_page_id for l in staged_links}
+    assert baseline_claim.id in staged_from_ids
+    assert staged_claim.id in staged_from_ids
+
+    # Observer sees only baseline link
+    observer_links = await observer_db.get_links_to(q.id)
+    observer_from_ids = {l.from_page_id for l in observer_links}
+    assert baseline_claim.id in observer_from_ids
+    assert staged_claim.id not in observer_from_ids
+
+
+async def test_staged_supersede_is_isolated(baseline_db, staged_db, observer_db):
+    """A staged run superseding a baseline page only affects that staged run's view."""
+    old_page = await _make_page(baseline_db, "original claim")
+    new_page = await _make_page(staged_db, "replacement claim")
+
+    await staged_db.supersede_page(old_page.id, new_page.id)
+
+    # Staged run sees old page as superseded
+    staged_pages = await staged_db.get_pages(active_only=True)
+    staged_ids = {p.id for p in staged_pages}
+    assert old_page.id not in staged_ids
+    assert new_page.id in staged_ids
+
+    # Observer still sees the old page as active
+    observer_pages = await observer_db.get_pages(active_only=True)
+    observer_ids = {p.id for p in observer_pages}
+    assert old_page.id in observer_ids
+
+
+async def test_staged_delete_link_is_isolated(baseline_db, staged_db, observer_db):
+    """A staged run deleting a baseline link only affects that staged run's view."""
+    q = await _make_page(baseline_db, "question", PageType.QUESTION)
+    claim = await _make_page(baseline_db, "some claim")
+    link = await _link(baseline_db, claim, q)
+
+    await staged_db.delete_link(link.id)
+
+    # Staged run no longer sees the link
+    staged_links = await staged_db.get_links_to(q.id)
+    assert all(l.id != link.id for l in staged_links)
+
+    # Observer still sees it
+    observer_links = await observer_db.get_links_to(q.id)
+    assert any(l.id == link.id for l in observer_links)
+
+
+async def test_staged_change_link_role_is_isolated(baseline_db, staged_db, observer_db):
+    """A staged run changing a link role only affects that staged run's view."""
+    q = await _make_page(baseline_db, "question", PageType.QUESTION)
+    claim = await _make_page(baseline_db, "some claim")
+    link = await _link(baseline_db, claim, q)
+    assert link.role == LinkRole.DIRECT
+
+    await staged_db.update_link_role(link.id, LinkRole.STRUCTURAL)
+
+    # Staged run sees the new role
+    staged_links = await staged_db.get_links_to(q.id)
+    staged_link = next(l for l in staged_links if l.id == link.id)
+    assert staged_link.role == LinkRole.STRUCTURAL
+
+    # Observer sees the original role
+    observer_links = await observer_db.get_links_to(q.id)
+    observer_link = next(l for l in observer_links if l.id == link.id)
+    assert observer_link.role == LinkRole.DIRECT
+
+
+async def test_two_staged_runs_are_isolated_from_each_other(project_id):
+    """Two different staged runs cannot see each other's data."""
+    db_a = await _make_db(project_id, staged=True)
+    await db_a.init_budget(100)
+    db_b = await _make_db(project_id, staged=True)
+    await db_b.init_budget(100)
+
+    page_a = await _make_page(db_a, "arm A claim")
+    page_b = await _make_page(db_b, "arm B claim")
+
+    pages_a = await db_a.get_pages()
+    pages_b = await db_b.get_pages()
+
+    assert page_a.id in {p.id for p in pages_a}
+    assert page_b.id not in {p.id for p in pages_a}
+
+    assert page_b.id in {p.id for p in pages_b}
+    assert page_a.id not in {p.id for p in pages_b}
+
+    await db_a.delete_run_data()
+    await db_b.delete_run_data()
+
+
+async def test_get_pages_by_ids_respects_staged_events(baseline_db, staged_db, observer_db):
+    """get_pages_by_ids applies supersede events from the staged run."""
+    page = await _make_page(baseline_db, "will be superseded")
+    replacement = await _make_page(staged_db, "replacement")
+    await staged_db.supersede_page(page.id, replacement.id)
+
+    staged_result = await staged_db.get_pages_by_ids([page.id])
+    assert page.id in staged_result
+    assert staged_result[page.id].is_superseded is True
+
+    observer_result = await observer_db.get_pages_by_ids([page.id])
+    assert page.id in observer_result
+    assert observer_result[page.id].is_superseded is False


### PR DESCRIPTION
## Summary

- Introduces **staged runs** — a run whose writes (pages, links, mutations) are isolated from all other runs. A staged run sees baseline data + its own data; non-staged runs never see staged data.
- **Event-sources page superseding, link deletion, and link role changes** via a new `mutation_events` table. Staged runs record events instead of mutating rows in place; non-staged runs still mutate directly. Events are applied in Python on every read path.
- **Reimplements A/B testing on top of staged runs** — each A/B arm is now a staged run. The `ab_run_id` column on pages/links is superseded by a `staged` boolean; `ab_runs` table stays as grouping metadata.
- Fixes `summarize.py` raw `.update()` to use `db.supersede_page()`.

## Key changes

- **Migration** (`20260328102907_staged_runs.sql`): `mutation_events` table, `staged` column on pages/page_links/runs, updated `match_pages` and `get_root_questions` RPCs, backfills existing AB data
- **`database.py`**: `_ab_filter` → `_staged_filter`, new `MutationState`/`_apply_page_events`/`_apply_link_events` helpers with caching, conditional event-sourcing in write methods
- **`embeddings.py`**: `filter_ab_run_id` → `filter_staged_run_id`, post-RPC event overlay
- **`main.py`** + **`run_call.py`**: A/B arms use `staged=True`
- **7 new integration tests** covering page/link visibility, supersede/delete/role-change isolation, and cross-staged-run isolation

## Test plan

- [x] All 107 tests pass (7 new + 100 existing)
- [x] Pyright clean (0 errors)
- [x] Local migration applied successfully
- [ ] Apply migration to prod with `supabase db push`
- [ ] Smoke test an A/B run to verify arms are isolated

🤖 Generated with [Claude Code](https://claude.com/claude-code)