### PR TITLE
Narrow prioritization context to scope + direct children

### DIFF
--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -361,6 +361,7 @@ async def render_subtree(
     detail: PageDetail = PageDetail.CONTENT,
     linked_detail: PageDetail | None = PageDetail.HEADLINE,
     content_page_ids: set[str] | None = None,
+    max_depth: int | None = None,
 ) -> str:
     """Render a full subtree of pages starting from a root page.
 
@@ -372,6 +373,9 @@ async def render_subtree(
 
     Pages whose IDs appear in *content_page_ids* are rendered at CONTENT
     detail regardless of the *detail* parameter.
+
+    *max_depth* limits how many levels of child questions to recurse into
+    (0 = root only, 1 = root + direct children, None = unlimited).
     """
     if graph is None:
         graph = await PageGraph.load(db)
@@ -427,6 +431,9 @@ async def render_subtree(
                     f'{indent}- '
                     + await format_page(j, linked_detail or PageDetail.HEADLINE, linked_detail=None, graph=graph)
                 )
+
+        if max_depth is not None and depth >= max_depth:
+            return
 
         children = await graph.get_child_questions(question.id)
         if children:
@@ -786,53 +793,6 @@ async def format_question_for_find_considerations(
     return "\n".join(parts), loaded_ids
 
 
-async def _build_question_index(
-    question_id: str,
-    db: DB,
-    indent: int = 0,
-    graph: PageGraph | None = None,
-    _visited: set[str] | None = None,
-) -> list[str]:
-    """Recursively build a flat index of all questions in the tree with their IDs.
-    Includes consideration count, last find-considerations fruit/date, and hypothesis flag."""
-    if _visited is None:
-        _visited = set()
-    if question_id in _visited:
-        return [f"{'  ' * indent}[child] `{question_id}` — *** cycle detected ***"]
-    _visited = _visited | {question_id}
-
-    source: DB | PageGraph = graph if graph is not None else db
-    question = await source.get_page(question_id)
-    if not question:
-        return []
-    prefix = "  " * indent
-    tag = "[scope]" if indent == 0 else "[child]"
-
-    extra = question.extra or {}
-    is_hypothesis = extra.get("hypothesis", False)
-    hypothesis_tag = " [hypothesis]" if is_hypothesis else ""
-
-    n_cons = len(await source.get_considerations_for_question(question_id))
-    fc_info = await db.get_last_find_considerations_info(question_id)
-    if fc_info:
-        date_str = fc_info[0][:10]
-        fruit = fc_info[1]
-        fruit_str = f"fruit={fruit}" if fruit is not None else "fruit=?"
-        fc_str = f"{fruit_str} · {date_str}"
-    else:
-        fc_str = "never explored"
-
-    lines = [
-        f"{prefix}{tag}{hypothesis_tag} `{question_id}` — {question.headline} "
-        f"({n_cons} cons · {fc_str})"
-    ]
-    for child in await source.get_child_questions(question_id):
-        lines.extend(await _build_question_index(
-            child.id, db, indent + 1, graph=graph, _visited=_visited,
-        ))
-    return lines
-
-
 def assemble_call_context(
     working_context: str,
     workspace_map: str | None = None,
@@ -897,8 +857,8 @@ async def build_prioritization_context(
     """Build context for a prioritization call.
 
     Uses embedding-similarity search to surface the most relevant pages
-    from the workspace, then appends the scope question's full subtree
-    (at ABSTRACT detail) and a dispatchable question index.
+    from the workspace, then appends the scope question and its direct
+    children (at ABSTRACT detail) and a dispatchable question index.
 
     Returns (context_text, short_id_map) where short_id_map maps 8-char
     short IDs to full UUIDs.
@@ -925,20 +885,6 @@ async def build_prioritization_context(
                 parts.append('---')
                 parts.append('')
 
-            index_lines = await _build_question_index(
-                scope_question_id, db, graph=graph,
-            )
-            parts.append('## Scope Subtree — Dispatchable Questions')
-            parts.append('')
-            parts.append(
-                'You can only dispatch research calls on questions in this subtree '
-                '(or on new subquestions you create during this call). '
-                'Use only these exact IDs in your dispatch tags:'
-            )
-            parts.append('')
-            parts.extend(index_lines)
-            parts.append('')
-
             direct_children = await source.get_child_questions(scope_question_id)
             full_page_ids = {scope_question_id} | {c.id for c in direct_children}
             subtree_text = await render_subtree(
@@ -947,17 +893,15 @@ async def build_prioritization_context(
                 detail=PageDetail.ABSTRACT,
                 linked_detail=PageDetail.ABSTRACT,
                 content_page_ids=full_page_ids,
+                max_depth=1,
             )
-            parts.append('## Scope Subtree — Detail')
+            parts.append('## Scope Question — Detail')
             parts.append('')
             parts.append(subtree_text)
             parts.append('')
 
-            subtree_ids = await collect_subtree_ids(
-                scope_question_id, db, graph=graph,
-            )
-            for sid in subtree_ids:
-                short_id_map[sid[:8]] = sid
+            for pid in full_page_ids:
+                short_id_map[pid[:8]] = pid
 
     dep_section = await _build_dependency_signal(db)
     if dep_section:

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -213,6 +213,7 @@ def _build_item_block(
     index: int,
     total: int,
     judgements_by_id: dict[str, list[Page]],
+    children_by_id: dict[str, list[Page]] | None = None,
 ) -> str:
     """Build the text block describing a single item for the scorer."""
     parts = [
@@ -240,6 +241,24 @@ def _build_item_block(
             )
     else:
         parts.append("\nNo prior assessment.")
+
+    if children_by_id is not None:
+        children = children_by_id.get(item.id, [])
+        if children:
+            parts.append("\nSubquestions:")
+            for child in children:
+                child_js = judgements_by_id.get(child.id, [])
+                if child_js:
+                    cj = max(child_js, key=lambda j: j.created_at)
+                    parts.append(
+                        f"- {child.headline} — judgement: {cj.headline} "
+                        f"(robustness {cj.robustness}/5)"
+                    )
+                else:
+                    parts.append(f"- {child.headline} — NO JUDGEMENT")
+        else:
+            parts.append("\nNo subquestions.")
+
     return "\n".join(parts)
 
 
@@ -271,9 +290,15 @@ async def score_items_sequentially(
     if not items:
         return []
 
-    judgements_by_id = await db.get_judgements_for_questions(
-        [item.id for item in items]
-    )
+    item_ids = [item.id for item in items]
+    children_by_id: dict[str, list[Page]] = {}
+    all_child_ids: list[str] = []
+    for item in items:
+        children = await db.get_child_questions(item.id)
+        children_by_id[item.id] = children
+        all_child_ids.extend(c.id for c in children)
+
+    judgements_by_id = await db.get_judgements_for_questions(item_ids + all_child_ids)
 
     batch_response_model = pydantic.create_model(
         f"{response_model.__name__}Batch",
@@ -315,7 +340,13 @@ async def score_items_sequentially(
         item_blocks = []
         for j, item in enumerate(batch_items):
             global_idx = sum(batch_sizes[:batch_idx]) + j
-            block = _build_item_block(item, global_idx, len(items), judgements_by_id)
+            block = _build_item_block(
+                item,
+                global_idx,
+                len(items),
+                judgements_by_id,
+                children_by_id,
+            )
             item_blocks.append(block)
 
         batch_text = (

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -44,6 +44,7 @@ from rumil.models import (
     CallType,
     Dispatch,
     FindConsiderationsMode,
+    LinkType,
     MoveType,
     Page,
     PageLayer,
@@ -291,12 +292,34 @@ async def score_items_sequentially(
         return []
 
     item_ids = [item.id for item in items]
-    children_by_id: dict[str, list[Page]] = {}
+    question_items = [i for i in items if i.page_type == PageType.QUESTION]
+    question_ids = [q.id for q in question_items]
+
+    children_by_id: dict[str, list[Page]] | None = None
     all_child_ids: list[str] = []
-    for item in items:
-        children = await db.get_child_questions(item.id)
-        children_by_id[item.id] = children
-        all_child_ids.extend(c.id for c in children)
+    if question_ids:
+        children_by_id = {}
+        links_by_parent = await db.get_links_from_many(question_ids)
+        child_page_ids: list[str] = []
+        for qid in question_ids:
+            child_page_ids.extend(
+                l.to_page_id for l in links_by_parent.get(qid, [])
+                if l.link_type == LinkType.CHILD_QUESTION
+            )
+        if child_page_ids:
+            child_pages = await db.get_pages_by_ids(child_page_ids)
+            for qid in question_ids:
+                children_by_id[qid] = [
+                    child_pages[l.to_page_id]
+                    for l in links_by_parent.get(qid, [])
+                    if l.link_type == LinkType.CHILD_QUESTION
+                    and l.to_page_id in child_pages
+                    and child_pages[l.to_page_id].is_active()
+                ]
+            all_child_ids = [p.id for p in child_pages.values() if p.is_active()]
+        else:
+            for qid in question_ids:
+                children_by_id[qid] = []
 
     judgements_by_id = await db.get_judgements_for_questions(item_ids + all_child_ids)
 


### PR DESCRIPTION
## Summary
- **Prioritization context limited to depth 1**: Both the detail rendering (`render_subtree`) and the short ID map in `build_prioritization_context` now only include the scope question and its direct children, rather than the full recursive subtree. The redundant question index section (`_build_question_index`) is removed entirely.
- **Fruit scoring sees subquestion structure**: `score_items_sequentially` now bulk-fetches each item's child questions and their judgements, and `_build_item_block` renders them in headline form with robustness scores (or "NO JUDGEMENT" if unassessed), giving the scorer better signal about structural completeness.

## Test plan
- [x] `uv run pyright` passes
- [x] `uv run pytest` — 199 passed
- [x] Smoke test a two-phase run to verify prioritization context is compact and fruit scoring includes subquestion info

🤖 Generated with [Claude Code](https://claude.com/claude-code)