### PR TITLE
Reduce question stats neighborhood from 3 hops to 2

### DIFF
--- a/frontend/src/app/pages/[pageId]/stats/page.tsx
+++ b/frontend/src/app/pages/[pageId]/stats/page.tsx
@@ -131,7 +131,7 @@ export default function QuestionStatsPage() {
         <div className="headline">{state.headline}</div>
         <div className="meta">
           <strong>{state.data.subgraph_page_count}</strong>{" "}
-          {state.data.subgraph_page_count === 1 ? "page" : "pages"} within 3 hops
+          {state.data.subgraph_page_count === 1 ? "page" : "pages"} within 2 hops
         </div>
         </div>
         <SubgraphView data={state.data.subgraph} anchorId={pageId} />
@@ -217,7 +217,7 @@ export default function QuestionStatsPage() {
       <div className="stats-header">
         <div>
           <h1>Statistics</h1>
-          <div className="subtitle">question neighborhood · 3 hops</div>
+          <div className="subtitle">question neighborhood · 2 hops</div>
         </div>
         <div className="stats-nav">
           <Link href={`/pages/${pageId}`}>Page</Link>

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -269,7 +269,7 @@ async def get_project_stats(project_id: str):
 
 @app.get("/api/pages/{page_id}/stats", response_model=QuestionStatsOut)
 async def get_question_stats(page_id: str):
-    """Aggregate stats over the 3-hop undirected neighborhood around a question.
+    """Aggregate stats over the 2-hop undirected neighborhood around a question.
 
     Returns 404 if the target page is not a question. v1 is baseline-only.
     """

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -1936,7 +1936,7 @@ class DB:
         return cast(dict[str, Any], result.data or {})
 
     async def get_question_stats(self, question_id: str) -> dict[str, Any]:
-        """Compute aggregate stats for the 3-hop undirected neighborhood of a question.
+        """Compute aggregate stats for the 2-hop undirected neighborhood of a question.
 
         Returns the same JSONB shape as get_project_stats plus a subgraph_page_count
         field. v1 is baseline-only: staged runs are not applied.

--- a/supabase/migrations/20260412201207_reduce_question_stats_to_2_hops.sql
+++ b/supabase/migrations/20260412201207_reduce_question_stats_to_2_hops.sql
@@ -1,0 +1,193 @@
+-- Reduce question stats neighborhood from 3 hops to 2 hops.
+-- Large workspaces have too many nodes at depth 3, making the subgraph
+-- visualization unusable.
+
+CREATE OR REPLACE FUNCTION compute_question_stats(p_question_id TEXT)
+RETURNS jsonb
+LANGUAGE sql STABLE AS $$
+    WITH RECURSIVE hood(page_id, depth) AS (
+        SELECT p_question_id, 0
+        UNION
+        SELECT
+            CASE WHEN l.from_page_id = h.page_id
+                 THEN l.to_page_id
+                 ELSE l.from_page_id END,
+            h.depth + 1
+        FROM hood h
+        JOIN page_links l
+          ON (l.from_page_id = h.page_id OR l.to_page_id = h.page_id)
+        WHERE h.depth < 2
+          AND l.staged = FALSE
+    ),
+    hood_depths AS (
+        SELECT page_id, MIN(depth)::int AS depth
+        FROM hood
+        GROUP BY page_id
+    ),
+    active_pages AS (
+        SELECT p.id, p.page_type, p.credence, p.robustness, p.headline,
+               hd.depth
+        FROM pages p
+        JOIN hood_depths hd ON hd.page_id = p.id
+        WHERE p.staged = FALSE
+          AND p.is_superseded = FALSE
+    ),
+    active_links AS (
+        SELECT l.id,
+               l.from_page_id,
+               l.to_page_id,
+               pf.page_type AS from_type,
+               pt.page_type AS to_type,
+               l.link_type
+        FROM page_links l
+        JOIN active_pages pf ON pf.id = l.from_page_id
+        JOIN active_pages pt ON pt.id = l.to_page_id
+        WHERE l.staged = FALSE
+    ),
+    pages_by_type AS (
+        SELECT page_type, COUNT(*)::int AS n
+        FROM active_pages
+        GROUP BY page_type
+    ),
+    links_by_type AS (
+        SELECT link_type, COUNT(*)::int AS n
+        FROM active_links
+        GROUP BY link_type
+    ),
+    out_counts AS (
+        SELECT from_type AS page_type, link_type, COUNT(*)::float AS n
+        FROM active_links
+        GROUP BY from_type, link_type
+    ),
+    in_counts AS (
+        SELECT to_type AS page_type, link_type, COUNT(*)::float AS n
+        FROM active_links
+        GROUP BY to_type, link_type
+    ),
+    degree_pairs AS (
+        SELECT page_type, link_type FROM out_counts
+        UNION
+        SELECT page_type, link_type FROM in_counts
+    ),
+    degree_cells AS (
+        SELECT
+            dp.page_type,
+            dp.link_type,
+            COALESCE(oc.n, 0) / pbt.n::float AS avg_out,
+            COALESCE(ic.n, 0) / pbt.n::float AS avg_in
+        FROM degree_pairs dp
+        JOIN pages_by_type pbt ON pbt.page_type = dp.page_type
+        LEFT JOIN out_counts oc
+               ON oc.page_type = dp.page_type AND oc.link_type = dp.link_type
+        LEFT JOIN in_counts ic
+               ON ic.page_type = dp.page_type AND ic.link_type = dp.link_type
+    ),
+    robustness_hist AS (
+        SELECT robustness AS bucket, COUNT(*)::int AS n
+        FROM active_pages
+        WHERE robustness IS NOT NULL
+        GROUP BY robustness
+    ),
+    credence_hist AS (
+        SELECT credence AS bucket, COUNT(*)::int AS n
+        FROM active_pages
+        WHERE credence IS NOT NULL
+        GROUP BY credence
+    ),
+    question_pages AS (
+        SELECT id, headline
+        FROM active_pages
+        WHERE page_type = 'question'
+    ),
+    calls_by_qt AS (
+        SELECT c.scope_page_id AS question_id,
+               c.call_type,
+               COUNT(*)::int AS n
+        FROM calls c
+        WHERE c.scope_page_id IN (SELECT id FROM question_pages)
+        GROUP BY c.scope_page_id, c.call_type
+    ),
+    calls_per_question AS (
+        SELECT
+            qp.id AS question_id,
+            qp.headline,
+            COALESCE(
+                (SELECT jsonb_object_agg(cbt.call_type, cbt.n)
+                 FROM calls_by_qt cbt WHERE cbt.question_id = qp.id),
+                '{}'::jsonb
+            ) AS by_type,
+            COALESCE(
+                (SELECT SUM(cbt.n)::int FROM calls_by_qt cbt WHERE cbt.question_id = qp.id),
+                0
+            ) AS total
+        FROM question_pages qp
+    )
+    SELECT jsonb_build_object(
+        'subgraph_page_count', (SELECT COUNT(*)::int FROM active_pages),
+        'pages_total', COALESCE((SELECT SUM(n)::int FROM pages_by_type), 0),
+        'pages_by_type', COALESCE(
+            (SELECT jsonb_object_agg(page_type, n) FROM pages_by_type),
+            '{}'::jsonb
+        ),
+        'links_total', COALESCE((SELECT SUM(n)::int FROM links_by_type), 0),
+        'links_by_type', COALESCE(
+            (SELECT jsonb_object_agg(link_type, n) FROM links_by_type),
+            '{}'::jsonb
+        ),
+        'degree_matrix', COALESCE(
+            (SELECT jsonb_object_agg(page_type, per_link)
+             FROM (
+                 SELECT page_type,
+                        jsonb_object_agg(
+                            link_type,
+                            jsonb_build_object('avg_out', avg_out, 'avg_in', avg_in)
+                        ) AS per_link
+                 FROM degree_cells
+                 GROUP BY page_type
+             ) _grouped),
+            '{}'::jsonb
+        ),
+        'robustness_histogram', COALESCE(
+            (SELECT jsonb_object_agg(bucket::text, n) FROM robustness_hist),
+            '{}'::jsonb
+        ),
+        'credence_histogram', COALESCE(
+            (SELECT jsonb_object_agg(bucket::text, n) FROM credence_hist),
+            '{}'::jsonb
+        ),
+        'calls_per_question', COALESCE(
+            (SELECT jsonb_agg(
+                jsonb_build_object(
+                    'question_id', question_id,
+                    'headline', headline,
+                    'by_type', by_type,
+                    'total', total
+                ) ORDER BY total DESC
+             ) FROM calls_per_question),
+            '[]'::jsonb
+        ),
+        'subgraph', jsonb_build_object(
+            'nodes', COALESCE(
+                (SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'id', id,
+                        'page_type', page_type,
+                        'headline', headline,
+                        'depth', depth
+                    ) ORDER BY depth, id
+                 ) FROM active_pages),
+                '[]'::jsonb
+            ),
+            'edges', COALESCE(
+                (SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'from_page_id', from_page_id,
+                        'to_page_id', to_page_id,
+                        'link_type', link_type
+                    ) ORDER BY from_page_id, to_page_id
+                 ) FROM active_links),
+                '[]'::jsonb
+            )
+        )
+    );
+$$;

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -210,7 +210,7 @@ async def test_project_stats_empty_project(tmp_db):
 async def linear_chain(tmp_db):
     """Build a chain q0 -- child -- q1 -- child -- q2 -- child -- q3 -- child -- q4.
 
-    Used to test the 3-hop boundary: from q0, we should see q0..q3 but not q4.
+    Used to test the 2-hop boundary: from q0, we should see q0..q2 but not q3/q4.
     """
     pages = []
     for i in range(5):
@@ -222,12 +222,12 @@ async def linear_chain(tmp_db):
 
 
 @pytest.mark.asyncio
-async def test_question_stats_three_hop_boundary(tmp_db, linear_chain):
+async def test_question_stats_two_hop_boundary(tmp_db, linear_chain):
     blob = await tmp_db.get_question_stats(linear_chain[0].id)
-    assert blob["subgraph_page_count"] == 4
-    assert blob["pages_total"] == 4
-    # Links within the subgraph: q0->q1, q1->q2, q2->q3 (q3->q4 is out).
-    assert blob["links_total"] == 3
+    assert blob["subgraph_page_count"] == 3
+    assert blob["pages_total"] == 3
+    # Links within the subgraph: q0->q1, q1->q2 (q2->q3 is out).
+    assert blob["links_total"] == 2
 
 
 @pytest.mark.asyncio
@@ -269,7 +269,7 @@ async def test_question_stats_nonexistent(tmp_db):
 async def test_question_stats_subgraph_depths(tmp_db, linear_chain):
     """Each node in the returned subgraph should report its min hop distance
     from the anchor. On a chain q0–q1–q2–q3–q4, scoping to q0 gives depths
-    0, 1, 2, 3 for q0..q3 respectively."""
+    0, 1, 2 for q0..q2 respectively."""
     blob = await tmp_db.get_question_stats(linear_chain[0].id)
     nodes = blob["subgraph"]["nodes"]
     depth_by_id = {n["id"]: n["depth"] for n in nodes}
@@ -277,7 +277,7 @@ async def test_question_stats_subgraph_depths(tmp_db, linear_chain):
     assert depth_by_id[linear_chain[0].id] == 0
     assert depth_by_id[linear_chain[1].id] == 1
     assert depth_by_id[linear_chain[2].id] == 2
-    assert depth_by_id[linear_chain[3].id] == 3
+    assert linear_chain[3].id not in depth_by_id
     assert linear_chain[4].id not in depth_by_id
 
 


### PR DESCRIPTION
## Summary
- 3-hop neighborhoods are too large in big workspaces, making the subgraph visualization unusable
- New migration replaces `compute_question_stats` RPC with `depth < 2` (was `< 3`)
- Updated frontend labels, docstrings, and test assertions to match

## Test plan
- [x] All 13 `test_stats.py` tests pass with updated boundary/depth assertions
- [ ] Verify on prod that large workspaces render a usable subgraph at 2 hops
- [ ] Run `supabase db push` to apply the migration to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)