### PR TITLE
Consistent cited→citing direction for inline citation links

### DIFF
--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -282,7 +282,6 @@ async def create_page(
             page.id,
             page.content,
             db,
-            citing_page_type=page_type,
         )
         if cited_ids:
             log.info(
@@ -320,15 +319,16 @@ async def extract_and_link_citations(
     page_id: str,
     content: str,
     db: DB,
-    citing_page_type: PageType | None = None,
 ) -> set[str]:
     """Extract [shortid] citations from content and create page links.
 
-    Link type depends on both citing and cited page types:
-    - Cited SOURCE → CITES
-    - Cited CLAIM (from QUESTION/JUDGEMENT/CLAIM) → CONSIDERATION (direction flipped:
-      from=cited claim, to=citing page, since "claim bears on citing page")
-    - Otherwise → RELATED
+    Link type depends on the cited page's type:
+    - Cited SOURCE → CITES (from=citing, to=cited)
+    - Cited CLAIM or JUDGEMENT → CONSIDERATION (from=cited, to=citing)
+    - Otherwise → RELATED (from=cited, to=citing)
+
+    Non-SOURCE citations always point from the cited page into the citing
+    page, so the citing page receives an incoming link.
 
     Returns the set of full UUIDs that were successfully linked.
     """
@@ -349,18 +349,15 @@ async def extract_and_link_citations(
         if not cited_page:
             continue
 
-        from_id, to_id = page_id, resolved
         if cited_page.page_type == PageType.SOURCE:
             link_type = LinkType.CITES
-        elif cited_page.page_type == PageType.CLAIM and citing_page_type in (
-            PageType.QUESTION,
-            PageType.JUDGEMENT,
-            PageType.CLAIM,
-        ):
+            from_id, to_id = page_id, resolved
+        elif cited_page.page_type in (PageType.CLAIM, PageType.JUDGEMENT):
             link_type = LinkType.CONSIDERATION
             from_id, to_id = resolved, page_id
         else:
             link_type = LinkType.RELATED
+            from_id, to_id = resolved, page_id
 
         await db.save_link(
             PageLink(

--- a/src/rumil/moves/promote_concept.py
+++ b/src/rumil/moves/promote_concept.py
@@ -6,7 +6,12 @@ from pydantic import BaseModel, Field
 
 from rumil.database import DB
 from rumil.models import Call, MoveType, Page, PageLayer, PageType, Workspace
-from rumil.moves.base import MoveDef, MoveResult, extract_and_link_citations, write_page_file
+from rumil.moves.base import (
+    MoveDef,
+    MoveResult,
+    extract_and_link_citations,
+    write_page_file,
+)
 
 log = logging.getLogger(__name__)
 
@@ -58,18 +63,23 @@ async def execute(payload: PromoteConceptPayload, call: Call, db: DB) -> MoveRes
     write_page_file(research_page)
     try:
         await extract_and_link_citations(
-            research_page.id, research_page.content, db,
-            citing_page_type=PageType.CONCEPT,
+            research_page.id,
+            research_page.content,
+            db,
         )
     except Exception:
         log.warning(
-            "Citation extraction failed for page %s", research_page.id[:8], exc_info=True,
+            "Citation extraction failed for page %s",
+            research_page.id[:8],
+            exc_info=True,
         )
     await db.supersede_page(resolved, research_page.id)
 
     log.info(
         "Concept promoted: staging=%s -> research=%s, headline=%s",
-        resolved[:8], research_page.id[:8], research_page.headline[:60],
+        resolved[:8],
+        research_page.id[:8],
+        research_page.headline[:60],
     )
     return MoveResult(
         message=(

--- a/src/rumil/moves/propose_concept.py
+++ b/src/rumil/moves/propose_concept.py
@@ -4,7 +4,12 @@ from pydantic import BaseModel, Field
 
 from rumil.database import DB
 from rumil.models import Call, MoveType, Page, PageLayer, PageType, Workspace
-from rumil.moves.base import MoveDef, MoveResult, extract_and_link_citations, write_page_file
+from rumil.moves.base import (
+    MoveDef,
+    MoveResult,
+    extract_and_link_citations,
+    write_page_file,
+)
 
 
 class ProposeConceptPayload(BaseModel):
@@ -21,8 +26,12 @@ class ProposeConceptPayload(BaseModel):
             "investigation it might clarify."
         )
     )
-    epistemic_status: float = Field(2.5, description="0-5 confidence that this concept is useful")
-    epistemic_type: str = Field("", description="Nature of uncertainty about this concept's value")
+    epistemic_status: float = Field(
+        2.5, description="0-5 confidence that this concept is useful"
+    )
+    epistemic_type: str = Field(
+        "", description="Nature of uncertainty about this concept's value"
+    )
 
 
 async def execute(payload: ProposeConceptPayload, call: Call, db: DB) -> MoveResult:
@@ -49,7 +58,9 @@ async def execute(payload: ProposeConceptPayload, call: Call, db: DB) -> MoveRes
     write_page_file(page)
     try:
         await extract_and_link_citations(
-            page.id, page.content, db, citing_page_type=PageType.CONCEPT,
+            page.id,
+            page.content,
+            db,
         )
     except Exception:
         pass

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -97,7 +97,7 @@ async def test_inline_citation_of_claim_creates_consideration_link(
 
     linked = await extract_and_link_citations(
         citing_page.id, citing_page.content, tmp_db,
-        citing_page_type=PageType.CLAIM,
+
     )
 
     assert linked == {claim_page.id}
@@ -126,7 +126,7 @@ async def test_multiple_inline_citations(
 
     linked = await extract_and_link_citations(
         citing_page.id, citing_page.content, tmp_db,
-        citing_page_type=PageType.CLAIM,
+
     )
 
     assert linked == {claim_page.id, second_claim_page.id}
@@ -151,7 +151,6 @@ async def test_judgement_citing_claim_creates_consideration_link(
 
     linked = await extract_and_link_citations(
         judgement.id, judgement.content, tmp_db,
-        citing_page_type=PageType.JUDGEMENT,
     )
 
     assert linked == {claim_page.id}
@@ -177,7 +176,6 @@ async def test_question_citing_claim_creates_consideration_link(
 
     linked = await extract_and_link_citations(
         question.id, question.content, tmp_db,
-        citing_page_type=PageType.QUESTION,
     )
 
     assert linked == {claim_page.id}

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -186,6 +186,38 @@ async def test_question_citing_claim_creates_consideration_link(
     assert cons[0].to_page_id == question.id
 
 
+async def test_citing_question_creates_related_link_cited_to_citing(tmp_db):
+    """Citing a QUESTION should produce a RELATED link from the cited question to the citing page."""
+    question = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Why is the sky blue?",
+        headline="Why is the sky blue?",
+    )
+    await tmp_db.save_page(question)
+
+    judgement = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"This relates to [{question.id[:8]}] but approaches it differently.",
+        headline="Alternative approach to sky color",
+    )
+    await tmp_db.save_page(judgement)
+
+    linked = await extract_and_link_citations(
+        judgement.id, judgement.content, tmp_db,
+    )
+
+    assert linked == {question.id}
+    links_to_judgement = await tmp_db.get_links_to(judgement.id)
+    related = [l for l in links_to_judgement if l.link_type == LinkType.RELATED]
+    assert len(related) == 1
+    assert related[0].from_page_id == question.id
+    assert related[0].to_page_id == judgement.id
+
+
 async def test_unresolvable_short_ids_skipped(tmp_db):
     """Citations referencing nonexistent pages are silently skipped."""
     page = Page(


### PR DESCRIPTION
## Summary
- Non-SOURCE inline citations now always create links from the cited page into the citing page (`from=cited, to=citing`), matching the existing CONSIDERATION convention
- Cited CLAIMs and JUDGEMENTs get CONSIDERATION links; other types (questions, concepts) get RELATED links — all with consistent direction
- Removed the `citing_page_type` parameter from `extract_and_link_citations()` since branching now depends only on the cited page's type

## Test plan
- [x] All 8 unit tests in `test_inline_citations.py` pass
- [x] LLM integration test (`test_assess_produces_inline_citations`) passes
- [x] Full test suite (99 passed, 35 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)