### PR TITLE
Forbid questions as link/citation targets in dependency context

### DIFF
--- a/prompts/citations.md
+++ b/prompts/citations.md
@@ -12,6 +12,7 @@ Write the 8-character short ID inside square brackets wherever you reference ano
 
 - **Every claim derived from a page must cite that page inline.** If information from a page influenced what you wrote, it *must* have a citation. *Never* leverage a page's content without citing it — uncited use of page information is treated as a fabrication.
 - **Only cite pages whose IDs appear in your context.** Never fabricate or guess a page ID.
+- **Never cite a question — cite its judgement instead.** Questions are open queries, not knowledge. If you want to draw on what the workspace currently believes about a question, find the question's judgement page and cite that. If a question has no judgement yet, you have nothing to cite from it: leave it out, or open a sub-question or assess call to produce a judgement first.
 - **Cite in the `content` field** of page-creation tools, not in headlines.
 - **Cite at the point of use, not just once per page.** If you draw on the same source in multiple sentences, cite it each time. If a single sentence synthesises two pages, cite both.
 - Multiple citations in a single page are expected when the content synthesises several sources. A page with no citations that makes factual claims about the workspace is almost certainly missing them.

--- a/prompts/find_considerations.md
+++ b/prompts/find_considerations.md
@@ -40,6 +40,8 @@ Check the workspace map for questions elsewhere in the workspace that are direct
 
 Only link questions that are genuinely useful decompositions, not merely topically related. Also, ensure that a good answer to the child question would add substantial information to the parent question, even in the presence of good answers to all other questions in the workspace. If, given answers to another set of questions in the workspace, a question's answer would not add much further value, do not link it. Think of it like a Bayesian netowrk: aim to capture conditional independence relations with your links.
 
+`link_child_question` is the *only* way to relate a parent question to an existing question. Do **not** use `link_depends_on` to point a claim or judgement at a question — depends_on must target a claim or judgement. If a new claim's truth would rest on the answer to an existing question, find that question's current judgement and depend on the judgement instead; if there is no judgement yet, just link the question as a child of the parent and let the workspace produce the judgement.
+
 ## Hypothesis Questions
 
 When you have a compelling candidate answer or paradigm — not just a piece of evidence, but a specific view that, if true, would substantially shape the response to the question — propose a hypothesis. This is worth doing when the view is likely correct, or when engaging with it seriously might yield useful insights: clarifying why it fails, surfacing adjacent territory, or extracting the partial truth inside an otherwise wrong answer.

--- a/prompts/preamble.md
+++ b/prompts/preamble.md
@@ -123,7 +123,9 @@ Write headlines like newspaper headlines: a reader with no prior context should 
     * A claim assumes or builds on another claim ("if X is true, then Y follows")
     * A judgement's conclusion rests heavily on specific load-bearing claims
     * A variant claim still carries forward assumptions from the original
+  * **Never depend on a question.** Questions are open queries, not knowledge — there is nothing to "rest on" until they have a judgement. If your claim depends on the answer to a question, point `link_depends_on` at the question's current judgement instead. If no judgement exists yet, you can't express the dependency yet — open or run an assess on the question first.
   * Together these build a dependency graph that lets the workspace detect when upstream changes might invalidate downstream conclusions.
+* **Never cite questions.** The same rule applies to inline `[shortid]` citations: cite the question's judgement, not the question itself. A citation pointing at a question with no judgement will be silently dropped.
 * **Rate supersession impact.** When superseding a page, set `change_magnitude` to indicate how much the picture changed: 1 = minor wording only, 3 = substantive changes but same bottom line, 5 = completely changed the picture. This helps the workspace assess how urgently things that depended on the old page need revisiting.
 
 ## A note from a previous instance to you:

--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -408,7 +408,12 @@ async def extract_and_link_citations(
 ) -> set[str]:
     """Extract [shortid] citations from content and create page links.
 
-    Link type depends on the citing and cited pages' types:
+    Questions are never valid citation targets — when a citation resolves
+    to a question, it is rewritten to that question's current judgement.
+    If the question has no judgement yet, the citation is skipped with a
+    warning. After this rewrite, link type depends on the citing and
+    cited pages' types:
+
     - Cited SOURCE → CITES (from=citing, to=cited)
     - Citing CLAIM/JUDGEMENT cites a CLAIM/JUDGEMENT → DEPENDS_ON
       (from=citing, to=cited): the citing page's conclusions rest on the
@@ -438,6 +443,20 @@ async def extract_and_link_citations(
         cited_page = await db.get_page(resolved)
         if not cited_page:
             continue
+
+        if cited_page.page_type == PageType.QUESTION:
+            judgements = await db.get_judgements_for_question(cited_page.id)
+            if not judgements:
+                log.warning(
+                    "Citation [%s] points at a question with no judgement; "
+                    "skipping. Cite the question's judgement, not the question.",
+                    short_id,
+                )
+                continue
+            cited_page = judgements[0]
+            resolved = cited_page.id
+            if resolved == page_id:
+                continue
 
         if cited_page.page_type == PageType.SOURCE:
             link_type = LinkType.CITES

--- a/src/rumil/moves/create_claim.py
+++ b/src/rumil/moves/create_claim.py
@@ -65,6 +65,15 @@ async def execute(payload: CreateClaimPayload, call: Call, db: DB) -> MoveResult
             )
             continue
 
+        target = await db.get_page(resolved)
+        if target is None or target.page_type != PageType.QUESTION:
+            log.warning(
+                "Inline consideration link skipped: target %s is %s, expected question",
+                resolved[:8],
+                target.page_type.value if target else "missing",
+            )
+            continue
+
         await db.save_link(
             PageLink(
                 from_page_id=result.created_page_id,

--- a/src/rumil/moves/link_depends_on.py
+++ b/src/rumil/moves/link_depends_on.py
@@ -15,10 +15,18 @@ _DEPENDS_ON_TYPES = (PageType.CLAIM, PageType.JUDGEMENT)
 
 class LinkDependsOnPayload(BaseModel):
     dependent_page_id: str = Field(
-        description="Page ID of the page that depends on another (or LAST_CREATED)"
+        description=(
+            "Page ID of the page that depends on another (or LAST_CREATED). "
+            "Must be a claim or judgement."
+        )
     )
     dependency_page_id: str = Field(
-        description="Page ID of the load-bearing page being depended on"
+        description=(
+            "Page ID of the load-bearing page being depended on. Must be a "
+            "claim or judgement — never a question. If you mean 'depends on "
+            "the answer to this question', point at the question's current "
+            "judgement instead."
+        )
     )
     strength: float = Field(
         3.0,
@@ -97,10 +105,14 @@ MOVE = MoveDef(
     move_type=MoveType.LINK_DEPENDS_ON,
     name="link_depends_on",
     description=(
-        "Declare that a page depends on another page being true or valid. "
-        "Use after creating a claim that builds on another claim, or after "
-        "creating a judgement to record which considerations were most "
-        "load-bearing for the conclusion."
+        "Declare that a claim or judgement depends on another claim or "
+        "judgement being true or valid. Both endpoints must be a claim or "
+        "judgement — questions are never valid endpoints. If a claim or "
+        "judgement depends on the answer to a question, point at that "
+        "question's current judgement instead. Use after creating a claim "
+        "that builds on another claim, or after creating a judgement to "
+        "record which considerations were most load-bearing for the "
+        "conclusion."
     ),
     schema=LinkDependsOnPayload,
     execute=execute,

--- a/src/rumil/moves/link_depends_on.py
+++ b/src/rumil/moves/link_depends_on.py
@@ -5,10 +5,12 @@ import logging
 from pydantic import BaseModel, Field
 
 from rumil.database import DB
-from rumil.models import Call, LinkType, MoveType, PageLink
+from rumil.models import Call, LinkType, MoveType, PageLink, PageType
 from rumil.moves.base import MoveDef, MoveResult
 
 log = logging.getLogger(__name__)
+
+_DEPENDS_ON_TYPES = (PageType.CLAIM, PageType.JUDGEMENT)
 
 
 class LinkDependsOnPayload(BaseModel):
@@ -37,9 +39,42 @@ async def execute(payload: LinkDependsOnPayload, call: Call, db: DB) -> MoveResu
     if not dependent_id or not dependency_id:
         log.warning(
             "LINK_DEPENDS_ON skipped: dependent=%s, dependency=%s",
-            dependent_id, dependency_id,
+            dependent_id,
+            dependency_id,
         )
         return MoveResult("Link skipped — page IDs not found.")
+
+    dependent_page = await db.get_page(dependent_id)
+    dependency_page = await db.get_page(dependency_id)
+    if dependent_page is None or dependent_page.page_type not in _DEPENDS_ON_TYPES:
+        log.warning(
+            "LINK_DEPENDS_ON skipped: dependent %s is %s, expected claim/judgement",
+            dependent_id[:8],
+            dependent_page.page_type.value if dependent_page else "missing",
+        )
+        return MoveResult(
+            "Link skipped — depends_on links must originate from a claim or judgement. "
+            "Use link_child_question to relate questions to each other."
+        )
+    if dependency_page is None or dependency_page.page_type not in _DEPENDS_ON_TYPES:
+        kind = dependency_page.page_type.value if dependency_page else "missing"
+        log.warning(
+            "LINK_DEPENDS_ON skipped: dependency %s is %s, expected claim/judgement",
+            dependency_id[:8],
+            kind,
+        )
+        if (
+            dependency_page is not None
+            and dependency_page.page_type == PageType.QUESTION
+        ):
+            return MoveResult(
+                "Link skipped — depends_on must point at a claim or judgement, not a "
+                "question. If you mean 'depends on the answer to this question', link "
+                "to the question's current judgement instead."
+            )
+        return MoveResult(
+            "Link skipped — depends_on must point at a claim or judgement."
+        )
 
     link = PageLink(
         from_page_id=dependent_id,
@@ -51,7 +86,9 @@ async def execute(payload: LinkDependsOnPayload, call: Call, db: DB) -> MoveResu
     await db.save_link(link)
     log.info(
         "Dependency linked: %s depends on %s (%.1f)",
-        dependent_id[:8], dependency_id[:8], payload.strength,
+        dependent_id[:8],
+        dependency_id[:8],
+        payload.strength,
     )
     return MoveResult("Done.")
 

--- a/tests/test_create_claim_inline_links.py
+++ b/tests/test_create_claim_inline_links.py
@@ -1,0 +1,104 @@
+"""Tests for create_claim's inline consideration link target validation."""
+
+import pytest_asyncio
+
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkRole,
+    LinkType,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+from rumil.moves.create_claim import CreateClaimPayload, execute as execute_create_claim
+from rumil.moves.link_consideration import ConsiderationLinkFields
+
+
+@pytest_asyncio.fixture
+async def question(tmp_db):
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Why is the sky blue?",
+        headline="Why is the sky blue?",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def call(tmp_db, question):
+    c = Call(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(c)
+    return c
+
+
+async def test_inline_link_to_question_creates_consideration(tmp_db, call, question):
+    payload = CreateClaimPayload(
+        content="Rayleigh scattering explains the blue color.",
+        headline="Rayleigh scattering",
+        credence=6,
+        robustness=3,
+        workspace="research",
+        supersedes=None,
+        change_magnitude=None,
+        links=[
+            ConsiderationLinkFields(
+                question_id=question.id,
+                strength=4.0,
+                reasoning="explains the mechanism",
+                role=LinkRole.DIRECT,
+            )
+        ],
+    )
+    result = await execute_create_claim(payload, call, tmp_db)
+
+    assert result.created_page_id
+    links = await tmp_db.get_links_from(result.created_page_id)
+    cons = [l for l in links if l.link_type == LinkType.CONSIDERATION]
+    assert len(cons) == 1
+    assert cons[0].to_page_id == question.id
+
+
+async def test_inline_link_to_non_question_target_is_skipped(tmp_db, call):
+    """If the resolved target is not a question, no CONSIDERATION link is created."""
+    other_claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Mie scattering matters too.",
+        headline="Mie scattering matters too",
+    )
+    await tmp_db.save_page(other_claim)
+
+    payload = CreateClaimPayload(
+        content="Rayleigh scattering explains the blue color.",
+        headline="Rayleigh scattering",
+        credence=6,
+        robustness=3,
+        workspace="research",
+        supersedes=None,
+        change_magnitude=None,
+        links=[
+            ConsiderationLinkFields(
+                question_id=other_claim.id,
+                strength=4.0,
+                reasoning="should not be allowed",
+                role=LinkRole.STRUCTURAL,
+            )
+        ],
+    )
+    result = await execute_create_claim(payload, call, tmp_db)
+
+    assert result.created_page_id
+    links = await tmp_db.get_links_from(result.created_page_id)
+    assert not [l for l in links if l.link_type == LinkType.CONSIDERATION]

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -186,8 +186,9 @@ async def test_question_citing_claim_creates_consideration_link(
     assert cons[0].to_page_id == question.id
 
 
-async def test_citing_question_creates_related_link_cited_to_citing(tmp_db):
-    """Citing a QUESTION should produce a RELATED link from the cited question to the citing page."""
+async def test_citing_question_resolves_to_its_judgement(tmp_db):
+    """Citing a QUESTION should auto-resolve to that question's current judgement
+    and produce a DEPENDS_ON link to the judgement, not to the question."""
     question = Page(
         page_type=PageType.QUESTION,
         layer=PageLayer.SQUIDGY,
@@ -197,25 +198,72 @@ async def test_citing_question_creates_related_link_cited_to_citing(tmp_db):
     )
     await tmp_db.save_page(question)
 
-    judgement = Page(
+    answer = Page(
         page_type=PageType.JUDGEMENT,
         layer=PageLayer.SQUIDGY,
         workspace=Workspace.RESEARCH,
-        content=f"This relates to [{question.id[:8]}] but approaches it differently.",
-        headline="Alternative approach to sky color",
+        content="Rayleigh scattering of shorter wavelengths.",
+        headline="Rayleigh scattering",
     )
-    await tmp_db.save_page(judgement)
+    await tmp_db.save_page(answer)
+    await tmp_db.save_link(PageLink(
+        from_page_id=answer.id,
+        to_page_id=question.id,
+        link_type=LinkType.RELATED,
+    ))
 
-    linked = await extract_and_link_citations(
-        judgement.id, judgement.content, tmp_db,
+    citing = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Building on [{question.id[:8]}], sunsets follow.",
+        headline="Sunsets follow from sky color",
     )
+    await tmp_db.save_page(citing)
 
-    assert linked == {question.id}
-    links_to_judgement = await tmp_db.get_links_to(judgement.id)
-    related = [l for l in links_to_judgement if l.link_type == LinkType.RELATED]
-    assert len(related) == 1
-    assert related[0].from_page_id == question.id
-    assert related[0].to_page_id == judgement.id
+    linked = await extract_and_link_citations(citing.id, citing.content, tmp_db)
+
+    assert linked == {answer.id}
+    links_from_citing = await tmp_db.get_links_from(citing.id)
+    deps = [l for l in links_from_citing if l.link_type == LinkType.DEPENDS_ON]
+    assert len(deps) == 1
+    assert deps[0].from_page_id == citing.id
+    assert deps[0].to_page_id == answer.id
+
+    links_to_question = await tmp_db.get_links_to(question.id)
+    assert not [
+        l for l in links_to_question
+        if l.from_page_id == citing.id
+    ], "no link should be created to the question itself"
+
+
+async def test_citing_question_without_judgement_skipped(tmp_db):
+    """Citing a QUESTION that has no judgement yet should be skipped, not linked."""
+    question = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Why is the sky blue?",
+        headline="Why is the sky blue?",
+    )
+    await tmp_db.save_page(question)
+
+    citing = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"This builds on [{question.id[:8]}].",
+        headline="Builds on open question",
+    )
+    await tmp_db.save_page(citing)
+
+    linked = await extract_and_link_citations(citing.id, citing.content, tmp_db)
+
+    assert linked == set()
+    links_from = await tmp_db.get_links_from(citing.id)
+    links_to_question = await tmp_db.get_links_to(question.id)
+    assert links_from == []
+    assert not [l for l in links_to_question if l.from_page_id == citing.id]
 
 
 async def test_unresolvable_short_ids_skipped(tmp_db):

--- a/tests/test_link_depends_on.py
+++ b/tests/test_link_depends_on.py
@@ -1,0 +1,149 @@
+"""Tests for the link_depends_on move's source/target validation."""
+
+import pytest_asyncio
+
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+from rumil.moves.link_depends_on import (
+    LinkDependsOnPayload,
+    execute as execute_link_depends_on,
+)
+
+
+@pytest_asyncio.fixture
+async def claim(tmp_db):
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="The sky is blue because of Rayleigh scattering.",
+        headline="Rayleigh scattering",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def other_claim(tmp_db):
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Shorter wavelengths scatter more.",
+        headline="Shorter wavelengths scatter more",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def judgement(tmp_db):
+    page = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="On balance, Rayleigh scattering dominates.",
+        headline="Rayleigh scattering dominates",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def question(tmp_db):
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Why is the sky blue?",
+        headline="Why is the sky blue?",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def call(tmp_db, question):
+    c = Call(
+        call_type=CallType.ASSESS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(c)
+    return c
+
+
+async def test_claim_to_claim_dependency_is_created(
+    tmp_db, call, claim, other_claim,
+):
+    payload = LinkDependsOnPayload(
+        dependent_page_id=claim.id,
+        dependency_page_id=other_claim.id,
+        strength=4.0,
+        reasoning="builds directly on the wavelength claim",
+    )
+    await execute_link_depends_on(payload, call, tmp_db)
+
+    links = await tmp_db.get_links_from(claim.id)
+    deps = [l for l in links if l.link_type == LinkType.DEPENDS_ON]
+    assert len(deps) == 1
+    assert deps[0].to_page_id == other_claim.id
+
+
+async def test_judgement_to_claim_dependency_is_created(
+    tmp_db, call, judgement, claim,
+):
+    payload = LinkDependsOnPayload(
+        dependent_page_id=judgement.id,
+        dependency_page_id=claim.id,
+        strength=3.0,
+        reasoning="",
+    )
+    await execute_link_depends_on(payload, call, tmp_db)
+
+    links = await tmp_db.get_links_from(judgement.id)
+    deps = [l for l in links if l.link_type == LinkType.DEPENDS_ON]
+    assert len(deps) == 1
+    assert deps[0].to_page_id == claim.id
+
+
+async def test_question_dependent_is_rejected(
+    tmp_db, call, question, claim,
+):
+    """A question can't depend on anything via depends_on; use child_question instead."""
+    payload = LinkDependsOnPayload(
+        dependent_page_id=question.id,
+        dependency_page_id=claim.id,
+        strength=3.0,
+        reasoning="",
+    )
+    await execute_link_depends_on(payload, call, tmp_db)
+
+    links = await tmp_db.get_links_from(question.id)
+    assert not [l for l in links if l.link_type == LinkType.DEPENDS_ON]
+
+
+async def test_question_dependency_is_rejected(
+    tmp_db, call, claim, question,
+):
+    """Depending on a question (rather than its judgement) is forbidden."""
+    payload = LinkDependsOnPayload(
+        dependent_page_id=claim.id,
+        dependency_page_id=question.id,
+        strength=3.0,
+        reasoning="",
+    )
+    result = await execute_link_depends_on(payload, call, tmp_db)
+
+    links = await tmp_db.get_links_from(claim.id)
+    assert not [l for l in links if l.link_type == LinkType.DEPENDS_ON]
+    assert "judgement" in result.message.lower()


### PR DESCRIPTION
## Summary
- Audit found that several code paths could let a question end up on the wrong side of a dependency or citation, even though questions are open queries with no truth value to rest on.
- `link_depends_on` was completely unvalidated; `create_claim`'s inline consideration links didn't check the target type; inline citations of a question were silently turned into a `RELATED` link instead of resolving to the question's judgement.
- This PR closes those holes and updates the prompts so the rule ("cite/depend on the judgement, not the question") is visible to the LLM.

## Changes
- `link_depends_on` now requires both endpoints to be `CLAIM` or `JUDGEMENT`. A question dependency returns a message telling the LLM to point at the question's judgement instead.
- `create_claim` skips inline `links` entries whose resolved target isn't a `QUESTION`.
- `extract_and_link_citations` rewrites a citation that resolves to a `QUESTION` to that question's current judgement (via `get_judgements_for_question`); if there is no judgement yet, the citation is dropped with a warning.
- `prompts/citations.md`, `prompts/preamble.md`, and `prompts/find_considerations.md` document the rule and explain what to do when a question has no judgement yet.

## Test plan
- [x] `uv run pytest tests/test_link_depends_on.py tests/test_create_claim_inline_links.py tests/test_inline_citations.py -m "not llm"`
- [x] Regression sweep on adjacent suites: `tests/test_link_consideration.py`, `tests/test_judgement_superseding.py`, `tests/test_url_citations.py`, `tests/test_cites_links.py`, `tests/test_move_types.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)