### PR TITLE
Fix typos in prioritization prompts

### DIFF
--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -409,7 +409,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             "your only turn and you will not get another chance. Distribute your budget "
             "among the scouting dispatch tools, weighting towards types that seem most "
             "useful for this question and skipping types that are clearly irrelevant. "
-            "For each scout you indend to dispatch now, you MUST call its tool on the curret turn, "
+            "For each scout you intend to dispatch now, you MUST call its tool on the current turn, "
             "in parallel with all others you intend to dispatch at this point. "
             "Do not do anything else — just dispatch."
         )
@@ -601,7 +601,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             "Plan conservatively: your total worst-case cost across all dispatches "
             f"must not exceed {dispatch_budget}.\n\n"
             f"{scores_text}\n\n"
-            "For each call you indend to dispatch now, you MUST call its tool on the curret turn, "
+            "For each call you intend to dispatch now, you MUST call its tool on the current turn, "
             "in parallel with all others you intend to dispatch at this point. "
             f"Each recurse call must have a budget of at least {MIN_TWOPHASE_BUDGET}."
         )

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -343,7 +343,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             'your only turn and you will not get another chance. Distribute your budget '
             'among the scouting dispatch tools, weighting towards types that seem most '
             'useful for this question and skipping types that are clearly irrelevant. '
-            'For each scout you indend to dispatch now, you MUST call its tool on the curret turn, '
+            'For each scout you intend to dispatch now, you MUST call its tool on the current turn, '
             'in parallel with all others you intend to dispatch at this point. '
             'Do not do anything else — just dispatch.'
         )
@@ -575,7 +575,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             'Plan conservatively: your total worst-case cost across all dispatches '
             f'must not exceed {dispatch_budget}.\n\n'
             f'{scores_text}\n\n'
-            'For each call you indend to dispatch now, you MUST call its tool on the curret turn, '
+            'For each call you intend to dispatch now, you MUST call its tool on the current turn, '
             'in parallel with all others you intend to dispatch at this point. '
             f'Each recurse call must have a budget of at least {MIN_TWOPHASE_BUDGET}.'
             f'{ingest_hint}'


### PR DESCRIPTION
## Summary
- Correct `indend` → `intend` and `curret` → `current` in the dispatch task prompts used by `TwoPhaseOrchestrator` and `ExperimentalOrchestrator`.

## Test plan
- [ ] Prompts render without typos in the next prioritization call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)