### PR TITLE
Sort pages by created_at, newest first

### DIFF
--- a/frontend/src/app/pages/[pageId]/links-container.tsx
+++ b/frontend/src/app/pages/[pageId]/links-container.tsx
@@ -106,9 +106,11 @@ function LinkSection({
   links: LinkedPageOut[];
   showSuperseded: boolean;
 }) {
-  const visible = showSuperseded
-    ? links
-    : links.filter((lp) => !lp.page.is_superseded);
+  const visible = (
+    showSuperseded ? links : links.filter((lp) => !lp.page.is_superseded)
+  ).toSorted(
+    (a, b) => new Date(b.page.created_at).getTime() - new Date(a.page.created_at).getTime(),
+  );
   if (visible.length === 0) return null;
   return (
     <div className="link-section">

--- a/frontend/src/app/projects/[projectId]/page.tsx
+++ b/frontend/src/app/projects/[projectId]/page.tsx
@@ -141,7 +141,8 @@ export default function PagesIndexPage() {
       .sort((a, b) => {
         const aHuman = a.provenance_model === "human" ? 0 : 1;
         const bHuman = b.provenance_model === "human" ? 0 : 1;
-        return aHuman - bHuman;
+        if (aHuman !== bHuman) return aHuman - bHuman;
+        return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
       });
   }, [pages, search, activeTypes]);
 


### PR DESCRIPTION
## Summary
- Adds `created_at` descending as a secondary sort in the project index page (human-generated pages still appear first)
- Sorts linked pages in the detail view's Outgoing/Incoming sections by `created_at` descending

## Test plan
- [ ] Open a project index — verify human pages appear first, and within each group newest pages are at the top
- [ ] Open a page detail view — verify linked pages in both Outgoing and Incoming sections are ordered newest-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)