### PR TITLE
Enable prompt caching on SimpleAgentLoop and grounding web search

### DIFF
--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -95,6 +95,7 @@ class SimpleAgentLoop(PageCreator):
             db=infra.db,
             state=infra.state,
             max_rounds=max_rounds,
+            cache=True,
         )
 
         log.info(

--- a/src/rumil/clean/grounding.py
+++ b/src/rumil/clean/grounding.py
@@ -410,6 +410,7 @@ async def _run_web_search_task(
                 server_tools,
                 metadata=meta,
                 db=db,
+                cache=True,
             )
             response = api_resp.message
 


### PR DESCRIPTION
## Summary
- Adds `cache=True` to `SimpleAgentLoop.create_pages()` — covers assess, ingest, concept assess, and all other call types using the simple agent loop
- Adds `cache=True` to the grounding web search task loop in `clean/grounding.py`

Both are multi-round LLM loops where rounds 2+ were paying full input token cost instead of getting the 90% cache-read discount on the prefix. The `MultiRoundLoop` (scout/find_considerations) already had this.

## Test plan
- [ ] Run a smoke test assess call, check trace for `cache_read_input_tokens` on rounds 2+
- [ ] Run a grounding call, check trace for cache hits on web search rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)