### PR TITLE
Stop telling scout prompts to call link_child_question

### DIFF
--- a/prompts/scout_analogies.md
+++ b/prompts/scout_analogies.md
@@ -10,7 +10,7 @@ For each analogy (aim for 1–3):
 
 1. **A claim** describing the analogy and why it may be relevant. Explain the structural parallel: what features of the analogous situation map onto the current question, and what the analogy would predict or suggest if it holds. **Also name the most important ways the analogy might break down — where the structural parallel is weakest, or where the analogous situation differs in ways that could change the conclusion.** Set credence to reflect how strong you think the parallel is, and robustness to reflect how thoroughly you've examined it.
 
-2. **A subquestion** asking about the relevance, limits, or details of the analogy — e.g. "How closely does [analogy] parallel [situation in the parent question]?" or "What does the [analogous case] suggest about [specific aspect]?". Link it as a child of the parent question.
+2. **A subquestion** asking about the relevance, limits, or details of the analogy — e.g. "How closely does [analogy] parallel [situation in the parent question]?" or "What does the [analogous case] suggest about [specific aspect]?". Created via `create_question`, it is automatically linked as a child of the parent question.
 
 3. Optionally, **link related** pages if the analogy connects to existing claims or questions elsewhere in the workspace.
 
@@ -18,7 +18,7 @@ For each analogy (aim for 1–3):
 
 1. Read the parent question and consider: what other domains, historical episodes, or known situations share structural features with this question?
 2. For each analogy, create a claim describing it using `create_claim`, then `link_consideration` to the parent question.
-3. Create a subquestion for further exploration using `create_question` and `link_child_question`.
+3. Create a subquestion for further exploration using `create_question`. It is automatically linked as a child of the parent question.
 4. If the analogy connects to existing pages in the workspace, use `link_related` to make those connections visible.
 
 ## What Makes a Good Analogy

--- a/prompts/scout_deep_questions.md
+++ b/prompts/scout_deep_questions.md
@@ -19,7 +19,7 @@ For each deep question target:
    - **Counterfactual**: "How would [outcome] change if [assumption] were false?" — for questions that probe the sensitivity of conclusions.
    - **Normative**: "What should [actor] prioritize given [constraints]?" — for questions that require value judgements or multi-criteria reasoning.
 
-2. **Link it as a child** of the parent question using `link_child_question`.
+2. Create the question using `create_question`. It will be automatically linked as a child of the parent question.
 
 ### High-level claims (1-3)
 
@@ -33,9 +33,8 @@ Alongside your questions, produce claims about high-level insights, structural o
    - Assumptions whose implications haven't been traced through
    - Places where the reasoning could go in multiple directions and the choice matters
    - Important "so what" questions that connect evidence to conclusions
-2. For each target, create a question using `create_question` that makes the required reasoning clear.
-3. Link each question as a child of the parent using `link_child_question`.
-4. Create high-level claims you are confident in that are non-obvious and important for the parent question. Use `create_claim` and `link_consideration`.
+2. For each target, create a question using `create_question` that makes the required reasoning clear. It is automatically linked as a child of the parent question.
+3. Create high-level claims you are confident in that are non-obvious and important for the parent question. Use `create_claim` and `link_consideration`.
 
 ## What Makes a Good Deep Question
 

--- a/prompts/scout_estimates.md
+++ b/prompts/scout_estimates.md
@@ -16,7 +16,7 @@ For each informative quantity (aim for 2–4):
 
 1. Read the parent question and consider what quantities, if known, would most constrain or resolve the answer. Think about: magnitudes, rates, proportions, costs, timelines, thresholds, population sizes, frequencies.
 2. For each quantity, create a claim with your initial estimate using `create_claim`, then `link_consideration` to the parent question.
-3. Create a corresponding subquestion using `create_question` and `link_child_question` to the parent.
+3. Create a corresponding subquestion using `create_question`. It is automatically linked as a child of the parent question.
 
 ## Quality Bar
 

--- a/prompts/scout_factchecks.md
+++ b/prompts/scout_factchecks.md
@@ -15,7 +15,7 @@ For each fact-check target (aim for 1-3):
    - **Lookup**: "What is the actual [quantity/date/figure] for [X]?" — for finding the real value of something estimated or assumed.
    - **Search**: "Are there known examples of [type of thing]?" — for finding concrete instances of a category or phenomenon mentioned in the workspace.
 
-2. **Link it as a child** of the parent question using `link_child_question`.
+2. Create the question using `create_question`. It will be automatically linked as a child of the parent question.
 
 ## How to Proceed
 
@@ -24,8 +24,7 @@ For each fact-check target (aim for 1-3):
    - Quantities that are estimated or assumed rather than sourced
    - Categories or phenomena where real examples would strengthen the analysis
    - Claims with low credence or low robustness that could be resolved with evidence
-2. For each target, create a question using `create_question` that is specific enough for a web search to answer.
-3. Link each question as a child of the parent using `link_child_question`.
+2. For each target, create a question using `create_question` that is specific enough for a web search to answer. It is automatically linked as a child of the parent question.
 
 ## What Makes a Good Fact-Check Target
 

--- a/prompts/scout_paradigm_cases.md
+++ b/prompts/scout_paradigm_cases.md
@@ -10,7 +10,7 @@ For each paradigm case (aim for 1–3):
 
 1. **A claim** describing the case and why it is relevant. Explain what happened, what makes it a paradigm case for the question at hand, and what it reveals about the dynamics, mechanisms, or principles involved. Set credence and robustness to reflect how well-established the case is.
 
-2. **A subquestion** asking about the implications, limits, or details of the case — e.g. "What does [case] reveal about [mechanism in the parent question]?" or "How representative is [case] of the broader phenomenon?". Link it as a child of the parent question.
+2. **A subquestion** asking about the implications, limits, or details of the case — e.g. "What does [case] reveal about [mechanism in the parent question]?" or "How representative is [case] of the broader phenomenon?". Created via `create_question`, it is automatically linked as a child of the parent question.
 
 3. Optionally, **link related** pages if the case connects to existing claims or questions elsewhere in the workspace.
 

--- a/prompts/scout_subquestions.md
+++ b/prompts/scout_subquestions.md
@@ -14,7 +14,7 @@ You are performing a **Scout Subquestions** call — an initial exploration of a
 
 1. Read the parent question and existing context carefully.
 2. Identify the most informative axes of decomposition — the subquestions whose answers would do the most to resolve the parent.
-3. For each subquestion, use `create_question` and then `link_child_question` to connect it to the parent.
+3. For each subquestion, use `create_question`. It is automatically linked as a child of the parent question.
 4. Where you can offer even a tentative answer or relevant consideration, use `create_claim` and `link_consideration` to attach it to the parent question (or to a subquestion, if it bears more directly there).
 
 ## Quality Bar

--- a/prompts/scout_web_questions.md
+++ b/prompts/scout_web_questions.md
@@ -18,7 +18,7 @@ For each web question target:
    - **Comparison**: "How does [X] compare to [Y] on [specific metric]?" — for finding a concrete comparison.
    - **Current state**: "What is the current [policy/status/approach] of [entity] regarding [X]?" — for establishing present-day facts.
 
-2. **Link it as a child** of the parent question using `link_child_question`.
+2. Create the question using `create_question`. It will be automatically linked as a child of the parent question.
 
 ### Factual claims (1-3)
 
@@ -31,9 +31,8 @@ Alongside your questions, produce claims about concrete facts that you are confi
    - Assumptions about the real world that could be replaced with actual data
    - Categories where knowing concrete examples would sharpen the reasoning
    - Areas where the current state of affairs (policies, technologies, markets) matters but hasn't been established
-2. For each target, create a question using `create_question` that is specific enough for a web search to answer.
-3. Link each question as a child of the parent using `link_child_question`.
-4. Create factual claims you are confident in that are non-obvious and important for the parent question. Use `create_claim` and `link_consideration`.
+2. For each target, create a question using `create_question` that is specific enough for a web search to answer. It is automatically linked as a child of the parent question.
+3. Create factual claims you are confident in that are non-obvious and important for the parent question. Use `create_claim` and `link_consideration`.
 
 ## What Makes a Good Web Question
 

--- a/src/rumil/calls/scout_deep_questions.py
+++ b/src/rumil/calls/scout_deep_questions.py
@@ -40,8 +40,9 @@ class ScoutDeepQuestionsCall(CallRunner):
             "Identify important questions bearing on the scope question that "
             "require judgement, interpretation, or involved reasoning to answer "
             "— questions that cannot be resolved by simply looking something up. "
-            "For each, create a question and link it as a child of the scope "
-            "question. Also produce confident, non-obvious high-level claims "
-            "that bear on the scope question.\n\n"
+            "For each, create a question using `create_question` (it is "
+            "automatically linked as a child of the scope question). Also "
+            "produce confident, non-obvious high-level claims that bear on "
+            "the scope question.\n\n"
             f"Question ID: `{self.infra.question_id}`"
         )

--- a/src/rumil/calls/scout_web_questions.py
+++ b/src/rumil/calls/scout_web_questions.py
@@ -41,8 +41,9 @@ class ScoutWebQuestionsCall(CallRunner):
             "on the scope question and that can be answered by reading the "
             "web, without judgement or tricky reasoning. Focus on questions "
             "where you do not already confidently know the answer. For each, "
-            "create a question and link it as a child of the scope question. "
-            "Also produce confident, non-obvious factual claims that bear on "
-            "the scope question.\n\n"
+            "create a question using `create_question` (it is automatically "
+            "linked as a child of the scope question). Also produce "
+            "confident, non-obvious factual claims that bear on the scope "
+            "question.\n\n"
             f"Question ID: `{self.infra.question_id}`"
         )


### PR DESCRIPTION
## Summary
- Scout calls that create questions use `CREATE_SCOUT_QUESTION`, which auto-links the new question as a child of the scope question, and do **not** expose `LINK_CHILD_QUESTION` as a tool.
- The scout prompts (and two `task_description()` strings) still instructed the model to link each question via `link_child_question`, so the model would report "wasn't able to link to the scope question" — a confabulation, since the link was already created. Wasted rounds chasing a non-existent tool also plausibly crowded out planned follow-on work like claim creation.
- Updates all scout prompts that create questions to describe the auto-linking behaviour instead: `scout_deep_questions`, `scout_web_questions`, `scout_factchecks`, `scout_subquestions`, `scout_estimates`, `scout_analogies`, `scout_paradigm_cases`. Also updates the `task_description()` strings in `scout_deep_questions.py` and `scout_web_questions.py`.
- Leaves `find_considerations.md` untouched — `FIND_CONSIDERATIONS` legitimately uses `CREATE_QUESTION` (no auto-link) and does have `LINK_CHILD_QUESTION` in its tool set.

## Test plan
- [ ] Run a scout_deep_questions call against a scratch workspace and confirm the fruit check no longer reports "couldn't link to scope question"
- [ ] Spot-check one or two other scout types (e.g. scout_factchecks, scout_subquestions) to confirm the model no longer references link_child_question in its output

🤖 Generated with [Claude Code](https://claude.com/claude-code)