### PR TITLE
Persist staged run toggle and extend to page detail

### DIFF
--- a/frontend/src/app/pages/[pageId]/links-container.tsx
+++ b/frontend/src/app/pages/[pageId]/links-container.tsx
@@ -65,12 +65,15 @@ function LinkMeta({ link }: { link: PageLink }) {
   );
 }
 
-function LinkedCard({ lp }: { lp: LinkedPageOut }) {
+function LinkedCard({ lp, stagedRunId }: { lp: LinkedPageOut; stagedRunId?: string }) {
   const cfg = TYPE_CONFIG[lp.page.page_type] || TYPE_CONFIG.source;
   const isSuperseded = lp.page.is_superseded;
+  const href = stagedRunId
+    ? `/pages/${lp.page.id}?staged_run_id=${stagedRunId}`
+    : `/pages/${lp.page.id}`;
   return (
     <Link
-      href={`/pages/${lp.page.id}`}
+      href={href}
       className={`linked-card${isSuperseded ? " linked-card-superseded" : ""}`}
     >
       <div className="linked-card-accent" style={{ background: cfg.accent }} />
@@ -101,10 +104,12 @@ function LinkSection({
   title,
   links,
   showSuperseded,
+  stagedRunId,
 }: {
   title: string;
   links: LinkedPageOut[];
   showSuperseded: boolean;
+  stagedRunId?: string;
 }) {
   const visible = (
     showSuperseded ? links : links.filter((lp) => !lp.page.is_superseded)
@@ -120,7 +125,7 @@ function LinkSection({
       </div>
       <div className="link-grid">
         {visible.map((lp) => (
-          <LinkedCard key={lp.link.id} lp={lp} />
+          <LinkedCard key={lp.link.id} lp={lp} stagedRunId={stagedRunId} />
         ))}
       </div>
     </div>
@@ -130,9 +135,11 @@ function LinkSection({
 export default function LinksContainer({
   links_from,
   links_to,
+  stagedRunId,
 }: {
   links_from: LinkedPageOut[];
   links_to: LinkedPageOut[];
+  stagedRunId?: string;
 }) {
   const [showSuperseded, setShowSuperseded] = useState(false);
 
@@ -160,8 +167,8 @@ export default function LinksContainer({
           </button>
         </div>
       )}
-      <LinkSection title="Outgoing" links={links_from} showSuperseded={showSuperseded} />
-      <LinkSection title="Incoming" links={links_to} showSuperseded={showSuperseded} />
+      <LinkSection title="Outgoing" links={links_from} showSuperseded={showSuperseded} stagedRunId={stagedRunId} />
+      <LinkSection title="Incoming" links={links_to} showSuperseded={showSuperseded} stagedRunId={stagedRunId} />
     </div>
   );
 }

--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Markdown from "react-markdown";
 import type { PageDetailOut, LinkedPageOut, Page, RunSummaryOut } from "@/api";
 import LinksContainer from "./links-container";
+import StagedBanner from "./staged-banner";
 
 import { API_BASE } from "@/lib/api-base";
 
@@ -47,26 +48,37 @@ const TYPE_CONFIG: Record<
   },
 };
 
-async function getPageDetail(pageId: string): Promise<PageDetailOut | null> {
-  const res = await fetch(`${API_BASE}/api/pages/${pageId}/detail`, {
-    cache: "no-store",
-  });
+function stagedQs(stagedRunId?: string): string {
+  return stagedRunId ? `?staged_run_id=${stagedRunId}` : "";
+}
+
+async function getPageDetail(
+  pageId: string,
+  stagedRunId?: string,
+): Promise<PageDetailOut | null> {
+  const res = await fetch(
+    `${API_BASE}/api/pages/${pageId}/detail${stagedQs(stagedRunId)}`,
+    { cache: "no-store" },
+  );
   if (!res.ok) return null;
   return res.json();
 }
 
 async function getPageHeadline(
   pageId: string,
+  stagedRunId?: string,
 ): Promise<{ headline: string; page_type: string } | null> {
-  const res = await fetch(`${API_BASE}/api/pages/${pageId}/detail`, {
-    cache: "no-store",
-  });
+  const res = await fetch(
+    `${API_BASE}/api/pages/${pageId}/detail${stagedQs(stagedRunId)}`,
+    { cache: "no-store" },
+  );
   if (!res.ok) return null;
   const data = (await res.json()) as PageDetailOut;
   return { headline: data.page.headline, page_type: data.page.page_type };
 }
 
-function pageHref(page: Page): string {
+function pageHref(page: Page, stagedRunId?: string): string {
+  if (stagedRunId) return `/pages/${page.id}?staged_run_id=${stagedRunId}`;
   return `/pages/${page.id}`;
 }
 
@@ -86,6 +98,7 @@ async function buildCitationMap(
   links_from: LinkedPageOut[],
   links_to: LinkedPageOut[],
   content: string,
+  stagedRunId?: string,
 ): Promise<Map<string, { fullId: string; pageType: string }>> {
   const map = new Map<string, { fullId: string; pageType: string }>();
   for (const lp of [...links_from, ...links_to]) {
@@ -95,11 +108,13 @@ async function buildCitationMap(
   const cited = extractCitedIds(content);
   const missing = [...cited].filter((id) => !map.has(id));
   if (missing.length > 0) {
+    const qs = stagedQs(stagedRunId);
     const results = await Promise.all(
       missing.map(async (shortId) => {
-        const res = await fetch(`${API_BASE}/api/pages/short/${shortId}`, {
-          cache: "no-store",
-        });
+        const res = await fetch(
+          `${API_BASE}/api/pages/short/${shortId}${qs}`,
+          { cache: "no-store" },
+        );
         if (!res.ok) return null;
         const page: Page = await res.json();
         return { shortId, fullId: page.id, pageType: page.page_type };
@@ -117,9 +132,11 @@ const CITATION_RE = /\[([a-f0-9]{8}(?:,\s*[a-f0-9]{8})*)\]/g;
 function injectCitationLinks(
   content: string,
   citationMap: Map<string, { fullId: string; pageType: string }>,
+  stagedRunId?: string,
 ): string {
   const orderMap = new Map<string, number>();
   let nextNum = 1;
+  const stagedSuffix = stagedRunId ? `&staged_run_id=${stagedRunId}` : "";
   return content.replace(CITATION_RE, (_match, group: string) => {
     const ids = group.split(/,\s*/);
     const parts = ids.map((shortId) => {
@@ -129,7 +146,7 @@ function injectCitationLinks(
         orderMap.set(shortId, nextNum++);
       }
       const num = orderMap.get(shortId)!;
-      return `[${num}](/pages/${entry.fullId}?cite=${entry.pageType})`;
+      return `[${num}](/pages/${entry.fullId}?cite=${entry.pageType}${stagedSuffix})`;
     });
     return parts.join(" ");
   });
@@ -165,12 +182,15 @@ function EpistemicGauge({ value }: { value: number }) {
 
 export default async function PageDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ pageId: string }>;
+  searchParams: Promise<{ staged_run_id?: string; cite?: string }>;
 }) {
   const { pageId } = await params;
+  const { staged_run_id: stagedRunId } = await searchParams;
   const [detail, run] = await Promise.all([
-    getPageDetail(pageId),
+    getPageDetail(pageId, stagedRunId),
     getPageRun(pageId),
   ]);
 
@@ -194,10 +214,10 @@ export default async function PageDetailPage({
   const { page, links_from, links_to } = detail;
   const cfg = TYPE_CONFIG[page.page_type] || TYPE_CONFIG.source;
   const [citationMap, supersedingPage] = await Promise.all([
-    buildCitationMap(links_from, links_to, page.content),
-    page.superseded_by ? getPageHeadline(page.superseded_by) : null,
+    buildCitationMap(links_from, links_to, page.content, stagedRunId),
+    page.superseded_by ? getPageHeadline(page.superseded_by, stagedRunId) : null,
   ]);
-  const processedContent = injectCitationLinks(page.content, citationMap);
+  const processedContent = injectCitationLinks(page.content, citationMap, stagedRunId);
 
   return (
     <>
@@ -206,6 +226,10 @@ export default async function PageDetailPage({
         <Link href={`/projects/${page.project_id}`} className="back-link">
         &larr; Workspace
       </Link>
+
+      {stagedRunId && (
+        <StagedBanner runId={stagedRunId} pageUrl={`/pages/${pageId}`} />
+      )}
 
       <article className="page-article">
         <div
@@ -228,7 +252,7 @@ export default async function PageDetailPage({
             <span className="page-id">{page.id.slice(0, 8)}</span>
             {page.is_superseded && page.superseded_by && supersedingPage ? (
               <Link
-                href={`/pages/${page.superseded_by}`}
+                href={`/pages/${page.superseded_by}${stagedRunId ? `?staged_run_id=${stagedRunId}` : ""}`}
                 className="superseded-link"
                 title={supersedingPage.headline}
               >
@@ -267,7 +291,10 @@ export default async function PageDetailPage({
                   const url = new URL(href, "http://x");
                   const pageType = url.searchParams.get("cite") || "claim";
                   const typeCfg = TYPE_CONFIG[pageType] || TYPE_CONFIG.source;
-                  const cleanHref = url.pathname;
+                  const stagedParam = url.searchParams.get("staged_run_id");
+                  const cleanHref = stagedParam
+                    ? `${url.pathname}?staged_run_id=${stagedParam}`
+                    : url.pathname;
                   return (
                     <Link href={cleanHref} className="citation-chip" style={{
                       color: typeCfg.accent,
@@ -300,7 +327,7 @@ export default async function PageDetailPage({
         </div>
       </article>
 
-      <LinksContainer links_from={links_from} links_to={links_to} />
+      <LinksContainer links_from={links_from} links_to={links_to} stagedRunId={stagedRunId} />
 
       <footer className="page-footer">
         <span>{new Date(page.created_at).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}</span>
@@ -950,5 +977,55 @@ const styles = `
       --type-wiki-bg-hover: #111d14;
       --type-wiki-border: #1a2e1f;
     }
+  }
+
+  .staged-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 0.75rem;
+    margin-bottom: 1rem;
+    background: rgba(90, 138, 122, 0.06);
+    border: 1px solid rgba(90, 138, 122, 0.2);
+    font-family: var(--font-geist-mono), monospace;
+    font-size: 0.75rem;
+    color: #5a8a7a;
+    animation: bannerSlideIn 0.2s ease both;
+  }
+  @keyframes bannerSlideIn {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .staged-banner-indicator {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #5a8a7a;
+    flex-shrink: 0;
+    animation: indicatorPulse 2s ease infinite;
+  }
+  @keyframes indicatorPulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
+  }
+  .staged-banner-text {
+    flex: 1;
+    letter-spacing: 0.02em;
+  }
+  .staged-banner-clear {
+    font-size: 0.7rem;
+    font-family: var(--font-geist-mono), monospace;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #5a8a7a;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.2rem 0.4rem;
+    opacity: 0.7;
+    transition: opacity 0.12s ease;
+  }
+  .staged-banner-clear:hover {
+    opacity: 1;
   }
 `;

--- a/frontend/src/app/pages/[pageId]/staged-banner.tsx
+++ b/frontend/src/app/pages/[pageId]/staged-banner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useStagedRun } from "@/lib/staged-run-context";
 
@@ -12,6 +13,10 @@ export default function StagedBanner({
 }) {
   const { setActiveStagedRunId } = useStagedRun();
   const router = useRouter();
+
+  useEffect(() => {
+    setActiveStagedRunId(runId);
+  }, [runId, setActiveStagedRunId]);
 
   return (
     <div className="staged-banner">

--- a/frontend/src/app/pages/[pageId]/staged-banner.tsx
+++ b/frontend/src/app/pages/[pageId]/staged-banner.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useStagedRun } from "@/lib/staged-run-context";
+
+export default function StagedBanner({
+  runId,
+  pageUrl,
+}: {
+  runId: string;
+  pageUrl: string;
+}) {
+  const { setActiveStagedRunId } = useStagedRun();
+  const router = useRouter();
+
+  return (
+    <div className="staged-banner">
+      <span className="staged-banner-indicator" />
+      <span className="staged-banner-text">
+        Viewing staged run {runId.slice(0, 8)}
+      </span>
+      <button
+        className="staged-banner-clear"
+        onClick={() => {
+          setActiveStagedRunId(null);
+          router.replace(pageUrl);
+        }}
+      >
+        Clear
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/projects/[projectId]/page.tsx
+++ b/frontend/src/app/projects/[projectId]/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, useMemo } from "react";
 import type { Page, PageType, RunListItemOut } from "@/api";
 
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
+import { useStagedRun } from "@/lib/staged-run-context";
 
 const PAGE_TYPES: PageType[] = [
   "question",
@@ -58,7 +59,8 @@ const TYPE_CONFIG: Record<
   },
 };
 
-function pageHref(page: Page): string {
+function pageHref(page: Page, stagedRunId?: string | null): string {
+  if (stagedRunId) return `/pages/${page.id}?staged_run_id=${stagedRunId}`;
   return `/pages/${page.id}`;
 }
 
@@ -81,7 +83,7 @@ export default function PagesIndexPage() {
   const [activeTypes, setActiveTypes] = useState<Set<PageType>>(new Set());
   const [runs, setRuns] = useState<RunListItemOut[]>([]);
   const [showSuperseded, setShowSuperseded] = useState(false);
-  const [activeStagedRunId, setActiveStagedRunId] = useState<string | null>(null);
+  const { activeStagedRunId, setActiveStagedRunId } = useStagedRun();
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -904,7 +906,7 @@ export default function PagesIndexPage() {
               return (
                 <Link
                   key={p.id}
-                  href={pageHref(p)}
+                  href={pageHref(p, activeStagedRunId)}
                   className={`page-row${p.provenance_model === "human" ? " human-created" : ""}${p.is_superseded ? " superseded" : ""}`}
                   style={{ animationDelay: `${Math.min(i * 15, 300)}ms` }}
                 >

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,10 +2,13 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
+import { StagedRunProvider } from "@/lib/staged-run-context";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <StagedRunProvider>{children}</StagedRunProvider>
+    </QueryClientProvider>
   );
 }

--- a/frontend/src/lib/staged-run-context.tsx
+++ b/frontend/src/lib/staged-run-context.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+const STORAGE_KEY = "activeStagedRunId";
+
+interface StagedRunContextValue {
+  activeStagedRunId: string | null;
+  setActiveStagedRunId: (id: string | null) => void;
+}
+
+const StagedRunContext = createContext<StagedRunContextValue>({
+  activeStagedRunId: null,
+  setActiveStagedRunId: () => {},
+});
+
+export function StagedRunProvider({ children }: { children: React.ReactNode }) {
+  const [activeStagedRunId, setRaw] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (stored) setRaw(stored);
+  }, []);
+
+  const setActiveStagedRunId = useCallback((id: string | null) => {
+    setRaw(id);
+    if (id) {
+      sessionStorage.setItem(STORAGE_KEY, id);
+    } else {
+      sessionStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  return (
+    <StagedRunContext.Provider value={{ activeStagedRunId, setActiveStagedRunId }}>
+      {children}
+    </StagedRunContext.Provider>
+  );
+}
+
+export function useStagedRun() {
+  return useContext(StagedRunContext);
+}

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -62,6 +62,21 @@ async def _get_db(project_id: str = "") -> DB:
     )
 
 
+async def _get_db_maybe_staged(
+    staged_run_id: str | None = None,
+    project_id: str = "",
+) -> DB:
+    if staged_run_id:
+        prod = get_settings().is_prod_db
+        return await DB.create(
+            run_id=staged_run_id,
+            prod=prod,
+            project_id=project_id,
+            staged=True,
+        )
+    return await _get_db(project_id)
+
+
 # --- Projects ---
 
 
@@ -88,16 +103,7 @@ async def list_pages(
     active_only: bool = True,
     staged_run_id: str | None = None,
 ):
-    if staged_run_id:
-        prod = get_settings().is_prod_db
-        db = await DB.create(
-            run_id=staged_run_id,
-            prod=prod,
-            project_id=project_id,
-            staged=True,
-        )
-    else:
-        db = await _get_db(project_id)
+    db = await _get_db_maybe_staged(staged_run_id, project_id)
     return await db.get_pages(
         workspace=workspace,
         page_type=page_type,
@@ -106,8 +112,8 @@ async def list_pages(
 
 
 @app.get("/api/pages/short/{short_id}", response_model=Page)
-async def get_page_by_short_id(short_id: str):
-    db = await _get_db()
+async def get_page_by_short_id(short_id: str, staged_run_id: str | None = None):
+    db = await _get_db_maybe_staged(staged_run_id)
     full_id = await db.resolve_page_id(short_id)
     if not full_id:
         raise HTTPException(status_code=404, detail="Page not found")
@@ -118,8 +124,8 @@ async def get_page_by_short_id(short_id: str):
 
 
 @app.get("/api/pages/{page_id}", response_model=Page)
-async def get_page(page_id: str):
-    db = await _get_db()
+async def get_page(page_id: str, staged_run_id: str | None = None):
+    db = await _get_db_maybe_staged(staged_run_id)
     page = await db.get_page(page_id)
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
@@ -139,8 +145,8 @@ async def get_links_to(page_id: str):
 
 
 @app.get("/api/pages/{page_id}/detail", response_model=PageDetailOut)
-async def get_page_detail(page_id: str):
-    db = await _get_db()
+async def get_page_detail(page_id: str, staged_run_id: str | None = None):
+    db = await _get_db_maybe_staged(staged_run_id)
     page = await db.get_page(page_id)
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")


### PR DESCRIPTION
## Summary
- Store the active staged run ID in sessionStorage via a React context provider, so the toggle persists across page navigations within a session
- Propagate `staged_run_id` to page detail pages via URL search params — all API fetches, citation links, linked page cards, and superseded-by links carry the staged context
- Add `staged_run_id` query param to backend endpoints (`/detail`, `/short/{id}`, `/{page_id}`) with a shared `_get_db_maybe_staged()` helper

## Test plan
- [x] Toggle "show result" on a staged run, refresh the index page — toggle should persist
- [x] Click a page card while staged run is active — page detail shows staged data with banner
- [x] Click linked pages and citation links on page detail — staged context propagates
- [x] Click "Clear" on the staged banner — returns to baseline view, sessionStorage cleared
- [x] Navigate back to index — toggle is deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)