### PR TITLE
Lock down RLS: enable on all tables, drop allow-all policies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,14 @@ Tests: `uv run pytest`.
 **Database:** Runs against local Supabase by default (`supabase start`). Pass `--prod` to any command to target production. Migrations live in `supabase/migrations/` and are pushed to prod with `supabase db push`.
 Always use the supabase cli to create new migrations: `supabase migration new`.
 
+**Row-Level Security:** RLS is enabled on all tables with **no policies**. This means:
+- `service_role` (used by all backend code) bypasses RLS entirely — no performance impact, full access.
+- `anon` and `authenticated` roles are denied all table access by PostgreSQL's implicit-deny default.
+- The frontend anon key is only used for Realtime broadcast subscriptions, which do not touch the database.
+
+If you add a new table, always enable RLS: `ALTER TABLE new_table ENABLE ROW LEVEL SECURITY;`
+Do NOT add "allow all" policies. If you need non-service-role access, add targeted policies.
+
 ## Architecture
 
 **Entry point:** `main.py` — CLI arg parsing, dispatches to command functions.

--- a/supabase/migrations/20260416085408_lock_down_rls.sql
+++ b/supabase/migrations/20260416085408_lock_down_rls.sql
@@ -1,0 +1,35 @@
+-- Lock down Row-Level Security across all tables.
+--
+-- SECURITY MODEL:
+-- All backend access (CLI, API, orchestrators) uses the service_role key,
+-- which has bypassrls privilege and is completely unaffected by RLS.
+-- The frontend anon key is used ONLY for Realtime broadcast subscriptions
+-- (not postgres_changes), so it never queries tables directly.
+--
+-- With RLS enabled and no policies, PostgreSQL's default behavior is to
+-- deny all access for non-bypassrls roles (anon, authenticated).
+-- This is the desired posture: the anon key cannot read or write any data.
+--
+-- If you need to add a new access path that does NOT use service_role,
+-- you must add explicit RLS policies for the relevant tables.
+
+-- 1. Enable RLS on the 5 tables that don't have it yet.
+ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE page_embeddings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE call_llm_exchanges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE epistemic_scores ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ab_eval_reports ENABLE ROW LEVEL SECURITY;
+
+-- 2. Drop the "allow all" policies on the 10 tables that have them.
+--    With these removed and no replacement policies, non-bypassrls roles
+--    are implicitly denied all access (PostgreSQL default).
+DROP POLICY IF EXISTS "allow all" ON pages;
+DROP POLICY IF EXISTS "allow all" ON page_links;
+DROP POLICY IF EXISTS "allow all" ON calls;
+DROP POLICY IF EXISTS "allow all" ON budget;
+DROP POLICY IF EXISTS "allow all" ON page_ratings;
+DROP POLICY IF EXISTS "allow all" ON page_flags;
+DROP POLICY IF EXISTS "allow all" ON call_sequences;
+DROP POLICY IF EXISTS "allow all" ON runs;
+DROP POLICY IF EXISTS "allow all" ON ab_runs;
+DROP POLICY IF EXISTS "allow all" ON mutation_events;


### PR DESCRIPTION
## Summary

- Enables Row-Level Security on the 5 tables that were missing it: `projects`, `page_embeddings`, `call_llm_exchanges`, `epistemic_scores`, `ab_eval_reports`
- Drops the permissive `"allow all"` policies from all 10 tables that had them
- Documents the RLS security model in CLAUDE.md

With RLS enabled and no policies, PostgreSQL's implicit-deny default blocks all access for non-`bypassrls` roles (`anon`, `authenticated`). The `service_role` key used by all backend code bypasses RLS entirely — zero performance impact, zero behavior change. The frontend anon key is only used for Realtime broadcast subscriptions which don't touch the database.

## Test plan

- [x] Migration applies cleanly via `supabase migration up --local`
- [x] All 15 tables show `rowsecurity = t` and zero policies
- [x] `uv run pytest` passes (410 passed, 3 pre-existing failures unrelated to RLS, 46 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)