### PR TITLE
Proxy API requests through Next.js middleware

### DIFF
--- a/frontend/src/api-config.ts
+++ b/frontend/src/api-config.ts
@@ -1,6 +1,6 @@
 import { client } from './api/client.gen';
 
 export const CLIENT_API_BASE =
-  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  process.env.NEXT_PUBLIC_API_URL || '';
 
 client.setConfig({ baseUrl: CLIENT_API_BASE });

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,24 +1,39 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:8000';
+
 export function middleware(request: NextRequest) {
   const password = process.env.AUTH_PASSWORD;
-  if (!password) return NextResponse.next();
 
-  const auth = request.headers.get('Authorization') ?? '';
-  if (auth.startsWith('Basic ')) {
-    try {
-      const decoded = atob(auth.slice(6));
-      const [, pw] = decoded.split(':', 2);
-      if (pw === password) return NextResponse.next();
-    } catch {
-      // fall through to 401
+  if (password) {
+    const auth = request.headers.get('Authorization') ?? '';
+    let authenticated = false;
+    if (auth.startsWith('Basic ')) {
+      try {
+        const decoded = atob(auth.slice(6));
+        const [, pw] = decoded.split(':', 2);
+        if (pw === password) authenticated = true;
+      } catch {
+        // fall through to 401
+      }
+    }
+    if (!authenticated) {
+      return new NextResponse('Unauthorized', {
+        status: 401,
+        headers: { 'WWW-Authenticate': 'Basic realm="rumil"' },
+      });
     }
   }
 
-  return new NextResponse('Unauthorized', {
-    status: 401,
-    headers: { 'WWW-Authenticate': 'Basic realm="rumil"' },
-  });
+  if (request.nextUrl.pathname.startsWith('/api/')) {
+    const target = new URL(
+      `${request.nextUrl.pathname}${request.nextUrl.search}`,
+      API_BASE,
+    );
+    return NextResponse.rewrite(target);
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Client-side API fetches were hitting the backend's internal cluster IP directly, causing `ERR_CONNECTION_TIMED_OUT` in the browser since that IP isn't publicly reachable
- Added API proxy in Next.js middleware: `/api/*` requests are rewritten to the backend using the existing `API_BASE_URL` env var
- Changed client-side `CLIENT_API_BASE` default from `http://localhost:8000` to `''` (relative URLs) so requests go through the proxy

## Test plan
- [x] Verified deployed app: all project-specific endpoints (`/projects/{id}`, `/pages`, `/runs`) return 200
- [x] Verified local dev: proxy from `localhost:3000` to `localhost:8000` works correctly
- [x] Auth still works (middleware checks auth before proxying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)