### PR TITLE
Fix evaluation discarding all but last assistant message

### DIFF
--- a/src/rumil/evaluate/runner.py
+++ b/src/rumil/evaluate/runner.py
@@ -120,9 +120,7 @@ async def run_evaluation(
 
     try:
         result = await run_sdk_agent(config)
-        result_text = "\n\n".join(
-            result.last_assistant_text or result.all_assistant_text
-        )
+        result_text = "\n\n".join(result.all_assistant_text)
         await trace.record(EvaluationCompleteEvent(evaluation=result_text))
         call.review_json = {"evaluation": result_text}
         call.result_summary = result_text


### PR DESCRIPTION
## Summary
- The evaluation runner joined `last_assistant_text or all_assistant_text`, but `last_assistant_text` (final turn only) is always truthy when the agent produces output, so `all_assistant_text` was never reached — the full evaluation was silently discarded in favour of the closing summary message.

## Test plan
- [ ] Run an evaluation with investigator subagents and verify the full evaluation text is captured, not just the final "investigators completed" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)