### PR TITLE
Support in_light_of pages for reassess_question

### DIFF
--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -129,10 +129,29 @@ class EmbeddingContext(ContextBuilder):
             require_judgement_for_questions=self._require_judgement_for_questions,
         )
         working_page_ids = result.page_ids
-        await _record_context_built(infra, working_page_ids, [])
+        preloaded_ids = infra.call.context_page_ids or []
+
+        context_text = result.context_text
+        if preloaded_ids:
+            parts: list[str] = []
+            for pid in preloaded_ids:
+                page = await infra.db.get_page(pid)
+                if page:
+                    parts += [
+                        "",
+                        "---",
+                        "",
+                        f"## Pre-loaded Page: `{pid[:8]}`",
+                        "",
+                        await format_page(page, PageDetail.CONTENT, db=infra.db),
+                    ]
+            context_text += "\n".join(parts)
+
+        await _record_context_built(infra, working_page_ids, preloaded_ids)
         return ContextResult(
-            context_text=result.context_text,
+            context_text=context_text,
             working_page_ids=working_page_ids,
+            preloaded_ids=preloaded_ids,
         )
 
 

--- a/src/rumil/clean/common.py
+++ b/src/rumil/clean/common.py
@@ -79,8 +79,11 @@ class UpdateOperation(BaseModel):
         default_factory=list,
         description=(
             "For reassess_claims / reassess_question: page IDs whose content "
-            "should inform the reassessment. Include only the minimal set of "
-            "pages that have been updated — avoid transitive dependencies. "
+            "should inform the reassessment. The update plan defines a chain "
+            "of updates — each operation's in_light_of should list the "
+            "updated pages that directly influence it. If page A depends on "
+            "page B only via an intermediate page C, B should not appear in "
+            "A's in_light_of (C is sufficient). "
             "If a page ID points to a question with an active judgement, "
             "the judgement is used instead."
         ),

--- a/src/rumil/clean/common.py
+++ b/src/rumil/clean/common.py
@@ -78,7 +78,9 @@ class UpdateOperation(BaseModel):
     in_light_of: list[str] = Field(
         default_factory=list,
         description=(
-            "For reassess_claims: page IDs whose content should inform the reassessment. "
+            "For reassess_claims / reassess_question: page IDs whose content "
+            "should inform the reassessment. Include only the minimal set of "
+            "pages that have been updated — avoid transitive dependencies. "
             "If a page ID points to a question with an active judgement, "
             "the judgement is used instead."
         ),
@@ -198,7 +200,9 @@ async def execute_update_plan(
                         op.page_ids, op.in_light_of, op.guidance, call, db, trace
                     )
                 elif op.operation == "reassess_question":
-                    await reassess_question(op.page_id, call, db, trace)
+                    await reassess_question(
+                        op.page_id, op.in_light_of, call, db, trace
+                    )
                 else:
                     log.warning("Unknown operation type: %s", op.operation)
 
@@ -326,11 +330,17 @@ async def reassess_claim(
 
 async def reassess_question(
     page_id: str,
+    in_light_of: Sequence[str],
     call: Call,
     db: DB,
     trace: CallTrace,
 ) -> None:
-    """Reassess a question's judgement by dispatching an AssessCall."""
+    """Reassess a question's judgement by dispatching an AssessCall.
+
+    *in_light_of* page IDs are resolved (questions → latest judgement) and
+    passed as ``context_page_ids`` on the child assess call so they appear
+    fully expanded in the assessment context.
+    """
     resolved_id = await db.resolve_page_id(page_id)
     if not resolved_id:
         log.warning("Could not resolve question page ID: %s", page_id)
@@ -340,10 +350,14 @@ async def reassess_question(
         log.warning("Question page %s not found", page_id)
         return
 
+    context_pages = await resolve_in_light_of(in_light_of, db)
+    context_page_ids = [p.id for p in context_pages]
+
     assess_call = await db.create_call(
         CallType.ASSESS,
         scope_page_id=resolved_id,
         parent_call_id=call.id,
+        context_page_ids=context_page_ids,
     )
     cls = ASSESS_CALL_CLASSES[get_settings().assess_call_variant]
     assess = cls(resolved_id, assess_call, db)

--- a/tests/test_reassess_in_light_of.py
+++ b/tests/test_reassess_in_light_of.py
@@ -1,0 +1,162 @@
+"""Tests for in_light_of resolution and its use in reassess_question."""
+
+import pytest
+
+from rumil.clean.common import reassess_question, resolve_in_light_of
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.tracing.tracer import CallTrace
+
+
+def _make_page(page_type: PageType, headline: str, **kwargs) -> Page:
+    return Page(
+        page_type=page_type,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Content for {headline}",
+        headline=headline,
+        **kwargs,
+    )
+
+
+async def test_resolve_in_light_of_returns_claim_pages(tmp_db):
+    claim = _make_page(PageType.CLAIM, "Some claim")
+    await tmp_db.save_page(claim)
+
+    resolved = await resolve_in_light_of([claim.id[:8]], tmp_db)
+
+    assert len(resolved) == 1
+    assert resolved[0].id == claim.id
+
+
+async def test_resolve_in_light_of_swaps_question_for_judgement(tmp_db):
+    question = _make_page(PageType.QUESTION, "Some question")
+    await tmp_db.save_page(question)
+
+    judgement = _make_page(PageType.JUDGEMENT, "Judgement on question")
+    await tmp_db.save_page(judgement)
+    await tmp_db.save_link(PageLink(
+        from_page_id=judgement.id,
+        to_page_id=question.id,
+        link_type=LinkType.RELATED,
+    ))
+
+    resolved = await resolve_in_light_of([question.id[:8]], tmp_db)
+
+    assert len(resolved) == 1
+    assert resolved[0].id == judgement.id
+
+
+async def test_resolve_in_light_of_returns_question_when_no_judgement(tmp_db):
+    question = _make_page(PageType.QUESTION, "Unjudged question")
+    await tmp_db.save_page(question)
+
+    resolved = await resolve_in_light_of([question.id[:8]], tmp_db)
+
+    assert len(resolved) == 1
+    assert resolved[0].id == question.id
+
+
+async def test_resolve_in_light_of_skips_unresolvable_ids(tmp_db):
+    resolved = await resolve_in_light_of(["deadbeef"], tmp_db)
+
+    assert resolved == []
+
+
+async def test_resolve_in_light_of_skips_superseded_pages(tmp_db):
+    old_claim = _make_page(PageType.CLAIM, "Old claim")
+    new_claim = _make_page(PageType.CLAIM, "New claim")
+    await tmp_db.save_page(old_claim)
+    await tmp_db.save_page(new_claim)
+    await tmp_db.supersede_page(old_claim.id, new_claim.id)
+
+    resolved = await resolve_in_light_of([old_claim.id[:8]], tmp_db)
+
+    assert resolved == []
+
+
+async def test_reassess_question_passes_context_page_ids(
+    tmp_db, question_page, mocker,
+):
+    """The child assess call should have context_page_ids set to the resolved
+    in_light_of pages."""
+    claim = _make_page(PageType.CLAIM, "Updated claim")
+    await tmp_db.save_page(claim)
+
+    parent_call = Call(
+        call_type=CallType.FEEDBACK_UPDATE,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.RUNNING,
+    )
+    await tmp_db.save_call(parent_call)
+    trace = CallTrace(parent_call.id, tmp_db)
+
+    # Mock CallRunner.run to avoid LLM calls — we only care about call creation
+    mocker.patch("rumil.clean.common.ASSESS_CALL_CLASSES", {
+        "embedding": type("FakeAssess", (), {
+            "__init__": lambda self, *a, **kw: None,
+            "run": mocker.AsyncMock(),
+        }),
+    })
+
+    await reassess_question(
+        question_page.id[:8], [claim.id[:8]], parent_call, tmp_db, trace,
+    )
+
+    # Find the child assess call
+    children = await tmp_db.get_child_calls(parent_call.id)
+    assess_calls = [c for c in children if c.call_type == CallType.ASSESS]
+    assert len(assess_calls) == 1
+    assert claim.id in assess_calls[0].context_page_ids
+
+
+async def test_reassess_question_resolves_question_to_judgement_in_context(
+    tmp_db, question_page, mocker,
+):
+    """When in_light_of contains a question with a judgement, the child assess
+    call's context_page_ids should contain the judgement ID, not the question."""
+    sub_question = _make_page(PageType.QUESTION, "Sub-question")
+    await tmp_db.save_page(sub_question)
+    judgement = _make_page(PageType.JUDGEMENT, "Sub-question judgement")
+    await tmp_db.save_page(judgement)
+    await tmp_db.save_link(PageLink(
+        from_page_id=judgement.id,
+        to_page_id=sub_question.id,
+        link_type=LinkType.RELATED,
+    ))
+
+    parent_call = Call(
+        call_type=CallType.FEEDBACK_UPDATE,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.RUNNING,
+    )
+    await tmp_db.save_call(parent_call)
+    trace = CallTrace(parent_call.id, tmp_db)
+
+    mocker.patch("rumil.clean.common.ASSESS_CALL_CLASSES", {
+        "embedding": type("FakeAssess", (), {
+            "__init__": lambda self, *a, **kw: None,
+            "run": mocker.AsyncMock(),
+        }),
+    })
+
+    await reassess_question(
+        question_page.id[:8], [sub_question.id[:8]], parent_call, tmp_db, trace,
+    )
+
+    children = await tmp_db.get_child_calls(parent_call.id)
+    assess_calls = [c for c in children if c.call_type == CallType.ASSESS]
+    assert len(assess_calls) == 1
+    assert judgement.id in assess_calls[0].context_page_ids
+    assert sub_question.id not in assess_calls[0].context_page_ids


### PR DESCRIPTION
## Summary
- `reassess_question` now accepts `in_light_of` page IDs (matching the existing `reassess_claims` pattern), resolves them via `resolve_in_light_of()`, and passes them as `context_page_ids` on the child assess call so they appear fully expanded in the assessment context.
- `EmbeddingContext` (used by the default `embedding` assess variant) now renders `context_page_ids` as "Pre-loaded Page" sections — previously it ignored them entirely.
- `UpdateOperation.in_light_of` description updated to cover `reassess_question` and guide the agent toward minimal, non-transitive page sets.

## Test plan
- [ ] Smoke test a feedback update that includes a `reassess_question` op with `in_light_of` pages — verify the child assess call's context includes the expected pre-loaded pages
- [ ] Verify existing `reassess_claims` with `in_light_of` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)