### PR TITLE
Show workspace name at top of all workspace pages

### DIFF
--- a/frontend/src/app/ab-traces/[abRunId]/page.tsx
+++ b/frontend/src/app/ab-traces/[abRunId]/page.tsx
@@ -4,6 +4,8 @@ import { ABTraceViewer } from "./ab-trace-viewer";
 import "../../traces/[runId]/trace.css";
 
 import { API_BASE } from "@/lib/api-base";
+import { WorkspaceIndicator } from "@/components/workspace-indicator";
+import { fetchProjectName } from "@/lib/fetch-project-name";
 
 async function getABRunTrace(abRunId: string): Promise<AbRunTraceOut | null> {
   const res = await fetch(`${API_BASE}/api/ab-runs/${abRunId}/trace`, {
@@ -21,6 +23,10 @@ export default async function ABTracePage({
   const { abRunId } = await params;
   const trace = await getABRunTrace(abRunId);
 
+  const projectName = trace?.question?.project_id
+    ? await fetchProjectName(trace.question.project_id)
+    : undefined;
+
   if (!trace) {
     return (
       <main className="trace-page">
@@ -34,6 +40,9 @@ export default async function ABTracePage({
 
   return (
     <main className="ab-trace-page">
+      {trace.question?.project_id && (
+        <WorkspaceIndicator projectId={trace.question.project_id} projectName={projectName} />
+      )}
       <header className="ab-trace-header">
         {trace.question && (
           <Link

--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -5,6 +5,8 @@ import LinksContainer from "./links-container";
 import StagedBanner from "./staged-banner";
 
 import { API_BASE } from "@/lib/api-base";
+import { WorkspaceIndicator } from "@/components/workspace-indicator";
+import { fetchProjectName } from "@/lib/fetch-project-name";
 
 const TYPE_CONFIG: Record<
   string,
@@ -205,9 +207,10 @@ export default async function PageDetailPage({
 
   const { page, links_from, links_to } = detail;
   const cfg = TYPE_CONFIG[page.page_type] || TYPE_CONFIG.source;
-  const [citationMap, supersedingPage] = await Promise.all([
+  const [citationMap, supersedingPage, projectName] = await Promise.all([
     buildCitationMap(links_from, links_to, page.content, stagedRunId),
     page.superseded_by ? getPageHeadline(page.superseded_by, stagedRunId) : null,
+    fetchProjectName(page.project_id),
   ]);
   const processedContent = injectCitationLinks(page.content, citationMap, stagedRunId);
 
@@ -215,9 +218,7 @@ export default async function PageDetailPage({
     <>
       <style>{styles}</style>
       <main className="page-detail">
-        <Link href={`/projects/${page.project_id}`} className="back-link">
-        &larr; Workspace
-      </Link>
+        <WorkspaceIndicator projectId={page.project_id} projectName={projectName} />
 
       {stagedRunId && (
         <StagedBanner runId={stagedRunId} pageUrl={`/pages/${pageId}`} />

--- a/frontend/src/app/projects/[projectId]/page.tsx
+++ b/frontend/src/app/projects/[projectId]/page.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useState, useMemo } from "react";
-import type { Page, PageType, RunListItemOut } from "@/api";
+import type { Page, PageType, Project, RunListItemOut } from "@/api";
 
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
 import { useStagedRun } from "@/lib/staged-run-context";
+import { WorkspaceIndicator } from "@/components/workspace-indicator";
 
 const PAGE_TYPES: PageType[] = [
   "question",
@@ -75,6 +76,7 @@ export default function PagesIndexPage() {
   const params = useParams<{ projectId: string }>();
   const projectId = params.projectId;
 
+  const [projectName, setProjectName] = useState<string>();
   const [pages, setPages] = useState<Page[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
@@ -82,6 +84,14 @@ export default function PagesIndexPage() {
   const [runs, setRuns] = useState<RunListItemOut[]>([]);
   const [showSuperseded, setShowSuperseded] = useState(false);
   const { activeStagedRunId, setActiveStagedRunId } = useStagedRun();
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/projects/${projectId}`, { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: Project | null) => {
+        if (data) setProjectName(data.name);
+      });
+  }, [projectId]);
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -729,9 +739,7 @@ export default function PagesIndexPage() {
         }
       `}</style>
 
-      <Link href="/" className="back-link">
-        &larr; Workspaces
-      </Link>
+      <WorkspaceIndicator projectId={projectId} projectName={projectName} />
 
       <div className="pages-header">
         <h1>Pages</h1>

--- a/frontend/src/app/traces/[runId]/page.tsx
+++ b/frontend/src/app/traces/[runId]/page.tsx
@@ -4,6 +4,8 @@ import { TraceViewer } from "./trace-viewer";
 import "./trace.css";
 
 import { API_BASE } from "@/lib/api-base";
+import { WorkspaceIndicator } from "@/components/workspace-indicator";
+import { fetchProjectName } from "@/lib/fetch-project-name";
 
 async function getRunTraceTree(runId: string): Promise<RunTraceTreeOut | null> {
   const res = await fetch(`${API_BASE}/api/runs/${runId}/trace-tree`, {
@@ -36,6 +38,10 @@ export default async function TracePage({
     getRealtimeConfig(),
   ]);
 
+  const projectName = trace?.question?.project_id
+    ? await fetchProjectName(trace.question.project_id)
+    : undefined;
+
   if (!trace) {
     return (
       <main className="trace-page">
@@ -49,6 +55,9 @@ export default async function TracePage({
 
   return (
     <main className="trace-page">
+      {trace.question?.project_id && (
+        <WorkspaceIndicator projectId={trace.question.project_id} projectName={projectName} />
+      )}
       <header className="trace-header">
         {trace.question && (
           <Link

--- a/frontend/src/components/workspace-indicator.tsx
+++ b/frontend/src/components/workspace-indicator.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+
+export function WorkspaceIndicator({
+  projectId,
+  projectName,
+}: {
+  projectId: string;
+  projectName?: string;
+}) {
+  return (
+    <>
+      <style>{`
+        .ws-indicator {
+          display: flex;
+          align-items: center;
+          gap: 0.4rem;
+          margin-bottom: 0.75rem;
+          font-family: var(--font-geist-mono), monospace;
+          font-size: 0.65rem;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: var(--color-dim);
+          user-select: none;
+        }
+        .ws-indicator a {
+          color: inherit;
+          text-decoration: none;
+          transition: color 0.15s;
+        }
+        .ws-indicator a:hover {
+          color: var(--color-muted);
+        }
+        .ws-indicator-sep {
+          opacity: 0.4;
+        }
+      `}</style>
+      <div className="ws-indicator">
+        <Link href="/">rumil</Link>
+        <span className="ws-indicator-sep">/</span>
+        <Link href={`/projects/${projectId}`}>
+          {projectName ?? projectId.slice(0, 8)}
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/lib/fetch-project-name.ts
+++ b/frontend/src/lib/fetch-project-name.ts
@@ -1,0 +1,17 @@
+import { API_BASE } from "@/lib/api-base";
+import type { Project } from "@/api";
+
+export async function fetchProjectName(
+  projectId: string,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(`${API_BASE}/api/projects/${projectId}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return undefined;
+    const project: Project = await res.json();
+    return project.name;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -86,6 +86,20 @@ async def list_projects():
     return await db.list_projects()
 
 
+@app.get("/api/projects/{project_id}", response_model=Project)
+async def get_project(project_id: str):
+    from rumil.database import _rows
+
+    db = await _get_db(project_id)
+    rows = _rows(
+        await db.client.table("projects").select("*").eq("id", project_id).execute()
+    )
+    if not rows:
+        raise HTTPException(status_code=404, detail="Project not found")
+    r = rows[0]
+    return Project(id=r["id"], name=r["name"], created_at=r["created_at"])
+
+
 @app.get("/api/projects/{project_id}/runs", response_model=list[RunListItemOut])
 async def list_project_runs(project_id: str):
     db = await _get_db(project_id)


### PR DESCRIPTION
## Summary
- Adds a subtle breadcrumb indicator (`rumil / workspace-name`) at the top of project, page detail, trace, and AB trace pages
- New `GET /api/projects/{project_id}` endpoint to resolve project names by ID
- New `WorkspaceIndicator` component and `fetchProjectName` helper

## Test plan
- [ ] Navigate to a project page — verify workspace name appears at top
- [ ] Navigate to a page detail — verify workspace name appears
- [ ] Navigate to a trace page — verify workspace name appears
- [ ] Navigate to an AB trace page — verify workspace name appears
- [ ] Verify both breadcrumb links (rumil → home, workspace name → project) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)