### PR TITLE
Retry DB calls on httpx.ReadTimeout and WriteTimeout

### DIFF
--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -52,8 +52,10 @@ def _rows(response: Any) -> _Rows:
 
 _DB_RETRYABLE_EXCEPTIONS = (
     httpx.ConnectTimeout,
-    httpx.ConnectError,
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
     httpx.PoolTimeout,
+    httpx.ConnectError,
     httpx.ReadError,
     httpx.RemoteProtocolError,
 )


### PR DESCRIPTION
## Summary

A long run crashed with `httpx.ReadTimeout` from a `consume_budget` RPC that should have been retried. The tenacity `@_db_retry` decorator on `DB._execute` only matches `_DB_RETRYABLE_EXCEPTIONS` at `src/rumil/database.py:53`, which listed `ConnectTimeout` and `PoolTimeout` but not `ReadTimeout` or `WriteTimeout`. A single transient slow RPC response therefore aborted the whole run instead of being retried with the existing exponential backoff.

This PR adds `httpx.ReadTimeout` and `httpx.WriteTimeout` to the retryable set.

## Observed crash

```
15:56:01 rumil.orchestrators.base INFO Orchestrator.run complete: budget used 39/40
Traceback (most recent call last):
  ...
  File ".../httpcore/_async/http2.py", line 455, in _read_incoming_data
    raise exc
  File ".../httpcore/_async/http2.py", line 441, in _read_incoming_data
    data = await self._network_stream.read(self.READ_NUM_BYTES, timeout)
  ...
httpcore.ReadTimeout

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File ".../main.py", line 1354, in <module>
    main()
  ...
  File ".../src/rumil/orchestrators/two_phase.py", line 189, in run
    await assess_question(
  File ".../src/rumil/orchestrators/common.py", line 561, in assess_question
    if not await _consume_budget(db, force=force):
  File ".../src/rumil/orchestrators/common.py", line 398, in _consume_budget
    ok = await db.consume_budget(1)
  File ".../src/rumil/database.py", line 1283, in consume_budget
    result = await self._execute(
  ...
httpx.ReadTimeout
```

The `Orchestrator.run complete` log line appears before the traceback because `two_phase.py:201`'s `finally` block ran `_teardown()` (which logs it) on the way out while the exception propagated.

## Root cause

`_DB_RETRYABLE_EXCEPTIONS` at `src/rumil/database.py:53` enumerated:

- `ConnectTimeout`
- `ConnectError`
- `PoolTimeout`
- `ReadError`
- `RemoteProtocolError`

Notably missing: `ReadTimeout` and `WriteTimeout`. `retry_if_exception_type` is a strict `isinstance` check against that tuple, so `ReadTimeout` propagated straight through without a single retry attempt.

## Fix

```python
_DB_RETRYABLE_EXCEPTIONS = (
    httpx.ConnectTimeout,
    httpx.ReadTimeout,
    httpx.WriteTimeout,
    httpx.PoolTimeout,
    httpx.ConnectError,
    httpx.ReadError,
    httpx.RemoteProtocolError,
)
```

Alternative considered: use the parent `httpx.TimeoutException`, which would automatically cover any future timeout subclass httpx adds. Went with explicit enumeration to match the existing style; happy to switch if preferred.

## Noted but not addressed

The traceback is deep inside `httpcore/_async/http2.py`, which hints at HTTP/2 stream exhaustion on a long-lived connection. `DB.fork()` at `src/rumil/database.py:225` already exists for exactly this reason — its docstring says:

> Use this to scope connections to a single call, avoiding HTTP/2 stream exhaustion on long-running jobs.

The final `assess_question` in `src/rumil/orchestrators/two_phase.py:189` runs on the top-level orchestrator's long-lived `DB`, so if the timeout reproduces even after retries land, switching that call to a forked DB is the next thing to try. Not in scope for this PR — retry is the right first line of defense and fixes the immediate fatal crash.

## Test plan

- [x] ruff check/format (PostToolUse hook)
- [x] pyright (PostToolUse hook)
- [ ] Re-run the `main.py` invocation that originally crashed and confirm a `ReadTimeout` (if one recurs) is logged as a retry via `_log_db_retry` rather than aborting the run.
- [ ] (Optional) Manually inject a `ReadTimeout` into `DB._execute` locally to confirm the tenacity retry path fires.

No automated test added: the change is a tuple membership extension with no existing coverage of `_DB_RETRYABLE_EXCEPTIONS`, and a unit test would essentially re-assert the tuple literal.

Fixes a crash mode seen in a live run; no migrations, no prompt changes, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)