### PR TITLE
Fix deploy: override NEXT_PUBLIC_API_URL to prevent .env.local leak

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -63,7 +63,7 @@ fi
 if $deploy_frontend; then
     echo "==> Building frontend (pnpm build)..."
     cd "$REPO_ROOT/frontend"
-    pnpm build
+    NEXT_PUBLIC_API_URL="" pnpm build
 
     echo "==> Building frontend image (linux/amd64)..."
     docker build --platform linux/amd64 \


### PR DESCRIPTION
## Summary
- When deploying from a worktree with `.env.local`, the local `NEXT_PUBLIC_API_URL` (`http://127.0.0.1:8003`) was baked into the production frontend bundle at build time
- Client-side fetches hit localhost instead of going through the Next.js middleware proxy, causing the project pages view to hang on "Loading pages..."
- Fix: explicitly set `NEXT_PUBLIC_API_URL=""` during `pnpm build` in `deploy.sh` so the env var is always empty regardless of local env files

## Test plan
- [x] Deployed to production and verified the project page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)