### PR TITLE
Use current View as context for prioritization and scoring

### DIFF
--- a/main.py
+++ b/main.py
@@ -850,7 +850,10 @@ async def cmd_continue(
             + "\n\nNot every extracted claim is necessarily important — use your "
             "judgement about which ones are worth investigating further. But the "
             "user specifically provided this source, so the material as a whole "
-            "may deserve more attention than scores alone suggest."
+            "may deserve more attention than scores alone suggest. "
+            "The View for this question has NOT yet been updated to reflect this "
+            "new material — ingested considerations are not yet factored into "
+            "View scores or item selection."
         )
     await orch.run(question_id)
     await _print_summary(db)

--- a/src/rumil/chat.py
+++ b/src/rumil/chat.py
@@ -765,7 +765,10 @@ async def run_continuation_chat(
     orch.ingest_hint = (
         "The researcher just had a conversation about the investigation findings. "
         "The transcript has been ingested as a source. The researcher may have "
-        "provided corrections, additional context, or steering for the next phase."
+        "provided corrections, additional context, or steering for the next phase. "
+        "The View for this question has NOT yet been updated to reflect this new "
+        "material — any corrections or new context from the conversation are not "
+        "yet factored into View scores or item selection."
     )
     await orch.run(question_id)
 

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -644,9 +644,9 @@ async def build_prioritization_context(
 ) -> tuple[str, dict[str, str]]:
     """Build context for a prioritization call.
 
-    Uses embedding-similarity search to surface the most relevant pages
-    from the workspace, then appends the scope question and its direct
-    children (at ABSTRACT detail) and a dispatchable question index.
+    Includes the current View (importance 2+) for the scope question,
+    then appends the scope question and its direct children (at ABSTRACT
+    detail) and a dependency signal.
 
     Returns (context_text, short_id_map) where short_id_map maps 8-char
     short IDs to full UUIDs.
@@ -657,19 +657,22 @@ async def build_prioritization_context(
     if scope_question_id:
         question = await db.get_page(scope_question_id)
         if question:
+            view = await db.get_view_for_question(scope_question_id)
+            if view:
+                view_items = await db.get_view_items(
+                    view.id, min_importance=2,
+                )
+                view_text = await render_view(
+                    view, view_items, min_importance=2,
+                )
+                if view_text.strip():
+                    parts.append(view_text)
+                    parts.append("")
+                    parts.append("---")
+                    parts.append("")
+
             direct_children = await db.get_child_questions(scope_question_id)
             full_page_ids = {scope_question_id} | {c.id for c in direct_children}
-            embedding_result = await build_embedding_based_context(
-                question.headline,
-                db,
-                scope_question_id=scope_question_id,
-                headline_only_ids=full_page_ids,
-            )
-            if embedding_result.context_text:
-                parts.append(embedding_result.context_text)
-                parts.append("")
-                parts.append("---")
-                parts.append("")
 
             subtree_text = await render_page_and_immediate_children(
                 scope_question_id,

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -269,6 +269,16 @@ async def score_items_sequentially(
             parent_parts.append(parent_judgement.headline)
         parent_parts.append("")
 
+    view = await db.get_view_for_question(parent_page.id)
+    if view:
+        from rumil.context import render_view
+
+        view_items = await db.get_view_items(view.id, min_importance=2)
+        view_text = await render_view(view, view_items, min_importance=2)
+        if view_text.strip():
+            parent_parts.append(view_text)
+            parent_parts.append("")
+
     parent_context = "\n".join(parent_parts)
     system_prompt = build_system_prompt(system_prompt_name)
     messages: list[dict] = []


### PR DESCRIPTION
Replace embedding-similarity search in build_prioritization_context with the current View (importance 2+), so prioritization sees the curated state of knowledge rather than raw similarity hits. Also include the View in score_items_sequentially so subquestion/claim scoring has the full picture.

Ingest hints now mention that the View hasn't been updated to reflect new material, giving prioritization awareness of View staleness.