### PR TITLE
Fix page links in staged run traces leading to 404s

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2340,6 +2340,32 @@
               }
             ],
             "title": "Cost Usd"
+          },
+          "has_thinking": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Has Thinking"
+          },
+          "tool_uses": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Uses"
           }
         },
         "type": "object",
@@ -2355,7 +2381,9 @@
           "cache_creation_input_tokens",
           "cache_read_input_tokens",
           "duration_ms",
-          "cost_usd"
+          "cost_usd",
+          "has_thinking",
+          "tool_uses"
         ],
         "title": "LLMExchangeEventOut"
       },
@@ -3315,6 +3343,11 @@
               }
             ],
             "title": "Cost Usd"
+          },
+          "staged": {
+            "type": "boolean",
+            "title": "Staged",
+            "default": false
           }
         },
         "type": "object",

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -696,6 +696,16 @@ export type LlmExchangeEventOut = {
      * Cost Usd
      */
     cost_usd: number | null;
+    /**
+     * Has Thinking
+     */
+    has_thinking: boolean | null;
+    /**
+     * Tool Uses
+     */
+    tool_uses: Array<{
+        [key: string]: unknown;
+    }> | null;
 };
 
 /**
@@ -1228,6 +1238,10 @@ export type RunTraceTreeOut = {
      * Cost Usd
      */
     cost_usd?: number | null;
+    /**
+     * Staged
+     */
+    staged?: boolean;
 };
 
 /**

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -13,6 +13,7 @@ import type {
   PageRef,
 } from "@/api/types.gen";
 import { CLIENT_API_BASE as QUERY_API_BASE } from "@/api-config";
+import { useStagedRun } from "@/lib/staged-run-context";
 import { traceKeys } from "@/lib/queries";
 import type { SequenceNode } from "./trace-viewer";
 
@@ -169,8 +170,12 @@ function getDuration(call: { created_at: string; completed_at?: string | null })
 function PageChip({ page }: { page: PageRef }) {
   const short = page.id.slice(0, 8);
   const label = page.headline || short;
+  const { activeStagedRunId } = useStagedRun();
+  const href = activeStagedRunId
+    ? `/pages/${page.id}?staged_run_id=${activeStagedRunId}`
+    : `/pages/${page.id}`;
   return (
-    <Link href={`/pages/${page.id}`} className="trace-page-chip" title={short}>
+    <Link href={href} className="trace-page-chip" title={short}>
       {label}
     </Link>
   );

--- a/frontend/src/app/traces/[runId]/trace-viewer.tsx
+++ b/frontend/src/app/traces/[runId]/trace-viewer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import type { RunTraceTreeOut, CallNodeOut } from "@/api/types.gen";
 import { useRunTraceTree } from "@/lib/use-run-trace";
+import { useStagedRun } from "@/lib/staged-run-context";
 import { CallNode, HashTargetProvider, type TreeNode } from "./call-node";
 
 export type SequenceNode = {
@@ -89,6 +90,13 @@ export function TraceViewer({
 }) {
   const trace = useRunTraceTree(runId, initialTrace, realtimeConfig);
   const tree = useMemo(() => buildTree(trace.calls), [trace.calls]);
+  const { setActiveStagedRunId } = useStagedRun();
+
+  useEffect(() => {
+    if (trace.staged) {
+      setActiveStagedRunId(runId);
+    }
+  }, [trace.staged, runId, setActiveStagedRunId]);
 
   return (
     <HashTargetProvider>

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -390,11 +390,15 @@ async def get_run_trace_tree(run_id: str):
             )
         )
     total_cost = sum(c.cost_usd or 0 for c in calls)
+    run_resp = await db.client.table("runs").select("staged").eq("id", run_id).execute()
+    run_data: list[dict[str, object]] = run_resp.data or []  # type: ignore[assignment]
+    is_staged = bool(run_data and run_data[0].get("staged"))
     return RunTraceTreeOut(
         run_id=run_id,
         question=question_page,
         calls=nodes,
         cost_usd=total_cost if total_cost > 0 else None,
+        staged=is_staged,
     )
 
 

--- a/src/rumil/api/schemas.py
+++ b/src/rumil/api/schemas.py
@@ -261,6 +261,7 @@ class RunTraceTreeOut(BaseModel):
     question: Page | None
     calls: list[CallNodeOut]
     cost_usd: float | None = None
+    staged: bool = False
 
 
 class RunSummaryOut(BaseModel):


### PR DESCRIPTION
## Summary
- Page links in trace views for staged runs now include `staged_run_id` query param, preventing 404s when clicking through to staged pages
- `TraceViewer` auto-activates the existing staged run context when viewing a staged trace, so users don't need to manually toggle visibility first
- Added `staged` field to `RunTraceTreeOut` API response so the frontend knows whether the trace belongs to a staged run

## Test plan
- [x] Navigate directly to a staged run's trace page
- [x] Expand a call node and verify page links include `?staged_run_id=...`
- [x] Click a page link and verify the page loads (not 404)
- [x] Verify the staged banner appears on the loaded page

🤖 Generated with [Claude Code](https://claude.com/claude-code)