### PR TITLE
Add --ingest-num-claims CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ uv run python main.py "Your question" --available-moves default --budget 10
 # 'default' = standard scouts, 'multi-subquestion' = replaces generic subquestions scout with web-questions and deep-questions scouts
 uv run python main.py "Your question" --available-calls multi-subquestion --budget 20
 
+# Tune how many considerations each ingest call extracts (default: 4)
+uv run python main.py --ingest FILE --for-question QUESTION_ID --ingest-num-claims 6 --budget 5
+
 # Suppress info-level logging (only warnings and errors)
 uv run python main.py "Your question" --budget 5 -q
 

--- a/main.py
+++ b/main.py
@@ -1077,6 +1077,17 @@ async def async_main():
         help="Available-calls preset name (default: 'default'). Controls which scout/dispatch types the two-phase orchestrator uses.",
     )
     parser.add_argument(
+        "--ingest-num-claims",
+        dest="ingest_num_claims",
+        type=int,
+        default=None,
+        help=(
+            "Target number of considerations to extract per ingest call "
+            "(default: 4). The prompt uses 'approximately', so the model "
+            "will still apply quality-over-quantity judgement."
+        ),
+    )
+    parser.add_argument(
         "--smoke-test",
         dest="smoke_test",
         action="store_true",
@@ -1144,6 +1155,8 @@ async def async_main():
         get_settings().available_moves = args.available_moves
     if args.available_calls is not None:
         get_settings().available_calls = args.available_calls
+    if args.ingest_num_claims is not None:
+        get_settings().ingest_num_claims = args.ingest_num_claims
     if args.smoke_test:
         get_settings().rumil_smoke_test = "1"
     if args.prod_db:

--- a/prompts/ingest.md
+++ b/prompts/ingest.md
@@ -23,7 +23,7 @@ Calibrate your `credence` and `robustness` accordingly. A well-evidenced finding
 
 ### Primary extraction
 
-Extract **3–5 considerations** that bear on the primary question. Quality over quantity — if only 2 genuinely matter, produce 2.
+Quality over quantity — if only 2 genuinely matter, produce 2. The task description specifies an approximate target count; treat it as guidance, not a quota.
 
 For each consideration, create the claim and link it to the primary question. Cite the source inline using its `[shortid]` so the link is auto-created.
 

--- a/src/rumil/calls/ingest.py
+++ b/src/rumil/calls/ingest.py
@@ -11,6 +11,7 @@ from rumil.calls.stages import (
 )
 from rumil.database import DB
 from rumil.models import Call, CallStage, CallType, Page
+from rumil.settings import get_settings
 
 
 class IngestCall(CallRunner):
@@ -52,8 +53,11 @@ class IngestCall(CallRunner):
         return IngestClosingReview(self.call_type, self._filename)
 
     def task_description(self) -> str:
+        n = get_settings().ingest_num_claims
         return (
-            "Extract considerations from the source document above for this question.\n\n"
+            f"Extract approximately {n} considerations from the source document "
+            "above for this question. Quality over quantity — produce fewer if "
+            "only fewer genuinely matter.\n\n"
             f"Question ID: `{self.infra.question_id}`\n"
             f"Source page ID: `{self._source_page.id}`"
         )

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -67,6 +67,7 @@ class Settings(BaseSettings):
     grounding_update_budget: int = _capture_field(default=10)
     feedback_update_budget: int = _capture_field(default=10)
     feedback_investigation_budget: int = _capture_field(default=30)
+    ingest_num_claims: int = _capture_field(default=4)
 
     sonnet_model: str = _capture_field(default="claude-sonnet-4-6")
     explore_subgraph_default_max_pages: int = _capture_field(default=30)

--- a/tests/test_ingest_num_claims.py
+++ b/tests/test_ingest_num_claims.py
@@ -1,0 +1,37 @@
+"""Verify that `ingest_num_claims` flows from Settings into the IngestCall task description."""
+
+import types
+from typing import cast
+
+from rumil.calls.ingest import IngestCall
+from rumil.calls.stages import CallInfra
+from rumil.models import Page
+from rumil.settings import override_settings
+
+
+def _make_bare_ingest_call() -> IngestCall:
+    """Build an IngestCall without running __init__ (avoids DB/broadcaster plumbing)."""
+    call = IngestCall.__new__(IngestCall)
+    call._source_page = cast(Page, types.SimpleNamespace(id="src_page_id", extra={}))
+    call._filename = "doc.md"
+    call.infra = cast(CallInfra, types.SimpleNamespace(question_id="q_abc"))
+    return call
+
+
+def test_task_description_honors_ingest_num_claims():
+    call = _make_bare_ingest_call()
+
+    with override_settings(ingest_num_claims=7):
+        desc = call.task_description()
+    assert "approximately 7 considerations" in desc
+
+    with override_settings(ingest_num_claims=2):
+        desc = call.task_description()
+    assert "approximately 2 considerations" in desc
+
+
+def test_task_description_uses_default_when_unset():
+    call = _make_bare_ingest_call()
+    with override_settings():
+        desc = call.task_description()
+    assert "approximately 4 considerations" in desc


### PR DESCRIPTION
## Summary
- New `--ingest-num-claims N` flag on `main.py` lets users tune how many considerations each ingest call extracts.
- Previously the count was hardcoded as "3–5 considerations" in `prompts/ingest.md`. The prompt now defers to the task description, which injects "approximately N considerations" from `Settings.ingest_num_claims` (default 4, midpoint of the old range).
- The setting is a `_capture_field`, so it's recorded in `capture_config()` for run reproducibility and A/B analysis.

## Test plan
- [x] `uv run pytest tests/test_ingest_num_claims.py -q` — new tests cover default and overridden values.
- [x] `uv run python main.py --help` shows the new flag.
- [ ] End-to-end smoke test: `uv run python main.py --ingest <file> --for-question <qid> --workspace scratch --ingest-num-claims 2 --smoke-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)