### PR TITLE
Parallelise feedback investigation calls

### DIFF
--- a/prompts/feedback-plan-updates.md
+++ b/prompts/feedback-plan-updates.md
@@ -29,14 +29,16 @@ Read the evaluation carefully and use the tools below to address each issue. Pri
 **Inconsistencies** — The evaluation identifies contradictory claims or judgements:
 - Create a targeted question (via `headline` + `content`) that asks specifically about the point of tension — e.g. "What is the actual X given conflicting claims A and B?" — and investigate it. Then in Phase 2, use the `reassess_claims` operation to reconcile the conflicting claims in light of the subquestion's findings.
 
+**`collect_investigations`** — Wait for all background investigations to complete and return their results. Call this once after dispatching all your `investigate_question` calls. Blocks until every investigation finishes. Takes no arguments.
+
 ### Important notes
 
 - You have a total **investigation budget of {investigation_budget}** research calls to distribute across all your `investigate_question` calls. Each call's `budget` parameter is deducted from this pool. Plan your allocation carefully — once the pool is exhausted, no further investigations can be commissioned.
-- **Dispatch investigations in parallel.** Investigations are independent of each other — call `investigate_question` multiple times in the same turn to run them concurrently. This is significantly faster than dispatching them one at a time. Only serialize investigations if a later one genuinely depends on the results of an earlier one.
+- **Dispatch all investigations first, then collect results.** Each `investigate_question` call returns immediately — the investigation runs in the background. Once you have dispatched all investigations, call `collect_investigations` to wait for all of them and get all results at once. This runs them in parallel, which is **dramatically** faster than calling them one at a time. Only serialize investigations if a later one genuinely depends on the results of an earlier one.
 - Focus on the highest-impact issues first — you may not have budget for everything.
 - Always use `explore_page` to understand the graph around a page before commissioning investigations. This doesn't count against your budget.
 - When creating new questions, write clear, specific headlines that capture what needs to be investigated.
-- Each investigation returns the resulting judgement on the target question, so you can use it to inform your propagation plan.
+- The results from `collect_investigations` include the resulting judgement on each target question, so you can use them to inform your propagation plan.
 
 ## Phase 2: Propagation plan
 

--- a/src/rumil/clean/feedback.py
+++ b/src/rumil/clean/feedback.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -76,17 +77,69 @@ class _InvestigateQuestionInput(BaseModel):
     )
 
 
-def _make_investigate_question_tool(
+@dataclass
+class _PendingInvestigation:
+    """A background investigation awaiting completion."""
+
+    question_id: str
+    display_headline: str
+    child_call_id: str
+    budget: int
+    task: asyncio.Task[str]
+
+
+def _make_investigation_tools(
     call: Call, db: DB, broadcaster: Broadcaster | None, investigation_budget: int
 ):
-    """MCP tool: commission investigation of a subquestion via the orchestrator.
+    """Create the investigate_question and collect_investigations MCP tools.
+
+    Returns a tuple of (investigate_tool, collect_tool) to register on the
+    MCP server.  ``investigate_question`` dispatches each investigation as a
+    background ``asyncio.Task`` and returns immediately so that the Claude
+    Agent SDK (which executes MCP tool calls serially) does not block on
+    long-running orchestrator runs.  ``collect_investigations`` awaits all
+    pending tasks and returns their results.
 
     *investigation_budget* is the total budget pool shared across all calls.
-    Each call's ``budget`` arg is deducted from this pool; calls that would
-    exceed it are rejected.
     """
     budget_remaining = investigation_budget
     budget_lock = asyncio.Lock()
+    pending: dict[str, _PendingInvestigation] = {}
+
+    async def _run_investigation(
+        question_id: str,
+        display_headline: str,
+        budget: int,
+    ) -> str:
+        """Run orchestrator and return a summary string."""
+        orchestrator = ExperimentalOrchestrator(db, broadcaster, budget_cap=budget)
+        orchestrator._parent_call_id = call.id
+        child_call_id = await orchestrator.create_initial_call(
+            question_id, parent_call_id=call.id
+        )
+        try:
+            await orchestrator.run(question_id)
+            judgement_text = ""
+            judgements = await db.get_judgements_for_question(question_id)
+            if judgements:
+                latest = max(judgements, key=lambda j: j.created_at)
+                judgement_text = (
+                    f"\n\n## Judgement on [{question_id[:8]}]\n\n"
+                    f"**{latest.headline}**\n\n{latest.content}"
+                )
+            return (
+                f"Investigation complete for [{question_id[:8]}] "
+                f'"{display_headline}". Child call: {child_call_id[:8]}. '
+                f"Remaining investigation budget: {budget_remaining}."
+                f"{judgement_text}"
+            )
+        except Exception:
+            log.exception("investigate_question failed for %s", question_id[:8])
+            return (
+                f"Investigation failed for [{question_id[:8]}] "
+                f'"{display_headline}". Child call: {child_call_id[:8]}. '
+                f"Remaining investigation budget: {budget_remaining}."
+            )
 
     @tool(
         "investigate_question",
@@ -96,7 +149,9 @@ def _make_investigate_question_tool(
         "new question (by headline + content). Either way, the question is "
         "automatically linked as a child of parent_question_id. "
         "Each call's budget is deducted from a shared investigation budget "
-        "pool — check the remaining budget in the tool response.",
+        "pool — check the remaining budget in the tool response. "
+        "This tool returns immediately — the investigation runs in the "
+        "background. Call collect_investigations to wait for results.",
         _InvestigateQuestionInput.model_json_schema(),
     )
     async def investigate_question(args: dict) -> dict:
@@ -194,39 +249,77 @@ def _make_investigate_question_tool(
             link_type=LinkType.CHILD_QUESTION,
         )
 
-        orchestrator = ExperimentalOrchestrator(db, broadcaster, budget_cap=budget)
-        orchestrator._parent_call_id = call.id
-        child_call_id = await orchestrator.create_initial_call(
-            resolved, parent_call_id=call.id
+        task = asyncio.create_task(
+            _run_investigation(resolved, display_headline, budget)
+        )
+        short_id = resolved[:8]
+        pending[short_id] = _PendingInvestigation(
+            question_id=resolved,
+            display_headline=display_headline,
+            child_call_id="",
+            budget=budget,
+            task=task,
+        )
+        log.info(
+            "Dispatched background investigation for %s (%d pending)",
+            short_id,
+            len(pending),
         )
 
-        try:
-            await orchestrator.run(resolved)
-            judgement_text = ""
-            judgements = await db.get_judgements_for_question(resolved)
-            if judgements:
-                latest = max(judgements, key=lambda j: j.created_at)
-                judgement_text = (
-                    f"\n\n## Judgement on [{resolved[:8]}]\n\n"
-                    f"**{latest.headline}**\n\n{latest.content}"
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Investigation dispatched for [{short_id}] "
+                        f'"{display_headline}" (budget {budget}). '
+                        f"Remaining investigation budget: {budget_remaining}. "
+                        f"{len(pending)} investigation(s) now running in the "
+                        f"background. Call collect_investigations when you are "
+                        f"done dispatching to wait for results."
+                    ),
+                }
+            ]
+        }
+
+    @tool(
+        "collect_investigations",
+        "Wait for all pending background investigations to complete and "
+        "return their results. Call this after dispatching all your "
+        "investigate_question calls. Blocks until every investigation "
+        "finishes.",
+        {"type": "object", "properties": {}, "required": []},
+    )
+    async def collect_investigations(args: dict) -> dict:
+        if not pending:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "No pending investigations to collect.",
+                    }
+                ]
+            }
+
+        log.info("Collecting %d pending investigations", len(pending))
+        results: list[str] = []
+        items = list(pending.items())
+        tasks = [inv.task for _, inv in items]
+        summaries = await asyncio.gather(*tasks, return_exceptions=True)
+        for (short_id, inv), summary in zip(items, summaries):
+            if isinstance(summary, BaseException):
+                log.exception("Investigation %s raised", short_id, exc_info=summary)
+                results.append(
+                    f"Investigation FAILED for [{short_id}] "
+                    f'"{inv.display_headline}": {summary}'
                 )
-            summary = (
-                f"Investigation complete for [{resolved[:8]}] "
-                f'"{display_headline}". Child call: {child_call_id[:8]}. '
-                f"Remaining investigation budget: {budget_remaining}."
-                f"{judgement_text}"
-            )
-        except Exception:
-            log.exception("investigate_question failed for %s", resolved[:8])
-            summary = (
-                f"Investigation failed for [{resolved[:8]}] "
-                f'"{display_headline}". Child call: {child_call_id[:8]}. '
-                f"Remaining investigation budget: {budget_remaining}."
-            )
+            else:
+                results.append(summary)
+        pending.clear()
 
-        return {"content": [{"type": "text", "text": summary}]}
+        return {"content": [{"type": "text", "text": "\n\n---\n\n".join(results)}]}
 
-    return investigate_question
+    return investigate_question, collect_investigations
 
 
 async def _plan_and_edit(
@@ -256,11 +349,11 @@ async def _plan_and_edit(
     )
 
     explore_tool = make_explore_tool(db)
-    investigate_tool = _make_investigate_question_tool(
+    investigate_tool, collect_tool = _make_investigation_tools(
         call, db, broadcaster, advertised_investigation_budget
     )
 
-    plan_tools = [explore_tool, investigate_tool]
+    plan_tools = [explore_tool, investigate_tool, collect_tool]
     all_tool_fqnames = [f"mcp__{_SERVER_NAME}__{t.name}" for t in plan_tools]
 
     investigator_prompt = build_investigator_prompt("feedback")

--- a/src/rumil/clean/feedback.py
+++ b/src/rumil/clean/feedback.py
@@ -162,23 +162,6 @@ def _make_investigation_tools(
         parent_question_id = args["parent_question_id"]
         budget = args["budget"]
 
-        async with budget_lock:
-            if budget > budget_remaining:
-                return {
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": (
-                                f"Rejected: requested budget {budget} exceeds "
-                                f"remaining investigation budget of "
-                                f"{budget_remaining}. "
-                                f"Use a smaller budget or skip this investigation."
-                            ),
-                        }
-                    ]
-                }
-            budget_remaining -= budget
-
         if not question_id and not headline:
             return {
                 "content": [
@@ -202,6 +185,35 @@ def _make_investigation_tools(
                     }
                 ]
             }
+
+        if not headline:
+            resolved = await db.resolve_page_id(question_id)
+            if not resolved:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Question '{question_id}' not found.",
+                        }
+                    ]
+                }
+
+        async with budget_lock:
+            if budget > budget_remaining:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                f"Rejected: requested budget {budget} exceeds "
+                                f"remaining investigation budget of "
+                                f"{budget_remaining}. "
+                                f"Use a smaller budget or skip this investigation."
+                            ),
+                        }
+                    ]
+                }
+            budget_remaining -= budget
 
         if headline:
             parent_page = await db.get_page(parent_resolved)
@@ -229,15 +241,7 @@ def _make_investigation_tools(
             )
         else:
             resolved = await db.resolve_page_id(question_id)
-            if not resolved:
-                return {
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"Question '{question_id}' not found.",
-                        }
-                    ]
-                }
+            assert resolved  # validated before budget deduction
             page = await db.get_page(resolved)
             display_headline = page.headline if page else resolved[:8]
 

--- a/tests/test_parallel_investigations.py
+++ b/tests/test_parallel_investigations.py
@@ -120,6 +120,44 @@ async def test_collect_with_no_pending(investigation_tools):
     assert "no pending" in text.lower()
 
 
+async def test_validation_failure_does_not_leak_budget(investigation_tools):
+    """If validation fails (e.g. missing question_id), budget must not be consumed."""
+    investigate_tool, _ = investigation_tools
+
+    result = await investigate_tool.handler(
+        {
+            "question_id": "",
+            "headline": "",
+            "parent_question_id": "aaaa1111",
+            "budget": 50,
+        }
+    )
+    text = result["content"][0]["text"]
+    assert "error" in text.lower()
+
+    with (
+        patch("rumil.clean.feedback.link_pages", new_callable=AsyncMock),
+        patch("rumil.clean.feedback.ExperimentalOrchestrator") as MockOrch,
+    ):
+        mock_instance = MagicMock()
+        mock_instance.create_initial_call = AsyncMock(return_value="child-id")
+        mock_instance.run = AsyncMock()
+        mock_instance._parent_call_id = None
+        MockOrch.return_value = mock_instance
+
+        result = await investigate_tool.handler(
+            {
+                "question_id": "q0000001",
+                "parent_question_id": "aaaa1111",
+                "budget": 100,
+            }
+        )
+        text = result["content"][0]["text"]
+        assert "dispatched" in text.lower(), (
+            f"Full budget should still be available after validation failure, got: {text}"
+        )
+
+
 async def test_budget_rejection(investigation_tools):
     """Requesting more than available budget is rejected immediately."""
     investigate_tool, _ = investigation_tools

--- a/tests/test_parallel_investigations.py
+++ b/tests/test_parallel_investigations.py
@@ -1,0 +1,179 @@
+"""Test that investigate_question dispatches run concurrently."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rumil.clean.feedback import _make_investigation_tools
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+
+
+def _fake_page(page_id: str = "aaaa1111", headline: str = "Test Q") -> Page:
+    return Page(
+        id=page_id,
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+    )
+
+
+def _fake_call() -> Call:
+    return Call(
+        call_type=CallType.FEEDBACK_UPDATE,
+        workspace=Workspace.RESEARCH,
+        scope_page_id="aaaa1111",
+        status=CallStatus.RUNNING,
+    )
+
+
+def _mock_db() -> MagicMock:
+    db = MagicMock()
+    db.resolve_page_id = AsyncMock(side_effect=lambda pid: pid)
+    db.get_page = AsyncMock(return_value=_fake_page())
+    db.save_page = AsyncMock()
+    db.get_judgements_for_question = AsyncMock(return_value=[])
+    return db
+
+
+SLEEP_SECONDS = 0.3
+
+
+@pytest.fixture
+def investigation_tools():
+    """Create investigation tools with mocked DB and orchestrator."""
+    call = _fake_call()
+    db = _mock_db()
+    investigate_tool, collect_tool = _make_investigation_tools(
+        call=call,
+        db=db,
+        broadcaster=None,
+        investigation_budget=100,
+    )
+    return investigate_tool, collect_tool
+
+
+async def test_investigations_run_concurrently(investigation_tools):
+    """Dispatching N investigations then collecting should take ~1x sleep, not Nx."""
+    investigate_tool, collect_tool = investigation_tools
+    num_investigations = 3
+
+    with (
+        patch("rumil.clean.feedback.link_pages", new_callable=AsyncMock),
+        patch("rumil.clean.feedback.ExperimentalOrchestrator") as MockOrch,
+    ):
+        mock_instance = MagicMock()
+        mock_instance.create_initial_call = AsyncMock(return_value="child-call-id-1234")
+
+        async def slow_run(question_id: str) -> None:
+            await asyncio.sleep(SLEEP_SECONDS)
+
+        mock_instance.run = AsyncMock(side_effect=slow_run)
+        mock_instance._parent_call_id = None
+        MockOrch.return_value = mock_instance
+
+        for i in range(num_investigations):
+            result = await investigate_tool.handler(
+                {
+                    "question_id": f"q{i:07d}",
+                    "parent_question_id": "aaaa1111",
+                    "budget": 5,
+                }
+            )
+            text = result["content"][0]["text"]
+            assert "dispatched" in text.lower(), (
+                f"Expected dispatch confirmation, got: {text}"
+            )
+
+        t0 = time.monotonic()
+        result = await collect_tool.handler({})
+        elapsed = time.monotonic() - t0
+
+        text = result["content"][0]["text"]
+        assert "complete" in text.lower(), f"Expected completion summaries, got: {text}"
+        assert text.count("Investigation complete") == num_investigations
+
+    max_serial_time = SLEEP_SECONDS * num_investigations
+    assert elapsed < max_serial_time * 0.8, (
+        f"Investigations appear serial: {elapsed:.2f}s >= "
+        f"{max_serial_time * 0.8:.2f}s (80% of serial time {max_serial_time:.2f}s). "
+        f"Expected ~{SLEEP_SECONDS:.2f}s for parallel execution."
+    )
+
+
+async def test_collect_with_no_pending(investigation_tools):
+    """collect_investigations with nothing pending returns a no-op message."""
+    _, collect_tool = investigation_tools
+    result = await collect_tool.handler({})
+    text = result["content"][0]["text"]
+    assert "no pending" in text.lower()
+
+
+async def test_budget_rejection(investigation_tools):
+    """Requesting more than available budget is rejected immediately."""
+    investigate_tool, _ = investigation_tools
+
+    with patch("rumil.clean.feedback.link_pages", new_callable=AsyncMock):
+        result = await investigate_tool.handler(
+            {
+                "question_id": "q0000001",
+                "parent_question_id": "aaaa1111",
+                "budget": 999,
+            }
+        )
+        text = result["content"][0]["text"]
+        assert "rejected" in text.lower()
+
+
+async def test_budget_deducted_across_dispatches(investigation_tools):
+    """Budget pool is shared across dispatches and enforced correctly."""
+    investigate_tool, collect_tool = investigation_tools
+
+    with (
+        patch("rumil.clean.feedback.link_pages", new_callable=AsyncMock),
+        patch("rumil.clean.feedback.ExperimentalOrchestrator") as MockOrch,
+    ):
+        mock_instance = MagicMock()
+        mock_instance.create_initial_call = AsyncMock(return_value="child-id")
+        mock_instance.run = AsyncMock()
+        mock_instance._parent_call_id = None
+        MockOrch.return_value = mock_instance
+
+        await investigate_tool.handler(
+            {
+                "question_id": "q0000001",
+                "parent_question_id": "aaaa1111",
+                "budget": 60,
+            }
+        )
+        await investigate_tool.handler(
+            {
+                "question_id": "q0000002",
+                "parent_question_id": "aaaa1111",
+                "budget": 35,
+            }
+        )
+        result = await investigate_tool.handler(
+            {
+                "question_id": "q0000003",
+                "parent_question_id": "aaaa1111",
+                "budget": 10,
+            }
+        )
+        text = result["content"][0]["text"]
+        assert "rejected" in text.lower(), (
+            f"Third dispatch should be rejected (budget 60+35+10>100), got: {text}"
+        )
+
+        await collect_tool.handler({})


### PR DESCRIPTION
## Summary
- The Claude Agent SDK executes MCP tool calls serially, so `investigate_question` was blocking for each full orchestrator run (~1h each), making N investigations take N hours instead of ~1h
- Refactored into a dispatch-then-collect pattern: `investigate_question` now spawns a background `asyncio.Task` and returns immediately; a new `collect_investigations` tool awaits all pending tasks concurrently via `asyncio.gather()`
- Updated the feedback prompt to guide the model to dispatch all investigations first, then call `collect_investigations` once

## Test plan
- [x] New unit tests verify parallel execution (3 mocked investigations with 0.3s sleep each complete in ~0.3s, not 0.9s)
- [x] Budget rejection and pool deduction tests pass
- [x] Full test suite passes (162 passed, 36 skipped)
- [ ] Run a real `--feedback` call and verify investigations overlap in the trace timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)