### PR TITLE
Fix test_staged_runs leaking project rows

### DIFF
--- a/tests/test_staged_runs.py
+++ b/tests/test_staged_runs.py
@@ -50,7 +50,10 @@ async def _link(db: DB, from_page: Page, to_page: Page) -> PageLink:
 async def project_id():
     db = await DB.create(run_id=str(uuid.uuid4()))
     project = await db.get_or_create_project(f"test-staged-{uuid.uuid4().hex[:8]}")
-    return project.id
+    yield project.id
+    await db._execute(
+        db.client.table("projects").delete().eq("id", project.id)
+    )
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Summary
- The `project_id` fixture in `test_staged_runs.py` used `return` instead of `yield`, so it had no teardown — every test run left an orphaned `test-staged-<id>` project row in the database (231 had accumulated locally).
- Switched to `yield` with a teardown that deletes the project row after the test completes.

## Test plan
- [x] All 13 tests in `test_staged_runs.py` pass
- [ ] Verify no new `test-staged-*` projects accumulate after running the test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)