### PR TITLE
Fix trace UI nesting and missing link move page refs

### DIFF
--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -57,6 +57,8 @@ PAGE_ID_FIELDS: dict[MoveType, list[str]] = {
     MoveType.LINK_CONSIDERATION: ["claim_id", "question_id"],
     MoveType.LINK_CHILD_QUESTION: ["child_id", "parent_id"],
     MoveType.LINK_RELATED: ["from_page_id", "to_page_id"],
+    MoveType.LINK_DEPENDS_ON: ["dependent_page_id", "dependency_page_id"],
+    MoveType.LINK_VARIANT: ["variant_page_id", "original_page_id"],
     MoveType.FLAG_FUNNINESS: ["page_id"],
     MoveType.REPORT_DUPLICATE: ["page_id_a", "page_id_b"],
 }

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -280,8 +280,6 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         if not self._executed_since_last_plan:
             return PrioritizationResult(dispatch_sequences=[])
 
-        await self._maybe_rerun_linker(question_id, self._parent_call_id)
-
         self._executed_since_last_plan = False
         self._invocation += 1
         return await self._main_phase_prioritization(
@@ -358,12 +356,6 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             initial_prioritization_budget,
         )
 
-        await self._run_subquestion_linker(question_id, parent_call_id)
-
-        context_text, short_id_map = await build_prioritization_context(
-            self.db,
-            scope_question_id=question_id,
-        )
         if self._initial_call is not None:
             p_call = self._initial_call
             self._initial_call = None
@@ -384,6 +376,13 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             )
             if self._sequence_id is not None:
                 self._seq_position += 1
+
+        await self._run_subquestion_linker(question_id, p_call.id)
+
+        context_text, short_id_map = await build_prioritization_context(
+            self.db,
+            scope_question_id=question_id,
+        )
         trace = CallTrace(p_call.id, self.db, broadcaster=self.broadcaster)
         set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=initial_prioritization_budget))
@@ -503,6 +502,9 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         )
         if self._sequence_id is not None:
             self._seq_position += 1
+
+        await self._maybe_rerun_linker(question_id, p_call.id)
+
         trace = CallTrace(p_call.id, self.db, broadcaster=self.broadcaster)
         set_trace(trace)
         await trace.record(ContextBuiltEvent(budget=budget))


### PR DESCRIPTION
## Summary
- **Nesting bug:** `link_subquestions` calls rendered at the top level instead of under the prioritization call that dispatched them. The linker was invoked with the outer parent's `parent_call_id` before the prioritization call existed. Now the prioritization call is created first and its id is passed as the linker's parent.
- **Missing move data:** Trace rows for `link_depends_on` and `link_variant` showed no src/dst page chips. Registered both in `PAGE_ID_FIELDS` so `moves_to_trace_event` resolves their payload IDs into `page_refs`, matching the other link moves.

## Test plan
- [x] `uv run pyright` clean
- [x] `uv run pytest` — 207 passed
- [ ] Spot-check the trace UI: confirm a linker call renders as a child of its prioritization call, and `link_depends_on` / `link_variant` rows show source and destination page chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)