### PR TITLE
Fix dangling pending prioritization calls when phase 1 is skipped

### DIFF
--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -209,6 +209,21 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         links = await self.db.get_links_to(question_id)
         return all(l.link_type == LinkType.CHILD_QUESTION for l in links)
 
+    async def _cancel_initial_call(self) -> None:
+        """Mark the eagerly-created phase-1 call as complete when phase 1 is skipped."""
+        if self._initial_call is None:
+            return
+        call = self._initial_call
+        self._initial_call = None
+        if self._sequence_id is not None:
+            call.sequence_id = self._sequence_id
+            call.sequence_position = self._seq_position
+            await self.db.save_call(call)
+            self._seq_position += 1
+        await mark_call_completed(
+            call, self.db, 'Phase 1 skipped — question already has research.',
+        )
+
     async def _get_next_batch(
         self,
         question_id: str,
@@ -219,6 +234,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             self._invocation += 1
             if await self._is_new_question(question_id):
                 return await self._phase1(question_id, budget, parent_call_id)
+            await self._cancel_initial_call()
             self._executed_since_last_plan = True
 
         if not self._executed_since_last_plan:

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -205,6 +205,21 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         links = await self.db.get_links_to(question_id)
         return all(l.link_type == LinkType.CHILD_QUESTION for l in links)
 
+    async def _cancel_initial_call(self) -> None:
+        """Mark the eagerly-created phase-1 call as complete when phase 1 is skipped."""
+        if self._initial_call is None:
+            return
+        call = self._initial_call
+        self._initial_call = None
+        if self._sequence_id is not None:
+            call.sequence_id = self._sequence_id
+            call.sequence_position = self._seq_position
+            await self.db.save_call(call)
+            self._seq_position += 1
+        await mark_call_completed(
+            call, self.db, 'Phase 1 skipped — question already has research.',
+        )
+
     async def _get_next_batch(
         self,
         question_id: str,
@@ -215,6 +230,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             self._invocation += 1
             if await self._is_new_question(question_id):
                 return await self._phase1(question_id, budget, parent_call_id)
+            await self._cancel_initial_call()
             self._executed_since_last_plan = True
 
         if not self._executed_since_last_plan:


### PR DESCRIPTION
## Summary
- When `TwoPhaseOrchestrator` skips phase 1 (question already has research), the eagerly-created initial prioritization call was left in PENDING status and unassigned to any sequence, appearing as a dangling node in the trace UI.
- Added `_cancel_initial_call()` which assigns the orphaned call to its parent sequence and marks it complete before proceeding to phase 2.

## Test plan
- [x] Existing tests pass (107 passed)
- [ ] Run an investigation against a question that already has research and verify the trace no longer shows a dangling pending prio call

🤖 Generated with [Claude Code](https://claude.com/claude-code)