### PR TITLE
Scope prioritization context to current project

### DIFF
--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -478,7 +478,9 @@ async def render_view(
 async def _build_dependency_signal(db: DB) -> str | None:
     """Build a section listing the most-depended-on pages in the workspace.
 
-    Returns None if no DEPENDS_ON links exist yet.
+    Returns None if there are no renderable load-bearing pages — either
+    because no DEPENDS_ON links exist, or because none of the top pages
+    could be resolved.
     """
     counts = await db.get_dependency_counts()
     if not counts:
@@ -486,20 +488,30 @@ async def _build_dependency_signal(db: DB) -> str | None:
 
     top = sorted(counts.items(), key=lambda x: x[1], reverse=True)[:10]
     pages = await db.get_pages_by_ids([pid for pid, _ in top])
-    lines = ["## Load-Bearing Pages (by dependency count)", ""]
-    lines.append(
-        "These pages are depended on by the most other pages. "
-        "Prioritize them for robustness assessment — if they turn out to "
-        "be wrong, the most downstream conclusions would be affected."
-    )
-    lines.append("")
+
+    item_lines: list[str] = []
     for pid, count in top:
         page = pages.get(pid)
         if page:
             stale_tag = " [SUPERSEDED]" if page.is_superseded else ""
-            lines.append(
+            item_lines.append(
                 f"- `{pid[:8]}` — {page.headline} ({count} dependents){stale_tag}"
             )
+
+    if not item_lines:
+        return None
+
+    lines = [
+        "## Load-Bearing Pages (by dependency count)",
+        "",
+        (
+            "These pages are depended on by the most other pages. "
+            "Prioritize them for robustness assessment — if they turn out to "
+            "be wrong, the most downstream conclusions would be affected."
+        ),
+        "",
+    ]
+    lines.extend(item_lines)
     return "\n".join(lines)
 
 

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -1269,18 +1269,49 @@ class DB:
         return stale
 
     async def get_dependency_counts(self) -> dict[str, int]:
-        """Return a map from page_id to how many pages depend on it."""
+        """Return a map from page_id to how many pages depend on it, within the current project.
+
+        Scopes by intersecting link endpoints with the project's page IDs.
+        `page_links` has no `project_id` column, so we resolve project membership
+        via `pages`.
+        """
+        project_page_ids: set[str] | None = None
+        if self.project_id:
+            project_page_ids = set()
+            offset = 0
+            page_size = 2000
+            while True:
+                pages_query = (
+                    self.client.table("pages")
+                    .select("id")
+                    .eq("project_id", self.project_id)
+                )
+                pages_query = self._staged_filter(pages_query)
+                rows = _rows(await self._execute(
+                    pages_query.range(offset, offset + page_size - 1)
+                ))
+                project_page_ids.update(r["id"] for r in rows)
+                if len(rows) < page_size:
+                    break
+                offset += page_size
+
         query = (
             self.client.table("page_links")
-            .select("to_page_id")
+            .select(_LINK_COLUMNS)
             .eq("link_type", LinkType.DEPENDS_ON.value)
         )
         query = self._staged_filter(query)
         rows = _rows(await self._execute(query))
+        links = await self._apply_link_events([_row_to_link(r) for r in rows])
+
         counts: dict[str, int] = {}
-        for row in rows:
-            pid = row["to_page_id"]
-            counts[pid] = counts.get(pid, 0) + 1
+        for link in links:
+            if project_page_ids is not None and (
+                link.from_page_id not in project_page_ids
+                or link.to_page_id not in project_page_ids
+            ):
+                continue
+            counts[link.to_page_id] = counts.get(link.to_page_id, 0) + 1
         return counts
 
     async def _get_supersession_magnitude(self, page_id: str) -> int | None:

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -190,3 +190,48 @@ async def test_get_pages_slim_isolated(two_workspaces):
     assert w["q_alpha"].id not in beta_ids
     assert w["q_beta"].id in beta_ids
     assert w["q_beta"].id not in alpha_ids
+
+
+async def _link_depends_on(db: DB, dependent: Page, dependency: Page) -> None:
+    await db.save_link(
+        PageLink(
+            from_page_id=dependent.id,
+            to_page_id=dependency.id,
+            link_type=LinkType.DEPENDS_ON,
+            strength=4.0,
+            reasoning="test dep",
+        )
+    )
+
+
+async def test_dependency_counts_isolated(two_workspaces):
+    w = two_workspaces
+    dep_alpha = await _make_claim(w["db_alpha"], "Foundational claim about sky")
+    dep_beta = await _make_claim(w["db_beta"], "Foundational claim about ocean")
+
+    for _ in range(2):
+        dependent = await _make_claim(w["db_alpha"], "Derived sky claim")
+        await _link_depends_on(w["db_alpha"], dependent, dep_alpha)
+
+    for _ in range(3):
+        dependent = await _make_claim(w["db_beta"], "Derived ocean claim")
+        await _link_depends_on(w["db_beta"], dependent, dep_beta)
+
+    alpha_counts = await w["db_alpha"].get_dependency_counts()
+    beta_counts = await w["db_beta"].get_dependency_counts()
+
+    assert alpha_counts.get(dep_alpha.id) == 2
+    assert dep_beta.id not in alpha_counts
+
+    assert beta_counts.get(dep_beta.id) == 3
+    assert dep_alpha.id not in beta_counts
+
+
+async def test_prioritization_context_no_load_bearing_section_when_empty():
+    db = await _make_db(f"empty-{uuid.uuid4().hex[:8]}")
+    try:
+        question = await _make_question(db, "What is 2+2?")
+        ctx, _ = await build_prioritization_context(db, question.id)
+        assert "Load-Bearing Pages" not in ctx
+    finally:
+        await db.delete_run_data(delete_project=True)


### PR DESCRIPTION
## Summary
- Fix cross-project leak in `get_dependency_counts()`: filter DEPENDS_ON links by the current project (via `pages.project_id`, since `page_links` has no project column) and apply link mutation events so staged runs see their own changes.
- Gate the "Load-Bearing Pages" section in the prioritization context: only render the header + explanation when at least one top page resolves. Prevents bare headers on empty workspaces and after other edge cases.

## Why
Caught in the orchestrator audit (`orchestrator-audit/metr.md` §4, §6-item-1; `SYNTHESIS.md` §W1). METR's prioritization prompt was pulling `Load-Bearing Pages` from the `default` and `forethought-recent` projects, occupying ~300 tokens of prime context on every multi-project workspace.

Went with option (b) from the session brief (filter via join rather than add `project_id` to `page_links`). Option (a) is still worth considering — a `project_id` column on `page_links` would enforce the within-project invariant at the schema level and remove the two-step fetch — but it's a migration + backfill that we shouldn't bundle with the hot fix.

## Audit
Surveyed other `page_links` queries in `database.py`:
- `get_stale_dependencies` (line 1248) has the same unscoped-by-project pattern. It has no callers today, so left alone — flagging here for future cleanup.
- Other link queries are either scoped by specific IDs (already within-project) or scoped via `pages.project_id` (e.g. `get_all_links`).
- RPCs in `supabase/migrations/`: `compute_project_stats` joins through project-scoped pages; `compute_question_stats` recursively traverses from a single question and is de-facto project-scoped. Not touched.

## Design decision on Bug 2
Went with empty-gate-only (session brief's default) rather than suppressing the section entirely in phase-1 prioritization. Phase-1 is fan-out scouting and doesn't directly act on the load-bearing signal, but the section is small and harmless when non-empty, and phase-1 can legitimately run over a pre-existing graph from ingests. Stronger phase-1 suppression can be a follow-up if the signal proves consistently noisy there.

## Test plan
- [x] `uv run pytest tests/test_workspace_isolation.py` — all 8 pass, including new `test_dependency_counts_isolated` and `test_prioritization_context_no_load_bearing_section_when_empty`
- [x] Full `uv run pytest` — 411 passed. Two failures (`test_execute_dispatch_assess_with_existing_view_redirects_to_create_view`, `test_update_page_content_on_missing_page_is_noop`) reproduce on `main` — pre-existing, unrelated.
- [ ] Spot-check: rerun a prioritization on one of the audit workspaces (e.g. `default`) and verify its own load-bearing pages (`43aaa1a7` etc.) still appear in its own context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)