### PR TITLE
Add --prod, --no-stage, and workspace autodetection to run_call

### DIFF
--- a/prompts/scout_paradigm_cases.md
+++ b/prompts/scout_paradigm_cases.md
@@ -18,8 +18,7 @@ For each paradigm case (aim for 1–3):
 
 1. Read the parent question and consider: what concrete, real-world instances best illustrate the dynamics at play?
 2. For each case, create a claim describing it using `create_claim`, then `link_consideration` to the parent question.
-3. Create a subquestion for further exploration using `create_question` and `link_child_question`.
-4. If the case connects to existing pages in the workspace, use `link_related` to make those connections visible.
+3. Create a subquestion for further exploration using `create_question` (it is automatically linked as a child of the scope question).
 
 ## What Makes a Good Paradigm Case
 

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -29,7 +29,8 @@ Usage:
     uv run python scripts/run_call.py find-considerations "Test question" --up-to-stage build_context
     uv run python scripts/run_call.py find-considerations "Test question" --up-to-stage create_pages
 
-All runs write to the local database under the workspace 'test-calls' by default.
+All runs are staged by default (use --no-stage to disable). Workspace defaults to
+'default' but is auto-detected from --question-id when possible.
 """
 
 import argparse
@@ -182,7 +183,8 @@ async def run(args: argparse.Namespace) -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     workspace = args.workspace
-    db = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod)
+    staged = not args.no_stage
+    db = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod, staged=staged)
     project = await db.get_or_create_project(workspace)
     db.project_id = project.id
 
@@ -194,6 +196,8 @@ async def run(args: argparse.Namespace) -> None:
         if not page:
             print(f"Question {question_id} not found.")
             return
+        if page.project_id and page.project_id != db.project_id:
+            db.project_id = page.project_id
         question_text = page.headline
         print(f"Using existing question: {question_text}")
     elif args.question_text:
@@ -340,8 +344,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--workspace",
-        default="test-calls",
-        help="Project workspace name (default: test-calls)",
+        default="default",
+        help="Project workspace name (default: 'default'). "
+        "Auto-detected from --question-id when possible.",
     )
     parser.add_argument(
         "--available-moves",
@@ -359,6 +364,12 @@ def main() -> None:
         "--prod",
         action="store_true",
         help="Use the production database instead of local Supabase",
+    )
+    parser.add_argument(
+        "--no-stage",
+        action="store_true",
+        dest="no_stage",
+        help="Run without staging (default: runs are staged)",
     )
     parser.add_argument(
         "--up-to-stage",

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -182,7 +182,7 @@ async def run(args: argparse.Namespace) -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     workspace = args.workspace
-    db = await DB.create(run_id=str(uuid.uuid4()))
+    db = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod)
     project = await db.get_or_create_project(workspace)
     db.project_id = project.id
 
@@ -354,6 +354,11 @@ def main() -> None:
         dest="available_calls",
         default=None,
         help="Available-calls preset name (default: 'default'). Controls which scout/dispatch types the two-phase orchestrator uses.",
+    )
+    parser.add_argument(
+        "--prod",
+        action="store_true",
+        help="Use the production database instead of local Supabase",
     )
     parser.add_argument(
         "--up-to-stage",


### PR DESCRIPTION
## Summary
- Runs from `scripts/run_call.py` are now **staged by default** (use `--no-stage` to disable)
- Added `--prod` flag to target the production database
- Workspace is auto-detected from the question's `project_id` when using `--question-id`, matching `main.py`'s behavior
- Default workspace changed from `test-calls` to `default`

## Test plan
- [ ] Run `uv run python scripts/run_call.py assess --question-id <UUID>` and verify run is staged
- [ ] Run with `--no-stage` and verify run is not staged
- [ ] Run with `--prod` and verify it connects to production
- [ ] Verify workspace is auto-detected from question's project when using `--question-id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)