### PR TITLE
Hot-path N+1 fixes and style cleanup

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,16 +18,29 @@ import sys
 import uuid
 from pathlib import Path
 
-from rumil.database import DB
-from rumil.models import Call, Page, PageLayer, PageLink, PageType, LinkType, Workspace
+from rumil.chat import run_chat, run_continuation_chat, run_scoping_chat
+from rumil.clean import run_feedback_update, run_grounding_feedback
 from rumil.constants import MIN_TWOPHASE_BUDGET
-from rumil.orchestrators import Orchestrator, create_root_question, run_concept_session
-from rumil.sources import create_source_page, run_ingest_calls
-from rumil.chat import run_chat, run_scoping_chat, run_continuation_chat
+from rumil.database import DB
+from rumil.evaluate.runner import run_evaluation
 from rumil.mapper import generate_map
-from rumil.summary import generate_summary, save_summary
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.orchestrators import Orchestrator, create_root_question, run_concept_session
 from rumil.report import generate_report, save_report
-from rumil.settings import Settings, get_settings, _settings_var
+from rumil.scope_subquestion_linker import run_scope_subquestion_linker
+from rumil.settings import Settings, _settings_var, get_settings
+from rumil.sources import create_source_page, run_ingest_calls
+from rumil.summary import generate_summary, save_summary
 
 PAGES_DIR = Path(__file__).parent / "pages"
 
@@ -185,7 +198,6 @@ async def cmd_link_subquestions(
     *,
     max_rounds: int | None = None,
 ) -> None:
-    from rumil.scope_subquestion_linker import run_scope_subquestion_linker
 
     resolved = await db.resolve_page_id(question_id)
     if not resolved:
@@ -215,7 +227,6 @@ async def cmd_link_subquestions(
 
 
 async def cmd_evaluate(question_id: str, db: DB, *, eval_type: str = "default") -> None:
-    from rumil.evaluate.runner import run_evaluation
 
     question = await db.get_page(question_id)
     if not question:
@@ -251,9 +262,6 @@ def _print_evaluation(call: Call) -> None:
 
 
 async def cmd_ground(eval_call_id: str, db: DB, *, from_stage: int = 1) -> None:
-    from rumil.clean import run_grounding_feedback
-    from rumil.models import CallStatus, CallType
-
     resolved_id = await db.resolve_call_id(eval_call_id)
     if not resolved_id:
         print(f"Error: call '{eval_call_id}' not found.")
@@ -325,9 +333,6 @@ async def cmd_ground(eval_call_id: str, db: DB, *, from_stage: int = 1) -> None:
 async def cmd_feedback_update(
     eval_call_id: str, db: DB, *, investigation_budget: int | None = None
 ) -> None:
-    from rumil.clean import run_feedback_update
-    from rumil.models import CallStatus, CallType
-
     resolved_id = await db.resolve_call_id(eval_call_id)
     if not resolved_id:
         print(f"Error: call '{eval_call_id}' not found.")
@@ -396,7 +401,6 @@ async def cmd_feedback_update_from_file(
     *,
     investigation_budget: int | None = None,
 ) -> None:
-    from rumil.clean import run_feedback_update
 
     path = Path(file_path)
     if not path.is_file():
@@ -447,7 +451,6 @@ async def cmd_feedback_update_from_file(
 
 async def _load_prior_checkpoints(question_id: str, from_stage: int, db: DB) -> dict:
     """Find the most recent grounding call for *question_id* and return its checkpoints."""
-    from rumil.models import CallType
 
     rows = await db._execute(
         db.client.table("calls")
@@ -485,7 +488,6 @@ async def _load_prior_checkpoints(question_id: str, from_stage: int, db: DB) -> 
 
 
 async def cmd_show_evaluation(call_id: str, db: DB) -> None:
-    from rumil.models import CallType
 
     call = await db.get_call(call_id)
     if not call:

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -4,6 +4,8 @@ FastAPI application for the Rumil research workspace.
 Read-only API for browsing projects, pages, links, and calls.
 """
 
+import asyncio
+import base64
 import logging
 import os
 import secrets
@@ -14,7 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import TypeAdapter, ValidationError
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from rumil.database import DB, _row_to_call
+from rumil.database import DB, _row_to_call, _rows
 from rumil.models import Call, Page, PageLink, PageType, Project, Workspace
 from rumil.settings import get_settings
 from rumil.api.schemas import (
@@ -55,8 +57,6 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         if request.url.path == "/healthz" or not _AUTH_PASSWORD:
             return await call_next(request)
-
-        import base64
 
         auth = request.headers.get("Authorization", "")
         if auth.startswith("Basic "):
@@ -114,9 +114,6 @@ async def _get_db_maybe_staged(
     return await _get_db(project_id)
 
 
-# --- Projects ---
-
-
 @app.get("/api/projects", response_model=list[Project])
 async def list_projects():
     db = await _get_db()
@@ -125,7 +122,6 @@ async def list_projects():
 
 @app.get("/api/projects/{project_id}", response_model=Project)
 async def get_project(project_id: str):
-    from rumil.database import _rows
 
     db = await _get_db(project_id)
     rows = _rows(
@@ -141,9 +137,6 @@ async def get_project(project_id: str):
 async def list_project_runs(project_id: str):
     db = await _get_db(project_id)
     return await db.list_runs_for_project(project_id)
-
-
-# --- Pages ---
 
 
 @app.get("/api/projects/{project_id}/pages", response_model=PaginatedPagesOut)
@@ -255,9 +248,6 @@ async def get_page_counts(page_id: str):
     return PageCountsOut(**counts)
 
 
-# --- Questions ---
-
-
 @app.get(
     "/api/projects/{project_id}/questions",
     response_model=list[Page],
@@ -268,9 +258,6 @@ async def list_root_questions(
 ):
     db = await _get_db(project_id)
     return await db.get_root_questions(workspace)
-
-
-# --- Calls ---
 
 
 @app.get(
@@ -284,7 +271,6 @@ async def list_calls(
     db = await _get_db(project_id)
     if question_id:
         return await db.get_root_calls_for_question(question_id)
-    from rumil.database import _rows
 
     rows = _rows(
         await db.client.table("calls")
@@ -316,29 +302,39 @@ async def _build_call_trace(db: DB, call_id: str) -> CallTraceOut:
     call = await db.get_call(call_id)
     if not call:
         raise HTTPException(status_code=404, detail="Call not found")
-    events = await _parse_trace_events(db, call_id)
+    events, children, db_sequences = await asyncio.gather(
+        _parse_trace_events(db, call_id),
+        db.get_child_calls(call_id),
+        db.get_sequences_for_call(call_id),
+    )
     scope_page_summary = None
     if call.scope_page_id:
         scope_page = await db.get_page(call.scope_page_id)
         if scope_page:
             scope_page_summary = scope_page.headline
-    children = await db.get_child_calls(call_id)
-    child_traces = [await _build_call_trace(db, c.id) for c in children]
+    child_traces = list(
+        await asyncio.gather(*[_build_call_trace(db, c.id) for c in children])
+    )
 
     sequences_out: list[CallSequenceOut] | None = None
-    db_sequences = await db.get_sequences_for_call(call_id)
     if db_sequences:
-        sequences_out = []
-        for seq in db_sequences:
-            seq_calls = await db.get_calls_for_sequence(seq.id)
-            seq_traces = [await _build_call_trace(db, sc.id) for sc in seq_calls]
-            sequences_out.append(
-                CallSequenceOut(
-                    id=seq.id,
-                    position_in_batch=seq.position_in_batch,
-                    calls=seq_traces,
-                )
+        seq_call_lists = await asyncio.gather(
+            *[db.get_calls_for_sequence(seq.id) for seq in db_sequences]
+        )
+        seq_trace_lists = await asyncio.gather(
+            *[
+                asyncio.gather(*[_build_call_trace(db, sc.id) for sc in seq_calls])
+                for seq_calls in seq_call_lists
+            ]
+        )
+        sequences_out = [
+            CallSequenceOut(
+                id=seq.id,
+                position_in_batch=seq.position_in_batch,
+                calls=list(seq_traces),
             )
+            for seq, seq_traces in zip(db_sequences, seq_trace_lists)
+        ]
 
     child_costs = [ct.cost_usd for ct in child_traces if ct.cost_usd is not None]
     total = (call.cost_usd or 0) + sum(child_costs)
@@ -430,7 +426,6 @@ async def get_call_events(call_id: str):
 @app.get("/api/ab-runs/{ab_run_id}/trace", response_model=ABRunTraceOut)
 async def get_ab_run_trace(ab_run_id: str):
     db = await _get_db()
-    from rumil.database import _rows
 
     ab_rows = _rows(
         await db.client.table("ab_runs").select("*").eq("id", ab_run_id).execute()
@@ -449,8 +444,8 @@ async def get_ab_run_trace(ab_run_id: str):
     qid = ab_row.get("question_id")
     if qid:
         question_page = await db.get_page(qid)
-    arms = []
-    for arm_row in arm_rows:
+
+    async def _build_arm(arm_row: dict) -> ABRunArmOut:
         run_id = arm_row["id"]
         question_id = await db.get_run_question_id(run_id)
         q_page = None
@@ -458,7 +453,9 @@ async def get_ab_run_trace(ab_run_id: str):
             q_page = await db.get_page(question_id)
         calls = await db.get_calls_for_run(run_id)
         root_calls = [c for c in calls if c.parent_call_id is None]
-        root_traces = [await _build_call_trace(db, c.id) for c in root_calls]
+        root_traces = list(
+            await asyncio.gather(*[_build_call_trace(db, c.id) for c in root_calls])
+        )
         run_costs = [ct.cost_usd for ct in root_traces if ct.cost_usd is not None]
         run_total = sum(run_costs)
         trace = RunTraceOut(
@@ -467,14 +464,14 @@ async def get_ab_run_trace(ab_run_id: str):
             root_calls=root_traces,
             cost_usd=run_total if run_total > 0 else None,
         )
-        arms.append(
-            ABRunArmOut(
-                run_id=run_id,
-                name=arm_row.get("name", ""),
-                config=arm_row.get("config", {}),
-                trace=trace,
-            )
+        return ABRunArmOut(
+            run_id=run_id,
+            name=arm_row.get("name", ""),
+            config=arm_row.get("config", {}),
+            trace=trace,
         )
+
+    arms = list(await asyncio.gather(*[_build_arm(arm_row) for arm_row in arm_rows]))
     return ABRunTraceOut(
         ab_run_id=ab_run_id,
         name=ab_row.get("name", ""),

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -35,6 +35,7 @@ from rumil.models import (
     Dispatch,
     Move,
     MoveType,
+    Page,
     PageDetail,
 )
 from rumil.moves.base import MoveState
@@ -71,7 +72,7 @@ PHASE1_TASK = (
 
 
 async def execute_tool_uses(
-    tool_uses: list[ToolUseBlock],
+    tool_uses: Sequence[ToolUseBlock],
     tool_fns: dict,
 ) -> tuple[list[ToolCall], list[dict]]:
     """Execute tool calls and build tool_result messages."""
@@ -148,7 +149,7 @@ async def record_round_moves(
         )
 
 
-def prepare_tools(tools: list[Tool]) -> tuple[list[dict], dict]:
+def prepare_tools(tools: Sequence[Tool]) -> tuple[list[dict], dict]:
     """Build API tool definitions and function lookup from Tool list."""
     tool_defs = [
         {"name": t.name, "description": t.description, "input_schema": t.input_schema}
@@ -393,7 +394,7 @@ async def run_agent_loop(
             budget_note = {
                 "type": "text",
                 "text": (
-                    f"After this round of tool calls, you will have "
+                    "After this round of tool calls, you will have "
                     f"{remaining - 1} rounds remaining."
                 ),
             }
@@ -520,11 +521,12 @@ class RunCallResult:
     agent_result: AgentResult = field(default_factory=AgentResult)
 
 
-async def _format_loaded_pages(page_ids: list[str], db: DB) -> str:
+async def _format_loaded_pages(page_ids: Sequence[str], db: DB) -> str:
     """Format loaded pages as context text for phase 2."""
+    pages = await db.get_pages_by_ids(page_ids)
     parts = []
     for pid in page_ids:
-        page = await db.get_page(pid)
+        page = pages.get(pid)
         if page:
             parts.append(
                 f"### Page `{pid[:8]}`\n\n{await format_page(page, PageDetail.HEADLINE, db=db)}"
@@ -673,48 +675,58 @@ async def extract_loaded_page_ids(result: RunCallResult, db: DB) -> list[str]:
 
 async def resolve_page_refs(page_ids: Sequence[str], db: DB) -> list[PageRef]:
     """Resolve a list of page IDs to PageRef objects with headlines."""
-    refs = []
-    for pid in page_ids:
-        page = await db.get_page(pid)
-        hl = page.headline if page else ""
-        refs.append(PageRef(id=pid, headline=hl))
-    return refs
+    pages = await db.get_pages_by_ids(page_ids)
+    return [
+        PageRef(id=pid, headline=pages[pid].headline if pid in pages else "")
+        for pid in page_ids
+    ]
 
 
-async def _resolve_payload_refs(move: Move, db: DB) -> list[PageRef]:
-    """Resolve page IDs referenced in a move's payload fields."""
+def _payload_raw_refs(move: Move) -> list[str]:
+    """Extract raw page ID strings from a move's payload fields."""
     fields = PAGE_ID_FIELDS.get(move.move_type, [])
-    refs: list[PageRef] = []
+    raws: list[str] = []
     for field_name in fields:
         raw = getattr(move.payload, field_name, None)
-        if not raw:
-            continue
-        full_id = await db.resolve_page_id(raw)
-        if not full_id:
-            continue
-        page = await db.get_page(full_id)
-        hl = page.headline if page else ""
-        refs.append(PageRef(id=full_id, headline=hl))
-    return refs
+        if raw:
+            raws.append(raw)
+    return raws
 
 
 async def moves_to_trace_event(
-    moves: list[Move],
-    move_created_ids: list[list[str]],
+    moves: Sequence[Move],
+    move_created_ids: Sequence[Sequence[str]],
     db: DB,
-    trace_extras: list[dict] | None = None,
+    trace_extras: Sequence[dict] | None = None,
 ) -> MovesExecutedEvent:
     """Build a typed MovesExecutedEvent from a list of moves."""
+    raw_payload_refs = [_payload_raw_refs(m) for m in moves]
+    all_raw_refs = [raw for refs in raw_payload_refs for raw in refs]
+    resolved_payload_ids = await db.resolve_page_ids(all_raw_refs)
+
+    all_full_ids: set[str] = set()
+    for created in move_created_ids:
+        all_full_ids.update(created)
+    all_full_ids.update(resolved_payload_ids.values())
+    pages = await db.get_pages_by_ids(list(all_full_ids))
+
+    def _ref(full_id: str) -> PageRef:
+        return PageRef(
+            id=full_id,
+            headline=pages[full_id].headline if full_id in pages else "",
+        )
+
     trace_items = []
     for i, m in enumerate(moves):
         created_ids = move_created_ids[i] if i < len(move_created_ids) else []
-        created_refs = await resolve_page_refs(created_ids, db)
-        payload_refs = await _resolve_payload_refs(m, db)
+        created_refs = [_ref(pid) for pid in created_ids]
         seen = {r.id for r in created_refs}
-        for pr in payload_refs:
-            if pr.id not in seen:
-                created_refs.append(pr)
-                seen.add(pr.id)
+        for raw in raw_payload_refs[i]:
+            full_id = resolved_payload_ids.get(raw)
+            if not full_id or full_id in seen:
+                continue
+            created_refs.append(_ref(full_id))
+            seen.add(full_id)
         payload_data = m.payload.model_dump(exclude_none=True, exclude_defaults=True)
         extra = trace_extras[i] if trace_extras and i < len(trace_extras) else {}
         trace_items.append(
@@ -768,11 +780,17 @@ async def run_closing_review(
     db: DB | None = None,
 ) -> dict | None:
     """Run the closing review as a separate call. Free (not counted against budget)."""
+    review_pages: dict[str, Page] = {}
+    if db and (loaded_page_ids or created_page_ids):
+        review_pages = await db.get_pages_by_ids(
+            list(loaded_page_ids or []) + list(created_page_ids or [])
+        )
+
     page_rating_note = ""
     if loaded_page_ids and db:
         page_lines = []
         for pid in loaded_page_ids:
-            page = await db.get_page(pid)
+            page = review_pages.get(pid)
             if page:
                 page_lines.append(f'  - `{pid[:8]}`: "{page.headline[:120]}"')
         if page_lines:
@@ -789,7 +807,7 @@ async def run_closing_review(
     if created_page_ids and db:
         created_lines = []
         for pid in created_page_ids:
-            page = await db.get_page(pid)
+            page = review_pages.get(pid)
             if page:
                 created_lines.append(f'  - `{pid[:8]}`: "{page.headline[:120]}"')
         if created_lines:
@@ -844,8 +862,13 @@ async def run_closing_review(
                 review.get("confidence_in_output"),
             )
             if db:
-                for r in review.get("page_ratings", []):
-                    pid = await db.resolve_page_id(r.get("page_id", ""))
+                ratings = review.get("page_ratings", [])
+                raw_rating_ids = [r.get("page_id", "") for r in ratings]
+                resolved_rating_ids = await db.resolve_page_ids(
+                    [rid for rid in raw_rating_ids if rid]
+                )
+                for r in ratings:
+                    pid = resolved_rating_ids.get(r.get("page_id", ""))
                     score = r.get("score")
                     if pid and isinstance(score, int):
                         await db.save_page_rating(
@@ -879,7 +902,7 @@ async def run_closing_review(
         return None
 
 
-def format_moves_for_review(moves: list[Move]) -> str:
+def format_moves_for_review(moves: Sequence[Move]) -> str:
     """Format moves as readable text for closing review context."""
     if not moves:
         return "(no moves)"

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -53,8 +53,8 @@ _B2_SEMAPHORE = asyncio.Semaphore(15)
 
 async def _record_context_built(
     infra: CallInfra,
-    working_page_ids: list[str],
-    preloaded_ids: list[str],
+    working_page_ids: Sequence[str],
+    preloaded_ids: Sequence[str],
     *,
     source_page_id: str | None = None,
     scout_mode: str | None = None,
@@ -422,12 +422,12 @@ async def _select_sensitive_pages(
     user_message_parts = [f"## Question\n\n**{question.headline}**"]
     if latest_judgement:
         user_message_parts.append(
-            f"## Judgement\n\n"
+            "## Judgement\n\n"
             f"**{latest_judgement.headline}**\n\n"
             f"{latest_judgement.content}"
         )
     user_message_parts.append(
-        f"## Candidate pages\n\n"
+        "## Candidate pages\n\n"
         f"Pick the {limit} pages whose content the judgement is most "
         f"sensitive to.\n\n{page_list}"
     )
@@ -626,11 +626,8 @@ async def _cites_superseded_pages(page: Page, db: DB) -> bool:
     short_ids = set(_CITATION_RE.findall(page.content))
     if not short_ids:
         return False
-    full_ids: list[str] = []
-    for sid in short_ids:
-        resolved = await db.resolve_page_id(sid)
-        if resolved:
-            full_ids.append(resolved)
+    resolved_map = await db.resolve_page_ids(list(short_ids))
+    full_ids = list(resolved_map.values())
     if not full_ids:
         return False
     cited_pages = await db.get_pages_by_ids(full_ids)
@@ -638,7 +635,7 @@ async def _cites_superseded_pages(page: Page, db: DB) -> bool:
 
 
 async def _reassess_pages_citing_superseded(
-    connected: list[tuple[Page, PageLink]],
+    connected: Sequence[tuple[Page, PageLink]],
     question: Page,
     latest_judgement: Page | None,
     infra: CallInfra,
@@ -701,7 +698,7 @@ async def _reassess_pages_citing_superseded(
 
 
 async def _find_higher_quality_replacements(
-    connected: list[tuple[Page, PageLink]],
+    connected: Sequence[tuple[Page, PageLink]],
     question: Page,
     latest_judgement: Page | None,
     infra: CallInfra,
@@ -778,7 +775,7 @@ async def _find_higher_quality_replacements(
         ][:10]
 
     async def _check_replacements(
-        page: Page, candidates: list[tuple[Page, float]],
+        page: Page, candidates: Sequence[tuple[Page, float]],
     ) -> set[str]:
         async with _B2_SEMAPHORE:
             target_text = await format_page(
@@ -1015,12 +1012,13 @@ class BigAssessContext(ContextBuilder):
         context_text = result.context_text
         already_in_context = set(working_page_ids) | {infra.question_id} | exclude_ids
         if all_extra:
+            extra_pages = await db.get_pages_by_ids(all_extra)
             parts: list[str] = []
             for pid in all_extra:
                 if pid in already_in_context:
                     continue
                 already_in_context.add(pid)
-                page = await db.get_page(pid)
+                page = extra_pages.get(pid)
                 if page and page.is_active():
                     parts += [
                         "",

--- a/src/rumil/clean/common.py
+++ b/src/rumil/clean/common.py
@@ -264,15 +264,15 @@ async def reassess_claim(
     if linked_text:
         user_parts.append(f"## Linked pages\n\n{linked_text}")
     user_parts.append(
-        f"## Claim to reassess\n\n"
+        "## Claim to reassess\n\n"
         f"**Headline:** {old_page.headline}\n"
         f"**ID:** `{old_page.id[:8]}`\n\n"
         f"{old_page.content}"
     )
     if findings:
         user_parts.append(
-            f"## Web research findings\n\n"
-            f"The following findings directly bear on this claim:\n\n"
+            "## Web research findings\n\n"
+            "The following findings directly bear on this claim:\n\n"
             f"{findings}"
         )
 

--- a/src/rumil/clean/feedback.py
+++ b/src/rumil/clean/feedback.py
@@ -206,9 +206,9 @@ def _make_investigation_tools(
                             "type": "text",
                             "text": (
                                 f"Rejected: requested budget {budget} exceeds "
-                                f"remaining investigation budget of "
+                                "remaining investigation budget of "
                                 f"{budget_remaining}. "
-                                f"Use a smaller budget or skip this investigation."
+                                "Use a smaller budget or skip this investigation."
                             ),
                         }
                     ]
@@ -279,8 +279,8 @@ def _make_investigation_tools(
                         f'"{display_headline}" (budget {budget}). '
                         f"Remaining investigation budget: {budget_remaining}. "
                         f"{len(pending)} investigation(s) now running in the "
-                        f"background. Call collect_investigations when you are "
-                        f"done dispatching to wait for results."
+                        "background. Call collect_investigations when you are "
+                        "done dispatching to wait for results."
                     ),
                 }
             ]
@@ -493,7 +493,7 @@ async def run_feedback_update(
         log.info("Stage 3 complete")
 
         call.result_summary = (
-            f"Feedback update complete: "
+            "Feedback update complete: "
             f"{total_ops} propagation operations executed "
             f"in {len(plan.waves)} waves."
         )

--- a/src/rumil/clean/grounding.py
+++ b/src/rumil/clean/grounding.py
@@ -500,22 +500,22 @@ async def _build_identification_user_message(
             f'<claim_findings index="{i}" claim="{task.claim}">\n'
             f"Search task: {task.search_task}\n\n"
             f"{task_findings}\n"
-            f"</claim_findings>"
+            "</claim_findings>"
         )
     findings_text = "\n\n".join(findings_text_parts)
 
     return (
-        f"<briefing>\n"
-        f"The following briefing was prepared from an evaluation of the "
-        f"workspace's evidential grounding. It identifies claims with "
-        f"grounding issues and lists the relevant workspace page IDs.\n\n"
+        "<briefing>\n"
+        "The following briefing was prepared from an evaluation of the "
+        "workspace's evidential grounding. It identifies claims with "
+        "grounding issues and lists the relevant workspace page IDs.\n\n"
         f"{briefing}\n"
-        f"</briefing>\n\n"
-        f"<web_research_findings>\n"
-        f"Web research agents investigated the issues outlined in the "
-        f"briefing above. Here is what they found.\n\n"
+        "</briefing>\n\n"
+        "<web_research_findings>\n"
+        "Web research agents investigated the issues outlined in the "
+        "briefing above. Here is what they found.\n\n"
         f"{findings_text}\n"
-        f"</web_research_findings>"
+        "</web_research_findings>"
     )
 
 

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -547,17 +547,17 @@ async def format_page(
                 )
             return (
                 f'{original}\n\n'
-                f'> **SUPERSEDED** — this page has been replaced by'
+                '> **SUPERSEDED** — this page has been replaced by'
                 f' `{replacement.id[:8]}` ({replacement.headline}).'
-                f' Current version:\n\n'
+                ' Current version:\n\n'
                 f'{replacement_text}'
             )
         if detail == PageDetail.HEADLINE:
             return f'[SUPERSEDED] {original}'
         return (
             f'{original}\n\n'
-            f'> **SUPERSEDED** — this page has been replaced'
-            f' (replacement not found).'
+            '> **SUPERSEDED** — this page has been replaced'
+            ' (replacement not found).'
         )
 
     if detail != PageDetail.HEADLINE and not page.content and db:
@@ -611,10 +611,13 @@ async def format_page(
             linked_items.append((line, j))
 
         children = await source.get_child_questions(page.id)
+        child_judgements = await source.get_judgements_for_questions(
+            [child.id for child in children if child.id not in _exclude]
+        )
         for child in children:
             if child.id in _exclude:
                 continue
-            for j in await source.get_judgements_for_question(child.id):
+            for j in child_judgements.get(child.id, []):
                 if j.id in _exclude:
                     continue
                 line = (
@@ -749,8 +752,11 @@ async def format_question_for_find_considerations(
         all_con_items.append((await format_page(j, PageDetail.HEADLINE), j))
 
     children = await source.get_child_questions(question_id)
+    child_judgements = await source.get_judgements_for_questions(
+        [c.id for c in children]
+    )
     for child in children:
-        for j in await source.get_judgements_for_question(child.id):
+        for j in child_judgements.get(child.id, []):
             loaded_ids.append(j.id)
             line = (
                 f"*On sub-question: {child.headline} (`{child.id}`)*\n"
@@ -1049,10 +1055,8 @@ async def build_embedding_based_context(
 
     if require_judgement_for_questions:
         question_ids = [p.id for p, _ in ranked if p.page_type == PageType.QUESTION]
-        has_judgement: set[str] = set()
-        for qid in question_ids:
-            if await db.get_judgements_for_question(qid):
-                has_judgement.add(qid)
+        judgements_by_qid = await db.get_judgements_for_questions(question_ids)
+        has_judgement = {qid for qid, js in judgements_by_qid.items() if js}
         ranked = [
             (p, s) for p, s in ranked
             if p.page_type != PageType.QUESTION or p.id in has_judgement

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -233,10 +233,14 @@ async def build_scout_context(
 
     considerations = await source.get_considerations_for_question(question_id)
     children = await source.get_child_questions(question_id)
-    child_judgements: list[tuple[Page, Page]] = []
-    for child in children:
-        for j in await source.get_judgements_for_question(child.id):
-            child_judgements.append((child, j))
+    child_judgements_by_qid = await source.get_judgements_for_questions(
+        [c.id for c in children]
+    )
+    child_judgements: list[tuple[Page, Page]] = [
+        (child, j)
+        for child in children
+        for j in child_judgements_by_qid.get(child.id, [])
+    ]
 
     if considerations or children or child_judgements:
         direct_items: list[tuple[str, Page]] = []
@@ -268,12 +272,23 @@ async def build_scout_context(
     headline_ids: list[str] = []
 
     if ancestry:
+        ancestor_ids = {a.id for a in ancestry}
+        siblings_by_ancestor: dict[str, list[Page]] = {
+            a.id: await source.get_child_questions(a.id) for a in ancestry
+        }
+        judgement_qids: list[str] = [a.id for a in ancestry]
+        for sibs in siblings_by_ancestor.values():
+            for sib in sibs:
+                if sib.id != question_id and sib.id not in ancestor_ids:
+                    judgement_qids.append(sib.id)
+        judgements_by_qid = await source.get_judgements_for_questions(judgement_qids)
+
         headline_lines.append('## Ancestry & Siblings')
         headline_lines.append('')
         for ancestor in reversed(ancestry):
             structural_ids.add(ancestor.id)
             headline_lines.append(await format_page(ancestor, PageDetail.HEADLINE))
-            a_judgements = await source.get_judgements_for_question(ancestor.id)
+            a_judgements = judgements_by_qid.get(ancestor.id, [])
             if a_judgements:
                 latest = max(a_judgements, key=lambda j: j.created_at)
                 headline_lines.append(
@@ -281,16 +296,16 @@ async def build_scout_context(
                 )
                 headline_ids.append(latest.id)
                 structural_ids.add(latest.id)
-            siblings = await source.get_child_questions(ancestor.id)
+            siblings = siblings_by_ancestor[ancestor.id]
             for sib in siblings:
-                if sib.id == question_id or any(a.id == sib.id for a in ancestry):
+                if sib.id == question_id or sib.id in ancestor_ids:
                     continue
                 headline_lines.append(
                     '  ' + await format_page(sib, PageDetail.HEADLINE)
                 )
                 headline_ids.append(sib.id)
                 structural_ids.add(sib.id)
-                sib_judgements = await source.get_judgements_for_question(sib.id)
+                sib_judgements = judgements_by_qid.get(sib.id, [])
                 if sib_judgements:
                     latest = max(sib_judgements, key=lambda j: j.created_at)
                     headline_lines.append(

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -387,8 +387,6 @@ class DB:
             for r in rows
         ]
 
-    # --- Pages ---
-
     async def save_page(self, page: Page) -> None:
         log.debug(
             "save_page: id=%s, type=%s, headline=%s",
@@ -847,8 +845,6 @@ class DB:
 
         return result
 
-    # --- Links ---
-
     async def save_link(self, link: PageLink) -> None:
         log.debug(
             "save_link: %s -> %s, type=%s",
@@ -916,6 +912,31 @@ class DB:
         applied = await self._apply_link_events(all_links)
         for link in applied:
             result.setdefault(link.from_page_id, []).append(link)
+        return result
+
+    async def get_links_to_many(
+        self, page_ids: Sequence[str],
+    ) -> dict[str, list[PageLink]]:
+        """Bulk-fetch incoming links for many pages. Returns {page_id: [links]}."""
+        result: dict[str, list[PageLink]] = {pid: [] for pid in page_ids}
+        if not page_ids:
+            return result
+        id_list = list(dict.fromkeys(page_ids))
+        batch_size = 200
+        all_links: list[PageLink] = []
+        for start in range(0, len(id_list), batch_size):
+            batch = id_list[start:start + batch_size]
+            query = (
+                self.client.table("page_links")
+                .select("*")
+                .in_("to_page_id", batch)
+            )
+            query = self._staged_filter(query)
+            rows = _rows(await self._execute(query))
+            all_links.extend(_row_to_link(r) for r in rows)
+        applied = await self._apply_link_events(all_links)
+        for link in applied:
+            result.setdefault(link.to_page_id, []).append(link)
         return result
 
     async def get_latest_summary_for_question(self, question_id: str) -> "Page | None":
@@ -1141,8 +1162,6 @@ class DB:
             return payload.get("change_magnitude")
         return None
 
-    # --- Calls ---
-
     async def create_call(
         self,
         call_type: CallType,
@@ -1253,8 +1272,6 @@ class DB:
                 {"call_id": call_id, "amount": amount},
             )
         )
-
-    # --- Per-run budget ---
 
     async def init_budget(self, total: int) -> None:
         await self._execute(
@@ -1483,9 +1500,7 @@ class DB:
             out.setdefault(row["source_id"], []).append(row["question_id"])
         return out
 
-    # --- Traces ---
-
-    async def save_call_trace(self, call_id: str, events: list[dict]) -> None:
+    async def save_call_trace(self, call_id: str, events: Sequence[dict]) -> None:
         """Append trace events to the call's trace_json column."""
         await self._execute(
             self.client.rpc(
@@ -1825,7 +1840,7 @@ class DB:
         system_prompt: str | None,
         user_message: str | None,
         response_text: str | None,
-        tool_calls: list[dict] | None = None,
+        tool_calls: Sequence[dict] | None = None,
         input_tokens: int | None = None,
         output_tokens: int | None = None,
         error: str | None = None,
@@ -1833,7 +1848,7 @@ class DB:
         round_num: int | None = None,
         cache_creation_input_tokens: int | None = None,
         cache_read_input_tokens: int | None = None,
-        user_messages: list[dict] | None = None,
+        user_messages: Sequence[dict] | None = None,
     ) -> str:
         exchange_id = str(uuid.uuid4())
         row: dict[str, Any] = {

--- a/src/rumil/evaluate/explore.py
+++ b/src/rumil/evaluate/explore.py
@@ -7,7 +7,6 @@ Produces a tiered text view of the local graph around a page:
 - Frontier connections beyond O hops are indicated but not expanded.
 """
 
-from collections import deque
 from collections.abc import Sequence
 
 from rumil.context import format_page
@@ -107,35 +106,39 @@ async def _bfs(
 ) -> tuple[dict[str, int], dict[str, set[str]]]:
     """BFS from *start_id* up to *max_hops*.
 
+    Issues two batched link queries (links_from + links_to) per BFS level,
+    so total round trips are O(max_hops) regardless of fan-out.
+
     Returns (visited, neighbor_map) where:
     - visited maps page_id → minimum hop distance
     - neighbor_map maps page_id → set of all neighbor page_ids (including beyond max_hops)
     """
-    visited: dict[str, int] = {}
+    visited: dict[str, int] = {start_id: 0}
     neighbor_map: dict[str, set[str]] = {}
-    queue: deque[tuple[str, int]] = deque([(start_id, 0)])
+    frontier: list[str] = [start_id]
+    dist = 0
 
-    while queue:
-        pid, dist = queue.popleft()
-        if pid in visited:
-            continue
-        if dist > max_hops:
-            continue
-        visited[pid] = dist
+    while frontier and dist <= max_hops:
+        links_from_map = await db.get_links_from_many(frontier)
+        links_to_map = await db.get_links_to_many(frontier)
 
-        links_from = await db.get_links_from(pid)
-        links_to = await db.get_links_to(pid)
+        next_frontier: list[str] = []
+        for pid in frontier:
+            neighbors: set[str] = set()
+            for link in links_from_map.get(pid, []):
+                neighbors.add(link.to_page_id)
+            for link in links_to_map.get(pid, []):
+                neighbors.add(link.from_page_id)
+            neighbor_map[pid] = neighbors
 
-        neighbors: set[str] = set()
-        for link in links_from:
-            neighbors.add(link.to_page_id)
-        for link in links_to:
-            neighbors.add(link.from_page_id)
-        neighbor_map[pid] = neighbors
+            if dist < max_hops:
+                for neighbor_id in neighbors:
+                    if neighbor_id not in visited:
+                        visited[neighbor_id] = dist + 1
+                        next_frontier.append(neighbor_id)
 
-        for neighbor_id in neighbors:
-            if neighbor_id not in visited:
-                queue.append((neighbor_id, dist + 1))
+        frontier = next_frontier
+        dist += 1
 
     return visited, neighbor_map
 

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -130,13 +130,13 @@ def build_user_message(context_text: str, task_description: str) -> str:
 _CACHE_BREAKPOINT = {"type": "ephemeral"}
 
 
-def _add_cache_breakpoint(messages: list[dict]) -> list[dict]:
+def _add_cache_breakpoint(messages: Sequence[dict]) -> list[dict]:
     """Return a shallow copy of messages with a cache breakpoint on the last block.
 
     Mutates nothing — copies only the last message and its content.
     """
     if not messages:
-        return messages
+        return list(messages)
     msgs = list(messages)
     last = dict(msgs[-1])
     content = last.get("content")
@@ -183,7 +183,7 @@ def _extract_json(text: str) -> dict:
     raise ValueError(f"No JSON found in response: {text[:200]}")
 
 
-def _serialize_messages(messages: list[dict]) -> list[dict]:
+def _serialize_messages(messages: Sequence[dict]) -> list[dict]:
     """Serialize messages for JSON storage, converting SDK objects to dicts."""
     result = []
     for msg in messages:

--- a/src/rumil/mapper.py
+++ b/src/rumil/mapper.py
@@ -71,26 +71,28 @@ def _render_consideration(claim: Page, link, parent_question_id: str) -> str:
     )
     btn = (
         f"{_budget_select(sel_id)}"
-        f'<button class="inv-btn" onclick="copyCmd(this, '
+        '<button class="inv-btn" onclick="copyCmd(this, '
         f"'python main.py --add-question &quot;{js_summary[:80]}&quot; "
         f"--parent {parent_question_id} --budget ' + "
         f"document.getElementById('{sel_id}').value)\">"
-        f"Dig into this</button>"
+        "Dig into this</button>"
     )
 
-    return f"""<div class="consideration" style="background:{color}">
-  <details>
-    <summary>
-      <span class="stars" title="Strength {link.strength:.1f}">{stars}</span>
-      <span class="summary-text">{escape(short)}</span>
-    </summary>
-    <div class="expanded">
-      <p class="epistemic">{epistemic}</p>
-      <p class="body">{escape(claim.content)}</p>
-      <div class="action-row">{source_link}<span class="action-gap"></span>{btn}</div>
-    </div>
-  </details>
-</div>"""
+    return (
+        f'<div class="consideration" style="background:{color}">\n'
+        '  <details>\n'
+        '    <summary>\n'
+        f'      <span class="stars" title="Strength {link.strength:.1f}">{stars}</span>\n'
+        f'      <span class="summary-text">{escape(short)}</span>\n'
+        '    </summary>\n'
+        '    <div class="expanded">\n'
+        f'      <p class="epistemic">{epistemic}</p>\n'
+        f'      <p class="body">{escape(claim.content)}</p>\n'
+        f'      <div class="action-row">{source_link}<span class="action-gap"></span>{btn}</div>\n'
+        '    </div>\n'
+        '  </details>\n'
+        '</div>'
+    )
 
 
 def _render_judgement(j: Page, index: int, total: int) -> str:
@@ -105,20 +107,22 @@ def _render_judgement(j: Page, index: int, total: int) -> str:
     if sens:
         meta += f'<p class="meta"><strong>Sensitivity:</strong> {escape(sens)}</p>'
 
-    return f"""<div class="judgement" style="background:{color}">
-  <details>
-    <summary>
-      <span class="j-label">{label}</span>
-      <span class="conf-badge">C{j.credence}/R{j.robustness}</span>
-      <span class="summary-text">{escape(j.headline[:100])}</span>
-    </summary>
-    <div class="expanded">
-      <p class="epistemic">Credence: {j.credence}/9 | Robustness: {j.robustness}/5</p>
-      <p class="body">{escape(j.content)}</p>
-      {meta}
-    </div>
-  </details>
-</div>"""
+    return (
+        f'<div class="judgement" style="background:{color}">\n'
+        '  <details>\n'
+        '    <summary>\n'
+        f'      <span class="j-label">{label}</span>\n'
+        f'      <span class="conf-badge">C{j.credence}/R{j.robustness}</span>\n'
+        f'      <span class="summary-text">{escape(j.headline[:100])}</span>\n'
+        '    </summary>\n'
+        '    <div class="expanded">\n'
+        f'      <p class="epistemic">Credence: {j.credence}/9 | Robustness: {j.robustness}/5</p>\n'
+        f'      <p class="body">{escape(j.content)}</p>\n'
+        f'      {meta}\n'
+        '    </div>\n'
+        '  </details>\n'
+        '</div>'
+    )
 
 
 async def _render_question(
@@ -188,100 +192,89 @@ async def _render_question(
     q_sel_id = f"qb-{question_id[:8]}"
     q_btn = (
         f'<div class="q-action-row">{_budget_select(q_sel_id)}'
-        f'<button class="inv-btn" onclick="copyCmd(this, '
+        '<button class="inv-btn" onclick="copyCmd(this, '
         f"'python main.py --continue {question_id} --budget ' + "
         f"document.getElementById('{q_sel_id}').value)\">"
-        f"Investigate further</button></div>"
+        "Investigate further</button></div>"
     )
 
     hn = min(depth + 2, 6)
-    return f"""<div class="q-node depth-{depth}">
-  <h{hn} class="q-heading">{escape(question.headline)}</h{hn}>
-  <p class="q-stats">{stats}</p>
-  {q_btn}
-  {j_html}{c_html}{ch_html}
-</div>"""
+    return (
+        f'<div class="q-node depth-{depth}">\n'
+        f'  <h{hn} class="q-heading">{escape(question.headline)}</h{hn}>\n'
+        f'  <p class="q-stats">{stats}</p>\n'
+        f'  {q_btn}\n'
+        f'  {j_html}{c_html}{ch_html}\n'
+        '</div>'
+    )
 
 
-_CSS = """
-* { box-sizing: border-box; margin: 0; padding: 0; }
-body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-size: 15px; line-height: 1.55; color: #1a1a1a;
-  background: #f4f4ef; padding: 2rem;
-}
-h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
-h2 { font-size: 1.25rem; margin-bottom: 0.6rem; color: #222; }
-h3 { font-size: 1.1rem;  margin-bottom: 0.5rem; color: #333; }
-h4 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: .06em;
-     color: #999; margin: 0.9rem 0 0.35rem; }
-h5, h6 { font-size: 0.95rem; margin-bottom: 0.35rem; color: #444; }
-
-.subtitle { font-size: 0.9rem; color: #888; margin-bottom: 1.5rem; }
-
-.q-node {
-  background: #fff; border: 1px solid #ddd; border-radius: 8px;
-  padding: 1.1rem 1.4rem; margin-bottom: 0.9rem;
-}
-.q-node.depth-0 { border-left: 4px solid #4a90d9; }
-.q-node.depth-1 { border-left: 4px solid #7ab5e8; margin-left: 1.5rem; }
-.q-node.depth-2 { border-left: 4px solid #a8cff0; margin-left: 3rem;   }
-.q-node.depth-3 { border-left: 4px solid #c5dff5; margin-left: 4.5rem; }
-.q-node.depth-4 { border-left: 4px solid #ddeef8; margin-left: 6rem;   }
-
-.q-heading { margin-bottom: 0.15rem; }
-.q-stats   { font-size: 0.78rem; color: #aaa; margin-bottom: 0.2rem; }
-
-.section { margin-top: 0.5rem; }
-
-.consideration, .judgement {
-  border-radius: 5px; margin-bottom: 0.35rem;
-  padding: 0.35rem 0.6rem; border: 1px solid rgba(0,0,0,.07);
-}
-.consideration          { border-left: 3px solid #9e9e9e; }
-.judgement              { border-left: 3px solid #9c27b0; }
-
-details > summary {
-  cursor: pointer; list-style: none;
-  display: flex; align-items: baseline; gap: 0.35rem;
-}
-details > summary::-webkit-details-marker { display: none; }
-details[open] > summary { margin-bottom: 0.35rem; }
-
-.stars    { color: #c89200; font-size: 0.82rem; flex-shrink: 0; }
-.summary-text { font-size: 0.88rem; }
-
-.j-label    { font-size: 0.72rem; background: #9c27b0; color: #fff;
-              border-radius: 3px; padding: 0 5px; flex-shrink: 0; }
-.conf-badge { font-size: 0.75rem; color: #777; flex-shrink: 0; }
-
-.expanded {
-  padding-top: 0.5rem; border-top: 1px solid rgba(0,0,0,.07);
-}
-.epistemic { font-size: 0.76rem; color: #888; font-style: italic; margin-bottom: 0.35rem; }
-.body      { font-size: 0.88rem; margin-bottom: 0.4rem; white-space: pre-wrap; }
-.meta      { font-size: 0.8rem;  color: #666; margin-top: 0.3rem; }
-
-.source-link { font-size: 0.76rem; color: #4a90d9; text-decoration: none; }
-.source-link:hover { text-decoration: underline; }
-
-.footer { font-size: 0.72rem; color: #ccc; margin-top: 2rem; text-align: center; }
-
-.action-row   { display: flex; align-items: center; gap: 0.4rem; margin-top: 0.5rem; }
-.q-action-row { display: flex; align-items: center; gap: 0.4rem; margin: 0.25rem 0 0.4rem; }
-.action-gap   { flex: 1; }
-
-.budget-select {
-  font-size: 0.75rem; border: 1px solid #ccc; border-radius: 4px;
-  padding: 2px 4px; background: #fff; color: #444; cursor: pointer;
-}
-.inv-btn {
-  font-size: 0.75rem; padding: 3px 9px; border-radius: 4px; border: 1px solid #bbb;
-  background: #f0f0f0; color: #333; cursor: pointer; transition: background 0.15s;
-}
-.inv-btn:hover   { background: #e0e8f5; border-color: #4a90d9; color: #1a1a1a; }
-.inv-btn.copied  { background: #d4edda; border-color: #4caf50; color: #2e7d32; }
-"""
+_CSS = (
+    "* { box-sizing: border-box; margin: 0; padding: 0; }\n"
+    "body {"
+    "  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+    "  font-size: 15px; line-height: 1.55; color: #1a1a1a;"
+    "  background: #f4f4ef; padding: 2rem;"
+    "}\n"
+    "h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }\n"
+    "h2 { font-size: 1.25rem; margin-bottom: 0.6rem; color: #222; }\n"
+    "h3 { font-size: 1.1rem;  margin-bottom: 0.5rem; color: #333; }\n"
+    "h4 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: .06em;"
+    "     color: #999; margin: 0.9rem 0 0.35rem; }\n"
+    "h5, h6 { font-size: 0.95rem; margin-bottom: 0.35rem; color: #444; }\n"
+    ".subtitle { font-size: 0.9rem; color: #888; margin-bottom: 1.5rem; }\n"
+    ".q-node {"
+    "  background: #fff; border: 1px solid #ddd; border-radius: 8px;"
+    "  padding: 1.1rem 1.4rem; margin-bottom: 0.9rem;"
+    "}\n"
+    ".q-node.depth-0 { border-left: 4px solid #4a90d9; }\n"
+    ".q-node.depth-1 { border-left: 4px solid #7ab5e8; margin-left: 1.5rem; }\n"
+    ".q-node.depth-2 { border-left: 4px solid #a8cff0; margin-left: 3rem;   }\n"
+    ".q-node.depth-3 { border-left: 4px solid #c5dff5; margin-left: 4.5rem; }\n"
+    ".q-node.depth-4 { border-left: 4px solid #ddeef8; margin-left: 6rem;   }\n"
+    ".q-heading { margin-bottom: 0.15rem; }\n"
+    ".q-stats   { font-size: 0.78rem; color: #aaa; margin-bottom: 0.2rem; }\n"
+    ".section { margin-top: 0.5rem; }\n"
+    ".consideration, .judgement {"
+    "  border-radius: 5px; margin-bottom: 0.35rem;"
+    "  padding: 0.35rem 0.6rem; border: 1px solid rgba(0,0,0,.07);"
+    "}\n"
+    ".consideration          { border-left: 3px solid #9e9e9e; }\n"
+    ".judgement              { border-left: 3px solid #9c27b0; }\n"
+    "details > summary {"
+    "  cursor: pointer; list-style: none;"
+    "  display: flex; align-items: baseline; gap: 0.35rem;"
+    "}\n"
+    "details > summary::-webkit-details-marker { display: none; }\n"
+    "details[open] > summary { margin-bottom: 0.35rem; }\n"
+    ".stars    { color: #c89200; font-size: 0.82rem; flex-shrink: 0; }\n"
+    ".summary-text { font-size: 0.88rem; }\n"
+    ".j-label    { font-size: 0.72rem; background: #9c27b0; color: #fff;"
+    "              border-radius: 3px; padding: 0 5px; flex-shrink: 0; }\n"
+    ".conf-badge { font-size: 0.75rem; color: #777; flex-shrink: 0; }\n"
+    ".expanded {"
+    "  padding-top: 0.5rem; border-top: 1px solid rgba(0,0,0,.07);"
+    "}\n"
+    ".epistemic { font-size: 0.76rem; color: #888; font-style: italic; margin-bottom: 0.35rem; }\n"
+    ".body      { font-size: 0.88rem; margin-bottom: 0.4rem; white-space: pre-wrap; }\n"
+    ".meta      { font-size: 0.8rem;  color: #666; margin-top: 0.3rem; }\n"
+    ".source-link { font-size: 0.76rem; color: #4a90d9; text-decoration: none; }\n"
+    ".source-link:hover { text-decoration: underline; }\n"
+    ".footer { font-size: 0.72rem; color: #ccc; margin-top: 2rem; text-align: center; }\n"
+    ".action-row   { display: flex; align-items: center; gap: 0.4rem; margin-top: 0.5rem; }\n"
+    ".q-action-row { display: flex; align-items: center; gap: 0.4rem; margin: 0.25rem 0 0.4rem; }\n"
+    ".action-gap   { flex: 1; }\n"
+    ".budget-select {"
+    "  font-size: 0.75rem; border: 1px solid #ccc; border-radius: 4px;"
+    "  padding: 2px 4px; background: #fff; color: #444; cursor: pointer;"
+    "}\n"
+    ".inv-btn {"
+    "  font-size: 0.75rem; padding: 3px 9px; border-radius: 4px; border: 1px solid #bbb;"
+    "  background: #f0f0f0; color: #333; cursor: pointer; transition: background 0.15s;"
+    "}\n"
+    ".inv-btn:hover   { background: #e0e8f5; border-color: #4a90d9; color: #1a1a1a; }\n"
+    ".inv-btn.copied  { background: #d4edda; border-color: #4caf50; color: #2e7d32; }\n"
+)
 
 
 async def generate_map(question_id: str, db: DB) -> Path:
@@ -299,36 +292,39 @@ async def generate_map(question_id: str, db: DB) -> Path:
     slug = slug.strip().replace(" ", "-").lower()
     output_path = MAPS_DIR / f"{timestamp}-{slug}.html"
 
-    html = f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Research Map: {escape(question.headline[:60])}</title>
-  <style>{_CSS}</style>
-  <script>
-  function copyCmd(btn, cmd) {{
-    navigator.clipboard.writeText(cmd).then(function() {{
-      var orig = btn.textContent;
-      btn.textContent = 'Copied!';
-      btn.classList.add('copied');
-      setTimeout(function() {{
-        btn.textContent = orig;
-        btn.classList.remove('copied');
-      }}, 1800);
-    }}).catch(function() {{
-      prompt('Copy this command:', cmd);
-    }});
-  }}
-  </script>
-</head>
-<body>
-  <p class="subtitle">Research Map</p>
-  <h1>{escape(question.headline)}</h1>
-  {tree_html}
-  <p class="footer">Generated {datetime.now(UTC).strftime("%Y-%m-%d %H:%M")} UTC</p>
-</body>
-</html>"""
+    generated_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M")
+    html = (
+        '<!DOCTYPE html>\n'
+        '<html lang="en">\n'
+        '<head>\n'
+        '  <meta charset="UTF-8">\n'
+        '  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n'
+        f'  <title>Research Map: {escape(question.headline[:60])}</title>\n'
+        f'  <style>{_CSS}</style>\n'
+        '  <script>\n'
+        '  function copyCmd(btn, cmd) {\n'
+        '    navigator.clipboard.writeText(cmd).then(function() {\n'
+        '      var orig = btn.textContent;\n'
+        "      btn.textContent = 'Copied!';\n"
+        "      btn.classList.add('copied');\n"
+        '      setTimeout(function() {\n'
+        '        btn.textContent = orig;\n'
+        "        btn.classList.remove('copied');\n"
+        '      }, 1800);\n'
+        '    }).catch(function() {\n'
+        "      prompt('Copy this command:', cmd);\n"
+        '    });\n'
+        '  }\n'
+        '  </script>\n'
+        '</head>\n'
+        '<body>\n'
+        '  <p class="subtitle">Research Map</p>\n'
+        f'  <h1>{escape(question.headline)}</h1>\n'
+        f'  {tree_html}\n'
+        f'  <p class="footer">Generated {generated_at} UTC</p>\n'
+        '</body>\n'
+        '</html>'
+    )
 
     output_path.write_text(html, encoding="utf-8")
     return output_path

--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -425,17 +425,20 @@ async def extract_and_link_citations(
     if not matches:
         return set()
 
-    citing_page = await db.get_page(page_id)
+    resolved_map = await db.resolve_page_ids(list(matches))
+    needed_ids = list({pid for pid in resolved_map.values()} | {page_id})
+    pages = await db.get_pages_by_ids(needed_ids)
+    citing_page = pages.get(page_id)
     citing_type = citing_page.page_type if citing_page else None
 
     linked: set[str] = set()
     for short_id in matches:
-        resolved = await db.resolve_page_id(short_id)
+        resolved = resolved_map.get(short_id)
         if not resolved:
             log.debug("Citation [%s] did not resolve to a page", short_id)
             continue
 
-        cited_page = await db.get_page(resolved)
+        cited_page = pages.get(resolved)
         if not cited_page:
             continue
 

--- a/src/rumil/moves/promote_concept.py
+++ b/src/rumil/moves/promote_concept.py
@@ -84,7 +84,7 @@ async def execute(payload: PromoteConceptPayload, call: Call, db: DB) -> MoveRes
     return MoveResult(
         message=(
             f"Promoted concept [{research_page.id[:8]}]: {research_page.headline}. "
-            f"Now active in research workspace."
+            "Now active in research workspace."
         ),
         created_page_id=research_page.id,
     )

--- a/src/rumil/moves/update_epistemic.py
+++ b/src/rumil/moves/update_epistemic.py
@@ -52,19 +52,17 @@ async def _context_check(
         return None
 
     state.context_page_ids.add(source_judgement.id)
-    formatted = await format_page(
-        source_judgement, PageDetail.CONTENT, db=state.db
-    )
+    formatted = await format_page(source_judgement, PageDetail.CONTENT, db=state.db)
     return MoveResult(
         f"Before updating scores on [{page_id[:8]}], please review the "
-        f"judgement that established the current scores "
+        "judgement that established the current scores "
         f"(C{score_entry['credence']}/R{score_entry['robustness']}):\n\n"
         f"**[{source_judgement.id[:8]}] {source_judgement.headline}**\n\n"
         f"{formatted}\n\n"
-        f"Reasoning for current scores: "
+        "Reasoning for current scores: "
         f"{score_entry.get('reasoning') or '(none)'}\n\n"
-        f"If you still want to update the scores after reviewing, "
-        f"call update_epistemic again with the same or modified values."
+        "If you still want to update the scores after reviewing, "
+        "call update_epistemic again with the same or modified values."
     )
 
 

--- a/src/rumil/orchestrators/base.py
+++ b/src/rumil/orchestrators/base.py
@@ -176,14 +176,15 @@ class BaseOrchestrator(ABC):
             seq_id = call_sequence.id
 
         pre_ids = [str(uuid.uuid4()) for _ in sequence]
-        resolves = []
-        headlines = []
-        for dispatch in sequence:
-            resolved = await self.db.resolve_page_id(dispatch.payload.question_id)
-            resolved = resolved or scope_question_id
-            resolves.append(resolved)
-            page = await self.db.get_page(resolved)
-            headlines.append(page.headline if page else '')
+        raw_qids = [d.payload.question_id for d in sequence]
+        resolved_map = await self.db.resolve_page_ids(raw_qids)
+        resolves = [resolved_map.get(qid) or scope_question_id for qid in raw_qids]
+        pages = await self.db.get_pages_by_ids(
+            [r for r in resolves if r is not None]
+        )
+        headlines = [
+            pages[r].headline if r in pages else '' for r in resolves
+        ]
 
         trace = get_trace()
         if trace:

--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -123,7 +123,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         effective = self._effective_budget(remaining)
         if effective < MIN_TWOPHASE_BUDGET:
             raise ValueError(
-                f'ClaimInvestigationOrchestrator requires a budget of at least '
+                'ClaimInvestigationOrchestrator requires a budget of at least '
                 f'{MIN_TWOPHASE_BUDGET}, got {effective}'
             )
         if self._parent_call_id:
@@ -175,7 +175,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                             )
                             await trace.record(ErrorEvent(
                                 message=(
-                                    f"Concurrent dispatch failed: "
+                                    "Concurrent dispatch failed: "
                                     f"{type(r).__name__}: {r}"
                                 ),
                                 phase="dispatch",
@@ -619,11 +619,14 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         await trace.record(DispatchesPlannedEvent(dispatches=all_trace_items))
 
         recurse_base = len(all_dispatches)
+        child_pages = await self.db.get_pages_by_ids(
+            [child_id for _, child_id in children]
+        )
         for ci, (child, child_id) in enumerate(children):
             child_call_id = await child.create_initial_call(
                 child_id, parent_call_id=p_call.id,
             )
-            child_page = await self.db.get_page(child_id)
+            child_page = child_pages.get(child_id)
             await trace.record(DispatchExecutedEvent(
                 index=recurse_base + ci,
                 child_call_type='recurse',

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -124,7 +124,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         effective = self._effective_budget(remaining)
         if effective < MIN_TWOPHASE_BUDGET:
             raise ValueError(
-                f'ExperimentalOrchestrator requires a budget of at least '
+                'ExperimentalOrchestrator requires a budget of at least '
                 f'{MIN_TWOPHASE_BUDGET}, got {effective}'
             )
         if self._parent_call_id:
@@ -171,7 +171,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                             )
                             await trace.record(ErrorEvent(
                                 message=(
-                                    f"Concurrent dispatch failed: "
+                                    "Concurrent dispatch failed: "
                                     f"{type(r).__name__}: {r}"
                                 ),
                                 phase="dispatch",
@@ -623,11 +623,14 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         await trace.record(DispatchesPlannedEvent(dispatches=all_trace_items))
 
         recurse_base = len(all_dispatches)
+        child_pages = await self.db.get_pages_by_ids(
+            [child_qid for _, child_qid in children]
+        )
         for ci, (child, child_qid) in enumerate(children):
             child_call_id = await child.create_initial_call(
                 child_qid, parent_call_id=p_call.id,
             )
-            child_page = await self.db.get_page(child_qid)
+            child_page = child_pages.get(child_qid)
             await trace.record(DispatchExecutedEvent(
                 index=recurse_base + ci,
                 child_call_type='recurse',

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -122,7 +122,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         effective = self._effective_budget(remaining)
         if effective < MIN_TWOPHASE_BUDGET:
             raise ValueError(
-                f'TwoPhaseOrchestrator requires a budget of at least '
+                'TwoPhaseOrchestrator requires a budget of at least '
                 f'{MIN_TWOPHASE_BUDGET}, got {effective}'
             )
         if self._parent_call_id:
@@ -174,7 +174,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                             )
                             await trace.record(ErrorEvent(
                                 message=(
-                                    f"Concurrent dispatch failed: "
+                                    "Concurrent dispatch failed: "
                                     f"{type(r).__name__}: {r}"
                                 ),
                                 phase="dispatch",
@@ -660,11 +660,14 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         await trace.record(DispatchesPlannedEvent(dispatches=all_trace_items))
 
         recurse_base = len(all_dispatches)
+        child_pages = await self.db.get_pages_by_ids(
+            [child_qid for _, child_qid in children]
+        )
         for ci, (child, child_qid) in enumerate(children):
             child_call_id = await child.create_initial_call(
                 child_qid, parent_call_id=p_call.id,
             )
-            child_page = await self.db.get_page(child_qid)
+            child_page = child_pages.get(child_qid)
             await trace.record(DispatchExecutedEvent(
                 index=recurse_base + ci,
                 child_call_type='recurse',

--- a/src/rumil/page_graph.py
+++ b/src/rumil/page_graph.py
@@ -158,6 +158,21 @@ class PageGraph:
                 result.append(page)
         return result
 
+    async def get_judgements_for_questions(
+        self,
+        question_ids: Sequence[str],
+    ) -> dict[str, list[Page]]:
+        """Bulk variant of get_judgements_for_question for many questions."""
+        result: dict[str, list[Page]] = {qid: [] for qid in question_ids}
+        for qid in question_ids:
+            for link in self._links_to.get(qid, []):
+                if link.link_type != LinkType.RELATED:
+                    continue
+                page = self._pages.get(link.from_page_id)
+                if page and page.is_active() and page.page_type == PageType.JUDGEMENT:
+                    result[qid].append(page)
+        return result
+
     async def get_parent_question(self, question_id: str) -> Page | None:
         """Return the parent question, or None if this is a root question."""
         for link in self._links_to.get(question_id, []):

--- a/src/rumil/sources.py
+++ b/src/rumil/sources.py
@@ -3,6 +3,7 @@ Source file reading, summarisation, and ingestion helpers.
 """
 
 import logging
+from collections.abc import Sequence
 from pathlib import Path
 
 from rumil.database import DB
@@ -139,7 +140,9 @@ async def _create_source_page_from_url(url: str, db: DB) -> Page | None:
     return page
 
 
-async def run_ingest_calls(source_pages: list[Page], question_id: str, db: DB) -> int:
+async def run_ingest_calls(
+    source_pages: Sequence[Page], question_id: str, db: DB
+) -> int:
     """Run ingest extraction calls for each source against a question. Returns calls made."""
     made = 0
     for source_page in source_pages:

--- a/tests/test_dispatch_types.py
+++ b/tests/test_dispatch_types.py
@@ -20,6 +20,7 @@ from rumil.models import (
 )
 from rumil.calls.page_creators import _resolve_round_mode
 from rumil.moves.base import MoveState
+from rumil.moves.create_question import CreateSubquestionPayload
 from rumil.settings import get_settings, override_settings
 
 
@@ -204,7 +205,6 @@ def test_allowed_find_considerations_modes_single():
 
 def test_filter_mode_schema_nested():
     """filter_mode_schema restricts FindConsiderationsMode in nested $defs."""
-    from rumil.moves.create_question import CreateSubquestionPayload
 
     schema = CreateSubquestionPayload.model_json_schema()
     filtered = filter_mode_schema(schema, [FindConsiderationsMode.ABSTRACT])

--- a/tests/test_embedding_context.py
+++ b/tests/test_embedding_context.py
@@ -181,12 +181,15 @@ async def test_require_judgement_filters_unjudged_questions(
     """Questions without judgements are excluded when require_judgement_for_questions is set."""
     db = mocker.AsyncMock()
 
-    async def fake_get_judgements(qid):
-        if qid == QUESTION_WITH_JUDGEMENT.id:
-            return [JUDGEMENT_PAGE]
-        return []
+    async def fake_get_judgements_many(qids):
+        return {
+            qid: [JUDGEMENT_PAGE] if qid == QUESTION_WITH_JUDGEMENT.id else []
+            for qid in qids
+        }
 
-    db.get_judgements_for_question = mocker.AsyncMock(side_effect=fake_get_judgements)
+    db.get_judgements_for_questions = mocker.AsyncMock(
+        side_effect=fake_get_judgements_many
+    )
 
     result = await build_embedding_based_context(
         "test query",

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -5,6 +5,7 @@ import re
 import pytest
 import pytest_asyncio
 
+from rumil.calls.assess import AssessCall
 from rumil.models import (
     Call,
     CallStatus,
@@ -319,7 +320,6 @@ async def test_assess_produces_inline_citations(tmp_db, question_page):
     )
     await tmp_db.save_call(call)
 
-    from rumil.calls.assess import AssessCall
 
     runner = AssessCall(question_page.id, call, tmp_db)
     await runner.run()

--- a/tests/test_investigate.py
+++ b/tests/test_investigate.py
@@ -2,15 +2,32 @@
 
 import pytest
 
+from rumil.models import Page, PageLayer, PageType, Workspace
 from rumil.orchestrators import Orchestrator
 
 
 @pytest.mark.integration
-async def test_investigate_creates_pages(tmp_db, question_page):
+async def test_investigate_creates_pages(tmp_db):
     """Investigation should produce at least one new page."""
+    question = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=(
+            "What are the main factors that determine whether a city's "
+            "investment in protected bike lanes leads to a sustained increase "
+            "in cycling commuting rates?"
+        ),
+        headline=(
+            "What determines whether protected bike lanes increase cycling "
+            "commute rates?"
+        ),
+    )
+    await tmp_db.save_page(question)
+
     await tmp_db.init_budget(4)
     orch = Orchestrator(tmp_db)
-    await orch.run(question_page.id)
+    await orch.run(question.id)
 
     rows = (
         await tmp_db.client.table("pages")
@@ -19,5 +36,5 @@ async def test_investigate_creates_pages(tmp_db, question_page):
         .execute()
     )
     page_ids = [r["id"] for r in rows.data]
-    new_ids = [pid for pid in page_ids if pid != question_page.id]
+    new_ids = [pid for pid in page_ids if pid != question.id]
     assert len(new_ids) >= 1, "Expected new pages, only found the original question"

--- a/tests/test_run_call.py
+++ b/tests/test_run_call.py
@@ -6,6 +6,7 @@ from rumil.calls.common import RunCallResult, run_call
 from rumil.calls.prioritization import run_prioritization_call
 from rumil.models import CallType, LinkType, MoveType, PageType
 from rumil.moves.base import MoveState
+from rumil.moves.registry import MOVES
 
 
 @pytest.mark.llm
@@ -40,7 +41,7 @@ async def test_scout_run_call(tmp_db, question_page, scout_call):
 async def test_prioritization_produces_dispatches(tmp_db, question_page, prioritization_call):
     """A prioritization call should produce at least one dispatch."""
     context = (
-        f"## Questions\n\n"
+        "## Questions\n\n"
         f"- `{question_page.id[:8]}`: {question_page.headline} (0 considerations)\n"
     )
     task = (
@@ -65,7 +66,6 @@ async def test_available_moves_restricts_tools(tmp_db, scout_call):
     """When available_moves is restricted, only those move types are bound."""
     allowed = [MoveType.CREATE_CLAIM, MoveType.LOAD_PAGE]
     state = MoveState(scout_call, tmp_db)
-    from rumil.moves.registry import MOVES
 
     tools = [MOVES[mt].bind(state) for mt in allowed]
 
@@ -78,7 +78,7 @@ async def test_available_moves_restricts_tools(tmp_db, scout_call):
 async def test_create_claim_with_inline_links(tmp_db, question_page, scout_call):
     """The LLM should create a claim linked as a consideration in a single tool call."""
     working_context = (
-        f"## Question\n\n"
+        "## Question\n\n"
         f"ID: `{question_page.id[:8]}`\n\n"
         f"{question_page.content}\n"
     )
@@ -117,7 +117,7 @@ async def test_create_claim_with_inline_links(tmp_db, question_page, scout_call)
 async def test_create_question_with_inline_links(tmp_db, question_page, scout_call):
     """The LLM should create a sub-question linked to its parent in a single tool call."""
     working_context = (
-        f"## Question\n\n"
+        "## Question\n\n"
         f"ID: `{question_page.id[:8]}`\n\n"
         f"{question_page.content}\n"
     )
@@ -156,7 +156,7 @@ async def test_create_question_with_inline_links(tmp_db, question_page, scout_ca
 async def test_create_judgement_with_inline_links(tmp_db, question_page, scout_call):
     """The LLM should create a judgement auto-linked to the scope question."""
     working_context = (
-        f"## Question\n\n"
+        "## Question\n\n"
         f"ID: `{question_page.id[:8]}`\n\n"
         f"{question_page.content}\n"
     )
@@ -196,7 +196,7 @@ async def test_create_subquestion_with_inline_dispatches(
 ):
     """Prioritization should create subquestions with inline dispatches."""
     context = (
-        f"## Questions\n\n"
+        "## Questions\n\n"
         f"- `{question_page.id[:8]}`: {question_page.headline} (0 considerations)\n"
     )
     task = (


### PR DESCRIPTION
## Summary
- Replaces per-node DB loops with batched fetches across `context.py`, `calls/common.py`, `calls/context_builders.py`, `moves/base.py`, the three orchestrators, `evaluate/explore.py` (now level-by-level BFS with O(depth) round trips), and the API trace builder (`api/app.py` parallelizes via `asyncio.gather`).
- Adds `DB.get_links_to_many` and a bulk `PageGraph.get_judgements_for_questions` so `format_page` and graph walks share a consistent batched API across the DB and PageGraph backends.
- Sweeps style conventions called out in CLAUDE.md: `mapper.py` triple-quoted HTML/CSS → parenthesized concatenation; drops `f` prefix from literals without placeholders; deletes `# --- Label ---` divider comments in `database.py` and `api/app.py`; hoists lazy imports to module top (cycle-breakers and `TYPE_CHECKING` blocks preserved); switches non-mutating `list[...]` params to `Sequence[...]` in `calls/common.py`, `calls/context_builders.py`, `llm.py`, `database.py`, and `sources.py`.
- Updates `tests/test_embedding_context.py` to mock the bulk `get_judgements_for_questions` (plural) used by the new code path.

## Test plan
- [x] `uv run pytest` — 192 passed, 36 skipped
- [x] `uv run pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)