### PR TITLE
Clarify superseded toggle button labels

### DIFF
--- a/frontend/src/app/pages/[pageId]/links-container.tsx
+++ b/frontend/src/app/pages/[pageId]/links-container.tsx
@@ -151,7 +151,7 @@ export default function LinksContainer({
             onClick={() => setShowSuperseded((prev) => !prev)}
             title="Show superseded pages"
           >
-            superseded
+            {showSuperseded ? "hide" : "show"} superseded
             {showSuperseded && supersededCount > 0 && (
               <span className="links-superseded-count">{supersededCount}</span>
             )}

--- a/frontend/src/app/projects/[projectId]/page.tsx
+++ b/frontend/src/app/projects/[projectId]/page.tsx
@@ -694,7 +694,7 @@ export default function PagesIndexPage() {
             onClick={() => setShowSuperseded((prev) => !prev)}
             title="Show superseded pages"
           >
-            superseded
+            {showSuperseded ? "hide" : "show"} superseded
             {showSuperseded && supersededCount > 0 && (
               <span className="count">{supersededCount}</span>
             )}


### PR DESCRIPTION
## Summary
- Changed "superseded" button text to "show superseded" / "hide superseded" on both the page detail links panel and the project page list
- Prevents users from misreading the toggle as a status indicator

## Test plan
- [x] Visit a page with superseded links and verify the button says "show superseded", then "hide superseded" when toggled
- [x] Visit the project page list and verify the same behavior on the filter chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)