### PR TITLE
Implement commit_staged_run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ uv run python main.py "Your question here" --name "baseline v2" --budget 10
 # Retroactively stage a completed run (hides its effects from baseline readers)
 uv run python main.py --stage-run RUN_ID
 
+# Commit a staged run (makes its effects visible to all readers)
+uv run python main.py --commit-run RUN_ID
+
 # Smoke-test mode: uses Haiku, fewer agent rounds, budget defaults to 1
 uv run python main.py "Your question here" --smoke-test
 

--- a/main.py
+++ b/main.py
@@ -905,6 +905,12 @@ async def async_main():
         "effects from baseline readers",
     )
     parser.add_argument(
+        "--commit-run",
+        dest="commit_run_id",
+        metavar="RUN_ID",
+        help="Commit a staged run, making its effects visible to all readers",
+    )
+    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -960,6 +966,11 @@ async def async_main():
     if args.stage_run_id:
         await db.stage_run(args.stage_run_id)
         print(f"Run {args.stage_run_id} has been staged.")
+        return
+
+    if args.commit_run_id:
+        await db.commit_staged_run(args.commit_run_id)
+        print(f"Run {args.commit_run_id} has been committed.")
         return
 
     if args.list:

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -1584,6 +1584,82 @@ class DB:
                     .eq("id", tid)
                 )
 
+    async def commit_staged_run(self, run_id: str) -> None:
+        """Commit a staged run, making its effects visible to all readers.
+
+        Flips the staged flag to false on the run's rows, then applies
+        mutation events (supersessions, link deletions, role changes) that
+        were recorded but never written directly to the database.
+        """
+        run_rows = _rows(
+            await self._execute(
+                self.client.table("runs").select("id, staged").eq("id", run_id)
+            )
+        )
+        if not run_rows:
+            raise ValueError(f"Run {run_id} not found")
+        if not run_rows[0].get("staged"):
+            raise ValueError(f"Run {run_id} is not staged")
+
+        await self._execute(
+            self.client.table("runs").update({"staged": False}).eq("id", run_id)
+        )
+        await self._execute(
+            self.client.table("pages")
+            .update({"staged": False})
+            .eq("run_id", run_id)
+        )
+        await self._execute(
+            self.client.table("page_links")
+            .update({"staged": False})
+            .eq("run_id", run_id)
+        )
+
+        events = _rows(
+            await self._execute(
+                self.client.table("mutation_events")
+                .select("event_type, target_id, payload")
+                .eq("run_id", run_id)
+                .order("created_at")
+            )
+        )
+        for ev in events:
+            et = ev["event_type"]
+            tid = ev["target_id"]
+            payload = ev.get("payload") or {}
+
+            if et == "supersede_page":
+                await self._execute(
+                    self.client.table("pages")
+                    .update(
+                        {
+                            "is_superseded": True,
+                            "superseded_by": payload["new_page_id"],
+                        }
+                    )
+                    .eq("id", tid)
+                )
+
+            elif et == "delete_link":
+                await self._execute(
+                    self.client.table("page_links").delete().eq("id", tid)
+                )
+
+            elif et == "change_link_role":
+                new_role = payload.get("new_role")
+                if not new_role:
+                    log.warning(
+                        "Cannot apply role change for link %s: "
+                        "no new_role in event payload",
+                        tid,
+                    )
+                    continue
+                await self._execute(
+                    self.client.table("page_links")
+                    .update({"role": new_role})
+                    .eq("id", tid)
+                )
+
     async def create_ab_run(
         self,
         ab_run_id: str,

--- a/tests/test_staged_runs.py
+++ b/tests/test_staged_runs.py
@@ -2,6 +2,7 @@
 
 import uuid
 
+import pytest
 import pytest_asyncio
 
 from rumil.database import DB
@@ -425,3 +426,208 @@ async def test_retroactively_staged_run_indistinguishable(project_id):
     await run_db.delete_run_data()
     await helper.delete_run_data()
     await observer.delete_run_data()
+
+
+async def _register_run(db: DB) -> None:
+    """Register a run in the runs table so commit_staged_run can find it."""
+    await db.create_run(name="test", question_id=None)
+
+
+async def test_commit_staged_run_reveals_pages(project_id):
+    """After commit_staged_run(), a natively staged run's pages and links become visible."""
+    staged_db = await _make_db(project_id, staged=True)
+    await staged_db.init_budget(100)
+    await _register_run(staged_db)
+    helper = await _make_db(project_id, staged=False)
+
+    q = await _make_page(staged_db, "question", PageType.QUESTION)
+    claim = await _make_page(staged_db, "a claim")
+    await _link(staged_db, claim, q)
+
+    # Before commit: observer cannot see staged pages/links
+    observer = await _make_db(project_id, staged=False)
+    obs_pages = await observer.get_pages()
+    assert q.id not in {p.id for p in obs_pages}
+
+    await helper.commit_staged_run(staged_db.run_id)
+
+    # After commit: observer sees the pages and links
+    obs_pages = await observer.get_pages()
+    obs_ids = {p.id for p in obs_pages}
+    assert q.id in obs_ids
+    assert claim.id in obs_ids
+
+    obs_links = await observer.get_links_to(q.id)
+    assert any(l.from_page_id == claim.id for l in obs_links)
+
+    await staged_db.delete_run_data()
+    await helper.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_commit_staged_run_applies_supersession(project_id):
+    """After commit_staged_run(), a staged supersession is applied to the baseline."""
+    baseline = await _make_db(project_id, staged=False)
+    await baseline.init_budget(100)
+    staged_db = await _make_db(project_id, staged=True)
+    await staged_db.init_budget(100)
+    await _register_run(staged_db)
+    helper = await _make_db(project_id, staged=False)
+
+    original = await _make_page(baseline, "original claim")
+    replacement = await _make_page(staged_db, "better claim")
+    await staged_db.supersede_page(original.id, replacement.id)
+
+    # Before commit: observer sees original as active
+    observer = await _make_db(project_id, staged=False)
+    obs_page = await observer.get_page(original.id)
+    assert obs_page is not None
+    assert obs_page.is_superseded is False
+
+    await helper.commit_staged_run(staged_db.run_id)
+
+    # After commit: observer sees original as superseded
+    obs_page = await observer.get_page(original.id)
+    assert obs_page is not None
+    assert obs_page.is_superseded is True
+    assert obs_page.superseded_by == replacement.id
+
+    await baseline.delete_run_data()
+    await staged_db.delete_run_data()
+    await helper.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_commit_staged_run_applies_link_deletion(project_id):
+    """After commit_staged_run(), a staged link deletion is applied to the baseline."""
+    baseline = await _make_db(project_id, staged=False)
+    await baseline.init_budget(100)
+    staged_db = await _make_db(project_id, staged=True)
+    await staged_db.init_budget(100)
+    await _register_run(staged_db)
+    helper = await _make_db(project_id, staged=False)
+
+    q = await _make_page(baseline, "question", PageType.QUESTION)
+    claim = await _make_page(baseline, "some claim")
+    link = await _link(baseline, claim, q)
+
+    await staged_db.delete_link(link.id)
+
+    # Before commit: observer still sees the link
+    observer = await _make_db(project_id, staged=False)
+    obs_links = await observer.get_links_to(q.id)
+    assert any(l.id == link.id for l in obs_links)
+
+    await helper.commit_staged_run(staged_db.run_id)
+
+    # After commit: observer no longer sees the link
+    obs_links = await observer.get_links_to(q.id)
+    assert all(l.id != link.id for l in obs_links)
+
+    await baseline.delete_run_data()
+    await staged_db.delete_run_data()
+    await helper.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_commit_staged_run_applies_role_change(project_id):
+    """After commit_staged_run(), a staged role change is applied to the baseline."""
+    baseline = await _make_db(project_id, staged=False)
+    await baseline.init_budget(100)
+    staged_db = await _make_db(project_id, staged=True)
+    await staged_db.init_budget(100)
+    await _register_run(staged_db)
+    helper = await _make_db(project_id, staged=False)
+
+    q = await _make_page(baseline, "question", PageType.QUESTION)
+    claim = await _make_page(baseline, "some claim")
+    link = await _link(baseline, claim, q)
+    assert link.role == LinkRole.DIRECT
+
+    await staged_db.update_link_role(link.id, LinkRole.STRUCTURAL)
+
+    # Before commit: observer sees original role
+    observer = await _make_db(project_id, staged=False)
+    obs_link = await observer.get_link(link.id)
+    assert obs_link is not None
+    assert obs_link.role == LinkRole.DIRECT
+
+    await helper.commit_staged_run(staged_db.run_id)
+
+    # After commit: observer sees the new role
+    obs_link = await observer.get_link(link.id)
+    assert obs_link is not None
+    assert obs_link.role == LinkRole.STRUCTURAL
+
+    await baseline.delete_run_data()
+    await staged_db.delete_run_data()
+    await helper.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_commit_staged_run_roundtrip(project_id):
+    """stage_run() then commit_staged_run() restores the original non-staged state."""
+    baseline = await _make_db(project_id, staged=False)
+    await baseline.init_budget(100)
+    run_db = await _make_db(project_id, staged=False)
+    await run_db.init_budget(100)
+    await _register_run(run_db)
+    helper = await _make_db(project_id, staged=False)
+
+    original = await _make_page(baseline, "original claim")
+    q = await _make_page(baseline, "question", PageType.QUESTION)
+    baseline_link = await _link(baseline, original, q)
+
+    replacement = await _make_page(run_db, "replacement claim")
+    await run_db.supersede_page(original.id, replacement.id)
+    await run_db.delete_link(baseline_link.id)
+
+    # Snapshot the post-run state before staging
+    observer = await _make_db(project_id, staged=False)
+    pre_stage_page = await observer.get_page(original.id)
+    assert pre_stage_page is not None
+    assert pre_stage_page.is_superseded is True
+    pre_stage_links = await observer.get_links_to(q.id)
+    assert all(l.id != baseline_link.id for l in pre_stage_links)
+
+    # Stage, then commit
+    await helper.stage_run(run_db.run_id)
+    await helper.commit_staged_run(run_db.run_id)
+
+    # After roundtrip: state matches the original non-staged post-run state
+    post_page = await observer.get_page(original.id)
+    assert post_page is not None
+    assert post_page.is_superseded is True
+    assert post_page.superseded_by == replacement.id
+
+    post_pages = await observer.get_pages()
+    assert replacement.id in {p.id for p in post_pages}
+
+    post_links = await observer.get_links_to(q.id)
+    assert all(l.id != baseline_link.id for l in post_links)
+
+    await baseline.delete_run_data()
+    await run_db.delete_run_data()
+    await helper.delete_run_data()
+    await observer.delete_run_data()
+
+
+async def test_commit_staged_run_validation(project_id):
+    """commit_staged_run() raises ValueError for missing or non-staged runs."""
+    helper = await _make_db(project_id, staged=False)
+
+    # Non-existent run
+    with pytest.raises(ValueError, match="not found"):
+        await helper.commit_staged_run("nonexistent-run-id")
+
+    # Non-staged run
+    run_db = await _make_db(project_id, staged=False)
+    await run_db.init_budget(100)
+    await _register_run(run_db)
+    await _make_page(run_db, "a page")
+
+    with pytest.raises(ValueError, match="is not staged"):
+        await helper.commit_staged_run(run_db.run_id)
+
+    await helper.delete_run_data()
+    await run_db.delete_run_data()


### PR DESCRIPTION
## Summary
- Adds `commit_staged_run()` to `DB` — the inverse of `stage_run()`. Validates the run is staged, flips `staged=false` on its rows, then applies recorded mutation events (supersessions, link deletions, role changes) to the base tables.
- Adds `--commit-run RUN_ID` CLI flag
- 6 new tests covering page visibility, supersession, link deletion, role changes, stage→commit roundtrip, and validation errors

## Test plan
- [x] `uv run pytest tests/test_staged_runs.py` — all 19 tests pass (13 existing + 6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)