### PR TITLE
Add --feedback-file flag for file-based feedback

### DIFF
--- a/main.py
+++ b/main.py
@@ -354,6 +354,62 @@ async def cmd_feedback_update(
         print(result.result_summary)
 
 
+async def cmd_feedback_update_from_file(
+    question_id: str,
+    file_path: str,
+    db: DB,
+    *,
+    investigation_budget: int | None = None,
+) -> None:
+    from rumil.clean import run_feedback_update
+
+    path = Path(file_path)
+    if not path.is_file():
+        print(f"Error: file '{file_path}' not found.")
+        sys.exit(1)
+
+    evaluation_text = path.read_text().strip()
+    if not evaluation_text:
+        print(f"Error: file '{file_path}' is empty.")
+        sys.exit(1)
+
+    resolved_id = await db.resolve_page_id(question_id)
+    if not resolved_id:
+        print(f"Error: question '{question_id}' not found.")
+        sys.exit(1)
+
+    question = await db.get_page(resolved_id)
+    if not question:
+        print(f"Error: question '{question_id}' not found.")
+        sys.exit(1)
+
+    if question.project_id and question.project_id != db.project_id:
+        db.project_id = question.project_id
+
+    await db.create_run(
+        name=f"feedback-update (file): {question.headline[:80]}",
+        question_id=resolved_id,
+        config=get_settings().capture_config(),
+    )
+
+    frontend = get_settings().frontend_url.rstrip("/")
+    print(f"\nRunning feedback update for: {question.headline[:80]}")
+    print(f"Source: {file_path}")
+    print(f"Trace: {frontend}/traces/{db.run_id}\n")
+
+    if investigation_budget is not None:
+        get_settings().feedback_investigation_budget = investigation_budget
+
+    result = await run_feedback_update(
+        resolved_id,
+        evaluation_text,
+        db,
+    )
+    print(f"\nFeedback update complete (call {result.id}).")
+    if result.result_summary:
+        print(result.result_summary)
+
+
 async def _load_prior_checkpoints(question_id: str, from_stage: int, db: DB) -> dict:
     """Find the most recent grounding call for *question_id* and return its checkpoints."""
     from rumil.models import CallType
@@ -854,6 +910,13 @@ async def async_main():
         help="Run feedback update pipeline on a completed feedback evaluation call",
     )
     parser.add_argument(
+        "--feedback-file",
+        dest="feedback_file",
+        nargs=2,
+        metavar=("QUESTION_ID", "FILE_PATH"),
+        help="Run feedback update pipeline using feedback text from a file",
+    )
+    parser.add_argument(
         "--show-evaluation",
         dest="show_evaluation_id",
         metavar="CALL_ID",
@@ -1058,6 +1121,14 @@ async def async_main():
     elif args.feedback_call_id:
         await cmd_feedback_update(
             args.feedback_call_id, db, investigation_budget=args.budget
+        )
+        return
+    elif args.feedback_file:
+        await cmd_feedback_update_from_file(
+            args.feedback_file[0],
+            args.feedback_file[1],
+            db,
+            investigation_budget=args.budget,
         )
         return
     elif args.show_evaluation_id:


### PR DESCRIPTION
## Summary
- Adds `--feedback-file QUESTION_ID FILE_PATH` CLI flag that reads feedback text from a file and runs the feedback update pipeline, bypassing the need for a completed evaluation call in the DB.
- Reuses `run_feedback_update()` — same pipeline, just a different input source.

## Test plan
- [ ] Run `--feedback-file <question_id> <file>` against local DB with a valid question and feedback file
- [ ] Verify error handling: missing file, empty file, invalid question ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)