### PR TITLE
Add dual-write mutation events and retroactive run staging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,15 +13,16 @@ Runs can be **staged** (`staged=True` on the `DB` instance), meaning their effec
 **How it works:**
 
 - **New pages/links** created by a staged run are written to their base tables with `staged=true` and tagged with `run_id`. Only that run can see them (via `_staged_filter()`).
-- **Mutations to existing state** (superseding pages, deleting links, changing link roles) are recorded as append-only events in the `mutation_events` table instead of modifying base tables. On read, `_apply_page_events()` / `_apply_link_events()` replay these events to materialize the run's view of the workspace. The `MutationState` cache (`_load_mutation_state()`) avoids re-reading events.
+- **Mutations to existing state** (superseding pages, deleting links, changing link roles) are **always** recorded as append-only events in the `mutation_events` table, regardless of whether the run is staged. Non-staged runs also apply the mutation directly to base tables (dual-write) so that other readers see the change immediately. On read, `_apply_page_events()` / `_apply_link_events()` replay events to materialize a staged run's view. The `MutationState` cache (`_load_mutation_state()`) avoids re-reading events.
+- **Retroactive staging:** because all runs record mutation events, a completed non-staged run can be retroactively staged via `DB.stage_run(run_id)`. This flips the run's rows to `staged=true` and reverts direct mutations using the event log, restoring baseline state for other readers.
 - **Visibility rule:** staged runs see `staged=false` (baseline) rows plus their own `run_id` rows. Non-staged runs see only baseline. Two staged runs are fully isolated.
 
 **What this means for new code:**
 
-- Any new operation that modifies workspace state (pages, links, or future tables) **must** go through the staged path: write new rows with `staged`/`run_id` flags, and record mutations to existing rows in `mutation_events` rather than updating base tables directly.
+- Any new operation that modifies workspace state (pages, links, or future tables) **must** record a mutation event **and** apply the direct mutation when `not self.staged`. Write new rows with `staged`/`run_id` flags.
 - Any new read path **must** apply `_staged_filter()` and the relevant `_apply_*_events()` methods so staged runs see their own mutations.
 - RPC functions that read pages or links must accept a `staged_run_id` parameter and apply the same visibility logic. See `match_pages()` and `get_root_questions()` in the migrations for examples.
-- Never introduce a write path that silently bypasses staging — it will break run isolation.
+- Never introduce a write path that silently bypasses event recording — it will break retroactive staging.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ uv run python main.py --ab "Your question here" --budget 10
 # Name a run for easier identification in the trace viewer
 uv run python main.py "Your question here" --name "baseline v2" --budget 10
 
+# Retroactively stage a completed run (hides its effects from baseline readers)
+uv run python main.py --stage-run RUN_ID
+
 # Smoke-test mode: uses Haiku, fewer agent rounds, budget defaults to 1
 uv run python main.py "Your question here" --smoke-test
 

--- a/main.py
+++ b/main.py
@@ -886,17 +886,17 @@ async def async_main():
         run_id=str(uuid.uuid4()), prod=args.prod_db, staged=args.staged
     )
 
-    if args.stage_run_id:
-        await db.stage_run(args.stage_run_id)
-        print(f"Run {args.stage_run_id} has been staged.")
-        return
-
     if args.list_workspaces:
         await cmd_list_workspaces(db)
         return
 
     project = await db.get_or_create_project(args.workspace_name)
     db.project_id = project.id
+
+    if args.stage_run_id:
+        await db.stage_run(args.stage_run_id)
+        print(f"Run {args.stage_run_id} has been staged.")
+        return
 
     if args.list:
         await cmd_list(db, args.workspace_name)

--- a/main.py
+++ b/main.py
@@ -834,6 +834,13 @@ async def async_main():
         "of modifying the database directly",
     )
     parser.add_argument(
+        "--stage-run",
+        dest="stage_run_id",
+        metavar="RUN_ID",
+        help="Retroactively stage a completed non-staged run, hiding its "
+        "effects from baseline readers",
+    )
+    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -878,6 +885,11 @@ async def async_main():
     db = await DB.create(
         run_id=str(uuid.uuid4()), prod=args.prod_db, staged=args.staged
     )
+
+    if args.stage_run_id:
+        await db.stage_run(args.stage_run_id)
+        print(f"Run {args.stage_run_id} has been staged.")
+        return
 
     if args.list_workspaces:
         await cmd_list_workspaces(db)

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -959,7 +959,9 @@ class DB:
     async def delete_link(self, link_id: str) -> None:
         """Delete a page link by ID."""
         rows = _rows(await self._execute(
-            self.client.table("page_links").select("*").eq("id", link_id)
+            self._staged_filter(
+                self.client.table("page_links").select("*").eq("id", link_id)
+            )
         ))
         link_snapshot = rows[0] if rows else {}
         await self.record_mutation_event("delete_link", link_id, link_snapshot)
@@ -1564,6 +1566,10 @@ class DB:
             elif et == "change_link_role":
                 old_role = payload.get("old_role")
                 if not old_role:
+                    log.warning(
+                        "Cannot revert role change for link %s: no old_role in event payload",
+                        tid,
+                    )
                     continue
                 link_rows = _rows(await self._execute(
                     self.client.table("page_links")

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -287,7 +287,7 @@ class DB:
     async def record_mutation_event(
         self, event_type: str, target_id: str, payload: dict,
     ) -> None:
-        """Record a mutation event (staged runs only)."""
+        """Record a mutation event for undo/staging support."""
         await self._execute(
             self.client.table("mutation_events").insert({
                 "id": str(uuid.uuid4()),
@@ -567,19 +567,18 @@ class DB:
         return pages
 
     async def supersede_page(self, old_id: str, new_id: str) -> None:
-        if self.staged:
-            await self.record_mutation_event(
-                "supersede_page", old_id, {"new_page_id": new_id},
-            )
-            return
-        await self._execute(
-            self.client.table("pages").update(
-                {
-                    "is_superseded": True,
-                    "superseded_by": new_id,
-                }
-            ).eq("id", old_id)
+        await self.record_mutation_event(
+            "supersede_page", old_id, {"new_page_id": new_id},
         )
+        if not self.staged:
+            await self._execute(
+                self.client.table("pages").update(
+                    {
+                        "is_superseded": True,
+                        "superseded_by": new_id,
+                    }
+                ).eq("id", old_id)
+            )
 
     # --- Links ---
 
@@ -959,27 +958,30 @@ class DB:
 
     async def delete_link(self, link_id: str) -> None:
         """Delete a page link by ID."""
-        if self.staged:
-            await self.record_mutation_event(
-                "delete_link", link_id, {},
+        rows = _rows(await self._execute(
+            self.client.table("page_links").select("*").eq("id", link_id)
+        ))
+        link_snapshot = rows[0] if rows else {}
+        await self.record_mutation_event("delete_link", link_id, link_snapshot)
+        if not self.staged:
+            await self._execute(
+                self.client.table("page_links").delete().eq("id", link_id)
             )
-            return
-        await self._execute(
-            self.client.table("page_links").delete().eq("id", link_id)
-        )
 
     async def update_link_role(self, link_id: str, role: LinkRole) -> None:
         """Update a link's role."""
-        if self.staged:
-            await self.record_mutation_event(
-                "change_link_role", link_id, {"new_role": role.value},
-            )
-            return
-        await self._execute(
-            self.client.table("page_links").update(
-                {"role": role.value}
-            ).eq("id", link_id)
+        link = await self.get_link(link_id)
+        old_role = link.role.value if link else None
+        await self.record_mutation_event(
+            "change_link_role", link_id,
+            {"new_role": role.value, "old_role": old_role},
         )
+        if not self.staged:
+            await self._execute(
+                self.client.table("page_links").update(
+                    {"role": role.value}
+                ).eq("id", link_id)
+            )
 
     async def get_last_find_considerations_info(
         self,
@@ -1492,6 +1494,89 @@ class DB:
                 }
             )
         )
+
+    async def stage_run(self, run_id: str) -> None:
+        """Retroactively stage a completed non-staged run.
+
+        Flips the staged flag on the run's rows, then reverts direct
+        mutations (supersessions, link deletions, role changes) so baseline
+        readers see the pre-run state. The mutation events remain, so a
+        staged reader replaying them will see the same view the run
+        originally produced.
+        """
+        await self._execute(
+            self.client.table("runs").update({"staged": True}).eq("id", run_id)
+        )
+        await self._execute(
+            self.client.table("pages").update({"staged": True}).eq("run_id", run_id)
+        )
+        await self._execute(
+            self.client.table("page_links")
+            .update({"staged": True})
+            .eq("run_id", run_id)
+        )
+
+        events = _rows(
+            await self._execute(
+                self.client.table("mutation_events")
+                .select("event_type, target_id, payload")
+                .eq("run_id", run_id)
+                .order("created_at")
+            )
+        )
+        for ev in events:
+            et = ev["event_type"]
+            tid = ev["target_id"]
+            payload = ev.get("payload") or {}
+
+            if et == "supersede_page":
+                await self._execute(
+                    self.client.table("pages")
+                    .update({"is_superseded": False, "superseded_by": None})
+                    .eq("id", tid)
+                )
+
+            elif et == "delete_link":
+                if not payload or "from_page_id" not in payload:
+                    log.warning(
+                        "Cannot restore deleted link %s: no snapshot in event payload",
+                        tid,
+                    )
+                    continue
+                was_own_link = payload.get("run_id") == run_id
+                restore_row = {
+                    "id": tid,
+                    "from_page_id": payload["from_page_id"],
+                    "to_page_id": payload["to_page_id"],
+                    "link_type": payload["link_type"],
+                    "direction": payload.get("direction"),
+                    "strength": payload.get("strength", 2.5),
+                    "reasoning": payload.get("reasoning", ""),
+                    "role": payload.get("role", "direct"),
+                    "created_at": payload.get("created_at"),
+                    "run_id": payload.get("run_id", run_id),
+                    "staged": was_own_link,
+                }
+                await self._execute(
+                    self.client.table("page_links").upsert(restore_row)
+                )
+
+            elif et == "change_link_role":
+                old_role = payload.get("old_role")
+                if not old_role:
+                    continue
+                link_rows = _rows(await self._execute(
+                    self.client.table("page_links")
+                    .select("run_id")
+                    .eq("id", tid)
+                ))
+                if link_rows and link_rows[0].get("run_id") == run_id:
+                    continue
+                await self._execute(
+                    self.client.table("page_links")
+                    .update({"role": old_role})
+                    .eq("id", tid)
+                )
 
     async def create_ab_run(
         self,

--- a/supabase/migrations/20260330214358_fix_rpc_staged_filter.sql
+++ b/supabase/migrations/20260330214358_fix_rpc_staged_filter.sql
@@ -1,0 +1,104 @@
+-- Fix staged visibility filter in RPCs.
+--
+-- The previous filter `(p_staged_run_id IS NULL OR p.staged = FALSE OR ...)`
+-- evaluates to TRUE for all rows when p_staged_run_id is NULL, letting
+-- staged pages through to non-staged readers. The correct filter is
+-- `(p.staged = FALSE OR p.run_id = p_staged_run_id)` which returns only
+-- baseline rows when no staged run is specified (since run_id = NULL is
+-- always false).
+
+DROP FUNCTION IF EXISTS match_pages(
+    extensions.vector, DOUBLE PRECISION, INTEGER, TEXT, UUID, TEXT, TEXT
+);
+
+CREATE OR REPLACE FUNCTION match_pages(
+    query_embedding extensions.vector(1024),
+    match_threshold DOUBLE PRECISION DEFAULT 0.5,
+    match_count INTEGER DEFAULT 10,
+    filter_workspace TEXT DEFAULT NULL,
+    filter_project_id UUID DEFAULT NULL,
+    filter_field_name TEXT DEFAULT NULL,
+    filter_staged_run_id TEXT DEFAULT NULL
+)
+RETURNS TABLE(
+    id TEXT,
+    page_type TEXT,
+    layer TEXT,
+    workspace TEXT,
+    content TEXT,
+    headline TEXT,
+    abstract TEXT,
+    project_id UUID,
+    epistemic_status DOUBLE PRECISION,
+    epistemic_type TEXT,
+    credence INTEGER,
+    robustness INTEGER,
+    provenance_model TEXT,
+    provenance_call_type TEXT,
+    provenance_call_id TEXT,
+    created_at TIMESTAMPTZ,
+    superseded_by TEXT,
+    is_superseded BOOLEAN,
+    extra JSONB,
+    run_id TEXT,
+    field_name TEXT,
+    similarity DOUBLE PRECISION
+)
+LANGUAGE sql STABLE
+SET search_path = public, extensions
+AS $$
+    SELECT
+        p.id,
+        p.page_type,
+        p.layer,
+        p.workspace,
+        p.content,
+        p.headline,
+        p.abstract,
+        p.project_id,
+        p.epistemic_status,
+        p.epistemic_type,
+        p.credence,
+        p.robustness,
+        p.provenance_model,
+        p.provenance_call_type,
+        p.provenance_call_id,
+        p.created_at,
+        p.superseded_by,
+        p.is_superseded,
+        p.extra,
+        p.run_id,
+        pe.field_name,
+        1 - (pe.embedding <=> query_embedding) AS similarity
+    FROM page_embeddings pe
+    JOIN pages p ON p.id = pe.page_id
+    WHERE p.is_superseded = FALSE
+      AND 1 - (pe.embedding <=> query_embedding) > match_threshold
+      AND (filter_workspace IS NULL OR p.workspace = filter_workspace)
+      AND (filter_project_id IS NULL OR p.project_id = filter_project_id)
+      AND (filter_field_name IS NULL OR pe.field_name = filter_field_name)
+      AND (p.staged = FALSE OR p.run_id = filter_staged_run_id)
+    ORDER BY pe.embedding <=> query_embedding
+    LIMIT match_count;
+$$;
+
+DROP FUNCTION IF EXISTS get_root_questions(TEXT, UUID, TEXT);
+
+CREATE OR REPLACE FUNCTION get_root_questions(
+    ws TEXT,
+    pid UUID DEFAULT NULL,
+    p_staged_run_id TEXT DEFAULT NULL
+)
+RETURNS SETOF pages
+LANGUAGE sql STABLE AS $$
+    SELECT p.* FROM pages p
+    WHERE p.page_type = 'question'
+      AND p.workspace = ws
+      AND p.is_superseded = FALSE
+      AND (pid IS NULL OR p.project_id = pid)
+      AND (p.staged = FALSE OR p.run_id = p_staged_run_id)
+      AND p.id NOT IN (
+          SELECT to_page_id FROM page_links WHERE link_type = 'child_question'
+      )
+    ORDER BY p.created_at DESC;
+$$;

--- a/tests/test_staged_runs.py
+++ b/tests/test_staged_runs.py
@@ -211,3 +211,214 @@ async def test_get_pages_by_ids_respects_staged_events(baseline_db, staged_db, o
     observer_result = await observer_db.get_pages_by_ids([page.id])
     assert page.id in observer_result
     assert observer_result[page.id].is_superseded is False
+
+
+async def test_nonstaged_runs_record_mutation_events(baseline_db, observer_db):
+    """Non-staged mutations now record events in mutation_events table."""
+    q = await _make_page(baseline_db, "question", PageType.QUESTION)
+    claim = await _make_page(baseline_db, "original claim")
+    link = await _link(baseline_db, claim, q)
+
+    replacement = await _make_page(observer_db, "replacement claim")
+    await observer_db.supersede_page(claim.id, replacement.id)
+    await observer_db.delete_link(link.id)
+
+    q2 = await _make_page(baseline_db, "question 2", PageType.QUESTION)
+    claim2 = await _make_page(baseline_db, "claim 2")
+    link2 = await _link(baseline_db, claim2, q2)
+    await observer_db.update_link_role(link2.id, LinkRole.STRUCTURAL)
+
+    events = (
+        await observer_db._execute(
+            observer_db.client.table("mutation_events")
+            .select("event_type, target_id")
+            .eq("run_id", observer_db.run_id)
+            .order("created_at")
+        )
+    ).data
+    event_types = [e["event_type"] for e in events]
+    target_ids = [e["target_id"] for e in events]
+
+    assert "supersede_page" in event_types
+    assert "delete_link" in event_types
+    assert "change_link_role" in event_types
+    assert claim.id in target_ids
+    assert link.id in target_ids
+    assert link2.id in target_ids
+
+
+async def test_stage_run_hides_pages_from_baseline(project_id):
+    """After stage_run(), the run's pages and links are invisible to baseline readers."""
+    run_db = await _make_db(project_id, staged=False)
+    await run_db.init_budget(100)
+    observer = await _make_db(project_id, staged=False)
+
+    q = await _make_page(run_db, "question", PageType.QUESTION)
+    claim = await _make_page(run_db, "a claim")
+    await _link(run_db, claim, q)
+
+    # Before staging: observer sees everything
+    obs_pages = await observer.get_pages()
+    assert q.id in {p.id for p in obs_pages}
+    assert claim.id in {p.id for p in obs_pages}
+
+    await observer.stage_run(run_db.run_id)
+
+    # After staging: observer sees nothing from that run
+    obs_pages = await observer.get_pages()
+    obs_ids = {p.id for p in obs_pages}
+    assert q.id not in obs_ids
+    assert claim.id not in obs_ids
+
+    obs_links = await observer.get_links_to(q.id)
+    assert len(obs_links) == 0
+
+    await run_db.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_stage_run_reverts_supersession(project_id):
+    """stage_run() restores a baseline page that the run had superseded."""
+    baseline = await _make_db(project_id, staged=False)
+    await baseline.init_budget(100)
+    run_db = await _make_db(project_id, staged=False)
+    await run_db.init_budget(100)
+    observer = await _make_db(project_id, staged=False)
+
+    original = await _make_page(baseline, "original claim")
+    replacement = await _make_page(run_db, "better claim")
+    await run_db.supersede_page(original.id, replacement.id)
+
+    # Before staging: observer sees original as superseded
+    obs_page = await observer.get_page(original.id)
+    assert obs_page is not None
+    assert obs_page.is_superseded is True
+
+    await observer.stage_run(run_db.run_id)
+
+    # After staging: observer sees original as active again
+    obs_page = await observer.get_page(original.id)
+    assert obs_page is not None
+    assert obs_page.is_superseded is False
+    assert obs_page.superseded_by is None
+
+    await baseline.delete_run_data()
+    await run_db.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_stage_run_restores_deleted_link(project_id):
+    """stage_run() re-inserts a baseline link that the run had deleted."""
+    baseline = await _make_db(project_id, staged=False)
+    await baseline.init_budget(100)
+    run_db = await _make_db(project_id, staged=False)
+    await run_db.init_budget(100)
+    observer = await _make_db(project_id, staged=False)
+
+    q = await _make_page(baseline, "question", PageType.QUESTION)
+    claim = await _make_page(baseline, "some claim")
+    link = await _link(baseline, claim, q)
+
+    await run_db.delete_link(link.id)
+
+    # Before staging: link is gone
+    obs_links = await observer.get_links_to(q.id)
+    assert all(l.id != link.id for l in obs_links)
+
+    await observer.stage_run(run_db.run_id)
+
+    # After staging: link is restored
+    obs_links = await observer.get_links_to(q.id)
+    assert any(l.id == link.id for l in obs_links)
+
+    await baseline.delete_run_data()
+    await run_db.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_stage_run_reverts_role_change(project_id):
+    """stage_run() restores a baseline link's original role."""
+    baseline = await _make_db(project_id, staged=False)
+    await baseline.init_budget(100)
+    run_db = await _make_db(project_id, staged=False)
+    await run_db.init_budget(100)
+    observer = await _make_db(project_id, staged=False)
+
+    q = await _make_page(baseline, "question", PageType.QUESTION)
+    claim = await _make_page(baseline, "some claim")
+    link = await _link(baseline, claim, q)
+    assert link.role == LinkRole.DIRECT
+
+    await run_db.update_link_role(link.id, LinkRole.STRUCTURAL)
+
+    # Before staging: observer sees STRUCTURAL
+    obs_link = await observer.get_link(link.id)
+    assert obs_link is not None
+    assert obs_link.role == LinkRole.STRUCTURAL
+
+    await observer.stage_run(run_db.run_id)
+
+    # After staging: observer sees original DIRECT
+    obs_link = await observer.get_link(link.id)
+    assert obs_link is not None
+    assert obs_link.role == LinkRole.DIRECT
+
+    await baseline.delete_run_data()
+    await run_db.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_retroactively_staged_run_indistinguishable(project_id):
+    """A retroactively staged run looks identical to a natively staged run."""
+    baseline = await _make_db(project_id, staged=False)
+    await baseline.init_budget(100)
+    run_db = await _make_db(project_id, staged=False)
+    await run_db.init_budget(100)
+    helper = await _make_db(project_id, staged=False)
+
+    # Baseline state
+    original_claim = await _make_page(baseline, "original claim")
+    q = await _make_page(baseline, "question", PageType.QUESTION)
+    baseline_link = await _link(baseline, original_claim, q)
+
+    # Run creates a page, supersedes the original, and deletes the baseline link
+    replacement = await _make_page(run_db, "replacement claim")
+    await run_db.supersede_page(original_claim.id, replacement.id)
+    await run_db.delete_link(baseline_link.id)
+
+    # Retroactively stage
+    await helper.stage_run(run_db.run_id)
+
+    # Open a staged reader for the now-staged run
+    staged_reader = await DB.create(run_id=run_db.run_id, staged=True)
+    staged_reader.project_id = project_id
+
+    # Staged reader sees the replacement page
+    pages = await staged_reader.get_pages()
+    page_ids = {p.id for p in pages}
+    assert replacement.id in page_ids
+
+    # Staged reader sees original_claim as superseded
+    page = await staged_reader.get_page(original_claim.id)
+    assert page is not None
+    assert page.is_superseded is True
+    assert page.superseded_by == replacement.id
+
+    # Staged reader does not see the deleted baseline link
+    links = await staged_reader.get_links_to(q.id)
+    assert all(l.id != baseline_link.id for l in links)
+
+    # Baseline observer sees none of the run's effects
+    observer = await _make_db(project_id, staged=False)
+    obs_pages = await observer.get_pages(active_only=True)
+    obs_ids = {p.id for p in obs_pages}
+    assert original_claim.id in obs_ids
+    assert replacement.id not in obs_ids
+
+    obs_links = await observer.get_links_to(q.id)
+    assert any(l.id == baseline_link.id for l in obs_links)
+
+    await baseline.delete_run_data()
+    await run_db.delete_run_data()
+    await helper.delete_run_data()
+    await observer.delete_run_data()


### PR DESCRIPTION
## Summary
- All mutation operations (`supersede_page`, `delete_link`, `update_link_role`) now always record events in `mutation_events`, regardless of whether the run is staged. Non-staged runs also apply the direct mutation for cross-run visibility (dual-write).
- New `DB.stage_run(run_id)` method retroactively stages a completed non-staged run: flips `staged=true` on its rows and reverts direct mutations using the event log, so baseline readers see pre-run state while a staged reader sees the run's full effects.
- New `--stage-run RUN_ID` CLI flag in `main.py`.
- Updated CLAUDE.md staged runs documentation to reflect the dual-write pattern.

## Test plan
- [x] All 7 existing staged run tests pass (dual-write preserves behavior)
- [x] 6 new tests: event recording for non-staged runs, `stage_run` hiding pages, reverting supersessions, restoring deleted links, reverting role changes, and verifying a retroactively staged run is indistinguishable from a natively staged one
- [x] Full test suite passes (114 passed, 36 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)