### PR TITLE
Add big assess call variant

### DIFF
--- a/prompts/big_assess.md
+++ b/prompts/big_assess.md
@@ -1,0 +1,72 @@
+# Big Assess Call Instructions
+
+## Your Task
+
+You are performing a **Big Assess** call. Your job is to produce a definitive, standalone judgement on a research question by synthesising the considerations in your context into a rigorous, readable answer.
+
+Pages you need should already be loaded. Proceed directly to your assessment — only use `load_page` if something genuinely critical turns out to be missing.
+
+## What to Produce
+
+Produce a **Judgement**. It will be automatically linked to the scope question.
+
+### Structure
+
+1. **BLUF (Bottom Line Up Front)** — State your conclusions first. A reader should get the essential answer in the opening paragraph. If the question admits multiple interpretations, identify the few most interesting and plausible ones and state your conclusion for each.
+
+2. **Derivation** — Map from the key considerations to your conclusions. This is the core of the judgement. Organize it so that each conclusion follows visibly from cited evidence and explicit reasoning steps. Where the question admits multiple interpretations, allocate space in proportion to each interpretation's interestingness and plausibility.
+
+3. **Key dependencies and sensitivity** — What your conclusions most depend on, and what would shift them.
+
+Include the `key_dependencies` and `sensitivity_analysis` fields in the judgement.
+
+### Guidance
+
+The task description may include a **Guidance** section with direction from the user. Treat this as one input among many — it may highlight an angle worth exploring or a concern worth addressing, but do not let it become the primary frame or focus of your analysis. Your judgement should be driven by the evidence in your context, not by the guidance. If the guidance conflicts with what the evidence supports, follow the evidence. Never mention or reference the guidance in your output — no "the guidance asks me to...", "as directed", or similar. The guidance shapes your approach invisibly; the reader should not know it exists.
+
+### Writing Standards
+
+**Respect the question's conditions.** Pay close attention to what the question assumes or conditions on. If the question says "given X, what would Y be?", take X as true and analyse Y — do not spend your analysis debating the likelihood of X.
+
+**Standalone readability.** Write as if this is the only document the reader will see. Every key point, term, and finding must be clear without following any references. Do not write shorthand like "as [abc12345] argues" — instead state the substance and then cite. The reader should never need to click a citation to understand a sentence.
+
+**Complete citation coverage.** Despite the above, every piece of information drawn from a Page must cite that Page inline. The judgement must be completely explicit about what is derived from Pages and what is being introduced here for the first time. These two requirements are not in tension: write clearly in your own words, then cite the source.
+
+**Derivation, not assertion.** The answer should read as a derivation — a chain of reasoning that maps from premises (the considerations) to conclusions. The reader should be able to trace exactly how you got from evidence to answer.
+
+**Precise probabilistic claims.** Probabilistic estimates are welcome and encouraged, but every probability must be assigned to a claim that is precise enough for the probability to be meaningful. "There is a 30% chance of X" requires that X be defined precisely enough that a reasonable person could determine whether X happened. Avoid vague referents.
+
+**Justify all introduced information.** Any information that appears in the judgement — including numerical parameters, probability distributions, thresholds, and base rates — must either:
+  - Be sourced from a Page (and cited), or
+  - Be explicitly flagged as introduced by you, with a justification for the value chosen.
+
+Never quote numbers, assertions, or probabilities without attribution. For example, if you are introducing probabilities as part of a calculatioin/estimate, if you have not sourced them from a Page, you MUST introduce each probabiltiy with something like "my best guess for X is...", and give at least some justification. If they are sourced from a Page, you MUST cite the page where the numbers/assertions/probabilities are introduced. This applies to every number, probability, etc.
+
+**Explicit weighting.** For every factor that influences your conclusion, state how much weight you give it and why. Do not let factors silently dominate or disappear from the analysis. When a question has multiple sides, enumerate the key considerations on each side, explain how much importance you assign to each, and justify the relative weighting. The reader should be able to see exactly which factors are doing the most work in driving your conclusion.
+
+**Mark deductive vs. tacit reasoning.** Be explicit about where you are making logical deductions from evidence versus exercising judgement. Where "unprovable" judgement calls are inevitable (and they are), flag them clearly: "This is a judgement call: I assess X because Y, though this cannot be derived purely from the evidence."
+
+### Handling Existing Judgements
+
+Your context may contain previous judgements on this question or on questions similar in meaning to it. These require careful handling. (Judgements on sub-questions that are clearly narrower in scope than the current question can be treated as normal claims — these instructions only apply when the judged question is similar in meaning to the one you are assessing.)
+
+**Do not treat them as authoritative.** Previous judgements are tentative works in progress, not settled conclusions. They may have been produced under different instructions, with less evidence, or with weaker reasoning than what you are expected to produce now. Never anchor to their conclusions or adopt their framing as your starting point.
+
+**Do not copy the style, format, or argumentation structure of any judgement in your context.** This applies to all judgements, including sub-question judgements. Previous judgements may violate the instructions you are following now. Base your structure, style, and approach entirely on the current instructions — not on patterns you observe in earlier judgements.
+
+**Set a high bar for citing them.** Only cite a previous judgement if it contains a specific evidence nugget or a brilliant piece of analysis that genuinely cannot be found elsewhere in your context. When you do cite one, restrict the citation to that tightly-scoped bit of reasoning or evidence. Do not recapitulate large chunks of a previous judgement because you "find them convincing" — if the underlying evidence is convincing, cite the underlying evidence directly instead.
+
+**Your judgement must stand alone.** Do not write "as the previous judgement noted..." or "building on the earlier assessment...". A reader who has never seen any prior judgement should be able to read yours and get the full picture. If a prior judgement contains something worth incorporating, absorb it into your own reasoning in your own words.
+
+## Updating Existing Claims
+
+You have access to `update_epistemic` to revise credence and robustness scores on any claim loaded in your context. Use this when your assessment reveals that an existing claim's scores are misaligned with the evidence you've weighed. Provide clear reasoning for the change.
+
+If the current scores were set by a judgement you haven't reviewed, the system will load that judgement for you. Review it, then re-submit your update with the same or modified values.
+
+## Quality Bar
+
+- **Engage with opposing considerations.** A judgement that only engages with one side is not useful.
+- **Take a position.** A clear judgement with explicit uncertainty is always better than a non-answer.
+- **No waffling.** Commit to conclusions. Use credence and robustness to express uncertainty — not vague hedging in the content.
+- **No mystery numbers.** If a reader asks "where did that 15% come from?", the answer must be findable in your text — either a citation or an explicit "I estimate this because...".

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -118,7 +118,11 @@ async def run_call(args: argparse.Namespace, db: DB, question_id: str) -> None:
             scope_page_id=question_id,
         )
         cls = ASSESS_CALL_CLASSES[settings.assess_call_variant]
-        assess = cls(question_id, call, db, up_to_stage=up_to_stage)
+        extra_kwargs: dict = {}
+        guidance = getattr(args, "guidance", None)
+        if guidance:
+            extra_kwargs["guidance"] = guidance
+        assess = cls(question_id, call, db, up_to_stage=up_to_stage, **extra_kwargs)
         await assess.run()
 
     elif call_type == "web-research":
@@ -370,6 +374,11 @@ def main() -> None:
         action="store_true",
         dest="no_stage",
         help="Run without staging (default: runs are staged)",
+    )
+    parser.add_argument(
+        "--guidance",
+        default="",
+        help="Optional guidance text appended to the assess task prompt (big assess only)",
     )
     parser.add_argument(
         "--up-to-stage",

--- a/src/rumil/calls/__init__.py
+++ b/src/rumil/calls/__init__.py
@@ -1,6 +1,6 @@
 """Call types for the research workspace."""
 
-from rumil.calls.assess import AssessCall, EmbeddingAssessCall
+from rumil.calls.assess import AssessCall, BigAssessCall, EmbeddingAssessCall
 from rumil.calls.call_registry import (
     ASSESS_CALL_CLASSES,
     INGEST_CALL_CLASSES,
@@ -45,6 +45,7 @@ from rumil.calls.scout_web_questions import ScoutWebQuestionsCall
 __all__ = [
     "CallRunner",
     "AssessCall",
+    "BigAssessCall",
     "EmbeddingAssessCall",
     "IngestCall",
     "EmbeddingIngestCall",

--- a/src/rumil/calls/assess.py
+++ b/src/rumil/calls/assess.py
@@ -71,8 +71,20 @@ class BigAssessCall(AssessCall):
     def _make_context_builder(self) -> ContextBuilder:
         return BigAssessContext(self.call_type)
 
+    def _make_page_creator(self) -> PageCreator:
+        return SimpleAgentLoop(
+            self.call_type,
+            self.task_description(),
+            available_moves=self._resolve_available_moves(),
+            prompt_name="big_assess",
+        )
+
     def task_description(self) -> str:
-        base = super().task_description()
+        base = (
+            "Assess this question and render a judgement.\n\n"
+            f"Question ID: `{self.infra.question_id}`\n\n"
+            "Follow the instructions in the system prompt."
+        )
         if self._guidance:
             return base + f"\n\n## Guidance\n\n{self._guidance}"
         return base

--- a/src/rumil/calls/assess.py
+++ b/src/rumil/calls/assess.py
@@ -1,7 +1,11 @@
 """Assess call: synthesise considerations and render a judgement."""
 
 from rumil.calls.closing_reviewers import StandardClosingReview
-from rumil.calls.context_builders import EmbeddingContext, GraphContextWithPhase1
+from rumil.calls.context_builders import (
+    BigAssessContext,
+    EmbeddingContext,
+    GraphContextWithPhase1,
+)
 from rumil.calls.page_creators import SimpleAgentLoop
 from rumil.calls.stages import CallRunner, ClosingReviewer, ContextBuilder, PageCreator
 from rumil.models import CallType
@@ -48,3 +52,27 @@ class EmbeddingAssessCall(AssessCall):
             self.call_type,
             require_judgement_for_questions=True,
         )
+
+
+class BigAssessCall(AssessCall):
+    """Assess call that freshens connected pages before embedding-based assessment.
+
+    Resolves superseded links, reassesses stale dependencies, and checks for
+    higher-quality replacement pages via embedding search before building
+    the final assessment context.
+    """
+
+    context_builder_cls = BigAssessContext
+
+    def __init__(self, *args, guidance: str = "", **kwargs) -> None:
+        self._guidance = guidance
+        super().__init__(*args, **kwargs)
+
+    def _make_context_builder(self) -> ContextBuilder:
+        return BigAssessContext(self.call_type)
+
+    def task_description(self) -> str:
+        base = super().task_description()
+        if self._guidance:
+            return base + f"\n\n## Guidance\n\n{self._guidance}"
+        return base

--- a/src/rumil/calls/call_registry.py
+++ b/src/rumil/calls/call_registry.py
@@ -4,7 +4,7 @@ Each call type (find_considerations, assess, ingest) has its own registry so
 callers can look up the concrete class by a short string name stored in settings.
 """
 
-from rumil.calls.assess import AssessCall, EmbeddingAssessCall
+from rumil.calls.assess import AssessCall, BigAssessCall, EmbeddingAssessCall
 from rumil.calls.assess_concept import AssessConceptCall
 from rumil.calls.ingest import EmbeddingIngestCall, IngestCall
 from rumil.calls.find_considerations import (
@@ -35,6 +35,7 @@ FIND_CONSIDERATIONS_CALL_CLASSES: dict[str, type[FindConsiderationsCall]] = {
 ASSESS_CALL_CLASSES: dict[str, type[AssessCall]] = {
     "default": AssessCall,
     "embedding": EmbeddingAssessCall,
+    "big": BigAssessCall,
 }
 
 INGEST_CALL_CLASSES: dict[str, type[IngestCall]] = {

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -619,19 +619,84 @@ class WebResearchEmbeddingContext(ContextBuilder):
         )
 
 
-class _LoadBearingSelection(BaseModel):
+class _PageSelection(BaseModel):
     page_ids: list[str] = Field(
-        description=(
-            "8-char short IDs of the pages whose content the judgement is "
-            "most sensitive to (up to 5)"
+        description="8-char short IDs of the selected pages"
+    )
+
+
+async def _select_sensitive_pages(
+    pages: Sequence[Page],
+    question: Page,
+    latest_judgement: Page | None,
+    limit: int,
+    infra: CallInfra,
+) -> list[Page]:
+    """Ask an LLM which pages the judgement is most sensitive to.
+
+    Formats each page with its headline and citation excerpts from the
+    judgement, then asks the model to select up to *limit* pages.
+    Returns the selected subset in the original order.
+    """
+    judgement_content = latest_judgement.content if latest_judgement else None
+
+    page_entries: list[str] = []
+    for p in pages:
+        entry = f"### `{p.id[:8]}` — {p.headline} ({p.page_type.value})"
+        if judgement_content:
+            cite_pattern = re.compile(
+                rf'[^\n]*\[{re.escape(p.id[:8])}\][^\n]*'
+            )
+            cite_lines = cite_pattern.findall(judgement_content)
+            if cite_lines:
+                entry += "\n\nCited in the judgement as follows:"
+                for line in cite_lines[:5]:
+                    entry += f"\n> {line.strip()}"
+            else:
+                entry += "\n\n(Not directly cited in the judgement.)"
+        page_entries.append(entry)
+
+    page_list = "\n\n".join(page_entries)
+
+    user_message_parts = [f"## Question\n\n**{question.headline}**"]
+    if latest_judgement:
+        user_message_parts.append(
+            f"## Judgement\n\n"
+            f"**{latest_judgement.headline}**\n\n"
+            f"{latest_judgement.content}"
         )
+    user_message_parts.append(
+        f"## Candidate pages\n\n"
+        f"Pick the {limit} pages whose content the judgement is most "
+        f"sensitive to.\n\n{page_list}"
     )
 
-
-class _ImportantConnectedPages(BaseModel):
-    page_ids: list[str] = Field(
-        description="8-char short IDs of the most important connected pages (up to 10)"
+    meta = LLMExchangeMetadata(
+        call_id=infra.call.id,
+        phase="big_assess_select_sensitive",
     )
+    result = await structured_call(
+        "You are deciding which pages are most important for a research "
+        "question's judgement.\n\n"
+        "A page is important if the judgement is **sensitive** to its "
+        "content — meaning that if the page's content changed, the "
+        "judgement's conclusions would likely change too. A page that "
+        "is cited heavily, or that supplies key numbers, thresholds, "
+        "or pivotal reasoning to the judgement, is more important than "
+        "one that is mentioned in passing or provides background colour.\n\n"
+        "You cannot see each page's full content, so judge importance "
+        "from the page's headline and how it is cited in the judgement.\n\n"
+        f"Select up to {limit} pages. Return their 8-char short IDs.",
+        user_message="\n\n".join(user_message_parts),
+        response_model=_PageSelection,
+        metadata=meta,
+        db=infra.db,
+    )
+    if result.data:
+        selected = _PageSelection.model_validate(result.data)
+        selected_ids = set(selected.page_ids)
+        return [p for p in pages if p.id[:8] in selected_ids][:limit]
+    return list(pages[:limit])
 
 
 class _ReplacementPick(BaseModel):
@@ -833,68 +898,9 @@ async def _reassess_pages_citing_superseded(
     log.info("Reassess stale: %d connected pages cite superseded pages", len(stale))
 
     if len(stale) > 5:
-        judgement_content = (
-            latest_judgement.content if latest_judgement else None
+        stale = await _select_sensitive_pages(
+            stale, question, latest_judgement, limit=5, infra=infra,
         )
-
-        page_entries: list[str] = []
-        for p in stale:
-            entry = f"### `{p.id[:8]}` — {p.headline} ({p.page_type.value})"
-            if judgement_content:
-                sid = p.id[:8]
-                cite_pattern = re.compile(
-                    rf'[^\n]*\[{re.escape(sid)}\][^\n]*'
-                )
-                cite_lines = cite_pattern.findall(judgement_content)
-                if cite_lines:
-                    entry += "\n\nCited in the judgement as follows:"
-                    for line in cite_lines[:5]:
-                        entry += f"\n> {line.strip()}"
-                else:
-                    entry += "\n\n(Not directly cited in the judgement.)"
-            page_entries.append(entry)
-
-        page_list = "\n\n".join(page_entries)
-
-        user_message_parts = [f"## Question\n\n**{question.headline}**"]
-        if latest_judgement:
-            user_message_parts.append(
-                f"## Judgement\n\n"
-                f"**{latest_judgement.headline}**\n\n"
-                f"{latest_judgement.content}"
-            )
-        user_message_parts.append(
-            f"## Candidate pages\n\n"
-            f"Each of the following pages may contain outdated information. "
-            f"We can only refresh 5 of them. Pick the 5 whose content the "
-            f"judgement is most sensitive to.\n\n{page_list}"
-        )
-
-        meta = LLMExchangeMetadata(
-            call_id=infra.call.id,
-            phase="big_assess_b1_select",
-        )
-        result = await structured_call(
-            "You are deciding which pages are most important to keep "
-            "up-to-date for a research question.\n\n"
-            "A page is important if the judgement is **sensitive** to its "
-            "content — meaning that if the page's content changed, the "
-            "judgement's conclusions would likely change too. A page that "
-            "is cited heavily, or that supplies key numbers, thresholds, "
-            "or pivotal reasoning to the judgement, is more important than "
-            "one that is mentioned in passing or provides background colour.\n\n"
-            "You cannot see each page's full content, so judge importance "
-            "from the page's headline and how it is cited in the judgement.\n\n"
-            "Select up to 5 pages. Return their 8-char short IDs.",
-            user_message="\n\n".join(user_message_parts),
-            response_model=_LoadBearingSelection,
-            metadata=meta,
-            db=infra.db,
-        )
-        if result.data:
-            selected = _LoadBearingSelection.model_validate(result.data)
-            selected_ids = set(selected.page_ids)
-            stale = [p for p in stale if p.id[:8] in selected_ids][:5]
 
     async def _do_reassess(page: Page) -> None:
         from rumil.clean.common import reassess_claim, reassess_question
@@ -1000,41 +1006,15 @@ async def _find_higher_quality_replacements(
     )
 
     if len(pages_with_matches) > 10:
-        judgement_context = ""
-        if latest_judgement:
-            judgement_context = (
-                f"\n\n## Latest Judgement\n\n"
-                f"**{latest_judgement.headline}**\n\n"
-                f"{latest_judgement.content}"
-            )
-        page_list = "\n".join(
-            f"- `{p.id[:8]}` — {p.headline} ({p.page_type.value})"
-            for p, _ in pages_with_matches
+        match_pages = [p for p, _ in pages_with_matches]
+        selected = await _select_sensitive_pages(
+            match_pages, question, latest_judgement, limit=10, infra=infra,
         )
-        meta = LLMExchangeMetadata(
-            call_id=infra.call.id,
-            phase="big_assess_b2_narrow",
-        )
-        result = await structured_call(
-            "You are selecting the most important connected pages for a "
-            "research question. Pick the 10 pages whose quality matters "
-            "most to the question. Return their 8-char short IDs.",
-            user_message=(
-                f"## Question\n\n**{question.headline}**"
-                f"{judgement_context}\n\n"
-                f"## Connected pages with potential replacements\n\n{page_list}"
-            ),
-            response_model=_ImportantConnectedPages,
-            metadata=meta,
-            db=infra.db,
-        )
-        if result.data:
-            selected = _ImportantConnectedPages.model_validate(result.data)
-            selected_ids = set(selected.page_ids)
-            pages_with_matches = [
-                (p, cs) for p, cs in pages_with_matches
-                if p.id[:8] in selected_ids
-            ][:10]
+        selected_ids = {p.id for p in selected}
+        pages_with_matches = [
+            (p, cs) for p, cs in pages_with_matches
+            if p.id in selected_ids
+        ][:10]
 
     async def _check_replacements(
         page: Page, candidates: list[tuple[Page, float]],

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -869,7 +869,28 @@ async def _phase_b1_reassess_stale(
         if page.page_type == PageType.QUESTION:
             await reassess_question(
                 page.id, [], infra.call, infra.db, infra.trace,
+                assess_variant="embedding",
             )
+        elif page.page_type == PageType.JUDGEMENT:
+            links = await infra.db.get_links_from(page.id)
+            question_links = [
+                l for l in links if l.link_type == LinkType.RELATED
+            ]
+            if question_links:
+                question_id = question_links[0].to_page_id
+                log.info(
+                    "Stale judgement %s: reassessing its question %s",
+                    page.id[:8], question_id[:8],
+                )
+                await reassess_question(
+                    question_id, [], infra.call, infra.db, infra.trace,
+                    assess_variant="embedding",
+                )
+            else:
+                log.warning(
+                    "Stale judgement %s has no linked question, skipping",
+                    page.id[:8],
+                )
         else:
             await reassess_claim(
                 page.id, "", infra.call, infra.db, infra.trace,
@@ -1152,6 +1173,10 @@ class BigAssessContext(ContextBuilder):
 
         await _generate_missing_abstracts(connected, infra)
 
+        exclude_ids: set[str] = set()
+        if latest_judgement:
+            exclude_ids.add(latest_judgement.id)
+
         query = question.headline
         settings = get_settings()
         result = await build_embedding_based_context(
@@ -1164,17 +1189,64 @@ class BigAssessContext(ContextBuilder):
             full_page_char_budget=settings.big_assess_full_page_char_budget,
             abstract_page_char_budget=settings.big_assess_abstract_page_char_budget,
             summary_page_char_budget=settings.big_assess_summary_page_char_budget,
+            full_page_similarity_floor=settings.big_assess_full_page_similarity_floor,
+            abstract_page_similarity_floor=settings.big_assess_abstract_page_similarity_floor,
+            exclude_page_ids=exclude_ids,
         )
         working_page_ids = result.page_ids
 
-        extra_ids = list(replacement_ids)
+        judgement_cited_ids: list[str] = []
+        if latest_judgement and latest_judgement.content:
+            cited_sids = sorted(set(
+                _CITATION_RE.findall(latest_judgement.content)
+            ))
+            if cited_sids:
+                resp = await db._execute(
+                    db.client.table("pages")
+                    .select("id,is_superseded")
+                    .or_(",".join(f"id.like.{sid}%" for sid in cited_sids))
+                )
+                rows = resp.data or []
+                prefix_to_row: dict[str, dict] = {}
+                for row in rows:
+                    prefix = row["id"][:8]
+                    if prefix in prefix_to_row:
+                        prefix_to_row.pop(prefix)
+                    else:
+                        prefix_to_row[prefix] = row
+
+                superseded_ids = [
+                    row["id"] for row in prefix_to_row.values()
+                    if row["is_superseded"]
+                ]
+                resolved = await db.resolve_supersession_chains(superseded_ids)
+
+                for sid in cited_sids:
+                    row = prefix_to_row.get(sid)
+                    if not row:
+                        continue
+                    full_id: str = row["id"]
+                    if full_id in exclude_ids:
+                        continue
+                    if row["is_superseded"]:
+                        replacement = resolved.get(full_id)
+                        if replacement and replacement.id not in exclude_ids:
+                            judgement_cited_ids.append(replacement.id)
+                    else:
+                        judgement_cited_ids.append(full_id)
+
+        extra_ids = judgement_cited_ids + list(replacement_ids)
         preloaded_ids = infra.call.context_page_ids or []
         all_extra = extra_ids + preloaded_ids
 
         context_text = result.context_text
+        already_in_context = set(working_page_ids) | {infra.question_id} | exclude_ids
         if all_extra:
             parts: list[str] = []
             for pid in all_extra:
+                if pid in already_in_context:
+                    continue
+                already_in_context.add(pid)
                 page = await db.get_page(pid)
                 if page and page.is_active():
                     parts += [

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -621,7 +621,10 @@ class WebResearchEmbeddingContext(ContextBuilder):
 
 class _LoadBearingSelection(BaseModel):
     page_ids: list[str] = Field(
-        description="8-char short IDs of the most load-bearing pages (up to 5)"
+        description=(
+            "8-char short IDs of the pages whose content the judgement is "
+            "most sensitive to (up to 5)"
+        )
     )
 
 
@@ -654,7 +657,7 @@ async def _gather_connected_pages(
     """Return all (page, link) pairs directly connected to a page.
 
     Gathers considerations, child questions, and judgements linked to *page_id*.
-    Includes superseded pages so that Phase A can detect and swap them.
+    Includes superseded pages so that supersession resolution can detect and swap them.
     """
     links_to = await db.get_links_to(page_id)
     links_from = await db.get_links_from(page_id)
@@ -747,12 +750,12 @@ async def _get_latest_judgement(
     return max(judgements, key=lambda j: j.created_at)
 
 
-async def _phase_a_resolve_supersessions(
+async def _resolve_superseded_connections(
     question_id: str,
     latest_judgement: Page | None,
     db: DB,
 ) -> list[tuple[Page, PageLink]]:
-    """Phase A: resolve superseded connected pages by swapping links.
+    """Resolve superseded connected pages by swapping links.
 
     Returns the refreshed list of connected (page, link) pairs.
     """
@@ -808,13 +811,13 @@ async def _cites_superseded_pages(page: Page, db: DB) -> bool:
     return any(p.is_superseded for p in cited_pages.values())
 
 
-async def _phase_b1_reassess_stale(
+async def _reassess_pages_citing_superseded(
     connected: list[tuple[Page, PageLink]],
     question: Page,
     latest_judgement: Page | None,
     infra: CallInfra,
 ) -> None:
-    """Phase B1: find connected pages with superseded dependencies and reassess."""
+    """Find connected pages that cite superseded content and reassess them."""
     stale: list[Page] = []
     checks = await asyncio.gather(
         *[_cites_superseded_pages(page, infra.db) for page, _ in connected]
@@ -824,36 +827,66 @@ async def _phase_b1_reassess_stale(
             stale.append(page)
 
     if not stale:
-        log.info("Phase B1: no connected pages cite superseded pages")
+        log.info("Reassess stale: no connected pages cite superseded pages")
         return
 
-    log.info("Phase B1: %d connected pages cite superseded pages", len(stale))
+    log.info("Reassess stale: %d connected pages cite superseded pages", len(stale))
 
     if len(stale) > 5:
-        judgement_context = ""
+        judgement_content = (
+            latest_judgement.content if latest_judgement else None
+        )
+
+        page_entries: list[str] = []
+        for p in stale:
+            entry = f"### `{p.id[:8]}` — {p.headline} ({p.page_type.value})"
+            if judgement_content:
+                sid = p.id[:8]
+                cite_pattern = re.compile(
+                    rf'[^\n]*\[{re.escape(sid)}\][^\n]*'
+                )
+                cite_lines = cite_pattern.findall(judgement_content)
+                if cite_lines:
+                    entry += "\n\nCited in the judgement as follows:"
+                    for line in cite_lines[:5]:
+                        entry += f"\n> {line.strip()}"
+                else:
+                    entry += "\n\n(Not directly cited in the judgement.)"
+            page_entries.append(entry)
+
+        page_list = "\n\n".join(page_entries)
+
+        user_message_parts = [f"## Question\n\n**{question.headline}**"]
         if latest_judgement:
-            judgement_context = (
-                f"\n\n## Latest Judgement\n\n"
+            user_message_parts.append(
+                f"## Judgement\n\n"
                 f"**{latest_judgement.headline}**\n\n"
                 f"{latest_judgement.content}"
             )
-        page_list = "\n".join(
-            f"- `{p.id[:8]}` — {p.headline} ({p.page_type.value})"
-            for p in stale
+        user_message_parts.append(
+            f"## Candidate pages\n\n"
+            f"Each of the following pages may contain outdated information. "
+            f"We can only refresh 5 of them. Pick the 5 whose content the "
+            f"judgement is most sensitive to.\n\n{page_list}"
         )
+
         meta = LLMExchangeMetadata(
             call_id=infra.call.id,
             phase="big_assess_b1_select",
         )
         result = await structured_call(
-            "You are selecting the most important pages for a research question. "
-            "Pick the 5 pages whose accuracy is most critical to answering the "
-            "question correctly. Return their 8-char short IDs.",
-            user_message=(
-                f"## Question\n\n**{question.headline}**"
-                f"{judgement_context}\n\n"
-                f"## Pages with stale dependencies\n\n{page_list}"
-            ),
+            "You are deciding which pages are most important to keep "
+            "up-to-date for a research question.\n\n"
+            "A page is important if the judgement is **sensitive** to its "
+            "content — meaning that if the page's content changed, the "
+            "judgement's conclusions would likely change too. A page that "
+            "is cited heavily, or that supplies key numbers, thresholds, "
+            "or pivotal reasoning to the judgement, is more important than "
+            "one that is mentioned in passing or provides background colour.\n\n"
+            "You cannot see each page's full content, so judge importance "
+            "from the page's headline and how it is cited in the judgement.\n\n"
+            "Select up to 5 pages. Return their 8-char short IDs.",
+            user_message="\n\n".join(user_message_parts),
             response_model=_LoadBearingSelection,
             metadata=meta,
             db=infra.db,
@@ -896,22 +929,22 @@ async def _phase_b1_reassess_stale(
                 page.id, "", infra.call, infra.db, infra.trace,
             )
 
-    log.info("Phase B1: reassessing %d pages", len(stale))
+    log.info("Reassess stale: reassessing %d pages", len(stale))
     await asyncio.gather(*[_do_reassess(p) for p in stale])
 
 
-async def _phase_b2_embedding_quality(
+async def _find_higher_quality_replacements(
     connected: list[tuple[Page, PageLink]],
     question: Page,
     latest_judgement: Page | None,
     infra: CallInfra,
 ) -> set[str]:
-    """Phase B2: embedding-based quality check on connected pages.
+    """Search for higher-quality replacements for connected pages via embeddings.
 
-    For each connected page, searches for similar pages (>0.4 similarity).
+    For each connected page, searches for similar pages by embedding distance.
     If more than 10 connected pages have matches, asks an LLM which 10 are
     most important to the question. For each chosen connected page, asks an
-    LLM whether any of its 5 closest matches should be used instead.
+    LLM whether any matches are more robust, credible, or useful versions.
 
     Returns a set of page IDs chosen as better replacements (for context only).
     """
@@ -944,12 +977,12 @@ async def _phase_b2_embedding_quality(
                 f"{c.headline[:40]} ({score:.2f})" for c, score in candidates
             )
             log.info(
-                "Phase B2: %s (%s) — %d matches: %s",
+                "Find replacements: %s (%s) — %d matches: %s",
                 page.id[:8], page.headline[:50], len(candidates), match_titles,
             )
         else:
             log.info(
-                "Phase B2: %s (%s) — no matches",
+                "Find replacements: %s (%s) — no matches",
                 page.id[:8], page.headline[:50],
             )
 
@@ -958,7 +991,7 @@ async def _phase_b2_embedding_quality(
     ]
 
     if not pages_with_matches:
-        log.info("Phase B2: no connected pages have similar matches")
+        log.info("Find replacements: no connected pages have similar matches")
         return set()
 
     log.info(
@@ -1058,7 +1091,7 @@ async def _phase_b2_embedding_quality(
     for ids in per_page_results:
         replacement_ids |= ids
 
-    log.info("Phase B2: found %d replacement pages", len(replacement_ids))
+    log.info("Find replacements: found %d replacement pages", len(replacement_ids))
     return replacement_ids
 
 
@@ -1126,11 +1159,12 @@ async def _generate_missing_abstracts(
 class BigAssessContext(ContextBuilder):
     """Elaborate context builder that freshens connected pages before assessment.
 
-    Runs four phases:
-    A) Resolve superseded connected pages (swaps links in DB)
-    B1) Reassess connected pages with stale dependencies
-    B2) Embedding-based quality check for better versions
-    C) Build final embedding context with all gathered pages
+    Steps:
+    1. Resolve superseded connections (swap links in DB)
+    2. Reassess pages that cite superseded content
+    3. Search for higher-quality replacement pages via embeddings
+    4. Generate missing abstracts
+    5. Build final embedding context with all gathered pages
     """
 
     def __init__(self, call_type: CallType) -> None:
@@ -1147,27 +1181,27 @@ class BigAssessContext(ContextBuilder):
 
         latest_judgement = await _get_latest_judgement(infra.question_id, db)
 
-        connected = await _phase_a_resolve_supersessions(
+        connected = await _resolve_superseded_connections(
             infra.question_id, latest_judgement, db,
         )
         log.info(
-            "Big assess phase A complete: %d connected pages after supersession",
+            "Big assess: %d connected pages after supersession resolution",
             len(connected),
         )
 
-        await _phase_b1_reassess_stale(
+        await _reassess_pages_citing_superseded(
             connected, question, latest_judgement, infra,
         )
         latest_judgement = await _get_latest_judgement(infra.question_id, db)
-        connected = await _phase_a_resolve_supersessions(
+        connected = await _resolve_superseded_connections(
             infra.question_id, latest_judgement, db,
         )
         log.info(
-            "Big assess post-B1 refresh: %d connected pages",
+            "Big assess: %d connected pages after reassessment refresh",
             len(connected),
         )
 
-        replacement_ids = await _phase_b2_embedding_quality(
+        replacement_ids = await _find_higher_quality_replacements(
             connected, question, latest_judgement, infra,
         )
 

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import re
 from collections.abc import Sequence
 
+from pydantic import BaseModel, Field
+
 from rumil.calls.common import (
+    ABSTRACT_INSTRUCTION,
+    PageSummaryItem,
     _format_loaded_pages,
     _run_phase1,
     resolve_page_refs,
     run_single_call,
+    save_page_abstracts,
 )
 from rumil.calls.stages import CallInfra, ContextBuilder, ContextResult
 from rumil.context import (
@@ -20,22 +27,34 @@ from rumil.context import (
     format_preloaded_pages,
 )
 from rumil.database import DB
-from rumil.llm import build_system_prompt, build_user_message
+from rumil.embeddings import search_pages
+from rumil.llm import (
+    LLMExchangeMetadata,
+    build_system_prompt,
+    build_user_message,
+    structured_call,
+)
 from rumil.models import (
     Call,
     CallType,
+    LinkType,
     MoveType,
     Page,
     PageDetail,
+    PageLink,
+    PageType,
     FindConsiderationsMode,
 )
 from rumil.moves.base import MoveState
+from rumil.settings import get_settings
 from rumil.moves.registry import MOVES
 from rumil.page_graph import PageGraph
 from rumil.tracing.trace_events import ContextBuiltEvent
 from rumil.workspace_map import build_workspace_map
 
 log = logging.getLogger(__name__)
+
+_B2_SEMAPHORE = asyncio.Semaphore(15)
 
 
 async def _record_context_built(
@@ -597,4 +616,581 @@ class WebResearchEmbeddingContext(ContextBuilder):
         return ContextResult(
             context_text=context_text,
             working_page_ids=working_page_ids,
+        )
+
+
+class _LoadBearingSelection(BaseModel):
+    page_ids: list[str] = Field(
+        description="8-char short IDs of the most load-bearing pages (up to 5)"
+    )
+
+
+class _ImportantConnectedPages(BaseModel):
+    page_ids: list[str] = Field(
+        description="8-char short IDs of the most important connected pages (up to 10)"
+    )
+
+
+class _ReplacementPick(BaseModel):
+    replacement_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "8-char short IDs of candidates that are more robust, credible, "
+            "or useful versions of the target page. Empty list if none qualify."
+        ),
+    )
+
+
+_CONNECTED_LINK_TYPES = {
+    LinkType.CONSIDERATION,
+    LinkType.CHILD_QUESTION,
+    LinkType.RELATED,
+}
+
+
+async def _gather_connected_pages(
+    page_id: str, db: DB,
+) -> list[tuple[Page, PageLink]]:
+    """Return all (page, link) pairs directly connected to a page.
+
+    Gathers considerations, child questions, and judgements linked to *page_id*.
+    Includes superseded pages so that Phase A can detect and swap them.
+    """
+    links_to = await db.get_links_to(page_id)
+    links_from = await db.get_links_from(page_id)
+
+    pairs: list[tuple[str, PageLink]] = []
+    for link in links_to:
+        if link.link_type in _CONNECTED_LINK_TYPES:
+            pairs.append((link.from_page_id, link))
+    for link in links_from:
+        if link.link_type in _CONNECTED_LINK_TYPES:
+            pairs.append((link.to_page_id, link))
+
+    if not pairs:
+        return []
+
+    all_ids = list({pid for pid, _ in pairs})
+    pages = await db.get_pages_by_ids(all_ids)
+
+    results: list[tuple[Page, PageLink]] = []
+    for pid, link in pairs:
+        page = pages.get(pid)
+        if page:
+            results.append((page, link))
+
+    return results
+
+
+async def _swap_superseded_link(
+    page: Page,
+    link: PageLink,
+    new_page: Page,
+    db: DB,
+) -> PageLink:
+    """Delete *link* and create a replacement pointing to/from *new_page*.
+
+    If an equivalent link (same endpoints, type, and direction) already exists
+    on *new_page*, the old link is simply deleted and the existing one returned.
+
+    Returns the new or pre-existing link.
+    """
+    await db.delete_link(link.id)
+    if link.from_page_id == page.id:
+        new_from = new_page.id
+        new_to = link.to_page_id
+    else:
+        new_from = link.from_page_id
+        new_to = new_page.id
+
+    existing_links = await db.get_links_from(new_from)
+    for existing in existing_links:
+        if (
+            existing.to_page_id == new_to
+            and existing.link_type == link.link_type
+            and existing.direction == link.direction
+        ):
+            log.info(
+                "Superseded link %s: equivalent link already exists on %s -> %s, skipping creation",
+                link.id[:8], new_from[:8], new_to[:8],
+            )
+            return existing
+
+    new_link = PageLink(
+        from_page_id=new_from,
+        to_page_id=new_to,
+        link_type=link.link_type,
+        direction=link.direction,
+        strength=link.strength,
+        reasoning=link.reasoning,
+        role=link.role,
+    )
+    await db.save_link(new_link)
+    log.info(
+        "Swapped superseded link %s: %s -> %s (page %s -> %s)",
+        link.id[:8],
+        link.from_page_id[:8],
+        link.to_page_id[:8],
+        page.id[:8],
+        new_page.id[:8],
+    )
+    return new_link
+
+
+async def _get_latest_judgement(
+    question_id: str, db: DB,
+) -> Page | None:
+    """Return the most recent active judgement for a question, or None."""
+    judgements = await db.get_judgements_for_question(question_id)
+    if not judgements:
+        return None
+    return max(judgements, key=lambda j: j.created_at)
+
+
+async def _phase_a_resolve_supersessions(
+    question_id: str,
+    latest_judgement: Page | None,
+    db: DB,
+) -> list[tuple[Page, PageLink]]:
+    """Phase A: resolve superseded connected pages by swapping links.
+
+    Returns the refreshed list of connected (page, link) pairs.
+    """
+    target_ids = [question_id]
+    if latest_judgement:
+        target_ids.append(latest_judgement.id)
+
+    connected: list[tuple[Page, PageLink]] = []
+    for tid in target_ids:
+        connected.extend(await _gather_connected_pages(tid, db))
+
+    seen_link_ids: set[str] = set()
+    deduped: list[tuple[Page, PageLink]] = []
+    for page, link in connected:
+        if link.id not in seen_link_ids:
+            seen_link_ids.add(link.id)
+            deduped.append((page, link))
+    connected = deduped
+
+    refreshed: list[tuple[Page, PageLink]] = []
+    for page, link in connected:
+        if page.is_superseded:
+            new_page = await db.resolve_supersession_chain(page.id)
+            if new_page:
+                new_link = await _swap_superseded_link(page, link, new_page, db)
+                refreshed.append((new_page, new_link))
+            else:
+                refreshed.append((page, link))
+        else:
+            refreshed.append((page, link))
+
+    return refreshed
+
+
+_CITATION_RE = re.compile(r"\[([a-f0-9]{8})\]")
+
+
+async def _cites_superseded_pages(page: Page, db: DB) -> bool:
+    """Check whether *page*'s inline citations reference any superseded page."""
+    if not page.content:
+        return False
+    short_ids = set(_CITATION_RE.findall(page.content))
+    if not short_ids:
+        return False
+    full_ids: list[str] = []
+    for sid in short_ids:
+        resolved = await db.resolve_page_id(sid)
+        if resolved:
+            full_ids.append(resolved)
+    if not full_ids:
+        return False
+    cited_pages = await db.get_pages_by_ids(full_ids)
+    return any(p.is_superseded for p in cited_pages.values())
+
+
+async def _phase_b1_reassess_stale(
+    connected: list[tuple[Page, PageLink]],
+    question: Page,
+    latest_judgement: Page | None,
+    infra: CallInfra,
+) -> None:
+    """Phase B1: find connected pages with superseded dependencies and reassess."""
+    stale: list[Page] = []
+    checks = await asyncio.gather(
+        *[_cites_superseded_pages(page, infra.db) for page, _ in connected]
+    )
+    for (page, _), is_stale in zip(connected, checks):
+        if is_stale:
+            stale.append(page)
+
+    if not stale:
+        log.info("Phase B1: no connected pages cite superseded pages")
+        return
+
+    log.info("Phase B1: %d connected pages cite superseded pages", len(stale))
+
+    if len(stale) > 5:
+        judgement_context = ""
+        if latest_judgement:
+            judgement_context = (
+                f"\n\n## Latest Judgement\n\n"
+                f"**{latest_judgement.headline}**\n\n"
+                f"{latest_judgement.content}"
+            )
+        page_list = "\n".join(
+            f"- `{p.id[:8]}` — {p.headline} ({p.page_type.value})"
+            for p in stale
+        )
+        meta = LLMExchangeMetadata(
+            call_id=infra.call.id,
+            phase="big_assess_b1_select",
+        )
+        result = await structured_call(
+            "You are selecting the most important pages for a research question. "
+            "Pick the 5 pages whose accuracy is most critical to answering the "
+            "question correctly. Return their 8-char short IDs.",
+            user_message=(
+                f"## Question\n\n**{question.headline}**"
+                f"{judgement_context}\n\n"
+                f"## Pages with stale dependencies\n\n{page_list}"
+            ),
+            response_model=_LoadBearingSelection,
+            metadata=meta,
+            db=infra.db,
+        )
+        if result.data:
+            selected = _LoadBearingSelection.model_validate(result.data)
+            selected_ids = set(selected.page_ids)
+            stale = [p for p in stale if p.id[:8] in selected_ids][:5]
+
+    async def _do_reassess(page: Page) -> None:
+        from rumil.clean.common import reassess_claim, reassess_question
+
+        if page.page_type == PageType.QUESTION:
+            await reassess_question(
+                page.id, [], infra.call, infra.db, infra.trace,
+            )
+        else:
+            await reassess_claim(
+                page.id, "", infra.call, infra.db, infra.trace,
+            )
+
+    log.info("Phase B1: reassessing %d pages", len(stale))
+    await asyncio.gather(*[_do_reassess(p) for p in stale])
+
+
+async def _phase_b2_embedding_quality(
+    connected: list[tuple[Page, PageLink]],
+    question: Page,
+    latest_judgement: Page | None,
+    infra: CallInfra,
+) -> set[str]:
+    """Phase B2: embedding-based quality check on connected pages.
+
+    For each connected page, searches for similar pages (>0.4 similarity).
+    If more than 10 connected pages have matches, asks an LLM which 10 are
+    most important to the question. For each chosen connected page, asks an
+    LLM whether any of its 5 closest matches should be used instead.
+
+    Returns a set of page IDs chosen as better replacements (for context only).
+    """
+    connected_ids = {page.id for page, _ in connected} | {infra.question_id}
+    scope_links = await infra.db.get_links_to(infra.question_id)
+    scope_linked_ids = {l.from_page_id for l in scope_links} | {
+        l.to_page_id for l in await infra.db.get_links_from(infra.question_id)
+    }
+    exclude_ids = connected_ids | scope_linked_ids
+
+    async def _search_for_page(page: Page) -> tuple[Page, list[tuple[Page, float]]]:
+        async with _B2_SEMAPHORE:
+            query_text = page.abstract if page.abstract else page.headline
+            results = await search_pages(
+                infra.db, query_text, match_threshold=0.6, match_count=5,
+            )
+        filtered = [
+            (p, score) for p, score in results
+            if p.id not in exclude_ids and p.is_active()
+        ]
+        return page, filtered
+
+    search_results = await asyncio.gather(
+        *[_search_for_page(page) for page, _ in connected]
+    )
+
+    for page, candidates in search_results:
+        if candidates:
+            match_titles = ", ".join(
+                f"{c.headline[:40]} ({score:.2f})" for c, score in candidates
+            )
+            log.info(
+                "Phase B2: %s (%s) — %d matches: %s",
+                page.id[:8], page.headline[:50], len(candidates), match_titles,
+            )
+        else:
+            log.info(
+                "Phase B2: %s (%s) — no matches",
+                page.id[:8], page.headline[:50],
+            )
+
+    pages_with_matches = [
+        (page, candidates) for page, candidates in search_results if candidates
+    ]
+
+    if not pages_with_matches:
+        log.info("Phase B2: no connected pages have similar matches")
+        return set()
+
+    log.info(
+        "Phase B2: %d connected pages have embedding matches",
+        len(pages_with_matches),
+    )
+
+    if len(pages_with_matches) > 10:
+        judgement_context = ""
+        if latest_judgement:
+            judgement_context = (
+                f"\n\n## Latest Judgement\n\n"
+                f"**{latest_judgement.headline}**\n\n"
+                f"{latest_judgement.content}"
+            )
+        page_list = "\n".join(
+            f"- `{p.id[:8]}` — {p.headline} ({p.page_type.value})"
+            for p, _ in pages_with_matches
+        )
+        meta = LLMExchangeMetadata(
+            call_id=infra.call.id,
+            phase="big_assess_b2_narrow",
+        )
+        result = await structured_call(
+            "You are selecting the most important connected pages for a "
+            "research question. Pick the 10 pages whose quality matters "
+            "most to the question. Return their 8-char short IDs.",
+            user_message=(
+                f"## Question\n\n**{question.headline}**"
+                f"{judgement_context}\n\n"
+                f"## Connected pages with potential replacements\n\n{page_list}"
+            ),
+            response_model=_ImportantConnectedPages,
+            metadata=meta,
+            db=infra.db,
+        )
+        if result.data:
+            selected = _ImportantConnectedPages.model_validate(result.data)
+            selected_ids = set(selected.page_ids)
+            pages_with_matches = [
+                (p, cs) for p, cs in pages_with_matches
+                if p.id[:8] in selected_ids
+            ][:10]
+
+    async def _check_replacements(
+        page: Page, candidates: list[tuple[Page, float]],
+    ) -> set[str]:
+        async with _B2_SEMAPHORE:
+            target_text = await format_page(
+                page, PageDetail.CONTENT, linked_detail=PageDetail.ABSTRACT,
+                db=infra.db,
+            )
+            candidate_parts: list[str] = []
+            for c, _ in candidates:
+                candidate_parts.append(
+                    await format_page(
+                        c, PageDetail.CONTENT, linked_detail=PageDetail.ABSTRACT,
+                        db=infra.db,
+                    )
+                )
+            candidate_descriptions = "\n\n---\n\n".join(candidate_parts)
+            meta = LLMExchangeMetadata(
+                call_id=infra.call.id,
+                phase=f"big_assess_b2_replace_{page.id[:8]}",
+            )
+            result = await structured_call(
+                "You are evaluating whether any candidate pages should replace a "
+                "target page because they analyse the same subject matter at "
+                "higher quality — better evidence, more nuance, stronger sourcing, "
+                "or higher credibility. A candidate must be about the same topic "
+                "as the target; do NOT select pages that are merely related to or "
+                "adjacent to the target's subject. You may pick multiple candidates "
+                "or none. Return the 8-char short IDs of qualifying candidates, "
+                "or an empty list if none qualify.",
+                user_message=(
+                    f"## Target page\n\n{target_text}\n\n"
+                    f"## Candidates\n\n{candidate_descriptions}"
+                ),
+                response_model=_ReplacementPick,
+                metadata=meta,
+                db=infra.db,
+            )
+        found: set[str] = set()
+        if result.data:
+            picks = _ReplacementPick.model_validate(result.data)
+            candidate_id_map = {c.id[:8]: c.id for c, _ in candidates}
+            for short_id in picks.replacement_ids:
+                full_id = candidate_id_map.get(short_id)
+                if full_id:
+                    found.add(full_id)
+        return found
+
+    per_page_results = await asyncio.gather(
+        *[_check_replacements(p, cs) for p, cs in pages_with_matches]
+    )
+    replacement_ids: set[str] = set()
+    for ids in per_page_results:
+        replacement_ids |= ids
+
+    log.info("Phase B2: found %d replacement pages", len(replacement_ids))
+    return replacement_ids
+
+
+class _AbstractBatch(BaseModel):
+    summaries: list[PageSummaryItem]
+
+
+async def _generate_missing_abstracts(
+    connected: Sequence[tuple[Page, PageLink]],
+    infra: CallInfra,
+) -> None:
+    """Generate and persist abstracts for connected pages that lack them."""
+    missing = [p for p, _ in connected if not p.abstract]
+    if not missing:
+        log.info("All connected pages have abstracts")
+        return
+
+    log.info(
+        "Generating abstracts for %d connected pages: %s",
+        len(missing),
+        ", ".join(p.id[:8] for p in missing),
+    )
+
+    page_contents = "\n\n---\n\n".join(
+        f'Page `{p.id[:8]}` — {p.headline}\n\n{p.content}'
+        for p in missing
+    )
+    system_prompt = (
+        "You are generating abstracts for workspace pages. "
+        "You will be given page contents and must produce a self-contained "
+        "abstract for each.\n\n"
+        f"Page contents:\n\n{page_contents}"
+    )
+    page_lines = "\n".join(
+        f'- `{p.id[:8]}`: "{p.headline[:120]}"'
+        for p in missing
+    )
+    user_message = (
+        "Generate an abstract for each of the following pages.\n\n"
+        f"{page_lines}\n\n"
+        f"Abstract requirements: {ABSTRACT_INSTRUCTION}\n\n"
+        "For each page, return its page_id and abstract."
+    )
+
+    meta = LLMExchangeMetadata(
+        call_id=infra.call.id,
+        phase="big_assess_abstract_generation",
+    )
+    result = await structured_call(
+        system_prompt,
+        user_message=user_message,
+        response_model=_AbstractBatch,
+        metadata=meta,
+        db=infra.db,
+    )
+    if result.data:
+        parsed = _AbstractBatch(**result.data)
+        await save_page_abstracts(parsed.summaries, infra.db)
+        log.info(
+            "Generated %d abstracts for connected pages",
+            len(parsed.summaries),
+        )
+
+
+class BigAssessContext(ContextBuilder):
+    """Elaborate context builder that freshens connected pages before assessment.
+
+    Runs four phases:
+    A) Resolve superseded connected pages (swaps links in DB)
+    B1) Reassess connected pages with stale dependencies
+    B2) Embedding-based quality check for better versions
+    C) Build final embedding context with all gathered pages
+    """
+
+    def __init__(self, call_type: CallType) -> None:
+        self._call_type = call_type
+
+    async def build_context(self, infra: CallInfra) -> ContextResult:
+        db = infra.db
+        question = await db.get_page(infra.question_id)
+        if not question:
+            return ContextResult(
+                context_text=f"[Question page {infra.question_id} not found]",
+                working_page_ids=[],
+            )
+
+        latest_judgement = await _get_latest_judgement(infra.question_id, db)
+
+        connected = await _phase_a_resolve_supersessions(
+            infra.question_id, latest_judgement, db,
+        )
+        log.info(
+            "Big assess phase A complete: %d connected pages after supersession",
+            len(connected),
+        )
+
+        await _phase_b1_reassess_stale(
+            connected, question, latest_judgement, infra,
+        )
+        latest_judgement = await _get_latest_judgement(infra.question_id, db)
+        connected = await _phase_a_resolve_supersessions(
+            infra.question_id, latest_judgement, db,
+        )
+        log.info(
+            "Big assess post-B1 refresh: %d connected pages",
+            len(connected),
+        )
+
+        replacement_ids = await _phase_b2_embedding_quality(
+            connected, question, latest_judgement, infra,
+        )
+
+        await _generate_missing_abstracts(connected, infra)
+
+        query = question.headline
+        settings = get_settings()
+        result = await build_embedding_based_context(
+            query,
+            db,
+            scope_question_id=infra.question_id,
+            scope_detail=PageDetail.CONTENT,
+            scope_linked_detail=PageDetail.ABSTRACT,
+            require_judgement_for_questions=True,
+            full_page_char_budget=settings.big_assess_full_page_char_budget,
+            abstract_page_char_budget=settings.big_assess_abstract_page_char_budget,
+            summary_page_char_budget=settings.big_assess_summary_page_char_budget,
+        )
+        working_page_ids = result.page_ids
+
+        extra_ids = list(replacement_ids)
+        preloaded_ids = infra.call.context_page_ids or []
+        all_extra = extra_ids + preloaded_ids
+
+        context_text = result.context_text
+        if all_extra:
+            parts: list[str] = []
+            for pid in all_extra:
+                page = await db.get_page(pid)
+                if page and page.is_active():
+                    parts += [
+                        "",
+                        "---",
+                        "",
+                        f"## Pre-loaded Page: `{pid[:8]}`",
+                        "",
+                        await format_page(page, PageDetail.CONTENT, db=db),
+                    ]
+            if parts:
+                context_text += "\n".join(parts)
+
+        await _record_context_built(infra, working_page_ids, all_extra)
+        return ContextResult(
+            context_text=context_text,
+            working_page_ids=working_page_ids,
+            preloaded_ids=all_extra,
         )

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -52,11 +52,13 @@ class SimpleAgentLoop(PageCreator):
         task_description: str,
         available_moves: Sequence[MoveType] | None = None,
         max_rounds: int | None = None,
+        prompt_name: str | None = None,
     ) -> None:
         self._call_type = call_type
         self._task_description = task_description
         self._available_moves = available_moves
         self._max_rounds = max_rounds
+        self._prompt_name = prompt_name
 
     async def create_pages(
         self,
@@ -79,7 +81,7 @@ class SimpleAgentLoop(PageCreator):
             else list(MoveType)
         )
         tools = [MOVES[mt].bind(infra.state) for mt in moves_list]
-        system_prompt = build_system_prompt(self._call_type.value)
+        system_prompt = build_system_prompt(self._prompt_name or self._call_type.value)
         user_message = build_user_message(
             context.context_text,
             self._task_description,

--- a/src/rumil/clean/common.py
+++ b/src/rumil/clean/common.py
@@ -337,12 +337,16 @@ async def reassess_question(
     call: Call,
     db: DB,
     trace: CallTrace,
+    assess_variant: str | None = None,
 ) -> None:
     """Reassess a question's judgement by dispatching an AssessCall.
 
     *in_light_of* page IDs are resolved (questions → latest judgement) and
     passed as ``context_page_ids`` on the child assess call so they appear
     fully expanded in the assessment context.
+
+    *assess_variant* overrides the settings-level ``assess_call_variant``
+    when provided.
     """
     resolved_id = await db.resolve_page_id(page_id)
     if not resolved_id:
@@ -362,7 +366,8 @@ async def reassess_question(
         parent_call_id=call.id,
         context_page_ids=context_page_ids,
     )
-    cls = ASSESS_CALL_CLASSES[get_settings().assess_call_variant]
+    variant = assess_variant or get_settings().assess_call_variant
+    cls = ASSESS_CALL_CLASSES[variant]
     assess = cls(resolved_id, assess_call, db)
     await assess.run()
 

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -5,6 +5,7 @@ Build context text from workspace pages for injection into LLM prompts.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
@@ -444,6 +445,66 @@ async def _resolve_superseding_page(
     return None
 
 
+_CITATION_RE = re.compile(r"\[([a-f0-9]{8})\]")
+
+
+async def _supersession_notes(body: str, db: DB) -> str:
+    """Return a note block for any inline citations that reference superseded pages.
+
+    Typically 2 DB queries: one to find superseded cited pages (prefix-match +
+    ``is_superseded`` filter), one bulk chain resolution.
+    """
+    short_ids = sorted(set(_CITATION_RE.findall(body)))
+    if not short_ids:
+        return ""
+
+    resp = await db._execute(
+        db.client.table("pages")
+        .select("id")
+        .eq("is_superseded", True)
+        .or_(",".join(f"id.like.{sid}%" for sid in short_ids))
+    )
+    rows = resp.data or []
+    if not rows:
+        return ""
+
+    prefix_to_full: dict[str, str] = {}
+    for row in rows:
+        prefix = row["id"][:8]
+        if prefix in prefix_to_full:
+            prefix_to_full.pop(prefix)
+        else:
+            prefix_to_full[prefix] = row["id"]
+
+    if not prefix_to_full:
+        return ""
+
+    superseded_ids = list(prefix_to_full.values())
+    resolved = await db.resolve_supersession_chains(superseded_ids)
+
+    notes: list[str] = []
+    for sid in short_ids:
+        full_id = prefix_to_full.get(sid)
+        if not full_id:
+            continue
+        replacement = resolved.get(full_id)
+        if not replacement:
+            notes.append(
+                f"> **Note:** `[{sid}]` has been superseded (replacement not found)."
+            )
+            continue
+        abstract_text = replacement.abstract or replacement.headline
+        notes.append(
+            f"> **Note:** `[{sid}]` has been superseded by "
+            f"`[{replacement.id[:8]}]` — {replacement.headline}\n"
+            f"> {abstract_text}"
+        )
+
+    if not notes:
+        return ""
+    return "\n\n" + "\n\n".join(notes)
+
+
 async def format_page(
     page: Page,
     detail: PageDetail = PageDetail.CONTENT,
@@ -452,6 +513,7 @@ async def format_page(
     db: DB | None = None,
     graph: PageGraph | None = None,
     include_superseding: bool = True,
+    exclude_page_ids: set[str] | None = None,
 ) -> str:
     """Format a single page at the requested detail level.
 
@@ -522,13 +584,20 @@ async def format_page(
     body = page.abstract if detail == PageDetail.ABSTRACT else page.content
     if body:
         lines += ["", body]
+        if db:
+            notes = await _supersession_notes(body, db)
+            if notes:
+                lines.append(notes)
 
     source: DB | PageGraph | None = graph if graph is not None else db
+    _exclude = exclude_page_ids or set()
     if linked_detail is not None and source and page.page_type == PageType.QUESTION:
         linked_items: list[tuple[str, Page]] = []
 
         considerations = await source.get_considerations_for_question(page.id)
         for claim, link in considerations:
+            if claim.id in _exclude:
+                continue
             line = "- " + await format_page(claim, linked_detail, db=db, graph=graph, linked_detail=None)
             if link.reasoning:
                 line += f"\n  Reasoning: {link.reasoning}"
@@ -536,12 +605,18 @@ async def format_page(
 
         judgements = await source.get_judgements_for_question(page.id)
         for j in judgements:
+            if j.id in _exclude:
+                continue
             line = '- ' + await format_page(j, linked_detail, db=db, graph=graph, linked_detail=None)
             linked_items.append((line, j))
 
         children = await source.get_child_questions(page.id)
         for child in children:
+            if child.id in _exclude:
+                continue
             for j in await source.get_judgements_for_question(child.id):
+                if j.id in _exclude:
+                    continue
                 line = (
                     f"- *On: {child.headline} (`{child.id[:8]}`)*  "
                     + await format_page(j, linked_detail, db=db, graph=graph, linked_detail=None)
@@ -897,6 +972,7 @@ async def build_embedding_based_context(
     abstract_page_similarity_floor: float | None = None,
     summary_page_similarity_floor: float | None = None,
     require_judgement_for_questions: bool = False,
+    exclude_page_ids: set[str] | None = None,
 ) -> EmbeddingBasedContextResult:
     """Build context by embedding-similarity search over the whole workspace.
 
@@ -934,6 +1010,10 @@ async def build_embedding_based_context(
         field_name='abstract',
     )
 
+    _exclude = exclude_page_ids or set()
+    if _exclude:
+        ranked = [(p, s) for p, s in ranked if p.id not in _exclude]
+
     scope_section = ''
     scope_page_ids: list[str] = []
     if scope_question_id:
@@ -946,6 +1026,7 @@ async def build_embedding_based_context(
                     scope_detail or PageDetail.ABSTRACT,
                     linked_detail=scope_linked_detail or PageDetail.HEADLINE,
                     db=db,
+                    exclude_page_ids=_exclude,
                 )
                 + '\n\n'
             )

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -886,6 +886,8 @@ async def build_embedding_based_context(
     db: DB,
     *,
     scope_question_id: str | None = None,
+    scope_detail: PageDetail | None = None,
+    scope_linked_detail: PageDetail | None = None,
     headline_only_ids: set[str] | None = None,
     full_page_char_budget: int | None = None,
     abstract_page_char_budget: int | None = None,
@@ -939,7 +941,12 @@ async def build_embedding_based_context(
         if scope_page:
             scope_section = (
                 '## Scope Question\n\n'
-                + await format_page(scope_page, PageDetail.ABSTRACT, db=db)
+                + await format_page(
+                    scope_page,
+                    scope_detail or PageDetail.ABSTRACT,
+                    linked_detail=scope_linked_detail or PageDetail.HEADLINE,
+                    db=db,
+                )
                 + '\n\n'
             )
             scope_page_ids = [scope_question_id]

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -735,6 +735,45 @@ class DB:
             current_id = page.superseded_by
         return None
 
+    async def resolve_supersession_chains(
+        self, page_ids: Sequence[str], max_depth: int = 10,
+    ) -> dict[str, Page]:
+        """Bulk-resolve supersession chains for multiple page IDs.
+
+        Returns ``{original_id: active_replacement}`` for each input ID whose
+        chain reaches an active page. IDs that are already active, have broken
+        chains, or exceed *max_depth* are omitted.
+        """
+        pages = await self.get_pages_by_ids(list(page_ids))
+        pending: dict[str, str] = {}
+        result: dict[str, Page] = {}
+        origin: dict[str, str] = {}
+
+        for pid in page_ids:
+            page = pages.get(pid)
+            if not page or not page.is_superseded or not page.superseded_by:
+                continue
+            pending[pid] = page.superseded_by
+            origin[pid] = pid
+
+        for _ in range(max_depth):
+            if not pending:
+                break
+            targets = list(set(pending.values()))
+            fetched = await self.get_pages_by_ids(targets)
+            next_pending: dict[str, str] = {}
+            for orig_id, target_id in pending.items():
+                target_page = fetched.get(target_id)
+                if not target_page:
+                    continue
+                if not target_page.is_superseded:
+                    result[orig_id] = target_page
+                elif target_page.superseded_by:
+                    next_pending[orig_id] = target_page.superseded_by
+            pending = next_pending
+
+        return result
+
     # --- Links ---
 
     async def save_link(self, link: PageLink) -> None:

--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -264,26 +264,40 @@ def write_page_file(page: Page) -> None:
 async def _copy_consideration_links(
     old_page_id: str, new_page_id: str, db: DB
 ) -> None:
-    """Copy outbound CONSIDERATION links from *old_page_id* to *new_page_id*."""
-    links = await db.get_links_from(old_page_id)
-    for link in links:
-        if link.link_type == LinkType.CONSIDERATION:
-            await db.save_link(
-                PageLink(
-                    from_page_id=new_page_id,
-                    to_page_id=link.to_page_id,
-                    link_type=LinkType.CONSIDERATION,
-                    direction=link.direction,
-                    strength=link.strength,
-                    reasoning=link.reasoning,
-                    role=link.role,
-                )
+    """Copy outbound CONSIDERATION links from *old_page_id* to *new_page_id*.
+
+    Skips links where *new_page_id* already has a CONSIDERATION link to the
+    same target with the same direction.
+    """
+    old_links = await db.get_links_from(old_page_id)
+    new_links = await db.get_links_from(new_page_id)
+    existing = {
+        (l.to_page_id, l.direction)
+        for l in new_links
+        if l.link_type == LinkType.CONSIDERATION
+    }
+    copied = 0
+    for link in old_links:
+        if link.link_type != LinkType.CONSIDERATION:
+            continue
+        if (link.to_page_id, link.direction) in existing:
+            continue
+        await db.save_link(
+            PageLink(
+                from_page_id=new_page_id,
+                to_page_id=link.to_page_id,
+                link_type=LinkType.CONSIDERATION,
+                direction=link.direction,
+                strength=link.strength,
+                reasoning=link.reasoning,
+                role=link.role,
             )
-    count = sum(1 for l in links if l.link_type == LinkType.CONSIDERATION)
-    if count:
+        )
+        copied += 1
+    if copied:
         log.info(
             "Copied %d consideration links from %s to %s",
-            count, old_page_id[:8], new_page_id[:8],
+            copied, old_page_id[:8], new_page_id[:8],
         )
 
 

--- a/src/rumil/orchestrators/llm.py
+++ b/src/rumil/orchestrators/llm.py
@@ -164,7 +164,8 @@ class LLMOrchestrator(BaseOrchestrator):
 
         d_label = await self.db.page_label(resolved)
 
-        if get_settings().budget_pacing_enabled:
+        pacing_enabled = get_settings().budget_pacing_enabled
+        if pacing_enabled:
             prev_total, prev_used = self._sub_budget_ledger.get(resolved, (0, 0))
             cumulative_total = prev_total + payload.budget
             sub_budget = compute_round_budget(cumulative_total, prev_used)
@@ -178,6 +179,7 @@ class LLMOrchestrator(BaseOrchestrator):
                 prev_used, sub_budget, payload.reason,
             )
         else:
+            prev_used = 0
             sub_budget = payload.budget
             log.info(
                 'Expanding sub-prioritization on %s (budget=%d) — %s',
@@ -192,7 +194,7 @@ class LLMOrchestrator(BaseOrchestrator):
             workspace=Workspace.PRIORITIZATION,
         )
 
-        if get_settings().budget_pacing_enabled:
+        if pacing_enabled:
             ct, _ = self._sub_budget_ledger.get(resolved, (0, 0))
             sub_remaining = ct - prev_used
         else:

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -88,6 +88,10 @@ class Settings(BaseSettings):
     full_page_similarity_floor: float = _capture_field(default=0.3)
     abstract_page_similarity_floor: float = _capture_field(default=0.2)
     summary_page_similarity_floor: float = _capture_field(default=0.1)
+    big_assess_full_page_similarity_floor: float | None = _capture_field(default=None)
+    big_assess_abstract_page_similarity_floor: float | None = _capture_field(
+        default=None
+    )
 
     @property
     def is_test_mode(self) -> bool:

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -80,6 +80,10 @@ class Settings(BaseSettings):
     abstract_page_char_budget: int = _capture_field(default=10_000)
     summary_page_char_budget: int = _capture_field(default=5_000)
     distillation_page_char_budget: int = _capture_field(default=3_000)
+
+    big_assess_full_page_char_budget: int | None = _capture_field(default=None)
+    big_assess_abstract_page_char_budget: int | None = _capture_field(default=None)
+    big_assess_summary_page_char_budget: int | None = _capture_field(default=None)
     full_page_similarity_floor: float = _capture_field(default=0.3)
     abstract_page_similarity_floor: float = _capture_field(default=0.2)
     summary_page_similarity_floor: float = _capture_field(default=0.1)

--- a/tests/test_big_assess_context.py
+++ b/tests/test_big_assess_context.py
@@ -7,7 +7,7 @@ from rumil.calls.context_builders import (
     _gather_connected_pages,
     _get_latest_judgement,
     _cites_superseded_pages,
-    _phase_a_resolve_supersessions,
+    _resolve_superseded_connections,
     _swap_superseded_link,
 )
 from rumil.models import (
@@ -222,7 +222,7 @@ async def test_phase_a_swaps_superseded_pages(tmp_db):
     ))
     await tmp_db.supersede_page(old.id, new.id)
 
-    connected = await _phase_a_resolve_supersessions(q.id, None, tmp_db)
+    connected = await _resolve_superseded_connections(q.id, None, tmp_db)
     page_ids = {p.id for p, _ in connected}
     assert new.id in page_ids
     assert old.id not in page_ids
@@ -230,7 +230,7 @@ async def test_phase_a_swaps_superseded_pages(tmp_db):
 
 async def test_phase_a_keeps_active_pages(tmp_db, question_with_considerations):
     q, c1, c2, child, *_ = question_with_considerations
-    connected = await _phase_a_resolve_supersessions(q.id, None, tmp_db)
+    connected = await _resolve_superseded_connections(q.id, None, tmp_db)
     page_ids = {p.id for p, _ in connected}
     assert c1.id in page_ids
     assert c2.id in page_ids
@@ -256,7 +256,7 @@ async def test_phase_a_includes_judgement_connections(tmp_db):
         link_type=LinkType.CONSIDERATION,
     ))
 
-    connected = await _phase_a_resolve_supersessions(q.id, j, tmp_db)
+    connected = await _resolve_superseded_connections(q.id, j, tmp_db)
     page_ids = {p.id for p, _ in connected}
     assert j.id in page_ids
     assert claim_on_j.id in page_ids
@@ -322,6 +322,6 @@ async def test_phase_a_deduplicates_shared_links(tmp_db):
     await tmp_db.save_link(link_to_q)
     await tmp_db.save_link(link_to_j)
 
-    connected = await _phase_a_resolve_supersessions(q.id, j, tmp_db)
+    connected = await _resolve_superseded_connections(q.id, j, tmp_db)
     link_ids = [link.id for _, link in connected]
     assert len(link_ids) == len(set(link_ids)), "Links should be deduplicated"

--- a/tests/test_big_assess_context.py
+++ b/tests/test_big_assess_context.py
@@ -1,0 +1,327 @@
+"""Tests for BigAssessContext and its helper functions."""
+
+import pytest
+import pytest_asyncio
+
+from rumil.calls.context_builders import (
+    _gather_connected_pages,
+    _get_latest_judgement,
+    _cites_superseded_pages,
+    _phase_a_resolve_supersessions,
+    _swap_superseded_link,
+)
+from rumil.models import (
+    ConsiderationDirection,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+
+
+def _page(page_type: PageType, headline: str, **overrides) -> Page:
+    defaults = {
+        "page_type": page_type,
+        "layer": PageLayer.SQUIDGY,
+        "workspace": Workspace.RESEARCH,
+        "content": f"Content for {headline}",
+        "headline": headline,
+        "abstract": f"Abstract of {headline}",
+    }
+    defaults.update(overrides)
+    return Page(**defaults)
+
+
+def _question(headline: str = "Test question", **kw) -> Page:
+    return _page(PageType.QUESTION, headline, **kw)
+
+
+def _claim(headline: str = "Test claim", **kw) -> Page:
+    return _page(PageType.CLAIM, headline, credence=6, robustness=3, **kw)
+
+
+def _judgement(headline: str = "Test judgement", **kw) -> Page:
+    return _page(PageType.JUDGEMENT, headline, **kw)
+
+
+@pytest_asyncio.fixture
+async def question_with_considerations(tmp_db):
+    """A question with two consideration claims and one child question."""
+    q = _question("Main question")
+    c1 = _claim("Claim A")
+    c2 = _claim("Claim B")
+    child = _question("Sub-question")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(c1)
+    await tmp_db.save_page(c2)
+    await tmp_db.save_page(child)
+
+    link_c1 = PageLink(
+        from_page_id=c1.id,
+        to_page_id=q.id,
+        link_type=LinkType.CONSIDERATION,
+        direction=ConsiderationDirection.SUPPORTS,
+        strength=3.0,
+    )
+    link_c2 = PageLink(
+        from_page_id=c2.id,
+        to_page_id=q.id,
+        link_type=LinkType.CONSIDERATION,
+        direction=ConsiderationDirection.OPPOSES,
+        strength=2.0,
+    )
+    link_child = PageLink(
+        from_page_id=q.id,
+        to_page_id=child.id,
+        link_type=LinkType.CHILD_QUESTION,
+    )
+    for link in (link_c1, link_c2, link_child):
+        await tmp_db.save_link(link)
+
+    return q, c1, c2, child, link_c1, link_c2, link_child
+
+
+async def test_gather_connected_pages_finds_considerations(
+    tmp_db, question_with_considerations,
+):
+    q, c1, c2, child, *_ = question_with_considerations
+    connected = await _gather_connected_pages(q.id, tmp_db)
+    page_ids = {p.id for p, _ in connected}
+    assert c1.id in page_ids
+    assert c2.id in page_ids
+    assert child.id in page_ids
+
+
+async def test_gather_connected_pages_finds_judgements(tmp_db):
+    q = _question()
+    j = _judgement()
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(j)
+    await tmp_db.save_link(PageLink(
+        from_page_id=j.id,
+        to_page_id=q.id,
+        link_type=LinkType.RELATED,
+    ))
+
+    connected = await _gather_connected_pages(q.id, tmp_db)
+    page_ids = {p.id for p, _ in connected}
+    assert j.id in page_ids
+
+
+async def test_gather_connected_pages_includes_superseded(tmp_db):
+    """Superseded pages should be included so Phase A can detect and swap them."""
+    q = _question()
+    old_claim = _claim("Old")
+    new_claim = _claim("New")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(old_claim)
+    await tmp_db.save_page(new_claim)
+    await tmp_db.save_link(PageLink(
+        from_page_id=old_claim.id,
+        to_page_id=q.id,
+        link_type=LinkType.CONSIDERATION,
+    ))
+    await tmp_db.supersede_page(old_claim.id, new_claim.id)
+
+    connected = await _gather_connected_pages(q.id, tmp_db)
+    page_ids = {p.id for p, _ in connected}
+    assert old_claim.id in page_ids
+
+
+async def test_get_latest_judgement_returns_most_recent(tmp_db):
+    q = _question()
+    j1 = _judgement("First")
+    j2 = _judgement("Second")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(j1)
+    await tmp_db.save_page(j2)
+    for j in (j1, j2):
+        await tmp_db.save_link(PageLink(
+            from_page_id=j.id,
+            to_page_id=q.id,
+            link_type=LinkType.RELATED,
+        ))
+
+    latest = await _get_latest_judgement(q.id, tmp_db)
+    assert latest is not None
+    assert latest.id == j2.id
+
+
+async def test_get_latest_judgement_returns_none_when_no_judgements(tmp_db):
+    q = _question()
+    await tmp_db.save_page(q)
+    latest = await _get_latest_judgement(q.id, tmp_db)
+    assert latest is None
+
+
+async def test_swap_superseded_link_updates_from_page(tmp_db):
+    """When the linked page is the from_page, the new link should update from_page_id."""
+    q = _question()
+    old = _claim("Old claim")
+    new = _claim("New claim")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(old)
+    await tmp_db.save_page(new)
+    link = PageLink(
+        from_page_id=old.id,
+        to_page_id=q.id,
+        link_type=LinkType.CONSIDERATION,
+        direction=ConsiderationDirection.SUPPORTS,
+        strength=4.0,
+        reasoning="important",
+    )
+    await tmp_db.save_link(link)
+
+    new_link = await _swap_superseded_link(old, link, new, tmp_db)
+
+    assert new_link.from_page_id == new.id
+    assert new_link.to_page_id == q.id
+    assert new_link.link_type == LinkType.CONSIDERATION
+    assert new_link.direction == ConsiderationDirection.SUPPORTS
+    assert new_link.strength == 4.0
+    assert new_link.reasoning == "important"
+
+    old_link = await tmp_db.get_link(link.id)
+    assert old_link is None
+
+
+async def test_swap_superseded_link_updates_to_page(tmp_db):
+    """When the linked page is the to_page, the new link should update to_page_id."""
+    parent = _question("Parent")
+    old_child = _question("Old child")
+    new_child = _question("New child")
+    await tmp_db.save_page(parent)
+    await tmp_db.save_page(old_child)
+    await tmp_db.save_page(new_child)
+    link = PageLink(
+        from_page_id=parent.id,
+        to_page_id=old_child.id,
+        link_type=LinkType.CHILD_QUESTION,
+    )
+    await tmp_db.save_link(link)
+
+    new_link = await _swap_superseded_link(old_child, link, new_child, tmp_db)
+
+    assert new_link.from_page_id == parent.id
+    assert new_link.to_page_id == new_child.id
+
+
+async def test_phase_a_swaps_superseded_pages(tmp_db):
+    q = _question()
+    old = _claim("Old claim")
+    new = _claim("New claim")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(old)
+    await tmp_db.save_page(new)
+    await tmp_db.save_link(PageLink(
+        from_page_id=old.id,
+        to_page_id=q.id,
+        link_type=LinkType.CONSIDERATION,
+    ))
+    await tmp_db.supersede_page(old.id, new.id)
+
+    connected = await _phase_a_resolve_supersessions(q.id, None, tmp_db)
+    page_ids = {p.id for p, _ in connected}
+    assert new.id in page_ids
+    assert old.id not in page_ids
+
+
+async def test_phase_a_keeps_active_pages(tmp_db, question_with_considerations):
+    q, c1, c2, child, *_ = question_with_considerations
+    connected = await _phase_a_resolve_supersessions(q.id, None, tmp_db)
+    page_ids = {p.id for p, _ in connected}
+    assert c1.id in page_ids
+    assert c2.id in page_ids
+    assert child.id in page_ids
+
+
+async def test_phase_a_includes_judgement_connections(tmp_db):
+    """Phase A should also gather connected pages of the latest judgement."""
+    q = _question()
+    j = _judgement()
+    claim_on_j = _claim("Claim bearing on judgement")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(j)
+    await tmp_db.save_page(claim_on_j)
+    await tmp_db.save_link(PageLink(
+        from_page_id=j.id,
+        to_page_id=q.id,
+        link_type=LinkType.RELATED,
+    ))
+    await tmp_db.save_link(PageLink(
+        from_page_id=claim_on_j.id,
+        to_page_id=j.id,
+        link_type=LinkType.CONSIDERATION,
+    ))
+
+    connected = await _phase_a_resolve_supersessions(q.id, j, tmp_db)
+    page_ids = {p.id for p, _ in connected}
+    assert j.id in page_ids
+    assert claim_on_j.id in page_ids
+
+
+async def test_cites_superseded_pages_true(tmp_db):
+    cited = _claim("Cited claim")
+    replacement = _claim("Replacement")
+    target = _claim(
+        "Target",
+        content=f"This depends on [{cited.id[:8]}] for support.",
+    )
+    await tmp_db.save_page(cited)
+    await tmp_db.save_page(replacement)
+    await tmp_db.save_page(target)
+    await tmp_db.supersede_page(cited.id, replacement.id)
+
+    assert await _cites_superseded_pages(target, tmp_db) is True
+
+
+async def test_cites_superseded_pages_false(tmp_db):
+    cited = _claim("Active cited claim")
+    target = _claim(
+        "Target",
+        content=f"This depends on [{cited.id[:8]}] for support.",
+    )
+    await tmp_db.save_page(cited)
+    await tmp_db.save_page(target)
+
+    assert await _cites_superseded_pages(target, tmp_db) is False
+
+
+async def test_cites_superseded_pages_no_citations(tmp_db):
+    target = _claim("Standalone", content="No citations here.")
+    await tmp_db.save_page(target)
+    assert await _cites_superseded_pages(target, tmp_db) is False
+
+
+async def test_phase_a_deduplicates_shared_links(tmp_db):
+    """If a page is linked to both the question and its judgement, it should
+    appear only once in the connected set."""
+    q = _question()
+    j = _judgement()
+    shared = _claim("Shared claim")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(j)
+    await tmp_db.save_page(shared)
+    await tmp_db.save_link(PageLink(
+        from_page_id=j.id,
+        to_page_id=q.id,
+        link_type=LinkType.RELATED,
+    ))
+    link_to_q = PageLink(
+        from_page_id=shared.id,
+        to_page_id=q.id,
+        link_type=LinkType.CONSIDERATION,
+    )
+    link_to_j = PageLink(
+        from_page_id=shared.id,
+        to_page_id=j.id,
+        link_type=LinkType.CONSIDERATION,
+    )
+    await tmp_db.save_link(link_to_q)
+    await tmp_db.save_link(link_to_j)
+
+    connected = await _phase_a_resolve_supersessions(q.id, j, tmp_db)
+    link_ids = [link.id for _, link in connected]
+    assert len(link_ids) == len(set(link_ids)), "Links should be deduplicated"


### PR DESCRIPTION
## Summary

- **New `BigAssessContext` context builder** that freshens the workspace around a question before assessment: resolves superseded connections, reassesses pages citing stale content, searches for higher-quality replacement pages via embeddings, generates missing abstracts, and builds final embedding context with judgement-cited pages included
- **New `BigAssessCall`** registered as the `"big"` assess variant with a dedicated prompt (`prompts/big_assess.md`) emphasizing BLUF structure, standalone readability, precise probabilistic claims, explicit weighting, and derivation-style reasoning
- **Supersession hygiene**: `_swap_superseded_link` and `_copy_consideration_links` are now idempotent (no duplicate links); `format_page` appends supersession notes when content cites superseded pages; `DB.resolve_supersession_chains` for bulk chain resolution
- **Context improvements**: `build_embedding_based_context` gains `scope_detail`, `scope_linked_detail`, and `exclude_page_ids` params; big assess excludes the existing judgement from context; separate big assess settings for char budgets and similarity floors
- **CLI**: `--guidance` flag on `scripts/run_call.py` for optional user direction
- **B1 reassessment**: routes judgements through `reassess_question` (not `reassess_claim`); `reassess_question` gains `assess_variant` param, forced to `"embedding"` in B1; staleness check uses inline citation analysis rather than graph links
- 14 unit tests covering helpers

## Test plan

- [x] `uv run pytest tests/test_big_assess_context.py` — 14 tests pass
- [x] `uv run pyright` — 0 errors
- [x] Smoke test: `uv run python scripts/run_call.py assess --question <ID> --variant big --smoke-test`
- [ ] Verify supersession notes appear in context for pages citing superseded content
- [ ] Verify no duplicate consideration links after big assess run

🤖 Generated with [Claude Code](https://claude.com/claude-code)