### PR TITLE
Replace full-workspace PageGraph loads with scope-rooted SubtreeGraph

### DIFF
--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -42,7 +42,7 @@ from rumil.models import (
     FindConsiderationsMode,
 )
 from rumil.settings import get_settings
-from rumil.page_graph import PageGraph
+from rumil.page_graph import PageGraph, SubtreeGraph
 from rumil.tracing.trace_events import ContextBuiltEvent
 from rumil.workspace_map import build_workspace_map
 
@@ -182,7 +182,12 @@ class ScoutEmbeddingContext(ContextBuilder):
         self._mode = mode
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
-        graph = await PageGraph.load(infra.db)
+        graph = await SubtreeGraph.load_for_root(
+            infra.db,
+            infra.question_id,
+            include_ancestors=True,
+            include_ancestor_children=True,
+        )
         scout_ctx = await build_scout_context(
             infra.question_id,
             infra.db,

--- a/src/rumil/calls/prioritization.py
+++ b/src/rumil/calls/prioritization.py
@@ -19,7 +19,7 @@ from rumil.calls.dispatches import (
 from rumil.context import build_prioritization_context, collect_subtree_ids
 from rumil.database import DB
 from rumil.available_moves import get_moves_for_call
-from rumil.page_graph import PageGraph
+from rumil.page_graph import SubtreeGraph
 from rumil.llm import build_system_prompt, build_user_message
 from rumil.models import Call, CallStatus, CallType, MoveType
 from rumil.moves.base import MoveState
@@ -113,18 +113,21 @@ async def run_prioritization_call(
         allocated = sum(estimate_dispatch_cost(d) for d in state.dispatches)
         if allocated < dispatch_budget * 0.5:
             log.warning(
-                'Prioritization under-allocated: %d/%d budget dispatched, retrying once',
-                allocated, dispatch_budget,
+                "Prioritization under-allocated: %d/%d budget dispatched, retrying once",
+                allocated,
+                dispatch_budget,
             )
             retry_msgs = list(agent_result.messages)
-            retry_msgs.append({
-                'role': 'user',
-                'content': (
-                    f'You have only dispatched ~{allocated} of {dispatch_budget} '
-                    'available budget units. Please make your remaining dispatch '
-                    'calls now.'
-                ),
-            })
+            retry_msgs.append(
+                {
+                    "role": "user",
+                    "content": (
+                        f"You have only dispatched ~{allocated} of {dispatch_budget} "
+                        "available budget units. Please make your remaining dispatch "
+                        "calls now."
+                    ),
+                }
+            )
             agent_result = await run_single_call(
                 system_prompt,
                 tools=tools,
@@ -170,7 +173,7 @@ async def run_prioritization(
         scope_question_id[:8],
         budget,
     )
-    graph = await PageGraph.load(db)
+    graph = await SubtreeGraph.load_for_root(db, scope_question_id)
     context_text, short_id_map = await build_prioritization_context(
         db,
         scope_question_id=scope_question_id,

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -839,23 +839,6 @@ def assemble_call_context(
     return "\n".join(parts)
 
 
-async def format_preloaded_pages(
-    page_ids: Sequence[str],
-    db: DB,
-    graph: PageGraph | None = None,
-) -> str:
-    """Format preloaded pages as context text."""
-    source: DB | PageGraph = graph if graph is not None else db
-    parts: list[str] = []
-    for pid in page_ids:
-        page = await source.get_page(pid)
-        if page:
-            parts += ["---", "", f"## Pre-loaded Page: `{pid[:8]}`", ""]
-            parts.append(await format_page(page, PageDetail.HEADLINE, db=db, graph=graph))
-            parts.append("")
-    return "\n".join(parts)
-
-
 async def _build_dependency_signal(db: DB) -> str | None:
     """Build a section listing the most-depended-on pages in the workspace.
 

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -916,6 +916,31 @@ class DB:
             result.setdefault(link.from_page_id, []).append(link)
         return result
 
+    async def get_links_to_many(
+        self, page_ids: Sequence[str],
+    ) -> dict[str, list[PageLink]]:
+        """Bulk-fetch incoming links for many pages. Returns {page_id: [links]}."""
+        result: dict[str, list[PageLink]] = {pid: [] for pid in page_ids}
+        if not page_ids:
+            return result
+        id_list = list(dict.fromkeys(page_ids))
+        batch_size = 200
+        all_links: list[PageLink] = []
+        for start in range(0, len(id_list), batch_size):
+            batch = id_list[start:start + batch_size]
+            query = (
+                self.client.table("page_links")
+                .select("*")
+                .in_("to_page_id", batch)
+            )
+            query = self._staged_filter(query)
+            rows = _rows(await self._execute(query))
+            all_links.extend(_row_to_link(r) for r in rows)
+        applied = await self._apply_link_events(all_links)
+        for link in applied:
+            result.setdefault(link.to_page_id, []).append(link)
+        return result
+
     async def get_latest_summary_for_question(self, question_id: str) -> "Page | None":
         """Return the most recent active SUMMARY page linked to a question."""
         links = await self.get_links_to(question_id)

--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -37,7 +37,7 @@ from rumil.orchestrators.common import (
     compute_priority_score,
     score_items_sequentially,
 )
-from rumil.page_graph import PageGraph
+from rumil.page_graph import SubtreeGraph
 from rumil.settings import get_settings
 from rumil.tracing.broadcast import Broadcaster
 from rumil.tracing.trace_events import (
@@ -286,7 +286,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             claim_id[:8], budget, phase1_budget,
         )
 
-        graph = await PageGraph.load(self.db)
+        graph = await SubtreeGraph.load_for_root(self.db, claim_id)
         context_text, short_id_map = await build_prioritization_context(
             self.db, scope_question_id=claim_id, graph=graph,
         )
@@ -426,11 +426,11 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=budget))
 
-        graph = await PageGraph.load(self.db)
+        graph = await SubtreeGraph.load_for_root(self.db, claim_id)
         scope_page = await graph.get_page(claim_id)
         if not scope_page:
             raise RuntimeError(
-                f'Scope claim {claim_id} not found in PageGraph.'
+                f'Scope claim {claim_id} not found in SubtreeGraph.'
             )
         scope_headline = scope_page.headline
 
@@ -452,7 +452,6 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             parent_page=scope_page,
             parent_judgement=scope_judgement,
             items=all_items,
-            graph=graph,
             system_prompt_name='score_claim_items',
             response_model=ClaimScore,
             call_id=p_call.id,

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -208,11 +208,11 @@ def _split_into_batches(n: int, max_per_batch: int) -> list[int]:
     return [base + (1 if i < extra else 0) for i in range(n_batches)]
 
 
-async def _build_item_block(
+def _build_item_block(
     item: Page,
     index: int,
     total: int,
-    graph: PageGraph,
+    judgements_by_id: dict[str, list[Page]],
 ) -> str:
     """Build the text block describing a single item for the scorer."""
     parts = [
@@ -223,7 +223,7 @@ async def _build_item_block(
     if item.abstract:
         parts.append(f"\nAbstract:\n{item.abstract}")
 
-    judgements = await graph.get_judgements_for_question(item.id)
+    judgements = judgements_by_id.get(item.id, [])
     if judgements:
         latest_j = max(judgements, key=lambda j: j.created_at)
         parts.append(
@@ -247,7 +247,6 @@ async def score_items_sequentially(
     parent_page: Page,
     parent_judgement: Page | None,
     items: Sequence[Page],
-    graph: PageGraph,
     system_prompt_name: str,
     response_model: type[BaseModel],
     call_id: str,
@@ -258,6 +257,10 @@ async def score_items_sequentially(
     Items are split into balanced batches of up to SCORING_BATCH_SIZE.
     Each batch is presented as a single user message; the model returns
     a list of scores for that batch.
+
+    Bulk-fetches each item's latest judgement up front via
+    ``db.get_judgements_for_questions`` so the per-item formatter doesn't
+    need a graph.
     """
     from rumil.llm import (
         LLMExchangeMetadata,
@@ -267,6 +270,10 @@ async def score_items_sequentially(
 
     if not items:
         return []
+
+    judgements_by_id = await db.get_judgements_for_questions(
+        [item.id for item in items]
+    )
 
     batch_response_model = pydantic.create_model(
         f"{response_model.__name__}Batch",
@@ -308,7 +315,7 @@ async def score_items_sequentially(
         item_blocks = []
         for j, item in enumerate(batch_items):
             global_idx = sum(batch_sizes[:batch_idx]) + j
-            block = await _build_item_block(item, global_idx, len(items), graph)
+            block = _build_item_block(item, global_idx, len(items), judgements_by_id)
             item_blocks.append(block)
 
         batch_text = (

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -33,7 +33,7 @@ from rumil.orchestrators.common import (
     score_items_sequentially,
 )
 from rumil.moves.base import link_pages
-from rumil.page_graph import PageGraph
+from rumil.page_graph import SubtreeGraph
 from rumil.scope_subquestion_linker import run_scope_subquestion_linker
 from rumil.settings import get_settings
 from rumil.tracing.broadcast import Broadcaster
@@ -328,7 +328,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
 
         await self._run_subquestion_linker(question_id, parent_call_id)
 
-        graph = await PageGraph.load(self.db)
+        graph = await SubtreeGraph.load_for_root(self.db, question_id)
         context_text, short_id_map = await build_prioritization_context(
             self.db, scope_question_id=question_id, graph=graph,
         )
@@ -457,12 +457,12 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=budget))
 
-        graph = await PageGraph.load(self.db)
+        graph = await SubtreeGraph.load_for_root(self.db, question_id)
         child_questions = await graph.get_child_questions(question_id)
         parent_question = await graph.get_page(question_id)
         if not parent_question:
             raise RuntimeError(
-                f'Parent question {question_id} not found in PageGraph. '
+                f'Parent question {question_id} not found in SubtreeGraph. '
                 'This usually means the question belongs to a different project '
                 'than the current DB scope.'
             )
@@ -478,7 +478,6 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             parent_page=parent_question,
             parent_judgement=parent_judgement,
             items=child_questions,
-            graph=graph,
             system_prompt_name='score_subquestions',
             response_model=SubquestionScore,
             call_id=p_call.id,

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -33,7 +33,7 @@ from rumil.orchestrators.common import (
     compute_priority_score,
     score_items_sequentially,
 )
-from rumil.page_graph import PageGraph
+from rumil.page_graph import SubtreeGraph
 from rumil.settings import get_settings
 from rumil.tracing.broadcast import Broadcaster
 from rumil.tracing.trace_events import (
@@ -282,7 +282,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             question_id[:8], budget, phase1_budget,
         )
 
-        graph = await PageGraph.load(self.db)
+        graph = await SubtreeGraph.load_for_root(self.db, question_id)
         context_text, short_id_map = await build_prioritization_context(
             self.db, scope_question_id=question_id, graph=graph,
         )
@@ -418,12 +418,12 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=budget))
 
-        graph = await PageGraph.load(self.db)
+        graph = await SubtreeGraph.load_for_root(self.db, question_id)
         child_questions = await graph.get_child_questions(question_id)
         parent_question = await graph.get_page(question_id)
         if not parent_question:
             raise RuntimeError(
-                f'Parent question {question_id} not found in PageGraph. '
+                f'Parent question {question_id} not found in SubtreeGraph. '
                 'This usually means the question belongs to a different project '
                 'than the current DB scope.'
             )
@@ -446,7 +446,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             parent_page=parent_question,
             parent_judgement=parent_judgement,
             items=child_questions,
-            graph=graph,
             system_prompt_name='score_subquestions',
             response_model=SubquestionScore,
             call_id=p_call.id,
@@ -456,7 +455,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             parent_page=parent_question,
             parent_judgement=parent_judgement,
             items=consideration_pages,
-            graph=graph,
             system_prompt_name='score_claim_items',
             response_model=ClaimScore,
             call_id=p_call.id,

--- a/src/rumil/page_graph.py
+++ b/src/rumil/page_graph.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from rumil.database import DB
     from rumil.database import DB as PageSource
 
 from rumil.models import (
@@ -218,3 +219,146 @@ class PageGraph:
 
     async def get_ingest_history(self) -> dict[str, list[str]]:
         return {}
+
+
+class SubtreeGraph(PageGraph):
+    """Scope-rooted graph view loaded with O(depth) batched round trips.
+
+    Walks ``CHILD_QUESTION`` edges down from ``root_id`` level-by-level via
+    ``get_links_from_many`` + ``get_pages_by_ids``. Optionally walks ancestors
+    upward and includes their direct children (siblings of the scope at each
+    level). For every visited question, all incident links and link-endpoint
+    pages are bulk-fetched, so the resulting view supports the same read
+    surface as ``PageGraph`` (considerations, judgements, dependents,
+    dependencies, parent/child questions) — but only for the loaded subset.
+
+    Round-trip cost: ``O(descend_depth + ancestor_depth)`` regardless of
+    fan-out, plus a constant number of bulk queries to materialize incident
+    links and endpoint pages.
+    """
+
+    @classmethod
+    async def load_for_root(
+        cls,
+        db: "DB",
+        root_id: str,
+        *,
+        descend_max_depth: int = 20,
+        include_ancestors: bool = False,
+        include_ancestor_children: bool = False,
+    ) -> "SubtreeGraph":
+        root = await db.get_page(root_id)
+        if root is None:
+            log.debug("SubtreeGraph.load: root %s not found", root_id[:8])
+            return cls([], [])
+
+        question_ids: set[str] = {root_id}
+
+        await _bfs_descend_questions(
+            db,
+            seeds=[root_id],
+            visited=question_ids,
+            max_depth=descend_max_depth,
+        )
+
+        if include_ancestors:
+            ancestor_ids = await _walk_ancestor_questions(db, root_id)
+            question_ids.update(ancestor_ids)
+            if include_ancestor_children:
+                await _bfs_descend_questions(
+                    db,
+                    seeds=list(ancestor_ids),
+                    visited=question_ids,
+                    max_depth=1,
+                )
+
+        pages_by_id = await db.get_pages_by_ids(list(question_ids))
+
+        in_links_map = await db.get_links_to_many(list(question_ids))
+        out_links_map = await db.get_links_from_many(list(question_ids))
+
+        seen_link_ids: set[str] = set()
+        links: list[PageLink] = []
+        for link_lists in (in_links_map.values(), out_links_map.values()):
+            for ls in link_lists:
+                for link in ls:
+                    if link.id in seen_link_ids:
+                        continue
+                    seen_link_ids.add(link.id)
+                    links.append(link)
+
+        endpoint_ids: set[str] = set()
+        for link in links:
+            if link.from_page_id not in pages_by_id:
+                endpoint_ids.add(link.from_page_id)
+            if link.to_page_id not in pages_by_id:
+                endpoint_ids.add(link.to_page_id)
+        if endpoint_ids:
+            extra_pages = await db.get_pages_by_ids(list(endpoint_ids))
+            pages_by_id.update(extra_pages)
+
+        active_pages = [p for p in pages_by_id.values() if p.is_active()]
+
+        log.debug(
+            "SubtreeGraph.load: root=%s, %d questions, %d pages, %d links",
+            root_id[:8],
+            len(question_ids),
+            len(active_pages),
+            len(links),
+        )
+        return cls(active_pages, links)
+
+
+async def _bfs_descend_questions(
+    db: "DB",
+    *,
+    seeds: Sequence[str],
+    visited: set[str],
+    max_depth: int,
+) -> None:
+    """Walk CHILD_QUESTION edges down from seeds, mutating *visited* in place."""
+    if not seeds or max_depth <= 0:
+        return
+    frontier: list[str] = [sid for sid in seeds]
+    for _ in range(max_depth):
+        if not frontier:
+            return
+        links_by_parent = await db.get_links_from_many(frontier)
+        next_ids: set[str] = set()
+        for parent_id in frontier:
+            for link in links_by_parent.get(parent_id, []):
+                if link.link_type != LinkType.CHILD_QUESTION:
+                    continue
+                if link.to_page_id in visited:
+                    continue
+                next_ids.add(link.to_page_id)
+        if not next_ids:
+            return
+        visited.update(next_ids)
+        frontier = list(next_ids)
+
+
+async def _walk_ancestor_questions(db: "DB", start_id: str) -> list[str]:
+    """Walk CHILD_QUESTION edges upward from start_id, returning ancestor IDs.
+
+    Cycle-safe; stops when no parent exists or a cycle is detected.
+    """
+    ancestors: list[str] = []
+    visited: set[str] = {start_id}
+    current = start_id
+    for _ in range(64):  # safety bound
+        in_links = await db.get_links_to_many([current])
+        parent_links = [
+            link
+            for link in in_links.get(current, [])
+            if link.link_type == LinkType.CHILD_QUESTION
+        ]
+        if not parent_links:
+            return ancestors
+        parent_id = parent_links[0].from_page_id
+        if parent_id in visited:
+            return ancestors
+        visited.add(parent_id)
+        ancestors.append(parent_id)
+        current = parent_id
+    return ancestors


### PR DESCRIPTION
## Summary

- Several hot call paths (prioritization, scout context, two-phase scoring) were loading the **entire workspace** into memory via `PageGraph.load(db)` just to read a small subtree's worth of pages and links. This swap replaces those loads with a new `SubtreeGraph` that walks `CHILD_QUESTION` edges in batched BFS from a scope root.
- Round-trip cost drops from `O(N/200)` (linear in workspace size) to `O(descend_depth + ancestor_depth)` plus a constant number of bulk queries.
- Also bulk-fetches judgements once in `score_items_sequentially` instead of asking the in-memory graph per item, removing the last reason that scorer needed a `PageGraph` at all.

## Changes

- **`SubtreeGraph`** (`page_graph.py`): new subclass of `PageGraph` with `load_for_root(db, root_id, *, descend_max_depth, include_ancestors, include_ancestor_children)`. Walks descendants level-by-level via `get_links_from_many`, optionally walks ancestors upward via `get_links_to_many`, then bulk-fetches incident links and endpoint pages. Implements the same read surface (`get_considerations_for_question`, `get_judgements_for_question`, etc.) as `PageGraph`, but only for the loaded subset.
- **`DB.get_links_to_many`**: mirror of the existing `get_links_from_many` (batched `in_(...)` query + `_apply_link_events`, respects staged-runs).
- **Prioritization sites switched to `SubtreeGraph.load_for_root(db, scope_id)`**: `prioritization.py`, `orchestrators/two_phase.py`, `orchestrators/experimental.py`, `orchestrators/claim_investigation.py`.
- **`ScoutEmbeddingContext`** (`calls/context_builders.py`): now loads `SubtreeGraph.load_for_root(infra.db, infra.question_id, include_ancestors=True, include_ancestor_children=True)` — covers root + descendants + ancestor chain + sibling-of-ancestor questions, which is everything `build_scout_context` actually walks.
- **`score_items_sequentially`** (`orchestrators/common.py`): dropped the `graph` parameter, bulk-fetches via `db.get_judgements_for_questions([item.id for item in items])` once at the top, and `_build_item_block` is now sync and reads from a `judgements_by_id` dict. Updated all four call sites.
- **`format_preloaded_pages`** (`context.py`): deleted — was dead code.

## Test plan

- [x] `uv run pytest` — 192 passed, 36 skipped
- [x] `uv run pyright` — 0 errors
- [x] `ruff check` on modified files — no new errors vs. baseline
- [x] Smoke-run a real prioritize on a non-trivial workspace (default workspace, question `71d4d3d9` with 12 considerations + 4 judgements, `--smoke-test`, staged): scope subtree resolved correctly, 4 dispatches planned, completed in ~20s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)