### PR TITLE
Move worktree/localhost guidance to gitignored CLAUDE.md.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 db/
 /pages/
 .claude/settings.local.json
+CLAUDE.md.local
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,10 +112,6 @@ To add a new call type: subclass `CallRunner`. Set `call_type`, override `_make_
 
 **Frontend** (`frontend/`): Next.js TypeScript app with Tailwind. Uses pnpm. Run with `cd frontend && pnpm dev`. The frontend port mirrors the API port: if the API is on `localhost:800X`, the frontend will be on `localhost:300X` (Next.js auto-increments when the default port is taken). Use this to find and stop the frontend process. TypeScript types in `frontend/src/api/` are auto-generated from the API's OpenAPI schema — **never create or edit these files by hand**. When API schemas change, theese need to be regenerated with `./scripts/generate-api-types.sh` (or `cd frontend && pnpm generate-api`). This is the only mechanism for sharing types between backend and frontend; do not manually duplicate type definitions. When `schemas.py` or `models.py` is edited, `./scripts/generate-api-types.sh` is automaticaly run via a hook.
 
-## Worktrees and localhost URLs
-
-When the user pastes a `localhost:<port>` URL, do NOT use that port literally. Instead, map it to this worktree's port. The frontend port is derived from `frontend/.env.local`: if the API URL there is `localhost:800X`, the frontend is on `localhost:300X`. Always read `frontend/.env.local` to determine the correct port and rewrite any user-provided localhost URL accordingly. Edits must go into the current worktree, not the main repo or other worktrees.
-
 ## Key Conventions
 
 - **NEVER pass `--prod` when running `main.py` unless the user explicitly asks you to.** The production database contains real research data. Default to the local database for all testing, development, and exploratory runs.
@@ -162,3 +158,5 @@ You must always invoke the relevant skill when doing certain types of work
 - **Writing unit tests** Always invoke the write-tests skill
 - **Writing frontend code** Always invoke the frontend-design skill
 When you write a plan that involes either of these things, always include a reminder to invoke the appropriate skill.
+
+@CLAUDE.md.local


### PR DESCRIPTION
## Summary
- Extract the worktree-specific localhost URL mapping section out of `CLAUDE.md` and into a new `CLAUDE.md.local` file, imported via `@CLAUDE.md.local`.
- Gitignore `CLAUDE.md.local` so each local setup can keep its own worktree-specific instructions without tracking them in the repo.

## Test plan
- [ ] Confirm `@CLAUDE.md.local` import resolves and Claude Code picks up the worktree/localhost guidance in a fresh session.
- [ ] Verify `CLAUDE.md.local` is ignored by git (`git status` stays clean after edits to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)