### PR TITLE
Add hidden projects

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3210,13 +3210,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At"
+          },
+          "hidden": {
+            "type": "boolean",
+            "title": "Hidden",
+            "default": false
           }
         },
         "type": "object",
         "required": [
           "name",
           "id",
-          "created_at"
+          "created_at",
+          "hidden"
         ],
         "title": "Project"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1108,6 +1108,10 @@ export type Project = {
      * Created At
      */
     created_at: string;
+    /**
+     * Hidden
+     */
+    hidden: boolean;
 };
 
 /**

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -130,7 +130,12 @@ async def get_project(project_id: str):
     if not rows:
         raise HTTPException(status_code=404, detail="Project not found")
     r = rows[0]
-    return Project(id=r["id"], name=r["name"], created_at=r["created_at"])
+    return Project(
+        id=r["id"],
+        name=r["name"],
+        created_at=r["created_at"],
+        hidden=r.get("hidden", False),
+    )
 
 
 @app.get("/api/projects/{project_id}/runs", response_model=list[RunListItemOut])

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -358,6 +358,7 @@ class DB:
                 id=row["id"],
                 name=row["name"],
                 created_at=datetime.fromisoformat(row["created_at"]),
+                hidden=row.get("hidden", False),
             )
         row = _rows(
             await self._execute(
@@ -368,21 +369,20 @@ class DB:
             id=row["id"],
             name=row["name"],
             created_at=datetime.fromisoformat(row["created_at"]),
+            hidden=row.get("hidden", False),
         )
 
-    async def list_projects(self) -> list[Project]:
-        rows = _rows(
-            await self._execute(
-                self.client.table("projects")
-                .select("*")
-                .order("created_at")
-            )
-        )
+    async def list_projects(self, include_hidden: bool = False) -> list[Project]:
+        query = self.client.table("projects").select("*").order("created_at")
+        if not include_hidden:
+            query = query.eq("hidden", False)
+        rows = _rows(await self._execute(query))
         return [
             Project(
                 id=r["id"],
                 name=r["name"],
                 created_at=datetime.fromisoformat(r["created_at"]),
+                hidden=r.get("hidden", False),
             )
             for r in rows
         ]

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -351,6 +351,7 @@ class Project(BaseModel):
     name: str
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    hidden: bool = False
 
 
 class Page(BaseModel):

--- a/supabase/migrations/20260410163750_add_hidden_projects.sql
+++ b/supabase/migrations/20260410163750_add_hidden_projects.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN hidden BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- Adds a `hidden` boolean column to the `projects` table (default `false`)
- `GET /api/projects` excludes hidden projects from the listing
- `GET /api/projects/{id}` and all project-scoped endpoints (pages, runs, questions) continue to work for hidden projects
- To hide a project, set `hidden = true` on its row in the `projects` table

## Test plan
- [x] Verified `GET /api/projects` returns 185 projects after hiding one (was 186)
- [x] Verified hidden project is absent from the list response
- [x] Verified `GET /api/projects/{id}` still returns the hidden project
- [x] Verified pages, runs, and questions endpoints still work for hidden projects
- [x] All 199 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)