### PR TITLE
Document staged runs and mutation log in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,25 @@ An LLM-powered research workspace. Users pose questions, and the system investig
 
 **The page graph can be cyclic.** Any code that traverses page links (parent/child questions, considerations, etc.) must track visited nodes to avoid infinite recursion. Use a `_visited: set[str]` parameter — see `context.py` for the standard pattern.
 
+## Staged Runs and the Mutation Log
+
+**Do not break this pattern. All workspace mutations must be stageable.**
+
+Runs can be **staged** (`staged=True` on the `DB` instance), meaning their effects are invisible to other runs and the wider workspace. This supports A/B testing and isolated experimentation.
+
+**How it works:**
+
+- **New pages/links** created by a staged run are written to their base tables with `staged=true` and tagged with `run_id`. Only that run can see them (via `_staged_filter()`).
+- **Mutations to existing state** (superseding pages, deleting links, changing link roles) are recorded as append-only events in the `mutation_events` table instead of modifying base tables. On read, `_apply_page_events()` / `_apply_link_events()` replay these events to materialize the run's view of the workspace. The `MutationState` cache (`_load_mutation_state()`) avoids re-reading events.
+- **Visibility rule:** staged runs see `staged=false` (baseline) rows plus their own `run_id` rows. Non-staged runs see only baseline. Two staged runs are fully isolated.
+
+**What this means for new code:**
+
+- Any new operation that modifies workspace state (pages, links, or future tables) **must** go through the staged path: write new rows with `staged`/`run_id` flags, and record mutations to existing rows in `mutation_events` rather than updating base tables directly.
+- Any new read path **must** apply `_staged_filter()` and the relevant `_apply_*_events()` methods so staged runs see their own mutations.
+- RPC functions that read pages or links must accept a `staged_run_id` parameter and apply the same visibility logic. See `match_pages()` and `get_root_questions()` in the migrations for examples.
+- Never introduce a write path that silently bypasses staging — it will break run isolation.
+
 ## Running
 
 Environment managed with `uv`.
@@ -74,7 +93,7 @@ To add a new call type: subclass `CallRunner`. Set `call_type`, override `_make_
 
 **Moves** (`src/rumil/moves/`): Package with one module per move type. Each module defines a pydantic payload schema, an `execute()` function, and a `MoveDef` that binds them together as a tool. `base.py` has shared helpers (page creation, linking, `LAST_CREATED` resolution). `registry.py` collects all moves into a `MOVES` dict keyed by `MoveType`. See `MoveType` enum in `models.py` for the full list.
 
-**Data layer** (`src/rumil/database.py`): Supabase (Postgres) via the `supabase` Python SDK. Tables: pages, page_links, calls, budget, page_ratings, page_flags. `DB.create(run_id, prod=True)` classmethod handles connection setup (delegated to `settings.py`); defaults to local Supabase. Several operations use Postgres RPC functions defined in the migrations.
+**Data layer** (`src/rumil/database.py`): Supabase (Postgres) via the `supabase` Python SDK. Tables: pages, page_links, calls, budget, page_ratings, page_flags, mutation_events, runs. `DB.create(run_id, prod=True, staged=False)` classmethod handles connection setup (delegated to `settings.py`); defaults to local Supabase. When `staged=True`, writes tag rows with `staged`/`run_id` and mutations go to `mutation_events` (see "Staged Runs and the Mutation Log" above). Several operations use Postgres RPC functions defined in the migrations.
 
 **Data models** (`src/rumil/models.py`): Pydantic BaseModels for Page, PageLink, Call, Project. Used directly as both internal models and FastAPI response types (no separate `*Out` duplicates). Fields with defaults use `_all_fields_required` schema helper so they appear required in the OpenAPI spec. Key enums: PageType, CallType, CallStage, LinkType, ConsiderationDirection, MoveType. MoveType is the source of truth for valid moves — the moves registry maps each to its `MoveDef`. `DISPATCHABLE_CALL_TYPES` defines which `CallType`s prioritization can dispatch (find_considerations/assess/prioritization) — the dispatch tool validates against it and the orchestrator dispatches on `CallType` enum values.
 


### PR DESCRIPTION
## Summary
- Adds a new "Staged Runs and the Mutation Log" section to CLAUDE.md documenting the event-sourcing architecture from PR #178
- Explains how staged runs isolate their effects via `staged` flags on rows and append-only `mutation_events`
- Lists requirements for new code: all writes must be stageable, all reads must apply visibility filters
- Updates the Data layer description to reference `mutation_events`, `runs`, and the `staged` flag

## Test plan
- [ ] Review that the documentation accurately reflects the implementation in `database.py` and the staged_runs migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)