### PR TITLE
Surface dependency staleness to the prioritizer

### DIFF
--- a/prompts/two_phase_main_phase_prioritization.md
+++ b/prompts/two_phase_main_phase_prioritization.md
@@ -67,6 +67,15 @@ The guidelines for scouts ranking fruit goes as:
 7-8 = substantial work remains
 9-10 = barely started
 
+## Stale Dependencies
+
+The context may include a **Stale Dependencies** section listing pages that depend on claims which have since been superseded. These pages rest on outdated premises and may need reassessment.
+
+When deciding how to allocate budget, factor in staleness:
+- **High link strength + high change magnitude** = the dependency was critical and changed significantly. Prioritize reassessing the question that the stale page bears on — the existing conclusions are likely wrong.
+- **Low link strength or no change magnitude** = the dependency was weaker or the change may be minor. Treat as lower priority — only spend budget here if nothing more productive is available.
+- The right response to a stale dependency is usually to dispatch an assess on the question the dependent page is a consideration for. This re-evaluates the question in light of the updated evidence.
+
 ## Budget Accounting
 
 Your total dispatched budget (worst case) must not exceed your allocated budget:

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -553,16 +553,13 @@ async def render_child_investigation_results(
                         c = page.credence if page.credence is not None else "?"
                         r = page.robustness if page.robustness is not None else "?"
                         lines.append(
-                            f"- [C{c}/R{r} I{imp}] `{page.id[:8]}` "
-                            f"— {page.headline}"
+                            f"- [C{c}/R{r} I{imp}] `{page.id[:8]}` — {page.headline}"
                         )
                         page_ids.append(page.id)
         elif summary:
             new = _is_new(summary)
             page_ids.append(summary.id)
-            lines.append(
-                f"**Status:** Summary available{' [NEW]' if new else ''}"
-            )
+            lines.append(f"**Status:** Summary available{' [NEW]' if new else ''}")
             lines.append("")
             if new:
                 lines.append(summary.content or summary.abstract or "")
@@ -571,17 +568,23 @@ async def render_child_investigation_results(
         elif latest_judgement:
             new = _is_new(latest_judgement)
             page_ids.append(latest_judgement.id)
-            c = latest_judgement.credence if latest_judgement.credence is not None else "?"
-            r = latest_judgement.robustness if latest_judgement.robustness is not None else "?"
-            lines.append(
-                f"**Status:** Judgement available{' [NEW]' if new else ''}"
+            c = (
+                latest_judgement.credence
+                if latest_judgement.credence is not None
+                else "?"
             )
-            lines.append(
-                f"[JUDGEMENT C{c}/R{r}] {latest_judgement.headline}"
+            r = (
+                latest_judgement.robustness
+                if latest_judgement.robustness is not None
+                else "?"
             )
+            lines.append(f"**Status:** Judgement available{' [NEW]' if new else ''}")
+            lines.append(f"[JUDGEMENT C{c}/R{r}] {latest_judgement.headline}")
             lines.append("")
             if new:
-                lines.append(latest_judgement.content or latest_judgement.abstract or "")
+                lines.append(
+                    latest_judgement.content or latest_judgement.abstract or ""
+                )
             else:
                 lines.append(latest_judgement.abstract or "")
         else:
@@ -650,6 +653,75 @@ async def _build_dependency_signal(db: DB) -> str | None:
     return "\n".join(lines)
 
 
+async def _build_staleness_signal(db: DB) -> str | None:
+    """Build a section listing pages whose DEPENDS_ON targets are superseded.
+
+    Calls the batched ``get_stale_dependencies()`` and enriches each
+    result with page headlines and link metadata so the prioritizer LLM
+    has enough to decide whether reassessment is worth budget.
+
+    Returns None if there are no stale dependencies in the workspace.
+    """
+    stale = await db.get_stale_dependencies()
+    if not stale:
+        return None
+
+    all_ids = list(
+        {link.from_page_id for link, _ in stale}
+        | {link.to_page_id for link, _ in stale}
+    )
+    pages = await db.get_pages_by_ids(all_ids)
+
+    item_lines: list[str] = []
+    for link, magnitude in stale:
+        dependent = pages.get(link.from_page_id)
+        target = pages.get(link.to_page_id)
+        if not dependent or not target:
+            continue
+        # Filter to current project when project_id is set, so the
+        # staleness signal matches the scope of everything else in the
+        # prioritization context.
+        if db.project_id and dependent.project_id != db.project_id:
+            continue
+
+        cred = (
+            f" (credence {dependent.credence}/9, robustness {dependent.robustness}/5)"
+            if dependent.credence is not None
+            else ""
+        )
+        mag_str = f", change magnitude: {magnitude}/5" if magnitude is not None else ""
+        item_lines.append(
+            f"- `{dependent.id[:8]}` — {dependent.headline}{cred}\n"
+            f"  depends on `{target.id[:8]}` — {target.headline}"
+            f" [SUPERSEDED{mag_str}]\n"
+            f"  Link strength: {link.strength:.0f}/5"
+        )
+
+    if not item_lines:
+        return None
+
+    # Cap at 10 entries to keep the context manageable.
+    shown = item_lines[:10]
+    overflow = len(item_lines) - len(shown)
+
+    lines = [
+        "## Stale Dependencies",
+        "",
+        (
+            "The following pages rest on claims that have since been "
+            "superseded. Their conclusions may no longer hold. Consider "
+            "dispatching an assess on the questions they bear on — "
+            "especially when link strength and change magnitude are both "
+            "high."
+        ),
+        "",
+    ]
+    lines.extend(shown)
+    if overflow > 0:
+        lines.append(f"\n({overflow} more stale dependencies not shown)")
+    return "\n".join(lines)
+
+
 async def build_prioritization_context(
     db: DB,
     scope_question_id: str | None = None,
@@ -672,10 +744,13 @@ async def build_prioritization_context(
             view = await db.get_view_for_question(scope_question_id)
             if view:
                 view_items = await db.get_view_items(
-                    view.id, min_importance=2,
+                    view.id,
+                    min_importance=2,
                 )
                 view_text = await render_view(
-                    view, view_items, min_importance=2,
+                    view,
+                    view_items,
+                    min_importance=2,
                 )
                 if view_text.strip():
                     parts.append(view_text)
@@ -704,6 +779,11 @@ async def build_prioritization_context(
     dep_section = await _build_dependency_signal(db)
     if dep_section:
         parts.append(dep_section)
+        parts.append("")
+
+    staleness_section = await _build_staleness_signal(db)
+    if staleness_section:
+        parts.append(staleness_section)
         parts.append("")
 
     return "\n".join(parts), short_id_map

--- a/tests/test_staleness_signal.py
+++ b/tests/test_staleness_signal.py
@@ -1,0 +1,183 @@
+"""Tests for the staleness signal surfaced to prioritization.
+
+_build_staleness_signal reads stale dependency links (DEPENDS_ON targets
+that have been superseded) and formats them as context text for the
+prioritizer LLM. build_prioritization_context should include this section
+when stale deps exist and omit it when they don't.
+
+Written against pre-implementation main: the tests that assert the
+staleness section is present in the output must fail until the feature
+is added.
+"""
+
+import pytest_asyncio
+
+from rumil.context import build_prioritization_context
+from rumil.database import DB
+from rumil.models import (
+    ConsiderationDirection,
+    LinkRole,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+
+
+def _claim(headline: str) -> Page:
+    return Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Content of {headline}",
+        headline=headline,
+        credence=7,
+        robustness=3,
+    )
+
+
+def _question(headline: str = "Root question") -> Page:
+    return Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+    )
+
+
+async def _depends_on(db: DB, dependent: Page, dependency: Page) -> PageLink:
+    link = PageLink(
+        from_page_id=dependent.id,
+        to_page_id=dependency.id,
+        link_type=LinkType.DEPENDS_ON,
+        direction=ConsiderationDirection.NEUTRAL,
+        strength=4.0,
+        reasoning="test dependency",
+        role=LinkRole.DIRECT,
+    )
+    await db.save_link(link)
+    return link
+
+
+async def _consideration(db: DB, claim: Page, question: Page) -> PageLink:
+    link = PageLink(
+        from_page_id=claim.id,
+        to_page_id=question.id,
+        link_type=LinkType.CONSIDERATION,
+        direction=ConsiderationDirection.SUPPORTS,
+        strength=3.0,
+        reasoning="test consideration",
+    )
+    await db.save_link(link)
+    return link
+
+
+@pytest_asyncio.fixture
+async def question_with_stale_dep(tmp_db):
+    """A question with a claim that depends on a superseded page.
+
+    Structure:
+      root_q <-- claim_a (consideration, SUPPORTS)
+      claim_a --depends_on--> claim_b [SUPERSEDED by claim_b_prime]
+
+    Returns (question, claim_a, claim_b, claim_b_prime, link_dep).
+    """
+    q = _question("What is the right policy?")
+    claim_a = _claim("Claim A: policy X is optimal")
+    claim_b = _claim("Claim B: cost estimate is $1M")
+    claim_b_prime = _claim("Claim B prime: cost estimate is $5M")
+
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(claim_a)
+    await tmp_db.save_page(claim_b)
+    await tmp_db.save_page(claim_b_prime)
+
+    await _consideration(tmp_db, claim_a, q)
+    link_dep = await _depends_on(tmp_db, claim_a, claim_b)
+    await tmp_db.supersede_page(claim_b.id, claim_b_prime.id, change_magnitude=4)
+
+    return q, claim_a, claim_b, claim_b_prime, link_dep
+
+
+async def test_staleness_signal_absent_when_no_stale_deps(tmp_db):
+    """When no DEPENDS_ON links exist (or all targets are active),
+    the staleness section should not appear in the prioritization context."""
+    q = _question()
+    await tmp_db.save_page(q)
+
+    ctx_text, _ = await build_prioritization_context(tmp_db, q.id)
+    assert "Stale Dependencies" not in ctx_text
+
+
+async def test_staleness_signal_absent_when_deps_active(tmp_db):
+    """Active dependencies should not trigger a staleness section."""
+    q = _question()
+    claim_a = _claim("Claim A")
+    claim_b = _claim("Claim B")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(claim_a)
+    await tmp_db.save_page(claim_b)
+
+    await _consideration(tmp_db, claim_a, q)
+    await _depends_on(tmp_db, claim_a, claim_b)
+
+    ctx_text, _ = await build_prioritization_context(tmp_db, q.id)
+    assert "Stale Dependencies" not in ctx_text
+
+
+async def test_staleness_signal_present_when_deps_superseded(
+    tmp_db,
+    question_with_stale_dep,
+):
+    """When a DEPENDS_ON target is superseded, the staleness section
+    should appear in the prioritization context with enough detail for
+    the prioritizer to decide whether reassessment is worth budget."""
+    q, claim_a, claim_b, claim_b_prime, _link = question_with_stale_dep
+
+    ctx_text, _ = await build_prioritization_context(tmp_db, q.id)
+
+    assert "Stale Dependencies" in ctx_text
+    # The dependent's headline should appear.
+    assert claim_a.headline in ctx_text
+    # The superseded target's headline should appear.
+    assert claim_b.headline in ctx_text
+    # The change magnitude should appear.
+    assert "4" in ctx_text
+
+
+async def test_staleness_signal_shows_link_strength(
+    tmp_db,
+    question_with_stale_dep,
+):
+    """The staleness section should include the link strength so the
+    prioritizer can weigh how critical the dependency is."""
+    q, *_ = question_with_stale_dep
+    ctx_text, _ = await build_prioritization_context(tmp_db, q.id)
+
+    # The link was created with strength 4.0.
+    assert "strength" in ctx_text.lower() or "4" in ctx_text
+
+
+async def test_staleness_signal_handles_missing_magnitude(tmp_db):
+    """When a supersession event has no change_magnitude, the section
+    should still render without crashing."""
+    q = _question()
+    claim_a = _claim("Claim A")
+    claim_b = _claim("Claim B")
+    claim_b2 = _claim("Claim B replacement")
+    await tmp_db.save_page(q)
+    await tmp_db.save_page(claim_a)
+    await tmp_db.save_page(claim_b)
+    await tmp_db.save_page(claim_b2)
+
+    await _consideration(tmp_db, claim_a, q)
+    await _depends_on(tmp_db, claim_a, claim_b)
+    await tmp_db.supersede_page(claim_b.id, claim_b2.id)  # no magnitude
+
+    ctx_text, _ = await build_prioritization_context(tmp_db, q.id)
+    assert "Stale Dependencies" in ctx_text
+    assert claim_a.headline in ctx_text
+    assert claim_b.headline in ctx_text


### PR DESCRIPTION
## Summary

When DEPENDS_ON link targets have been superseded, the prioritizer now sees a **Stale Dependencies** section in its context. This gives the LLM enough information to decide whether reassessing affected questions is worth budget — without automatically cascading updates.

Fixes chaosGuppy/rumil#251.

## What the prioritizer sees

```
## Stale Dependencies

The following pages rest on claims that have since been superseded.
Their conclusions may no longer hold. Consider dispatching an assess
on the questions they bear on — especially when link strength and
change magnitude are both high.

- `abc12345` — Claim A: policy X is optimal (credence 7/9, robustness 3/5)
  depends on `def67890` — Claim B: cost estimate is $1M [SUPERSEDED, change magnitude: 4/5]
  Link strength: 4/5
```

Each entry shows: the dependent page (headline, credence, robustness), the superseded target (headline, change magnitude), and the link strength. Capped at 10 entries.

## Implementation

**`src/rumil/context.py`** — new `_build_staleness_signal(db)`:
1. Calls `get_stale_dependencies()` (already batched in #293) — O(1) round trips
2. Fetches all dependent + target pages in one `get_pages_by_ids` call
3. Filters to the current project via `db.project_id` (so staleness signal doesn't leak cross-project data)
4. Formats each stale link as a bullet with all the info the prioritizer needs
5. Returns `None` if no stale deps exist

Wired into `build_prioritization_context` alongside the existing `_build_dependency_signal`.

**`prompts/two_phase_main_phase_prioritization.md`** — new "Stale Dependencies" guidance section:
- High link strength + high change magnitude = prioritize reassessment
- Low link strength or no magnitude = lower priority
- Right response is usually to dispatch an assess on the relevant question

## Scope

- **Read-side only.** No mutation events, no write-side plumbing, no schema changes.
- **Only supersession-based staleness.** Credence/robustness shifts via UPDATE_EPISTEMIC don't emit mutation events and aren't detected. That's #253's territory.
- **Only main-phase prompt.** Initial fan-out just distributes scouts; staleness is irrelevant there.
- **Assess context enrichment** (making the assess call itself aware of dependency changes) is tracked separately as #252 — different files, different concern.

## Tests

`tests/test_staleness_signal.py` (new, 5 tests):

| Test | What it pins |
|------|--------------|
| `test_staleness_signal_absent_when_no_stale_deps` | No DEPENDS_ON links -> section absent |
| `test_staleness_signal_absent_when_deps_active` | Active targets -> section absent |
| `test_staleness_signal_present_when_deps_superseded` | Superseded target -> section appears with dependent + target headlines + magnitude |
| `test_staleness_signal_shows_link_strength` | Link strength visible in output |
| `test_staleness_signal_handles_missing_magnitude` | No change_magnitude -> renders without crash |

Tests-first: written against main (2 failed, 3 passed), all 5 pass after the feature.

## Verification

- `uv run pytest` — **424 passed, 46 skipped, 0 failed**
- `uv run pyright` — **0 errors**

## Test plan

- [ ] CI: `uv run pytest`
- [ ] CI: `uv run pyright`
- [ ] Manual: run a workspace with superseded claims that have DEPENDS_ON links, trigger a prioritization call, and verify the LLM sees the staleness section and responds to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)