### PR TITLE
Disable single-tilde strikethrough in markdown

### DIFF
--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -351,7 +351,7 @@ export default async function PageDetailPage({
 
         <div className="page-content">
           <Markdown
-            remarkPlugins={[remarkGfm]}
+            remarkPlugins={[[remarkGfm, { singleTilde: false }]]}
             components={{
               a: ({ href, children }) => {
                 if (href && href.startsWith("/pages/") && href.includes("?cite=")) {


### PR DESCRIPTION
## Summary
- Tildes used for approximations (`~$45`, `~17%`) were being parsed as strikethrough by remark-gfm, wrapping content in `<del>` tags
- Pass `{ singleTilde: false }` to remark-gfm to disable single-tilde strikethrough while keeping `~~double-tilde~~` strikethrough available

## Test plan
- [ ] Visit a page with tilde-prefixed numbers (e.g. `~$45-130`) and confirm they render as plain text, not strikethrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)