### PR TITLE
Deploy rumil on GKE with Helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,4 +227,7 @@ __marimo__/
 .a.env
 .b.env
 
+# Decrypted secrets (encrypted version secrets.enc.yaml is safe to commit)
+deploy/chart/secrets.yaml
+
 data

--- a/deploy/Dockerfile.api
+++ b/deploy/Dockerfile.api
@@ -1,0 +1,17 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS build
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+FROM python:3.13-slim
+
+ENV PATH="/app/.venv/bin:$PATH"
+EXPOSE 8000
+CMD ["uvicorn", "rumil.api.app:app", "--host", "0.0.0.0", "--port", "8000"]
+
+WORKDIR /app
+COPY --from=build /app/.venv .venv
+COPY src/rumil ./rumil

--- a/deploy/Dockerfile.api
+++ b/deploy/Dockerfile.api
@@ -3,8 +3,9 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
-COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev
+COPY pyproject.toml uv.lock README.md ./
+COPY src/rumil ./src/rumil
+RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
@@ -14,4 +15,3 @@ CMD ["uvicorn", "rumil.api.app:app", "--host", "0.0.0.0", "--port", "8000"]
 
 WORKDIR /app
 COPY --from=build /app/.venv .venv
-COPY src/rumil ./rumil

--- a/deploy/Dockerfile.frontend
+++ b/deploy/Dockerfile.frontend
@@ -1,0 +1,30 @@
+FROM node:22-alpine AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+WORKDIR /workspace
+
+FROM base AS production
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --gid 1001 --system nodejs \
+    && adduser --uid 1001 --system nextjs
+
+COPY .next/standalone ./standalone/frontend
+COPY public ./standalone/frontend/public
+COPY .next/static ./standalone/frontend/.next/static
+RUN mv /workspace/standalone/frontend/node_modules /workspace/standalone/node_modules
+
+RUN mkdir -p /workspace/standalone/frontend/.next/cache \
+    && chown -R nextjs:nodejs /workspace/standalone
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+WORKDIR /workspace/standalone/frontend
+
+CMD ["node", "server.js"]

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: rumil
+description: A Helm chart for the Rumil research workspace
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/chart/secrets.yaml.template
+++ b/deploy/chart/secrets.yaml.template
@@ -9,3 +9,6 @@ secrets:
     ANTHROPIC_API_KEY: ""
     VOYAGE_AI_API_KEY: ""
     JINA_API_KEY: ""
+    RUMIL_AUTH_PASSWORD: ""
+  frontend:
+    AUTH_PASSWORD: ""  # same value as RUMIL_AUTH_PASSWORD above

--- a/deploy/chart/secrets.yaml.template
+++ b/deploy/chart/secrets.yaml.template
@@ -1,0 +1,11 @@
+# Template for secrets.enc.yaml
+# Fill in values and encrypt with:
+#   sops encrypt --gcp-kms projects/varuna-400921/locations/global/keyRings/sops/cryptoKeys/sops-key \
+#     secrets.yaml.template > secrets.enc.yaml
+
+secrets:
+  api:
+    SUPABASE_PROD_KEY: ""
+    ANTHROPIC_API_KEY: ""
+    VOYAGE_AI_API_KEY: ""
+    JINA_API_KEY: ""

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rumil.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "rumil.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rumil.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rumil.labels" -}}
+helm.sh/chart: {{ include "rumil.chart" . }}
+{{ include "rumil.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rumil.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rumil.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deploy/chart/templates/api-deployment.yaml
+++ b/deploy/chart/templates/api-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rumil.fullname" . }}-api
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "rumil.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.secrets.enabled }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
+      labels:
+        {{- include "rumil.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-api
+          image: "{{ .Values.api.image.repository }}:{{ .Values.releaseId }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          command: ["uvicorn", "rumil.api.app:app", "--host", "0.0.0.0", "--port", "{{ .Values.api.service.port }}"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.api.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.api.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.api.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          env:
+            {{- range $key, $value := .Values.api.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- if .Values.secrets.enabled }}
+          envFrom:
+            - secretRef:
+                name: {{ include "rumil.fullname" . }}-api-secrets
+          {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/chart/templates/api-httproute.yaml
+++ b/deploy/chart/templates/api-httproute.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.api.httproute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "rumil.fullname" . }}-api
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  parentRefs:
+  - name: shared-tls-gateway
+    namespace: cert-manager
+  hostnames:
+  - {{ .Values.api.httproute.host | quote }}
+  rules:
+  - backendRefs:
+    - name: {{ include "rumil.fullname" . }}-api
+      port: {{ .Values.api.service.port }}
+{{- end }}

--- a/deploy/chart/templates/api-service.yaml
+++ b/deploy/chart/templates/api-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rumil.fullname" . }}-api
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.api.service.type }}
+  ports:
+    - port: {{ .Values.api.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "rumil.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api

--- a/deploy/chart/templates/frontend-deployment.yaml
+++ b/deploy/chart/templates/frontend-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rumil.fullname" . }}-frontend
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "rumil.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "rumil.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.releaseId }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.frontend.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.frontend.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.frontend.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          env:
+            {{- range $key, $value := .Values.frontend.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/chart/templates/frontend-deployment.yaml
+++ b/deploy/chart/templates/frontend-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       app.kubernetes.io/component: frontend
   template:
     metadata:
+      annotations:
+        {{- if .Values.secrets.enabled }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         {{- include "rumil.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
@@ -38,6 +42,11 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- if .Values.secrets.enabled }}
+          envFrom:
+            - secretRef:
+                name: {{ include "rumil.fullname" . }}-frontend-secrets
+          {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/deploy/chart/templates/frontend-httproute.yaml
+++ b/deploy/chart/templates/frontend-httproute.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.frontend.httproute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "rumil.fullname" . }}-frontend
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  parentRefs:
+  - name: shared-tls-gateway
+    namespace: cert-manager
+  hostnames:
+  - {{ .Values.frontend.httproute.host | quote }}
+  rules:
+  - backendRefs:
+    - name: {{ include "rumil.fullname" . }}-frontend
+      port: {{ .Values.frontend.service.port }}
+{{- end }}

--- a/deploy/chart/templates/frontend-service.yaml
+++ b/deploy/chart/templates/frontend-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rumil.fullname" . }}-frontend
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "rumil.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend

--- a/deploy/chart/templates/secrets.yaml
+++ b/deploy/chart/templates/secrets.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secrets.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "rumil.fullname" . }}-api-secrets
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets.api }}
+  {{- if and $value (kindIs "string" $value) }}
+  {{ $key | upper }}: {{ $value | b64enc }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/chart/templates/secrets.yaml
+++ b/deploy/chart/templates/secrets.yaml
@@ -13,4 +13,19 @@ data:
   {{ $key | upper }}: {{ $value | b64enc }}
   {{- end }}
   {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "rumil.fullname" . }}-frontend-secrets
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets.frontend }}
+  {{- if and $value (kindIs "string" $value) }}
+  {{ $key | upper }}: {{ $value | b64enc }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,0 +1,126 @@
+nameOverride: ""
+fullnameOverride: ""
+
+releaseId: "latest"
+
+api:
+  replicaCount: 1
+
+  image:
+    repository: us-central1-docker.pkg.dev/varuna-400921/delphos/rumil-api
+    pullPolicy: IfNotPresent
+
+  service:
+    type: LoadBalancer
+    port: 8000
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 8000
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    failureThreshold: 4
+    timeoutSeconds: 5
+
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: 8000
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    failureThreshold: 3
+    timeoutSeconds: 5
+
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: 8000
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 5
+
+  env:
+    USE_PROD_DB: "1"
+    SUPABASE_PROD_URL: https://aesjaehibxrzearctiqp.supabase.co
+
+  httproute:
+    enabled: false
+
+frontend:
+  replicaCount: 1
+
+  image:
+    repository: us-central1-docker.pkg.dev/varuna-400921/delphos/rumil-frontend
+    pullPolicy: IfNotPresent
+
+  service:
+    type: LoadBalancer
+    port: 3000
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: 3000
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 5
+
+  readinessProbe:
+    httpGet:
+      path: /
+      port: 3000
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+
+  startupProbe:
+    httpGet:
+      path: /
+      port: 3000
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 5
+
+  # NOTE: NEXT_PUBLIC_API_URL is baked into the frontend at build time (client-side fetch).
+  # Set it to the external API URL when building the Docker image, not here.
+  # This env section is for any runtime server-side env vars the frontend might need.
+  env: {}
+
+  httproute:
+    enabled: false
+
+secrets:
+  enabled: true
+
+tolerations:
+  - key: "hyperdiskonly"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: hyperdiskonly
+              operator: In
+              values:
+                - "true"

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -11,7 +11,7 @@ api:
     pullPolicy: IfNotPresent
 
   service:
-    type: LoadBalancer
+    type: ClusterIP
     port: 8000
 
   resources:
@@ -76,7 +76,7 @@ frontend:
 
   livenessProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: 3000
     initialDelaySeconds: 10
     periodSeconds: 15
@@ -84,7 +84,7 @@ frontend:
 
   readinessProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: 3000
     initialDelaySeconds: 10
     periodSeconds: 10
@@ -92,16 +92,16 @@ frontend:
 
   startupProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: 3000
     periodSeconds: 10
     failureThreshold: 30
     timeoutSeconds: 5
 
-  # NOTE: NEXT_PUBLIC_API_URL is baked into the frontend at build time (client-side fetch).
-  # Set it to the external API URL when building the Docker image, not here.
-  # This env section is for any runtime server-side env vars the frontend might need.
-  env: {}
+  # NEXT_PUBLIC_API_URL is baked at build time (client-side fetch) — set when building the image.
+  # API_BASE_URL is read at runtime for server-side rendering.
+  env:
+    API_BASE_URL: http://rumil-api.rumil.svc.cluster.local:8000
 
   httproute:
     enabled: false

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/frontend/src/app/ab-traces/[abRunId]/page.tsx
+++ b/frontend/src/app/ab-traces/[abRunId]/page.tsx
@@ -3,12 +3,12 @@ import type { AbRunTraceOut } from "@/api/types.gen";
 import { ABTraceViewer } from "./ab-trace-viewer";
 import "../../traces/[runId]/trace.css";
 
-import { API_BASE } from "@/lib/api-base";
+import { API_BASE, serverFetch } from "@/lib/api-base";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { fetchProjectName } from "@/lib/fetch-project-name";
 
 async function getABRunTrace(abRunId: string): Promise<AbRunTraceOut | null> {
-  const res = await fetch(`${API_BASE}/api/ab-runs/${abRunId}/trace`, {
+  const res = await serverFetch(`${API_BASE}/api/ab-runs/${abRunId}/trace`, {
     cache: "no-store",
   });
   if (!res.ok) return null;

--- a/frontend/src/app/healthz/route.ts
+++ b/frontend/src/app/healthz/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ status: 'ok' });
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import type { Project } from "@/api";
-import { API_BASE } from "@/lib/api-base";
+import { API_BASE, serverFetch } from "@/lib/api-base";
 
 async function getProjects(): Promise<Project[]> {
-  const res = await fetch(`${API_BASE}/api/projects`, {
+  const res = await serverFetch(`${API_BASE}/api/projects`, {
     cache: "no-store",
   });
   if (!res.ok) return [];

--- a/frontend/src/app/traces/[runId]/page.tsx
+++ b/frontend/src/app/traces/[runId]/page.tsx
@@ -3,12 +3,12 @@ import type { RunTraceTreeOut, RealtimeConfigOut } from "@/api/types.gen";
 import { TraceViewer } from "./trace-viewer";
 import "./trace.css";
 
-import { API_BASE } from "@/lib/api-base";
+import { API_BASE, serverFetch } from "@/lib/api-base";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { fetchProjectName } from "@/lib/fetch-project-name";
 
 async function getRunTraceTree(runId: string): Promise<RunTraceTreeOut | null> {
-  const res = await fetch(`${API_BASE}/api/runs/${runId}/trace-tree`, {
+  const res = await serverFetch(`${API_BASE}/api/runs/${runId}/trace-tree`, {
     cache: "no-store",
   });
   if (!res.ok) return null;
@@ -17,7 +17,7 @@ async function getRunTraceTree(runId: string): Promise<RunTraceTreeOut | null> {
 
 async function getRealtimeConfig(): Promise<RealtimeConfigOut | null> {
   try {
-    const res = await fetch(`${API_BASE}/api/realtime/config`, {
+    const res = await serverFetch(`${API_BASE}/api/realtime/config`, {
       cache: "no-store",
     });
     if (!res.ok) return null;

--- a/frontend/src/lib/api-base.ts
+++ b/frontend/src/lib/api-base.ts
@@ -1,2 +1,13 @@
 export const API_BASE =
   process.env.API_BASE_URL || "http://localhost:8000";
+
+export function serverFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const pw = process.env.AUTH_PASSWORD;
+  if (!pw) return fetch(url, init);
+  const headers = new Headers(init?.headers);
+  headers.set("Authorization", `Basic ${btoa(`user:${pw}`)}`);
+  return fetch(url, { ...init, headers });
+}

--- a/frontend/src/lib/fetch-project-name.ts
+++ b/frontend/src/lib/fetch-project-name.ts
@@ -1,11 +1,11 @@
-import { API_BASE } from "@/lib/api-base";
+import { API_BASE, serverFetch } from "@/lib/api-base";
 import type { Project } from "@/api";
 
 export async function fetchProjectName(
   projectId: string,
 ): Promise<string | undefined> {
   try {
-    const res = await fetch(`${API_BASE}/api/projects/${projectId}`, {
+    const res = await serverFetch(`${API_BASE}/api/projects/${projectId}`, {
       cache: "no-store",
     });
     if (!res.ok) return undefined;

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const password = process.env.AUTH_PASSWORD;
+  if (!password) return NextResponse.next();
+
+  const auth = request.headers.get('Authorization') ?? '';
+  if (auth.startsWith('Basic ')) {
+    try {
+      const decoded = atob(auth.slice(6));
+      const [, pw] = decoded.split(':', 2);
+      if (pw === password) return NextResponse.next();
+    } catch {
+      // fall through to 401
+    }
+  }
+
+  return new NextResponse('Unauthorized', {
+    status: 401,
+    headers: { 'WWW-Authenticate': 'Basic realm="rumil"' },
+  });
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|healthz).*)'],
+};

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -47,10 +47,15 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_origins=["*"],
     allow_methods=["GET"],
     allow_headers=["*"],
 )
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
 
 
 async def _get_db(project_id: str = "") -> DB:

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -6,11 +6,13 @@ Read-only API for browsing projects, pages, links, and calls.
 
 import logging
 import os
+import secrets
 import uuid
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import TypeAdapter, ValidationError
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from rumil.database import DB, _row_to_call
 from rumil.models import Call, Page, PageLink, PageType, Project, Workspace
@@ -44,6 +46,35 @@ app = FastAPI(
     version="0.1.0",
     description="Read-only API for the Rumil research workspace.",
 )
+
+_AUTH_PASSWORD = os.environ.get("RUMIL_AUTH_PASSWORD", "")
+
+
+class BasicAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if request.url.path == "/healthz" or not _AUTH_PASSWORD:
+            return await call_next(request)
+
+        import base64
+
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Basic "):
+            try:
+                decoded = base64.b64decode(auth[6:]).decode()
+                _, password = decoded.split(":", 1)
+            except Exception:
+                password = ""
+            if secrets.compare_digest(password, _AUTH_PASSWORD):
+                return await call_next(request)
+
+        return Response(
+            status_code=401,
+            headers={"WWW-Authenticate": 'Basic realm="rumil"'},
+            content="Unauthorized",
+        )
+
+
+app.add_middleware(BasicAuthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- Add Helm chart for deploying API (FastAPI) and frontend (Next.js) on the existing GKE cluster
- Multi-stage Dockerfiles for both services (API via uv, frontend via Next.js standalone output)
- HTTP Basic Auth on the frontend (gated by `AUTH_PASSWORD` env var, disabled locally)
- API is ClusterIP (internal only); frontend is LoadBalancer with auth
- Server-side rendering uses `serverFetch()` to authenticate against the API in-cluster
- Health endpoints (`/healthz`) on both services for k8s probes, excluded from auth
- SOPS-encrypted secrets template for API keys and auth passwords

## Test plan
- [x] Deployed and verified on GKE cluster (namespace: `rumil`)
- [x] Frontend loads project list from Supabase via API
- [x] Project detail pages render with all pages visible
- [x] Auth blocks unauthenticated access to frontend
- [x] API not externally accessible (ClusterIP)
- [x] Health probes pass for both services
- [x] Verify local dev still works with no auth env vars set

🤖 Generated with [Claude Code](https://claude.com/claude-code)