### PR TITLE
Surface child investigation results in View update context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 db/
 /pages/
 /reports/
+frontend/package-lock.json
 .claude/settings.local.json
 .claude/state/
 CLAUDE.md.local

--- a/prompts/update_view.md
+++ b/prompts/update_view.md
@@ -17,6 +17,8 @@ A View is a curated, structured summary of the workspace's current best understa
 
 You will be asked to review View items in batches across several phases. Apply your judgement carefully — small, well-justified changes are better than sweeping revisions.
 
+The context may include a **Child Investigation Results** section showing the latest findings from recursive sub-question investigations. Items marked **[NEW]** were produced since the View was last updated. These results should inform your review — new findings may confirm, contradict, or refine existing View items, or may reveal gaps needing new items.
+
 <!-- PHASE:score_unscored — DO NOT RENAME THIS MARKER -->
 ## Phase: Score Unscored Proposals
 

--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -20,7 +20,7 @@ from rumil.calls.stages import (
     WorkspaceUpdater,
 )
 from rumil.constants import DEFAULT_VIEW_SECTIONS
-from rumil.context import build_embedding_based_context
+from rumil.context import build_embedding_based_context, render_child_investigation_results
 from rumil.database import DB
 from rumil.embeddings import embed_and_store_page
 from rumil.llm import LLMExchangeMetadata, structured_call
@@ -195,12 +195,26 @@ def _render_item_full(
 class UpdateViewContext(ContextBuilder):
     """Context for View update: embedding-based with raised similarity floors."""
 
-    def __init__(self, view_id: str) -> None:
+    def __init__(self, view_id: str, old_view_id: str | None = None) -> None:
         self._view_id = view_id
+        self._old_view_id = old_view_id
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
         question = await infra.db.get_page(infra.question_id)
         query = question.headline if question else infra.question_id
+
+        old_view = (
+            await infra.db.get_page(self._old_view_id)
+            if self._old_view_id
+            else None
+        )
+        last_view_created_at = old_view.created_at if old_view else None
+
+        child_section, child_page_ids = await render_child_investigation_results(
+            infra.db,
+            infra.question_id,
+            last_view_created_at,
+        )
 
         items = await infra.db.get_view_items(self._view_id)
         item_ids = [page.id for page, _ in items]
@@ -213,6 +227,8 @@ class UpdateViewContext(ContextBuilder):
                 if link.link_type in (LinkType.CITES, LinkType.DEPENDS_ON):
                     cited_ids.add(link.to_page_id)
 
+        exclude_ids = cited_ids | set(item_ids) | set(child_page_ids)
+
         result = await build_embedding_based_context(
             query,
             infra.db,
@@ -221,13 +237,17 @@ class UpdateViewContext(ContextBuilder):
             full_page_similarity_floor=0.6,
             abstract_page_similarity_floor=0.5,
             summary_page_similarity_floor=0.4,
-            exclude_page_ids=cited_ids | set(item_ids),
+            exclude_page_ids=exclude_ids,
         )
+
+        context_text = result.context_text
+        if child_section:
+            context_text = child_section + "\n\n" + context_text
 
         preloaded_ids = list(infra.call.context_page_ids or [])
         return ContextResult(
-            context_text=result.context_text,
-            working_page_ids=result.page_ids,
+            context_text=context_text,
+            working_page_ids=result.page_ids + child_page_ids,
             preloaded_ids=preloaded_ids,
         )
 
@@ -1128,7 +1148,7 @@ class UpdateViewCall(CallRunner):
         return existing_view.id, new_view.id
 
     def _make_context_builder(self) -> ContextBuilder:
-        return UpdateViewContext(self._view_id)
+        return UpdateViewContext(self._view_id, old_view_id=self._old_view_id)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:
         return UpdateViewWorkspaceUpdater(self._view_id, self.call_type)

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 from rumil.database import DB
 from rumil.embeddings import embed_query, search_pages_by_vector
-from rumil.models import LinkType, Page, PageDetail, PageLink, PageType
+from rumil.models import Page, PageDetail, PageLink, PageType
 from rumil.settings import get_settings
 
 log = logging.getLogger(__name__)
@@ -585,9 +585,12 @@ async def render_child_investigation_results(
             else:
                 lines.append(latest_judgement.abstract or "")
         else:
-            lines.append("**Status:** Not yet investigated")
+            continue
 
         entries.append((new, "\n".join(lines), page_ids))
+
+    if not entries:
+        return "", []
 
     entries.sort(key=lambda e: (not e[0], e[1]))
 

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -4,14 +4,16 @@ Build context text from workspace pages for injection into LLM prompts.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from datetime import datetime
 
 from rumil.database import DB
 from rumil.embeddings import embed_query, search_pages_by_vector
-from rumil.models import Page, PageDetail, PageLink, PageType
+from rumil.models import LinkType, Page, PageDetail, PageLink, PageType
 from rumil.settings import get_settings
 
 log = logging.getLogger(__name__)
@@ -473,6 +475,136 @@ async def render_view(
             parts.append("")
 
     return "\n".join(parts)
+
+
+async def render_child_investigation_results(
+    db: DB,
+    parent_question_id: str,
+    last_view_created_at: datetime | None,
+) -> tuple[str, list[str]]:
+    """Render investigation results from child questions for the View updater.
+
+    Returns (rendered_section_text, page_ids_used). If there are no child
+    questions, returns ("", []).
+
+    Detail level varies by newness (created after *last_view_created_at*):
+    - NEW View: NL content + compact I4/I5 item headlines
+    - Old View: NL content only
+    - NEW Summary/Judgement: full content
+    - Old Summary/Judgement: abstract only
+    """
+    children = await db.get_child_questions(parent_question_id)
+    if not children:
+        return "", []
+
+    child_ids = [c.id for c in children]
+    views_map, summaries_map, judgements_map = await asyncio.gather(
+        db.get_views_for_questions(child_ids),
+        db.get_latest_summaries_for_questions(child_ids),
+        db.get_judgements_for_questions(child_ids),
+    )
+
+    def _is_new(page: Page) -> bool:
+        if last_view_created_at is None:
+            return True
+        return page.created_at > last_view_created_at
+
+    new_view_ids: list[str] = []
+    for cid in child_ids:
+        v = views_map.get(cid)
+        if v and _is_new(v):
+            new_view_ids.append(v.id)
+    view_items_map: dict[str, list[tuple[Page, PageLink]]] = {}
+    if new_view_ids:
+        items_results = await asyncio.gather(
+            *(db.get_view_items(vid, min_importance=4) for vid in new_view_ids)
+        )
+        for vid, items in zip(new_view_ids, items_results):
+            view_items_map[vid] = items
+
+    entries: list[tuple[bool, str, list[str]]] = []
+    for child in children:
+        cid = child.id
+        view = views_map.get(cid)
+        summary = summaries_map.get(cid)
+        judgements = judgements_map.get(cid, [])
+        latest_judgement = (
+            max(judgements, key=lambda p: p.created_at) if judgements else None
+        )
+
+        new = False
+        page_ids: list[str] = []
+        lines: list[str] = [f"### `{cid[:8]}` — {child.headline}"]
+
+        if view:
+            new = _is_new(view)
+            page_ids.append(view.id)
+            lines.append(f"**Status:** View available{' [NEW]' if new else ''}")
+            if view.content:
+                lines.append("")
+                lines.append(view.content)
+            if new and view.id in view_items_map:
+                items = view_items_map[view.id]
+                if items:
+                    lines.append("")
+                    lines.append("**Key items:**")
+                    for page, link in items:
+                        imp = link.importance or 0
+                        c = page.credence if page.credence is not None else "?"
+                        r = page.robustness if page.robustness is not None else "?"
+                        lines.append(
+                            f"- [C{c}/R{r} I{imp}] `{page.id[:8]}` "
+                            f"— {page.headline}"
+                        )
+                        page_ids.append(page.id)
+        elif summary:
+            new = _is_new(summary)
+            page_ids.append(summary.id)
+            lines.append(
+                f"**Status:** Summary available{' [NEW]' if new else ''}"
+            )
+            lines.append("")
+            if new:
+                lines.append(summary.content or summary.abstract or "")
+            else:
+                lines.append(summary.abstract or "")
+        elif latest_judgement:
+            new = _is_new(latest_judgement)
+            page_ids.append(latest_judgement.id)
+            c = latest_judgement.credence if latest_judgement.credence is not None else "?"
+            r = latest_judgement.robustness if latest_judgement.robustness is not None else "?"
+            lines.append(
+                f"**Status:** Judgement available{' [NEW]' if new else ''}"
+            )
+            lines.append(
+                f"[JUDGEMENT C{c}/R{r}] {latest_judgement.headline}"
+            )
+            lines.append("")
+            if new:
+                lines.append(latest_judgement.content or latest_judgement.abstract or "")
+            else:
+                lines.append(latest_judgement.abstract or "")
+        else:
+            lines.append("**Status:** Not yet investigated")
+
+        entries.append((new, "\n".join(lines), page_ids))
+
+    entries.sort(key=lambda e: (not e[0], e[1]))
+
+    all_page_ids: list[str] = []
+    parts = [
+        "## Child Investigation Results",
+        "",
+        "The following sub-questions have been investigated. "
+        "Items marked [NEW] have been updated since the last View revision.",
+        "",
+    ]
+    for _, text, pids in entries:
+        parts.append(text)
+        parts.append("")
+        all_page_ids.extend(pids)
+
+    return "\n".join(parts), all_page_ids
 
 
 async def _build_dependency_signal(db: DB) -> str | None:

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -927,6 +927,41 @@ class DB:
                 return page
         return None
 
+    async def get_views_for_questions(
+        self,
+        question_ids: Sequence[str],
+    ) -> dict[str, Page | None]:
+        """Bulk-fetch the active (non-superseded) View page for many questions.
+
+        Returns {question_id: view_page_or_None}. Issues two batched queries
+        (links + pages) regardless of input size.
+        """
+        result: dict[str, Page | None] = {qid: None for qid in question_ids}
+        if not question_ids:
+            return result
+        id_list = list(dict.fromkeys(question_ids))
+        links_by_target = await self.get_links_to_many(id_list)
+        view_from_ids: list[str] = []
+        view_links_by_question: dict[str, list[PageLink]] = {}
+        for qid in id_list:
+            qlinks = [
+                l for l in links_by_target.get(qid, [])
+                if l.link_type == LinkType.VIEW_OF
+            ]
+            if qlinks:
+                view_links_by_question[qid] = qlinks
+                view_from_ids.extend(l.from_page_id for l in qlinks)
+        if not view_from_ids:
+            return result
+        pages = await self.get_pages_by_ids(list(dict.fromkeys(view_from_ids)))
+        for qid, qlinks in view_links_by_question.items():
+            for link in qlinks:
+                page = pages.get(link.from_page_id)
+                if page and not page.is_superseded:
+                    result[qid] = page
+                    break
+        return result
+
     async def get_view_items(
         self,
         view_id: str,
@@ -1062,6 +1097,47 @@ class DB:
         if not candidates:
             return None
         return max(candidates, key=lambda p: p.created_at)
+
+    async def get_latest_summaries_for_questions(
+        self,
+        question_ids: Sequence[str],
+    ) -> dict[str, Page | None]:
+        """Bulk-fetch the most recent active SUMMARY page for many questions.
+
+        Returns {question_id: summary_page_or_None}. Issues two batched queries
+        (links + pages) regardless of input size.
+        """
+        result: dict[str, Page | None] = {qid: None for qid in question_ids}
+        if not question_ids:
+            return result
+        id_list = list(dict.fromkeys(question_ids))
+        links_by_target = await self.get_links_to_many(id_list)
+        summary_from_ids: list[str] = []
+        summary_links_by_question: dict[str, list[PageLink]] = {}
+        for qid in id_list:
+            qlinks = [
+                l for l in links_by_target.get(qid, [])
+                if l.link_type == LinkType.SUMMARIZES
+            ]
+            if qlinks:
+                summary_links_by_question[qid] = qlinks
+                summary_from_ids.extend(l.from_page_id for l in qlinks)
+        if not summary_from_ids:
+            return result
+        pages = await self.get_pages_by_ids(
+            list(dict.fromkeys(summary_from_ids))
+        )
+        for qid, qlinks in summary_links_by_question.items():
+            candidates = [
+                pages[l.from_page_id]
+                for l in qlinks
+                if l.from_page_id in pages
+                and pages[l.from_page_id].is_active()
+                and pages[l.from_page_id].page_type == PageType.SUMMARY
+            ]
+            if candidates:
+                result[qid] = max(candidates, key=lambda p: p.created_at)
+        return result
 
     async def get_considerations_for_question(
         self,


### PR DESCRIPTION
## Summary

- The View updater previously relied solely on embedding similarity search for context, which could miss results from recursive child question investigations (scout -> web_research -> summarize -> assess) when they're semantically tangential to the parent question
- Now `UpdateViewContext` explicitly fetches the latest View/summary/judgement from each child question via new batch DB methods (`get_views_for_questions`, `get_latest_summaries_for_questions`) and renders them in a dedicated section prepended before embedding results
- Items created after the previous View revision are marked `[NEW]` with increased detail (I4/I5 item headlines for new Views, full content for new summaries/judgements; abstracts only for older results)

## Test plan

- [x] All 23 existing `test_update_view.py` tests pass
- [x] Pyright clean on all modified files
- [ ] Smoke test with `--smoke-test` to verify child investigation section appears in update_view trace context
- [ ] Add unit tests for `render_child_investigation_results` with mocked child questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)