### PR TITLE
Internalize pydantic validation in structured_call

### DIFF
--- a/src/rumil/calls/closing_reviewers.py
+++ b/src/rumil/calls/closing_reviewers.py
@@ -226,7 +226,7 @@ async def _self_assessment(
         db=infra.db,
         cache=True,
     )
-    review_data = review_result.data or {}
+    review_data = review_result.parsed.model_dump() if review_result.parsed else {}
 
     if review_data:
         log.info(
@@ -444,7 +444,7 @@ class ConceptAssessReview(ClosingReviewer):
                 metadata=meta,
                 db=infra.db,
             )
-            review = result.data
+            review = result.parsed.model_dump() if result.parsed else None
         except Exception as e:
             log.error(
                 "Concept closing review failed for call=%s: %s",

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -835,7 +835,7 @@ async def run_closing_review(
             metadata=meta,
             db=db,
         )
-        review = result.data
+        review = result.parsed.model_dump() if result.parsed else None
         if review:
             log.info(
                 "Closing review complete: call=%s, fruit=%s, confidence=%s",

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -692,9 +692,8 @@ async def _select_sensitive_pages(
         metadata=meta,
         db=infra.db,
     )
-    if result.data:
-        selected = _PageSelection.model_validate(result.data)
-        selected_ids = set(selected.page_ids)
+    if result.parsed:
+        selected_ids = set(result.parsed.page_ids)
         return [p for p in pages if p.id[:8] in selected_ids][:limit]
     return list(pages[:limit])
 
@@ -1056,10 +1055,9 @@ async def _find_higher_quality_replacements(
                 db=infra.db,
             )
         found: set[str] = set()
-        if result.data:
-            picks = _ReplacementPick.model_validate(result.data)
+        if result.parsed:
             candidate_id_map = {c.id[:8]: c.id for c, _ in candidates}
-            for short_id in picks.replacement_ids:
+            for short_id in result.parsed.replacement_ids:
                 full_id = candidate_id_map.get(short_id)
                 if full_id:
                     found.add(full_id)
@@ -1128,12 +1126,11 @@ async def _generate_missing_abstracts(
         metadata=meta,
         db=infra.db,
     )
-    if result.data:
-        parsed = _AbstractBatch(**result.data)
-        await save_page_abstracts(parsed.summaries, infra.db)
+    if result.parsed:
+        await save_page_abstracts(result.parsed.summaries, infra.db)
         log.info(
             "Generated %d abstracts for connected pages",
-            len(parsed.summaries),
+            len(result.parsed.summaries),
         )
 
 

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -318,7 +318,7 @@ class MultiRoundLoop(PageCreator):
         system_prompt: str,
         resume_messages: list[dict],
         tool_defs: list[dict],
-        fruit_check_model: type,
+        fruit_check_model: type[_FruitCheck],
     ) -> int:
         check_messages = list(resume_messages) + [
             {"role": "user", "content": _FRUIT_CHECK_MESSAGE},
@@ -337,14 +337,13 @@ class MultiRoundLoop(PageCreator):
             db=infra.db,
             cache=True,
         )
-        if result.data:
-            score = result.data.get("remaining_fruit", 5)
+        if result.parsed:
             log.info(
                 "Fruit check: score=%d, reasoning=%s",
-                score,
-                result.data.get("brief_reasoning", ""),
+                result.parsed.remaining_fruit,
+                result.parsed.brief_reasoning,
             )
-            return score
+            return result.parsed.remaining_fruit
         log.warning("Fruit check returned empty data, defaulting to 5")
         return 5
 

--- a/src/rumil/calls/summarize.py
+++ b/src/rumil/calls/summarize.py
@@ -272,7 +272,7 @@ async def summarize_question(
             db=db,
         )
 
-        if not result.data:
+        if not result.parsed:
             log.warning(
                 "summarize_question: structured call returned no data for %s",
                 question_id[:8],
@@ -280,10 +280,10 @@ async def summarize_question(
             await _fail_call(call, db)
             return None
 
-        data = result.data
+        data = result.parsed
         question = await db.get_page(question_id)
         page_headline = (
-            data.get("page_headline")
+            data.page_headline
             or f"Summary of {question.headline[:60] if question else question_id[:8]}"
         )
 
@@ -291,9 +291,9 @@ async def summarize_question(
             page_type=PageType.SUMMARY,
             layer=PageLayer.SQUIDGY,
             workspace=Workspace.RESEARCH,
-            content=data.get("content", ""),
-            headline=data.get("headline") or page_headline,
-            abstract=data.get("abstract", ""),
+            content=data.content,
+            headline=data.headline or page_headline,
+            abstract=data.abstract,
             credence=5,
             robustness=2,
             provenance_model="claude-sonnet-4-6",

--- a/src/rumil/chat.py
+++ b/src/rumil/chat.py
@@ -301,7 +301,7 @@ def _render_transcript_markdown(history: Sequence[dict]) -> str:
                             query = tool_input.get("query", json.dumps(tool_input))
                             text_parts.append(f"*[Searched workspace for: {query}]*")
                 if text_parts:
-                    parts.append(f"## Assistant\n\n" + "\n\n".join(text_parts) + "\n")
+                    parts.append("## Assistant\n\n" + "\n\n".join(text_parts) + "\n")
     return "\n".join(parts)
 
 
@@ -523,8 +523,8 @@ async def _extract_question(
         user_message=transcript,
         response_model=RefinedQuestion,
     )
-    if result.data:
-        return RefinedQuestion(**result.data)
+    if result.parsed:
+        return result.parsed
     return RefinedQuestion(headline=original_question, content=original_question)
 
 

--- a/src/rumil/clean/common.py
+++ b/src/rumil/clean/common.py
@@ -290,11 +290,11 @@ async def reassess_claim(
         db=db,
     )
 
-    if result.data is None:
+    if result.parsed is None:
         log.warning("Reassess claim %s returned no data", old_page.id[:8])
         return
 
-    reassessed = ReassessedClaim.model_validate(result.data)
+    reassessed = result.parsed
 
     new_page = Page(
         page_type=PageType.CLAIM,
@@ -551,11 +551,11 @@ async def reassess_claims(
         db=db,
     )
 
-    if result.data is None:
+    if result.parsed is None:
         log.warning("reassess_claims returned no data")
         return
 
-    parsed = ReassessedClaimsResult.model_validate(result.data)
+    parsed = result.parsed
 
     new_pages: list[Page] = []
     superseded_by: dict[str, list[str]] = {}
@@ -699,6 +699,5 @@ async def generate_abstracts(call: Call, db: DB) -> None:
         metadata=meta,
         db=db,
     )
-    if result.data:
-        parsed = _PageAbstractList(**result.data)
-        await save_page_abstracts(parsed.summaries, db)
+    if result.parsed:
+        await save_page_abstracts(result.parsed.summaries, db)

--- a/src/rumil/clean/grounding.py
+++ b/src/rumil/clean/grounding.py
@@ -361,10 +361,9 @@ async def _generate_tasks(
         metadata=meta,
         db=db,
     )
-    if result.data is None:
+    if result.parsed is None:
         return []
-    task_list = GroundingTaskList.model_validate(result.data)
-    return task_list.tasks
+    return result.parsed.tasks
 
 
 async def _run_web_search_task(

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -18,7 +18,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TYPE_CHECKING
+from typing import Any, Generic, TYPE_CHECKING, TypeVar, overload
 
 from collections.abc import Awaitable, Callable, Sequence
 
@@ -417,9 +417,7 @@ async def call_api(
             if isinstance(block, TextBlock):
                 text_parts.append(block.text)
             elif isinstance(block, (ToolUseBlock, ServerToolUseBlock)):
-                tool_call_data.append(
-                    {"name": block.name, "input": block.input}
-                )
+                tool_call_data.append({"name": block.name, "input": block.input})
             elif isinstance(block, WebSearchToolResultBlock):
                 tool_call_data.append(
                     {
@@ -462,8 +460,7 @@ async def call_api(
                 await trace.record(
                     ErrorEvent(
                         message=(
-                            f"Failed to save exchange: "
-                            f"{type(exc).__name__}: {exc}"
+                            f"Failed to save exchange: {type(exc).__name__}: {exc}"
                         ),
                         phase=metadata.phase,
                     )
@@ -500,11 +497,19 @@ async def text_call(
     return ""
 
 
-@dataclass
-class StructuredCallResult:
-    """Result of a structured_call invocation."""
+T = TypeVar("T", bound=BaseModel)
 
-    data: dict | None = None
+
+@dataclass
+class StructuredCallResult(Generic[T]):
+    """Result of a structured_call invocation.
+
+    `parsed` holds the validated pydantic instance, or None if the model
+    returned no parseable output. The type parameter matches the
+    `response_model` passed to `structured_call`.
+    """
+
+    parsed: T | None = None
     response_text: str | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
@@ -513,13 +518,13 @@ class StructuredCallResult:
 
 async def _structured_call_cached(
     system_prompt: str,
-    response_model: type[BaseModel],
+    response_model: type[T],
     msg_list: list[dict],
     *,
     tools: Sequence[dict] | None = None,
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
-) -> StructuredCallResult:
+) -> StructuredCallResult[T]:
     """Structured output via create() + manual JSON parsing for cache reuse.
 
     Uses call_api (messages.create) so the request shares the same cache
@@ -559,7 +564,7 @@ async def _structured_call_cached(
                 api_resp.message.usage.output_tokens,
             )
             return StructuredCallResult(
-                data=parsed.model_dump(),
+                parsed=parsed,
                 response_text=response_text or None,
                 input_tokens=api_resp.message.usage.input_tokens,
                 output_tokens=api_resp.message.usage.output_tokens,
@@ -638,14 +643,14 @@ def _inject_into_last_user_message(
 
 async def _structured_call_parse(
     system_prompt: str,
-    response_model: type[BaseModel] | None,
+    response_model: type[T] | None,
     msg_list: list[dict],
     *,
     tools: Sequence[dict] | None = None,
     tool_choice: dict | None = None,
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
-) -> StructuredCallResult:
+) -> StructuredCallResult[T]:
     """Structured output via messages.parse (no cache sharing with create)."""
     settings = get_settings()
     client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
@@ -683,9 +688,7 @@ async def _structured_call_parse(
         if metadata.user_message is None and metadata.user_messages is None:
             if len(msg_list) == 1:
                 content = msg_list[0].get("content", "")
-                metadata.user_message = (
-                    content if isinstance(content, str) else None
-                )
+                metadata.user_message = content if isinstance(content, str) else None
             if len(msg_list) > 1 or metadata.user_message is None:
                 metadata.user_messages = _serialize_messages(msg_list)
         await _save_exchange(
@@ -715,7 +718,7 @@ async def _structured_call_parse(
             response.usage.output_tokens,
         )
         return StructuredCallResult(
-            data=response.parsed_output.model_dump(),
+            parsed=response.parsed_output,
             response_text=response_text or None,
             input_tokens=response.usage.input_tokens,
             output_tokens=response.usage.output_tokens,
@@ -734,10 +737,11 @@ async def _structured_call_parse(
     )
 
 
+@overload
 async def structured_call(
     system_prompt: str,
-    user_message: str = "",
-    response_model: type[BaseModel] | None = None,
+    user_message: str,
+    response_model: type[T],
     *,
     messages: list[dict] | None = None,
     tools: Sequence[dict] | None = None,
@@ -745,7 +749,51 @@ async def structured_call(
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     cache: bool = False,
-) -> StructuredCallResult:
+) -> StructuredCallResult[T]: ...
+
+
+@overload
+async def structured_call(
+    system_prompt: str,
+    user_message: str = "",
+    *,
+    response_model: type[T],
+    messages: list[dict] | None = None,
+    tools: Sequence[dict] | None = None,
+    tool_choice: dict | None = None,
+    metadata: LLMExchangeMetadata | None = None,
+    db: DB | None = None,
+    cache: bool = False,
+) -> StructuredCallResult[T]: ...
+
+
+@overload
+async def structured_call(
+    system_prompt: str,
+    user_message: str = "",
+    response_model: None = None,
+    *,
+    messages: list[dict] | None = None,
+    tools: Sequence[dict] | None = None,
+    tool_choice: dict | None = None,
+    metadata: LLMExchangeMetadata | None = None,
+    db: DB | None = None,
+    cache: bool = False,
+) -> StructuredCallResult[BaseModel]: ...
+
+
+async def structured_call(
+    system_prompt: str,
+    user_message: str = "",
+    response_model: type[T] | None = None,
+    *,
+    messages: list[dict] | None = None,
+    tools: Sequence[dict] | None = None,
+    tool_choice: dict | None = None,
+    metadata: LLMExchangeMetadata | None = None,
+    db: DB | None = None,
+    cache: bool = False,
+) -> StructuredCallResult[T] | StructuredCallResult[BaseModel]:
     """Run an LLM call that returns structured output matching response_model.
 
     When cache=True, uses messages.create with manual JSON parsing so the

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -164,7 +164,9 @@ async def _describe_considerations_on_page(
 
 
 def compute_priority_score(
-    impact_on_question: int, broader_impact: int, fruit: int,
+    impact_on_question: int,
+    broader_impact: int,
+    fruit: int,
 ) -> int:
     """Synthetic priority from three scoring dimensions.
 
@@ -221,8 +223,6 @@ class FruitResult(BaseModel):
     reasoning: str = Field(description="Brief explanation")
 
 
-
-
 SCORING_BATCH_SIZE = 10
 
 
@@ -239,23 +239,26 @@ def _split_into_batches(n: int, max_per_batch: int) -> list[int]:
 
 
 async def _build_item_block(
-    item: Page, index: int, total: int, graph: PageGraph,
+    item: Page,
+    index: int,
+    total: int,
+    graph: PageGraph,
 ) -> str:
     """Build the text block describing a single item for the scorer."""
     parts = [
-        f'### Item {index + 1}/{total}',
-        f'ID: `{item.id}`',
-        f'Headline: {item.headline}',
+        f"### Item {index + 1}/{total}",
+        f"ID: `{item.id}`",
+        f"Headline: {item.headline}",
     ]
     if item.abstract:
-        parts.append(f'\nAbstract:\n{item.abstract}')
+        parts.append(f"\nAbstract:\n{item.abstract}")
 
     judgements = await graph.get_judgements_for_question(item.id)
     if judgements:
         latest_j = max(judgements, key=lambda j: j.created_at)
         parts.append(
-            f'\nLatest judgement (credence {latest_j.credence}/9, '
-            f'robustness {latest_j.robustness}/5):'
+            f"\nLatest judgement (credence {latest_j.credence}/9, "
+            f"robustness {latest_j.robustness}/5):"
         )
         if latest_j.abstract:
             parts.append(latest_j.abstract)
@@ -263,11 +266,11 @@ async def _build_item_block(
             parts.append(latest_j.headline)
         if latest_j.fruit_remaining is not None:
             parts.append(
-                f'\nPrior fruit_remaining estimate: {latest_j.fruit_remaining}/10'
+                f"\nPrior fruit_remaining estimate: {latest_j.fruit_remaining}/10"
             )
     else:
-        parts.append('\nNo prior assessment.')
-    return '\n'.join(parts)
+        parts.append("\nNo prior assessment.")
+    return "\n".join(parts)
 
 
 async def score_items_sequentially(
@@ -296,29 +299,32 @@ async def score_items_sequentially(
         return []
 
     batch_response_model = pydantic.create_model(
-        f'{response_model.__name__}Batch',
-        scores=(list[response_model], Field(description='One score per item in the batch')),
+        f"{response_model.__name__}Batch",
+        scores=(
+            list[response_model],
+            Field(description="One score per item in the batch"),
+        ),
     )
 
     parent_parts = [
-        f'Parent: {parent_page.headline}',
-        '',
+        f"Parent: {parent_page.headline}",
+        "",
     ]
     if parent_page.abstract:
         parent_parts.append(parent_page.abstract)
-        parent_parts.append('')
+        parent_parts.append("")
     if parent_judgement:
         parent_parts.append(
-            f'Latest judgement (credence {parent_judgement.credence}/9, '
-            f'robustness {parent_judgement.robustness}/5):'
+            f"Latest judgement (credence {parent_judgement.credence}/9, "
+            f"robustness {parent_judgement.robustness}/5):"
         )
         if parent_judgement.abstract:
             parent_parts.append(parent_judgement.abstract)
         else:
             parent_parts.append(parent_judgement.headline)
-        parent_parts.append('')
+        parent_parts.append("")
 
-    parent_context = '\n'.join(parent_parts)
+    parent_context = "\n".join(parent_parts)
     system_prompt = build_system_prompt(system_prompt_name)
     messages: list[dict] = []
     results: list[dict] = []
@@ -326,7 +332,7 @@ async def score_items_sequentially(
     batch_sizes = _split_into_batches(len(items), SCORING_BATCH_SIZE)
     offset = 0
     for batch_idx, batch_size in enumerate(batch_sizes):
-        batch_items = items[offset:offset + batch_size]
+        batch_items = items[offset : offset + batch_size]
         offset += batch_size
 
         item_blocks = []
@@ -336,18 +342,18 @@ async def score_items_sequentially(
             item_blocks.append(block)
 
         batch_text = (
-            f'## Batch {batch_idx + 1}/{len(batch_sizes)} '
-            f'({batch_size} items)\n\n'
-            + '\n\n'.join(item_blocks)
-            + '\n\nScore all items in this batch now.'
+            f"## Batch {batch_idx + 1}/{len(batch_sizes)} "
+            f"({batch_size} items)\n\n"
+            + "\n\n".join(item_blocks)
+            + "\n\nScore all items in this batch now."
         )
 
         if batch_idx == 0:
-            user_content = parent_context + '\n' + batch_text
+            user_content = parent_context + "\n" + batch_text
         else:
             user_content = batch_text
 
-        messages.append({'role': 'user', 'content': user_content})
+        messages.append({"role": "user", "content": user_content})
 
         result = await structured_call(
             system_prompt,
@@ -356,17 +362,18 @@ async def score_items_sequentially(
             cache=True,
             metadata=LLMExchangeMetadata(
                 call_id=call_id,
-                phase=f'score_batch_{batch_idx}',
-                user_messages=[{'role': 'user', 'content': user_content}],
+                phase=f"score_batch_{batch_idx}",
+                user_messages=[{"role": "user", "content": user_content}],
             ),
             db=db,
         )
 
-        response_text = result.response_text or ''
-        messages.append({'role': 'assistant', 'content': response_text})
+        response_text = result.response_text or ""
+        messages.append({"role": "assistant", "content": response_text})
 
-        if result.data:
-            for score in result.data.get('scores', []):
+        if result.parsed:
+            parsed_dict = result.parsed.model_dump()
+            for score in parsed_dict.get("scores", []):
                 results.append(score)
 
     return results

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -432,7 +432,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             ))
         else:
             async def _empty_scores():
-                return type('R', (), {'data': {'scores': []}})()
+                return None
             scoring_tasks.append(_empty_scores())
 
         scoring_tasks.append(self.db.get_latest_scout_fruit(question_id))
@@ -441,7 +441,9 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         subq_result = scoring_results[0]
         scout_fruit: dict[str, int | None] = scoring_results[1]
 
-        subq_scores = subq_result.data.get('scores', []) if subq_result.data else []
+        subq_scores: list[dict] = []
+        if subq_result is not None and subq_result.parsed:
+            subq_scores = [s.model_dump() for s in subq_result.parsed.scores]
 
         await trace.record(ScoringCompletedEvent(
             subquestion_scores=[

--- a/src/rumil/report.py
+++ b/src/rumil/report.py
@@ -82,26 +82,20 @@ class SectionDraft(BaseModel):
     flags_for_integrator: str = ""
 
 
-
 async def _run_outliner(research_tree: str) -> ReportOutline:
     system_prompt = _load_prompt("report-outliner.md")
-    user_message = (
-        "Here is the full research tree:\n\n"
-        f"{research_tree}"
-    )
+    user_message = f"Here is the full research tree:\n\n{research_tree}"
     result = await structured_call(
         system_prompt=system_prompt,
         user_message=user_message,
         response_model=ReportOutline,
     )
-    if not result.data:
+    if not result.parsed:
         raise RuntimeError("Outliner returned no data")
-    return ReportOutline.model_validate(result.data)
+    return result.parsed
 
 
-async def _collect_section_pages(
-    section: OutlineSection, db: DB
-) -> str:
+async def _collect_section_pages(section: OutlineSection, db: DB) -> str:
     all_ids: list[str] = []
     all_ids.extend(section.source_judgements)
     all_ids.extend(section.source_considerations)
@@ -166,9 +160,11 @@ async def _run_section_writer(
         user_message=user_message,
         response_model=SectionDraft,
     )
-    if not result.data:
-        raise RuntimeError(f"Section writer returned no data for section {section.sequence}")
-    return SectionDraft.model_validate(result.data)
+    if not result.parsed:
+        raise RuntimeError(
+            f"Section writer returned no data for section {section.sequence}"
+        )
+    return result.parsed
 
 
 async def _run_integrator(
@@ -202,7 +198,6 @@ async def _run_integrator(
         system_prompt=system_prompt,
         user_message=user_message,
     )
-
 
 
 async def generate_report(
@@ -240,7 +235,9 @@ async def generate_report(
 def save_report(report_text: str, question_headline: str) -> Path:
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
-    slug = "".join(c if c.isalnum() or c in " -" else "" for c in question_headline[:50])
+    slug = "".join(
+        c if c.isalnum() or c in " -" else "" for c in question_headline[:50]
+    )
     slug = slug.strip().replace(" ", "-").lower()
     filename = f"{timestamp}-{slug}.md"
     path = REPORTS_DIR / filename

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -148,9 +148,9 @@ async def test_structured_call_returns_parsed_dict():
         "Rate the color blue on a scale of 1-5.",
         response_model=Rating,
     )
-    assert result.data is not None
-    assert isinstance(result.data["score"], int)
-    assert "reason" in result.data
+    assert result.parsed is not None
+    assert isinstance(result.parsed.score, int)
+    assert result.parsed.reason
     assert result.input_tokens is not None
     assert result.output_tokens is not None
     assert result.duration_ms is not None


### PR DESCRIPTION
## Summary
- `StructuredCallResult` is now `Generic[T]` with `parsed: T | None` replacing `data: dict | None`. The function already validated internally; callers were re-validating the same schema or accessing the dict untyped.
- `structured_call` gains `@overload`s so the `response_model` type flows through to the result, giving call sites real type checking on field access.
- Re-validation sites (`report.py`, `chat.py`, `clean/*`, `context_builders.py`) collapse to `result.parsed`. Dict-style sites either use typed field access or `.model_dump()` at the boundary to preserve existing dict-based downstream code without a wider rewrite.
- Removed the `_empty_scores` hack in `orchestrators/experimental.py` that fabricated a fake `.data` attribute on a dummy object.

## Test plan
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 179 passed, 36 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)