### PR TITLE
Skip initial prioritization if question has a view

### DIFF
--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -229,9 +229,12 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         return result
 
     async def _needs_initial_prioritization(self, question_id: str) -> bool:
-        """Run initial_prioritization iff no judgement answers the question yet."""
+        """Run initial_prioritization iff no judgement or view answers the question yet."""
         judgements = await self.db.get_judgements_for_question(question_id)
-        return not judgements
+        if judgements:
+            return False
+        view = await self.db.get_view_for_question(question_id)
+        return view is None
 
     async def _cancel_initial_call(self) -> None:
         """Mark the eagerly-created initial_prioritization call as complete when it is skipped."""
@@ -249,13 +252,13 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         await trace.record(
             PhaseSkippedEvent(
                 phase="initial_prioritization",
-                reason="Question already has a judgement.",
+                reason="Question already has a judgement or view.",
             )
         )
         await mark_call_completed(
             call,
             self.db,
-            "Initial prioritization skipped — question already has a judgement.",
+            "Initial prioritization skipped — question already has a judgement or view.",
         )
 
     async def _get_next_batch(

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -221,9 +221,12 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         return result
 
     async def _needs_initial_prioritization(self, question_id: str) -> bool:
-        """Run initial_prioritization iff no judgement answers the question yet."""
+        """Run initial_prioritization iff no judgement or view answers the question yet."""
         judgements = await self.db.get_judgements_for_question(question_id)
-        return not judgements
+        if judgements:
+            return False
+        view = await self.db.get_view_for_question(question_id)
+        return view is None
 
     async def _cancel_initial_call(self) -> None:
         """Mark the eagerly-created initial_prioritization call as complete when it is skipped."""
@@ -240,11 +243,11 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         set_trace(trace)
         await trace.record(PhaseSkippedEvent(
             phase='initial_prioritization',
-            reason='Question already has a judgement.',
+            reason='Question already has a judgement or view.',
         ))
         await mark_call_completed(
             call, self.db,
-            'Initial prioritization skipped — question already has a judgement.',
+            'Initial prioritization skipped — question already has a judgement or view.',
         )
 
     async def _get_next_batch(


### PR DESCRIPTION
## Summary
- Extend the skip condition for `initial_prioritization` so that a question with an existing **view** (not just a judgement) bypasses the initial phase.
- Applied to both `TwoPhaseOrchestrator` and `ExperimentalOrchestrator`; updated the `PhaseSkippedEvent` reason and call-completion message accordingly.

## Test plan
- [ ] Run a question that already has a view and confirm initial_prioritization is skipped in the trace.
- [ ] Run a fresh question (no judgement, no view) and confirm initial_prioritization still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)