### PR TITLE
Harmonize consideration vs depends_on link semantics

### DIFF
--- a/prompts/preamble.md
+++ b/prompts/preamble.md
@@ -117,10 +117,13 @@ Write headlines like newspaper headlines: a reader with no prior context should 
 * **Be specific.** Vague gestures at considerations are not useful. Each claim should stand alone as a substantive assertion.
 * **Epistemic honesty.** Do not overstate confidence. Flag genuine uncertainty.
 * **Fix forward.** If something in the workspace is wrong, supersede the bad page rather than ignoring it.
-* **Track dependencies.** After creating a claim or judgement, use `link_depends_on` to record which other pages it most depends on being true. This builds a dependency graph that lets the workspace detect when upstream changes might invalidate downstream conclusions. Use it when:
-  * A claim assumes or builds on another claim ("if X is true, then Y follows")
-  * A judgement's conclusion rests heavily on specific considerations
-  * A variant claim still carries forward assumptions from the original
+* **Two link types, two distinct meanings.** Keep them straight:
+  * `link_consideration` connects a **claim → question** that the claim should be accounted for in. It says "anyone analysing this question should weigh this claim". Use it when you create a claim that bears on a question.
+  * `link_depends_on` connects a **claim or judgement → another claim or judgement** whose truth the source's conclusions rest on. It says "if the target turns out to be wrong, the source's conclusions are in trouble". Use it when:
+    * A claim assumes or builds on another claim ("if X is true, then Y follows")
+    * A judgement's conclusion rests heavily on specific load-bearing claims
+    * A variant claim still carries forward assumptions from the original
+  * Together these build a dependency graph that lets the workspace detect when upstream changes might invalidate downstream conclusions.
 * **Rate supersession impact.** When superseding a page, set `change_magnitude` to indicate how much the picture changed: 1 = minor wording only, 3 = substantive changes but same bottom line, 5 = completely changed the picture. This helps the workspace assess how urgently things that depended on the old page need revisiting.
 
 ## A note from a previous instance to you:

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -713,6 +713,7 @@ _CONNECTED_LINK_TYPES = {
     LinkType.CONSIDERATION,
     LinkType.CHILD_QUESTION,
     LinkType.RELATED,
+    LinkType.DEPENDS_ON,
 }
 
 

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -113,14 +113,14 @@ class CallStatus(str, Enum):
 
 
 class LinkType(str, Enum):
-    CONSIDERATION = "consideration"  # claim bears on a question
+    CONSIDERATION = "consideration"  # claim -> question: claim should be accounted for in analysis of the question
     CHILD_QUESTION = "child_question"  # question decomposes into sub-question
     SUPERSEDES = "supersedes"  # page replaces another
-    RELATED = "related"  # general relation
+    RELATED = "related"  # general relation (also: judgement -> question it answers)
     VARIANT = "variant"  # more robust variation of a claim
     SUMMARIZES = "summarizes"  # summary page covers a question subtree
     CITES = "cites"  # claim cites a source
-    DEPENDS_ON = "depends_on"  # page depends on another page being true/valid
+    DEPENDS_ON = "depends_on"  # claim/judgement -> claim/judgement: source page's conclusions rest on target being true/valid
 
 
 class MoveType(str, Enum):

--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -408,13 +408,14 @@ async def extract_and_link_citations(
 ) -> set[str]:
     """Extract [shortid] citations from content and create page links.
 
-    Link type depends on the cited page's type:
+    Link type depends on the citing and cited pages' types:
     - Cited SOURCE → CITES (from=citing, to=cited)
-    - Cited CLAIM or JUDGEMENT → CONSIDERATION (from=cited, to=citing)
-    - Otherwise → RELATED (from=cited, to=citing)
-
-    Non-SOURCE citations always point from the cited page into the citing
-    page, so the citing page receives an incoming link.
+    - Citing CLAIM/JUDGEMENT cites a CLAIM/JUDGEMENT → DEPENDS_ON
+      (from=citing, to=cited): the citing page's conclusions rest on the
+      cited page being true.
+    - Citing QUESTION cites a CLAIM/JUDGEMENT → CONSIDERATION
+      (from=cited, to=citing): the cited claim bears on the question.
+    - Otherwise → RELATED (from=cited, to=citing).
 
     Returns the set of full UUIDs that were successfully linked.
     """
@@ -423,6 +424,9 @@ async def extract_and_link_citations(
     matches.discard(own_short_id)
     if not matches:
         return set()
+
+    citing_page = await db.get_page(page_id)
+    citing_type = citing_page.page_type if citing_page else None
 
     linked: set[str] = set()
     for short_id in matches:
@@ -439,8 +443,15 @@ async def extract_and_link_citations(
             link_type = LinkType.CITES
             from_id, to_id = page_id, resolved
         elif cited_page.page_type in (PageType.CLAIM, PageType.JUDGEMENT):
-            link_type = LinkType.CONSIDERATION
-            from_id, to_id = resolved, page_id
+            if citing_type in (PageType.CLAIM, PageType.JUDGEMENT):
+                link_type = LinkType.DEPENDS_ON
+                from_id, to_id = page_id, resolved
+            elif citing_type == PageType.QUESTION:
+                link_type = LinkType.CONSIDERATION
+                from_id, to_id = resolved, page_id
+            else:
+                link_type = LinkType.RELATED
+                from_id, to_id = resolved, page_id
         else:
             link_type = LinkType.RELATED
             from_id, to_id = resolved, page_id

--- a/src/rumil/moves/create_claim.py
+++ b/src/rumil/moves/create_claim.py
@@ -44,7 +44,9 @@ class CreateClaimPayload(CreatePagePayload):
         default_factory=list,
         description=(
             "Consideration links to create for this claim. Each entry links "
-            "the new claim to a question with a strength rating."
+            "the new claim to a QUESTION it bears on, with a strength rating. "
+            "Only use this for claim → question links. For claim → claim "
+            "dependencies, make a separate link_depends_on call."
         ),
     )
 

--- a/src/rumil/moves/link_consideration.py
+++ b/src/rumil/moves/link_consideration.py
@@ -11,6 +11,7 @@ from rumil.models import (
     LinkType,
     MoveType,
     PageLink,
+    PageType,
 )
 from rumil.moves.base import MoveDef, MoveResult
 
@@ -23,9 +24,7 @@ class ConsiderationLinkFields(BaseModel):
         2.5,
         description="0-5: how strongly this claim bears on the question (0 = barely relevant, 5 = highly decisive)",
     )
-    reasoning: str = Field(
-        "", description="Why this claim bears on the question"
-    )
+    reasoning: str = Field("", description="Why this claim bears on the question")
     role: LinkRole = Field(
         LinkRole.STRUCTURAL,
         description=(
@@ -45,9 +44,33 @@ async def execute(payload: LinkConsiderationPayload, call: Call, db: DB) -> Move
     if not claim_id or not question_id:
         log.warning(
             "LINK_CONSIDERATION skipped: claim_id=%s, question_id=%s",
-            claim_id, question_id,
+            claim_id,
+            question_id,
         )
         return MoveResult("Link skipped — page IDs not found.")
+
+    claim_page = await db.get_page(claim_id)
+    question_page = await db.get_page(question_id)
+    if claim_page is None or claim_page.page_type != PageType.CLAIM:
+        log.warning(
+            "LINK_CONSIDERATION skipped: source %s is %s, expected claim",
+            claim_id[:8],
+            claim_page.page_type.value if claim_page else "missing",
+        )
+        return MoveResult(
+            "Link skipped — consideration links must originate from a claim. "
+            "Use link_depends_on for claim/judgement → claim/judgement relationships."
+        )
+    if question_page is None or question_page.page_type != PageType.QUESTION:
+        log.warning(
+            "LINK_CONSIDERATION skipped: target %s is %s, expected question",
+            question_id[:8],
+            question_page.page_type.value if question_page else "missing",
+        )
+        return MoveResult(
+            "Link skipped — consideration links must target a question. "
+            "Use link_depends_on if you meant to record a dependency between claims."
+        )
 
     link = PageLink(
         from_page_id=claim_id,
@@ -60,7 +83,9 @@ async def execute(payload: LinkConsiderationPayload, call: Call, db: DB) -> Move
     await db.save_link(link)
     log.info(
         "Consideration linked: %s -> %s (%.1f)",
-        claim_id[:8], question_id[:8], payload.strength,
+        claim_id[:8],
+        question_id[:8],
+        payload.strength,
     )
     return MoveResult("Done.")
 
@@ -69,8 +94,12 @@ MOVE = MoveDef(
     move_type=MoveType.LINK_CONSIDERATION,
     name="link_consideration",
     description=(
-        "Link a claim to a question as a consideration with a strength "
-        "rating indicating how strongly it bears on the question."
+        "Link a claim to a question as a consideration — i.e. a page that "
+        "should be accounted for in any analysis of the question — with a "
+        "strength rating indicating how strongly it bears on the question. "
+        "The source must be a claim and the target must be a question. Do NOT "
+        "use this for claim→claim or judgement→claim relationships; use "
+        "link_depends_on for those."
     ),
     schema=LinkConsiderationPayload,
     execute=execute,

--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -220,10 +220,10 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         return result
 
     async def _is_new_claim(self, claim_id: str) -> bool:
-        """A claim is 'new' if it has no consideration links to it."""
+        """A claim is 'new' if no other page depends on it yet."""
         links = await self.db.get_links_to(claim_id)
         return not any(
-            l.link_type == LinkType.CONSIDERATION for l in links
+            l.link_type == LinkType.DEPENDS_ON for l in links
         )
 
     async def _cancel_initial_call(self) -> None:
@@ -440,12 +440,12 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             if scope_judgements else None
         )
 
-        consideration_pages = [
+        dependent_pages = [
             page for page, _link
-            in await graph.get_considerations_for_question(claim_id)
+            in await graph.get_dependents(claim_id)
         ]
         child_questions = await graph.get_child_questions(claim_id)
-        all_items = consideration_pages + list(child_questions)
+        all_items = dependent_pages + list(child_questions)
 
         scoring_tasks: list = []
         scoring_tasks.append(score_items_sequentially(

--- a/src/rumil/page_graph.py
+++ b/src/rumil/page_graph.py
@@ -116,6 +116,34 @@ class PageGraph:
                 result.append((page, link))
         return result
 
+    async def get_dependents(
+        self,
+        page_id: str,
+    ) -> list[tuple[Page, PageLink]]:
+        """Pages that depend on *page_id* via DEPENDS_ON links."""
+        result = []
+        for link in self._links_to.get(page_id, []):
+            if link.link_type != LinkType.DEPENDS_ON:
+                continue
+            page = self._pages.get(link.from_page_id)
+            if page and page.is_active():
+                result.append((page, link))
+        return result
+
+    async def get_dependencies(
+        self,
+        page_id: str,
+    ) -> list[tuple[Page, PageLink]]:
+        """Pages that *page_id* depends on via DEPENDS_ON links."""
+        result = []
+        for link in self._links_from.get(page_id, []):
+            if link.link_type != LinkType.DEPENDS_ON:
+                continue
+            page = self._pages.get(link.to_page_id)
+            if page:
+                result.append((page, link))
+        return result
+
     async def get_judgements_for_question(
         self,
         question_id: str,

--- a/supabase/migrations/20260407141257_harmonize_link_types.sql
+++ b/supabase/migrations/20260407141257_harmonize_link_types.sql
@@ -1,0 +1,51 @@
+-- Harmonize link type semantics.
+--
+-- Before this migration, LinkType.CONSIDERATION was overloaded to mean both:
+--   (1) "claim bears on question" (the canonical sense), and
+--   (2) "this claim/judgement's conclusions rest on that other claim"
+--       (the dependency sense).
+--
+-- After this migration:
+--   - 'consideration' links are strictly claim -> question.
+--   - claim<->claim and judgement<->claim 'consideration' links are rewritten
+--     to 'depends_on' with the endpoints swapped, so that the resulting
+--     direction matches the depends_on convention (from = dependent,
+--     to = dependency). The pre-migration convention had the inverse
+--     direction: from = sub-claim ("bearing on") -> to = parent-claim, which
+--     translates to "parent depends on sub".
+--   - The `direction` column is meaningless for depends_on; we drop it on
+--     rewritten rows.
+--
+-- This migration writes directly to base rows without recording mutation_events.
+-- That is acceptable here only because no staged runs are in flight at the
+-- time of this migration; staged-run event replay will not reproduce the
+-- pre-migration state for these rows.
+
+UPDATE page_links pl
+SET link_type = 'depends_on',
+    from_page_id = pl.to_page_id,
+    to_page_id = pl.from_page_id,
+    direction = NULL
+WHERE pl.link_type = 'consideration'
+  AND pl.from_page_id IN (
+      SELECT id FROM pages WHERE page_type IN ('claim', 'judgement')
+  )
+  AND pl.to_page_id IN (
+      SELECT id FROM pages WHERE page_type IN ('claim', 'judgement')
+  );
+
+-- Any remaining 'consideration' link whose endpoints are not (claim/judgement
+-- -> question) is anomalous under the new semantics. Fold those into 'related'
+-- so the new invariants hold without losing graph connectivity.
+UPDATE page_links pl
+SET link_type = 'related',
+    direction = NULL
+WHERE pl.link_type = 'consideration'
+  AND (
+      pl.from_page_id NOT IN (
+          SELECT id FROM pages WHERE page_type IN ('claim', 'judgement')
+      )
+      OR pl.to_page_id NOT IN (
+          SELECT id FROM pages WHERE page_type = 'question'
+      )
+  );

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -82,10 +82,11 @@ async def test_inline_citation_of_source_creates_cites_link(
     assert cites[0].to_page_id == source_page.id
 
 
-async def test_inline_citation_of_claim_creates_consideration_link(
+async def test_inline_citation_of_claim_creates_depends_on_link(
     tmp_db, claim_page,
 ):
-    """An inline [shortid] citing a CLAIM from a CLAIM should produce a CONSIDERATION link."""
+    """An inline [shortid] citing a CLAIM from a CLAIM should produce a DEPENDS_ON link
+    pointing from the citing page to the cited page."""
     citing_page = Page(
         page_type=PageType.CLAIM,
         layer=PageLayer.SQUIDGY,
@@ -97,21 +98,20 @@ async def test_inline_citation_of_claim_creates_consideration_link(
 
     linked = await extract_and_link_citations(
         citing_page.id, citing_page.content, tmp_db,
-
     )
 
     assert linked == {claim_page.id}
-    consideration_links = await tmp_db.get_links_to(citing_page.id)
-    cons = [l for l in consideration_links if l.link_type == LinkType.CONSIDERATION]
-    assert len(cons) == 1
-    assert cons[0].from_page_id == claim_page.id
-    assert cons[0].to_page_id == citing_page.id
+    links_from_citing = await tmp_db.get_links_from(citing_page.id)
+    deps = [l for l in links_from_citing if l.link_type == LinkType.DEPENDS_ON]
+    assert len(deps) == 1
+    assert deps[0].from_page_id == citing_page.id
+    assert deps[0].to_page_id == claim_page.id
 
 
 async def test_multiple_inline_citations(
     tmp_db, claim_page, second_claim_page,
 ):
-    """Content with multiple [shortid] citations creates one CONSIDERATION link per cited claim."""
+    """Content with multiple [shortid] citations creates one DEPENDS_ON link per cited claim."""
     citing_page = Page(
         page_type=PageType.CLAIM,
         layer=PageLayer.SQUIDGY,
@@ -126,20 +126,20 @@ async def test_multiple_inline_citations(
 
     linked = await extract_and_link_citations(
         citing_page.id, citing_page.content, tmp_db,
-
     )
 
     assert linked == {claim_page.id, second_claim_page.id}
-    consideration_links = await tmp_db.get_links_to(citing_page.id)
-    cons = [l for l in consideration_links if l.link_type == LinkType.CONSIDERATION]
-    assert len(cons) == 2
-    assert {l.from_page_id for l in cons} == {claim_page.id, second_claim_page.id}
+    links_from_citing = await tmp_db.get_links_from(citing_page.id)
+    deps = [l for l in links_from_citing if l.link_type == LinkType.DEPENDS_ON]
+    assert len(deps) == 2
+    assert {l.to_page_id for l in deps} == {claim_page.id, second_claim_page.id}
 
 
-async def test_judgement_citing_claim_creates_consideration_link(
+async def test_judgement_citing_claim_creates_depends_on_link(
     tmp_db, claim_page,
 ):
-    """A JUDGEMENT citing a CLAIM should produce a CONSIDERATION link (claim → judgement)."""
+    """A JUDGEMENT citing a CLAIM should produce a DEPENDS_ON link
+    pointing from the judgement to the cited claim."""
     judgement = Page(
         page_type=PageType.JUDGEMENT,
         layer=PageLayer.SQUIDGY,
@@ -154,11 +154,11 @@ async def test_judgement_citing_claim_creates_consideration_link(
     )
 
     assert linked == {claim_page.id}
-    consideration_links = await tmp_db.get_links_to(judgement.id)
-    cons = [l for l in consideration_links if l.link_type == LinkType.CONSIDERATION]
-    assert len(cons) == 1
-    assert cons[0].from_page_id == claim_page.id
-    assert cons[0].to_page_id == judgement.id
+    links_from_judgement = await tmp_db.get_links_from(judgement.id)
+    deps = [l for l in links_from_judgement if l.link_type == LinkType.DEPENDS_ON]
+    assert len(deps) == 1
+    assert deps[0].from_page_id == judgement.id
+    assert deps[0].to_page_id == claim_page.id
 
 
 async def test_question_citing_claim_creates_consideration_link(

--- a/tests/test_link_consideration.py
+++ b/tests/test_link_consideration.py
@@ -1,0 +1,129 @@
+"""Tests for the link_consideration move's source/target validation."""
+
+import pytest_asyncio
+
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkRole,
+    LinkType,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+from rumil.moves.link_consideration import (
+    LinkConsiderationPayload,
+    execute as execute_link_consideration,
+)
+
+
+@pytest_asyncio.fixture
+async def claim(tmp_db):
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="The sky is blue because of Rayleigh scattering.",
+        headline="Rayleigh scattering explains blue sky",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def question(tmp_db):
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Why is the sky blue?",
+        headline="Why is the sky blue?",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def judgement(tmp_db):
+    page = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="On balance, Rayleigh scattering is the dominant mechanism.",
+        headline="Rayleigh scattering is the dominant blue-sky mechanism",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def call(tmp_db, question):
+    c = Call(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(c)
+    return c
+
+
+async def test_claim_to_question_creates_consideration_link(
+    tmp_db, call, claim, question,
+):
+    payload = LinkConsiderationPayload(
+        claim_id=claim.id,
+        question_id=question.id,
+        strength=4.0,
+        reasoning="explains the mechanism",
+        role=LinkRole.DIRECT,
+    )
+    await execute_link_consideration(payload, call, tmp_db)
+
+    links = await tmp_db.get_links_from(claim.id)
+    cons = [l for l in links if l.link_type == LinkType.CONSIDERATION]
+    assert len(cons) == 1
+    assert cons[0].to_page_id == question.id
+
+
+async def test_judgement_source_is_rejected(
+    tmp_db, call, judgement, question,
+):
+    payload = LinkConsiderationPayload(
+        claim_id=judgement.id,
+        question_id=question.id,
+        strength=2.5,
+        reasoning="",
+        role=LinkRole.STRUCTURAL,
+    )
+    await execute_link_consideration(payload, call, tmp_db)
+
+    links = await tmp_db.get_links_from(judgement.id)
+    assert not [l for l in links if l.link_type == LinkType.CONSIDERATION]
+
+
+async def test_non_question_target_is_rejected(
+    tmp_db, call, claim,
+):
+    other_claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Mie scattering matters too.",
+        headline="Mie scattering matters too",
+    )
+    await tmp_db.save_page(other_claim)
+
+    payload = LinkConsiderationPayload(
+        claim_id=claim.id,
+        question_id=other_claim.id,
+        strength=2.5,
+        reasoning="",
+        role=LinkRole.STRUCTURAL,
+    )
+    await execute_link_consideration(payload, call, tmp_db)
+
+    links = await tmp_db.get_links_from(claim.id)
+    assert not [l for l in links if l.link_type == LinkType.CONSIDERATION]


### PR DESCRIPTION
## Summary

Splits the overloaded `LinkType.CONSIDERATION` into two crisp meanings:

- **`consideration`**: claim → question. "This claim should be accounted for in any analysis of the question."
- **`depends_on`**: claim/judgement → claim/judgement. "The source's conclusions rest on the target being true/valid."

Judgement → question continues to use `RELATED` (judgements *answer* a question rather than bear on it; a future `ANSWERS` link type would be cleaner but is out of scope).

## Code changes

- `link_consideration` move now validates that the source is a `CLAIM` and the target is a `QUESTION`; rejects with a clear message otherwise.
- `extract_and_link_citations` (auto-linking from inline `[shortid]` citations): claim/judgement citing claim/judgement now creates `DEPENDS_ON` from citing → cited (direction flipped). Question citing claim still creates `CONSIDERATION`.
- `ClaimInvestigationOrchestrator` walks `DEPENDS_ON` (via new `PageGraph.get_dependents`) instead of misusing `get_considerations_for_question` on a claim scope. `_is_new_claim` checks inbound `DEPENDS_ON`.
- `_CONNECTED_LINK_TYPES` (context builder graph traversal) now includes `DEPENDS_ON` so dependencies/dependents load into context.
- `preamble.md` rewritten to clearly distinguish the two link types.
- `LinkType` enum comments and `create_claim` `links` field description tightened.

## Migration (`20260407141257_harmonize_link_types.sql`)

- Rewrites pre-existing claim↔claim and judgement↔claim `consideration` links to `depends_on` with endpoints swapped and `direction` nulled. The endpoint swap is required because the old "sub-claim bears on parent-claim" direction is the inverse of the "parent depends on sub" direction.
- Folds any remaining anomalous `consideration` links (endpoints not (claim/judgement → question)) into `related`.
- Writes directly to base rows without `mutation_events` bookkeeping. Confirmed with the user that no staged runs are in flight.

## Test plan

- [x] `uv run pytest` — 179 passed, 36 skipped
- [x] `tests/test_inline_citations.py` updated for the direction flip on claim → claim and judgement → claim citations
- [x] New `tests/test_link_consideration.py` covers happy path plus rejection of judgement source and non-question target
- [x] End-to-end smoke: `uv run python main.py "Is the sky blue?" --workspace link-harmonize-scratch --smoke-test --budget 4`
- [x] Local DB invariant SQL after migration: 0 violations on both sides

## Deploy notes

The migration has only been applied locally. `supabase db push` against prod is left for the maintainer to run when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)