### PR TITLE
Allow --summary to auto-summarize after investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ uv run python main.py --chat QUESTION_ID
 # Generate executive summary
 uv run python main.py --summary QUESTION_ID
 
+# Investigate and summarize in one command
+uv run python main.py "Your question here" --budget 20 --summary
+
 # Generate a multi-section research report
 uv run python main.py --report QUESTION_ID
 

--- a/main.py
+++ b/main.py
@@ -555,6 +555,7 @@ async def cmd_new(
     db: DB,
     ingest_files: list[str] | None = None,
     name: str = "",
+    auto_summary: bool = False,
 ) -> str:
     budget = _default_budget(budget)
     await db.init_budget(budget)
@@ -587,7 +588,7 @@ async def cmd_new(
             await run_ingest_calls(source_pages, question_id, db)
 
     await Orchestrator(db).run(question_id)
-    await _print_summary(db)
+    await _print_summary(db, suppress_hint=auto_summary)
     return question_id
 
 
@@ -860,10 +861,11 @@ async def cmd_continue(
     await _print_summary(db)
 
 
-async def _print_summary(db: DB) -> None:
+async def _print_summary(db: DB, suppress_hint: bool = False) -> None:
     total, used = await db.get_budget()
     print(f"\nBudget used: {used}/{total} calls")
-    print("\nRun --list to see all questions.")
+    if not suppress_hint:
+        print("\nRun --list to see all questions.")
 
 
 async def async_main():
@@ -1283,14 +1285,16 @@ async def async_main():
         await cmd_ab(q, args.budget, db, name=args.run_name)
     elif args.question:
         q = parse_question_input(args.question)
+        do_summary = args.summary_id == "__auto__"
         question_id = await cmd_new(
             q,
             args.budget,
             db,
             ingest_files=args.ingest_files,
             name=args.run_name,
+            auto_summary=do_summary,
         )
-        if args.summary_id == "__auto__":
+        if do_summary:
             await cmd_summary(
                 question_id,
                 db,

--- a/main.py
+++ b/main.py
@@ -555,7 +555,7 @@ async def cmd_new(
     db: DB,
     ingest_files: list[str] | None = None,
     name: str = "",
-) -> None:
+) -> str:
     budget = _default_budget(budget)
     await db.init_budget(budget)
     question_id = await create_root_question(
@@ -588,6 +588,7 @@ async def cmd_new(
 
     await Orchestrator(db).run(question_id)
     await _print_summary(db)
+    return question_id
 
 
 def _batch_label(entry: dict) -> str:
@@ -903,7 +904,13 @@ async def async_main():
         "--summary",
         dest="summary_id",
         metavar="QUESTION_ID",
-        help="Generate an executive summary for a question",
+        nargs="?",
+        const="__auto__",
+        help=(
+            "Generate an executive summary. Pass a QUESTION_ID to "
+            "summarize an existing question, or combine with a new "
+            "question to auto-summarize after investigation."
+        ),
     )
     parser.add_argument(
         "--report",
@@ -1245,7 +1252,7 @@ async def async_main():
     elif args.add_question:
         q = parse_question_input(args.add_question)
         await cmd_add_question(q, args.parent_id, args.budget, db)
-    elif args.summary_id:
+    elif args.summary_id and args.summary_id != "__auto__":
         await cmd_summary(
             args.summary_id,
             db,
@@ -1276,13 +1283,20 @@ async def async_main():
         await cmd_ab(q, args.budget, db, name=args.run_name)
     elif args.question:
         q = parse_question_input(args.question)
-        await cmd_new(
+        question_id = await cmd_new(
             q,
             args.budget,
             db,
             ingest_files=args.ingest_files,
             name=args.run_name,
         )
+        if args.summary_id == "__auto__":
+            await cmd_summary(
+                question_id,
+                db,
+                max_depth=args.max_depth,
+                summary_cutoff=args.summarize_after_depth,
+            )
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary

Investigate and summarize in one command:

\`\`\`bash
uv run python main.py "Your question here" --budget 20 --summary
\`\`\`

Previously this required three separate commands (ask, list, summarize by ID). The existing \`--summary QUESTION_ID\` form continues to work unchanged.

## Changes

- \`--summary\` now uses \`nargs='?'\` so it can be used as a flag (no argument = auto-summarize) or with a question ID (existing behavior)
- \`cmd_new\` returns the \`question_id\` so the dispatch block can pass it to \`cmd_summary\`
- Guard in the standalone \`--summary\` dispatch branch to not treat the sentinel as a question ID
- README updated with the new usage example

## Verification

- \`uv run pytest\` — 419 passed, 46 skipped
- \`uv run pyright\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)