### PR TITLE
Allow update_page_content in mutation_events CHECK constraint

### DIFF
--- a/supabase/migrations/20260414235145_allow_update_page_content_event.sql
+++ b/supabase/migrations/20260414235145_allow_update_page_content_event.sql
@@ -1,0 +1,23 @@
+-- Widen mutation_events.event_type CHECK to include 'update_page_content'.
+--
+-- The staged-runs migration (20260328102907) added a CHECK constraint that
+-- only permitted 'supersede_page', 'delete_link', 'change_link_role'. Later,
+-- DB.update_page_content was added to src/rumil/database.py and records an
+-- 'update_page_content' event, but the CHECK was never widened. Every call
+-- to update_page_content (e.g. from the create_view closing review) failed
+-- with a Postgres CHECK-violation error (chaosGuppy/rumil#281).
+--
+-- The Python replay side (_load_mutation_state, _apply_page_events) already
+-- handles 'update_page_content' correctly; only the DB constraint is missing.
+
+ALTER TABLE mutation_events
+    DROP CONSTRAINT IF EXISTS mutation_events_event_type_check;
+
+ALTER TABLE mutation_events
+    ADD CONSTRAINT mutation_events_event_type_check
+    CHECK (event_type IN (
+        'supersede_page',
+        'delete_link',
+        'change_link_role',
+        'update_page_content'
+    ));

--- a/tests/test_update_page_content.py
+++ b/tests/test_update_page_content.py
@@ -1,0 +1,143 @@
+"""Regression tests for DB.update_page_content.
+
+update_page_content records a mutation event with event_type='update_page_content'
+and, for non-staged runs, also updates the page row directly.
+
+Before the CHECK-constraint-widening migration, the mutation_events CHECK
+constraint only accepted 'supersede_page', 'delete_link', 'change_link_role'
+and any call to update_page_content would fail with a Postgres APIError
+(chaosGuppy/rumil#281).
+"""
+
+import uuid
+from typing import Any, cast
+
+import pytest_asyncio
+
+from rumil.database import DB
+from rumil.models import (
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+
+
+async def _make_page(db: DB, content: str = "original") -> Page:
+    page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=content,
+        headline="test page",
+    )
+    await db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def project_id():
+    db = await DB.create(run_id=str(uuid.uuid4()))
+    project = await db.get_or_create_project(f"test-upc-{uuid.uuid4().hex[:8]}")
+    yield project.id
+    await db._execute(db.client.table("projects").delete().eq("id", project.id))
+
+
+async def _make_db(project_id: str, staged: bool = False) -> DB:
+    db = await DB.create(run_id=str(uuid.uuid4()), staged=staged)
+    db.project_id = project_id
+    return db
+
+
+async def test_update_page_content_non_staged_writes_new_content(project_id):
+    """Regression: a non-staged update_page_content must succeed and write
+    the new content to the base table. On main (pre-migration), this raises
+    a Postgres APIError because the mutation_events CHECK constraint does
+    not include 'update_page_content'."""
+    db = await _make_db(project_id, staged=False)
+    try:
+        page = await _make_page(db, content="original content")
+
+        await db.update_page_content(page.id, "replaced content")
+
+        fetched = await db.get_page(page.id)
+        assert fetched is not None
+        assert fetched.content == "replaced content"
+    finally:
+        await db.delete_run_data()
+
+
+async def test_update_page_content_records_mutation_event(project_id):
+    """update_page_content must record a mutation event with the old and
+    new content in the payload. Locks in the event shape so retroactive
+    staging of non-staged runs can replay content updates."""
+    db = await _make_db(project_id, staged=False)
+    try:
+        page = await _make_page(db, content="before")
+
+        await db.update_page_content(page.id, "after")
+
+        rows = (
+            await db.client.table("mutation_events")
+            .select("event_type, target_id, payload")
+            .eq("run_id", db.run_id)
+            .eq("target_id", page.id)
+            .execute()
+        )
+        data = cast(list[dict[str, Any]], rows.data)
+        events = [r for r in data if r["event_type"] == "update_page_content"]
+        assert len(events) == 1
+        payload = cast(dict[str, Any], events[0]["payload"])
+        assert payload["old_content"] == "before"
+        assert payload["new_content"] == "after"
+    finally:
+        await db.delete_run_data()
+
+
+async def test_update_page_content_staged_leaves_base_row_alone(project_id):
+    """In a staged run, update_page_content must only record the event;
+    the base table row keeps its original content. Another (non-staged)
+    reader should still see 'original'."""
+    baseline = await _make_db(project_id, staged=False)
+    staged = await _make_db(project_id, staged=True)
+    reader = await _make_db(project_id, staged=False)
+    try:
+        page = await _make_page(baseline, content="baseline content")
+
+        await staged.update_page_content(page.id, "staged content")
+
+        # Staged run sees its own overlay.
+        staged_view = await staged.get_page(page.id)
+        assert staged_view is not None
+        assert staged_view.content == "staged content"
+
+        # Non-staged reader still sees the original.
+        baseline_view = await reader.get_page(page.id)
+        assert baseline_view is not None
+        assert baseline_view.content == "baseline content"
+    finally:
+        await staged.delete_run_data()
+        await baseline.delete_run_data()
+        await reader.delete_run_data()
+
+
+async def test_update_page_content_on_missing_page_is_noop(project_id):
+    """update_page_content on a nonexistent page returns silently and
+    does not write a mutation event."""
+    db = await _make_db(project_id, staged=False)
+    try:
+        fake_id = str(uuid.uuid4())
+
+        await db.update_page_content(fake_id, "irrelevant")
+
+        rows = (
+            await db.client.table("mutation_events")
+            .select("event_type")
+            .eq("run_id", db.run_id)
+            .eq("target_id", fake_id)
+            .execute()
+        )
+        data = cast(list[dict[str, Any]], rows.data)
+        assert data == []
+    finally:
+        await db.delete_run_data()


### PR DESCRIPTION
## Summary

- Add a migration that widens the \`mutation_events_event_type_check\` constraint to include \`'update_page_content'\`.
- Add regression tests for \`DB.update_page_content\` (non-staged write, mutation event shape, staged-run isolation, no-op on missing page).

Fixes chaosGuppy/rumil#281.

## Root cause

\`DB.update_page_content\` in \`src/rumil/database.py:449-452\` records a mutation event with \`event_type='update_page_content'\`:

\`\`\`python
await self.record_mutation_event(
    \"update_page_content\", page_id,
    {\"old_content\": page.content, \"new_content\": new_content},
)
\`\`\`

But the \`mutation_events\` table has a CHECK constraint from the original staged-runs migration (\`20260328102907_staged_runs.sql\`) that only permits three event types:

\`\`\`sql
event_type TEXT NOT NULL CHECK (event_type IN (
    'supersede_page', 'delete_link', 'change_link_role'
))
\`\`\`

Every call to \`update_page_content\` — notably the \`create_view\` closing review at \`src/rumil/calls/closing_reviewers.py:129\`, which is how normal questions finish today — hit the constraint and raised \`postgrest.APIError\`. The exception propagated up through \`two_phase.py:191\` and crashed the CLI run.

The Python replay side was already correct: \`_load_mutation_state\` handles \`'update_page_content'\` at \`src/rumil/database.py:308\` and \`_apply_page_events\` overlays the content override at line 327. Only the DB constraint was missing.

## Audit

All \`record_mutation_event\` call sites in \`src/rumil/database.py\`:

| Event type | Line | In old CHECK? |
|------------|------|---------------|
| \`supersede_page\` | 752 | ✓ |
| \`delete_link\` | 1570 | ✓ |
| \`change_link_role\` | 1581 | ✓ |
| \`update_page_content\` | 450 | ✗ (this PR) |

\`update_page_content\` was the only orphan.

## Fix

New migration \`20260414235145_allow_update_page_content_event.sql\`:

\`\`\`sql
ALTER TABLE mutation_events
    DROP CONSTRAINT IF EXISTS mutation_events_event_type_check;

ALTER TABLE mutation_events
    ADD CONSTRAINT mutation_events_event_type_check
    CHECK (event_type IN (
        'supersede_page',
        'delete_link',
        'change_link_role',
        'update_page_content'
    ));
\`\`\`

Pure DDL that widens the allowed set. Existing rows are untouched. No downtime.

## Tests-first workflow

\`tests/test_update_page_content.py\` was written *before* the migration and run against unmodified \`main\`. 3 of 4 tests failed with exactly the bug's signature:

\`\`\`
postgrest.exceptions.APIError: {
  'message': 'new row for relation \"mutation_events\" violates check constraint \"mutation_events_event_type_check\"',
  'code': '23514',
  ...
}
\`\`\`

The 4th test (\`test_update_page_content_on_missing_page_is_noop\`) passed pre-migration because \`update_page_content\` short-circuits before recording the event when the target page doesn't exist. Kept as a behavioural lock.

After \`supabase migration up\`, all 4 tests pass.

## Test coverage

| Test | What it pins |
|------|--------------|
| \`test_update_page_content_non_staged_writes_new_content\` | Non-staged path: base table row updated, \`get_page\` returns new content. The direct regression test for #281. |
| \`test_update_page_content_records_mutation_event\` | Mutation event shape: correct \`event_type\`, \`target_id\`, \`{old_content, new_content}\` payload |
| \`test_update_page_content_staged_leaves_base_row_alone\` | Staged-runs semantics: staged writer sees overlay, non-staged reader sees baseline |
| \`test_update_page_content_on_missing_page_is_noop\` | Behavioural lock: silent no-op when page doesn't exist, no event recorded |

## Verification

- \`uv run pytest\` — **211 passed, 35 skipped, 0 failed**
- \`uv run pyright\` — **0 errors, 0 warnings, 0 informations**
- \`supabase migration up\` applied cleanly

## Discovered during testing, filed separately

While running a question end-to-end to verify the fix, hit a different latent bug — the closing review can exceed the Anthropic API's context size limit (HTTP 422 \`'context reduction is suggested'\`). Filed as:

- chaosGuppy/rumil#282 — root cause (context size)
- chaosGuppy/rumil#283 — silent-failure shape (\`run_closing_review\` swallows the exception and the orchestrator reports success)

These are independent of the mutation-events fix and should not block this PR.

## Test plan

- [ ] CI: \`uv run pytest\`
- [ ] CI: \`uv run pyright\`
- [ ] Manual: run a question end-to-end with a view-producing call and confirm no CHECK violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)