### PR TITLE
Add retry logic for transient DB connection failures

### DIFF
--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -9,9 +9,17 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any, cast
 
+import httpx
 from postgrest.types import CountMethod
 from supabase import acreate_client, AsyncClient
 from supabase.lib.client_options import AsyncClientOptions
+from tenacity import (
+    RetryCallState,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from rumil.settings import get_settings
 from rumil.models import (
@@ -40,6 +48,39 @@ _Rows = list[dict[str, Any]]
 def _rows(response: Any) -> _Rows:
     """Extract rows from a Supabase API response with proper typing."""
     return cast(_Rows, response.data) if response.data else []
+
+
+_DB_RETRYABLE_EXCEPTIONS = (
+    httpx.ConnectTimeout,
+    httpx.ConnectError,
+    httpx.PoolTimeout,
+)
+
+
+def _stop_after_db_retries(retry_state: RetryCallState) -> bool:
+    return retry_state.attempt_number >= get_settings().max_db_retries
+
+
+def _log_db_retry(retry_state: RetryCallState) -> None:
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    wait = retry_state.next_action.sleep if retry_state.next_action else 0
+    max_retries = get_settings().max_db_retries
+    log.warning(
+        "DB request failed (%s), retrying in %gs (attempt %d/%d)",
+        type(exc).__name__ if exc else "unknown",
+        wait,
+        retry_state.attempt_number,
+        max_retries,
+    )
+
+
+_db_retry = retry(
+    retry=retry_if_exception_type(_DB_RETRYABLE_EXCEPTIONS),
+    stop=_stop_after_db_retries,
+    wait=wait_exponential(multiplier=0.5, min=0.5, max=8),
+    before_sleep=_log_db_retry,
+    reraise=True,
+)
 
 
 _SLIM_PAGE_COLUMNS = (
@@ -206,6 +247,7 @@ class DB:
         except Exception:
             log.debug('Failed to close postgrest client', exc_info=True)
 
+    @_db_retry
     async def _execute(self, query: Any) -> Any:
         """Execute a query builder through the concurrency semaphore."""
         async with self._semaphore:

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -29,7 +29,6 @@ from tenacity import (
     RetryCallState,
     retry,
     retry_if_exception,
-    stop_after_attempt,
     wait_exponential,
 )
 

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -68,6 +68,7 @@ class Settings(BaseSettings):
     sdk_agent_max_turns: int = _capture_field(default=200)
     grounding_update_budget: int = _capture_field(default=10)
 
+    max_db_retries: int = _capture_field(default=4)
     max_api_retries: int = _capture_field(default=4)
     max_api_retries_429: int | None = _capture_field(default=None)
     max_api_retries_500: int | None = _capture_field(default=None)


### PR DESCRIPTION
## Summary
- Adds tenacity-based exponential backoff retry to `DB._execute()` for transient httpx errors (`ConnectTimeout`, `ConnectError`, `PoolTimeout`)
- Adds configurable `max_db_retries` setting (default 4), matching the existing `max_api_retries` pattern
- Cleans up unused `stop_after_attempt` import in `llm.py`

## Context
Under concurrent dispatch load, local Supabase (Docker Desktop on macOS) occasionally produces `ConnectTimeout` errors. Investigation pointed to Docker Desktop's userspace networking rather than an application-level issue, but retrying is the right mitigation since these are transient.

## Test plan
- [x] Verified retries fire correctly in local dev (`WARNING DB request failed (ConnectTimeout), retrying in 0.5s`)
- [ ] Confirm no regressions with `uv run pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)