### PR TITLE
Filter unjudged questions from embedding assess context

### DIFF
--- a/src/rumil/calls/assess.py
+++ b/src/rumil/calls/assess.py
@@ -44,4 +44,7 @@ class EmbeddingAssessCall(AssessCall):
     context_builder_cls = EmbeddingContext
 
     def _make_context_builder(self) -> ContextBuilder:
-        return EmbeddingContext(self.call_type)
+        return EmbeddingContext(
+            self.call_type,
+            require_judgement_for_questions=True,
+        )

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -110,8 +110,14 @@ class GraphContextWithPhase1(ContextBuilder):
 class EmbeddingContext(ContextBuilder):
     """Embedding-based context (no phase1). Used by embedding variants."""
 
-    def __init__(self, call_type: CallType) -> None:
+    def __init__(
+        self,
+        call_type: CallType,
+        *,
+        require_judgement_for_questions: bool = False,
+    ) -> None:
         self._call_type = call_type
+        self._require_judgement_for_questions = require_judgement_for_questions
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
         question = await infra.db.get_page(infra.question_id)
@@ -120,6 +126,7 @@ class EmbeddingContext(ContextBuilder):
             query,
             infra.db,
             scope_question_id=infra.question_id,
+            require_judgement_for_questions=self._require_judgement_for_questions,
         )
         working_page_ids = result.page_ids
         await _record_context_built(infra, working_page_ids, [])

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -894,6 +894,7 @@ async def build_embedding_based_context(
     full_page_similarity_floor: float | None = None,
     abstract_page_similarity_floor: float | None = None,
     summary_page_similarity_floor: float | None = None,
+    require_judgement_for_questions: bool = False,
 ) -> EmbeddingBasedContextResult:
     """Build context by embedding-similarity search over the whole workspace.
 
@@ -943,6 +944,17 @@ async def build_embedding_based_context(
             )
             scope_page_ids = [scope_question_id]
             ranked = [(p, s) for p, s in ranked if p.id != scope_question_id]
+
+    if require_judgement_for_questions:
+        question_ids = [p.id for p, _ in ranked if p.page_type == PageType.QUESTION]
+        has_judgement: set[str] = set()
+        for qid in question_ids:
+            if await db.get_judgements_for_question(qid):
+                has_judgement.add(qid)
+        ranked = [
+            (p, s) for p, s in ranked
+            if p.page_type != PageType.QUESTION or p.id in has_judgement
+        ]
 
     distillation_budget = distillation_page_char_budget
     full_budget = full_page_char_budget

--- a/tests/test_embedding_context.py
+++ b/tests/test_embedding_context.py
@@ -10,7 +10,9 @@ from rumil.context import (
 from rumil.models import Page, PageDetail, PageLayer, PageType, Workspace
 
 
-def _make_page(headline: str, content: str, page_type: PageType = PageType.CLAIM) -> Page:
+def _make_page(
+    headline: str, content: str, page_type: PageType = PageType.CLAIM
+) -> Page:
     return Page(
         page_type=page_type,
         layer=PageLayer.SQUIDGY,
@@ -23,11 +25,11 @@ def _make_page(headline: str, content: str, page_type: PageType = PageType.CLAIM
 
 
 PAGES = [
-    _make_page('Alpha finding', 'A' * 200),
-    _make_page('Beta finding', 'B' * 200),
-    _make_page('Gamma finding', 'C' * 200),
-    _make_page('Delta finding', 'D' * 200),
-    _make_page('Epsilon finding', 'E' * 200),
+    _make_page("Alpha finding", "A" * 200),
+    _make_page("Beta finding", "B" * 200),
+    _make_page("Gamma finding", "C" * 200),
+    _make_page("Delta finding", "D" * 200),
+    _make_page("Epsilon finding", "E" * 200),
 ]
 
 RANKED = [(page, 0.9 - i * 0.1) for i, page in enumerate(PAGES)]
@@ -38,12 +40,12 @@ FAKE_EMBEDDING = [0.1] * 1024
 @pytest.fixture
 def mock_embeddings(mocker):
     mocker.patch(
-        'rumil.context.embed_query',
+        "rumil.context.embed_query",
         new_callable=mocker.AsyncMock,
         return_value=FAKE_EMBEDDING,
     )
     mocker.patch(
-        'rumil.context.search_pages_by_vector',
+        "rumil.context.search_pages_by_vector",
         new_callable=mocker.AsyncMock,
         return_value=RANKED,
     )
@@ -60,7 +62,7 @@ def mock_db(mocker):
 async def test_basic_budget_split(mock_embeddings, mock_db):
     """Pages fill full tier first, then summary tier."""
     result = await build_embedding_based_context(
-        'test query',
+        "test query",
         mock_db,
         full_page_char_budget=6_000,
         summary_page_char_budget=3_000,
@@ -68,17 +70,18 @@ async def test_basic_budget_split(mock_embeddings, mock_db):
 
     assert isinstance(result, EmbeddingBasedContextResult)
     assert len(result.full_page_ids) > 0
-    assert result.budget_usage['full'] <= 6_000
-    assert result.budget_usage['summary'] <= 3_000
+    assert result.budget_usage["full"] <= 6_000
+    assert result.budget_usage["summary"] <= 3_000
     assert result.distillation_page_ids == []
     assert set(result.page_ids) == set(
         result.full_page_ids + result.abstract_page_ids + result.summary_page_ids
     )
 
+
 async def test_similarity_ordering(mock_embeddings, mock_db):
     """Pages appear in similarity order: highest-similarity first in full tier."""
     result = await build_embedding_based_context(
-        'test query',
+        "test query",
         mock_db,
         full_page_char_budget=10_000,
     )
@@ -93,7 +96,7 @@ async def test_similarity_ordering(mock_embeddings, mock_db):
 async def test_small_budget_forces_lower_tiers(mock_embeddings, mock_db):
     """With a tiny full budget, pages overflow to abstract/summary tiers."""
     result = await build_embedding_based_context(
-        'test query',
+        "test query",
         mock_db,
         full_page_char_budget=100,
         abstract_page_char_budget=800,
@@ -106,27 +109,27 @@ async def test_small_budget_forces_lower_tiers(mock_embeddings, mock_db):
 async def test_section_headers_present(mock_embeddings, mock_db):
     """Output contains expected section headers."""
     result = await build_embedding_based_context(
-        'test query',
+        "test query",
         mock_db,
         full_page_char_budget=10_000,
     )
 
-    assert '## Credence' in result.context_text
+    assert "## Credence" in result.context_text
 
 
 async def test_format_page_headline():
     """format_page with HEADLINE detail produces the expected compact line."""
-    page = _make_page('Test summary', 'content')
+    page = _make_page("Test summary", "content")
     line = await format_page(page, PageDetail.HEADLINE)
-    assert '[CLAIM C6/R2]' in line
+    assert "[CLAIM C6/R2]" in line
     assert page.id[:8] in line
-    assert 'Test summary' in line
+    assert "Test summary" in line
 
 
 async def test_zero_budget_returns_empty(mock_embeddings, mock_db):
     """A zero budget produces no pages."""
     result = await build_embedding_based_context(
-        'test query',
+        "test query",
         mock_db,
         full_page_char_budget=0,
         abstract_page_char_budget=0,
@@ -136,3 +139,82 @@ async def test_zero_budget_returns_empty(mock_embeddings, mock_db):
     assert result.page_ids == []
     assert result.full_page_ids == []
     assert result.summary_page_ids == []
+
+
+QUESTION_WITH_JUDGEMENT = _make_page(
+    "Answered question", "Q with judgement", page_type=PageType.QUESTION
+)
+QUESTION_WITHOUT_JUDGEMENT = _make_page(
+    "Open question", "Q without judgement", page_type=PageType.QUESTION
+)
+CLAIM_PAGE = _make_page("Regular claim", "A claim page")
+
+MIXED_RANKED = [
+    (QUESTION_WITH_JUDGEMENT, 0.9),
+    (QUESTION_WITHOUT_JUDGEMENT, 0.8),
+    (CLAIM_PAGE, 0.7),
+]
+
+JUDGEMENT_PAGE = _make_page(
+    "A judgement", "Judgement content", page_type=PageType.JUDGEMENT
+)
+
+
+@pytest.fixture
+def mock_embeddings_mixed(mocker):
+    mocker.patch(
+        "rumil.context.embed_query",
+        new_callable=mocker.AsyncMock,
+        return_value=FAKE_EMBEDDING,
+    )
+    mocker.patch(
+        "rumil.context.search_pages_by_vector",
+        new_callable=mocker.AsyncMock,
+        return_value=MIXED_RANKED,
+    )
+
+
+async def test_require_judgement_filters_unjudged_questions(
+    mock_embeddings_mixed,
+    mocker,
+):
+    """Questions without judgements are excluded when require_judgement_for_questions is set."""
+    db = mocker.AsyncMock()
+
+    async def fake_get_judgements(qid):
+        if qid == QUESTION_WITH_JUDGEMENT.id:
+            return [JUDGEMENT_PAGE]
+        return []
+
+    db.get_judgements_for_question = mocker.AsyncMock(side_effect=fake_get_judgements)
+
+    result = await build_embedding_based_context(
+        "test query",
+        db,
+        require_judgement_for_questions=True,
+        full_page_char_budget=10_000,
+    )
+
+    assert QUESTION_WITH_JUDGEMENT.id in result.page_ids
+    assert QUESTION_WITHOUT_JUDGEMENT.id not in result.page_ids
+    assert CLAIM_PAGE.id in result.page_ids
+
+
+async def test_require_judgement_false_keeps_all_questions(
+    mock_embeddings_mixed,
+    mocker,
+):
+    """Without the flag, all questions appear regardless of judgement status."""
+    db = mocker.AsyncMock()
+    db.get_judgements_for_question = mocker.AsyncMock(return_value=[])
+
+    result = await build_embedding_based_context(
+        "test query",
+        db,
+        require_judgement_for_questions=False,
+        full_page_char_budget=10_000,
+    )
+
+    assert QUESTION_WITH_JUDGEMENT.id in result.page_ids
+    assert QUESTION_WITHOUT_JUDGEMENT.id in result.page_ids
+    assert CLAIM_PAGE.id in result.page_ids


### PR DESCRIPTION
## Summary
- Adds `require_judgement_for_questions` param to `EmbeddingContext` and `build_embedding_based_context()`
- When enabled, question pages without an active judgement are excluded from embedding context results
- `EmbeddingAssessCall` sets this flag so assess calls only see questions that already have a judgement

## Test plan
- [x] New unit tests for filtering (judged question kept, unjudged excluded, claims unaffected)
- [x] New unit test confirming default behavior (flag=False) preserves all questions
- [x] All existing embedding context tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)