### PR TITLE
Pass full budget to phase 1 prioritization instead of capping at 4

### DIFF
--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -105,7 +105,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
     ) -> str:
         """Eagerly create the phase-1 prioritization call record."""
         budget = self._effective_budget(await self.db.budget_remaining())
-        phase1_budget = min(budget - 3, MIN_TWOPHASE_BUDGET)
+        phase1_budget = budget
         p_call = await self.db.create_call(
             CallType.PRIORITIZATION,
             scope_page_id=claim_id,
@@ -261,7 +261,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         parent_call_id: str | None,
     ) -> 'PrioritizationResult':
 
-        phase1_budget = min(budget - 3, MIN_TWOPHASE_BUDGET)
+        phase1_budget = budget
         log.info(
             'ClaimInvestigationOrchestrator phase1: claim=%s, budget=%d, phase1_budget=%d',
             claim_id[:8], budget, phase1_budget,

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -98,7 +98,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         before ``run()`` begins. ``_phase1`` reuses the pre-created call.
         """
         budget = self._effective_budget(await self.db.budget_remaining())
-        phase1_budget = min(budget - 3, MIN_TWOPHASE_BUDGET)
+        phase1_budget = budget
         p_call = await self.db.create_call(
             CallType.PRIORITIZATION,
             scope_page_id=question_id,
@@ -250,7 +250,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         budget: int,
         parent_call_id: str | None,
     ) -> PrioritizationResult:
-        phase1_budget = min(budget - 3, MIN_TWOPHASE_BUDGET)
+        phase1_budget = budget
         log.info(
             'ExperimentalOrchestrator phase1: question=%s, budget=%d, phase1_budget=%d',
             question_id[:8], budget, phase1_budget,

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -98,7 +98,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         before ``run()`` begins. ``_phase1`` reuses the pre-created call.
         """
         budget = self._effective_budget(await self.db.budget_remaining())
-        phase1_budget = min(budget - 3, MIN_TWOPHASE_BUDGET)
+        phase1_budget = budget
         p_call = await self.db.create_call(
             CallType.PRIORITIZATION,
             scope_page_id=question_id,
@@ -250,7 +250,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         budget: int,
         parent_call_id: str | None,
     ) -> PrioritizationResult:
-        phase1_budget = min(budget - 3, MIN_TWOPHASE_BUDGET)
+        phase1_budget = budget
         log.info(
             'TwoPhaseOrchestrator phase1: question=%s, budget=%d, phase1_budget=%d',
             question_id[:8], budget, phase1_budget,


### PR DESCRIPTION
The min(budget - 3, MIN_TWOPHASE_BUDGET) formula always capped phase 1 at 4 budget units regardless of total budget. The phase 1 prompt is written assuming it receives the full budget, so pass it through.