### PR TITLE
Scope MoveState/CallTrace DB to the per-call fork

### DIFF
--- a/src/rumil/calls/stages.py
+++ b/src/rumil/calls/stages.py
@@ -14,7 +14,7 @@ from rumil.models import Call, CallStage, CallStatus, CallType, Dispatch, Move, 
 from rumil.available_moves import get_moves_for_call
 from rumil.moves.base import MoveState
 from rumil.tracing.trace_events import ErrorEvent
-from rumil.tracing.tracer import CallTrace, set_trace
+from rumil.tracing.tracer import CallTrace, reset_trace, set_trace
 
 log = logging.getLogger(__name__)
 
@@ -154,13 +154,18 @@ class CallRunner(ABC):
     async def run(self) -> None:
         call_db = await self.infra.db.fork()
         self.infra.db = call_db
+        self.infra.state.db = call_db
+        self.infra.trace.db = call_db
+        trace_token = set_trace(self.infra.trace)
         try:
             await self._run_stages()
         finally:
-            await call_db.close()
+            try:
+                await call_db.close()
+            finally:
+                reset_trace(trace_token)
 
     async def _run_stages(self) -> None:
-        set_trace(self.infra.trace)
         try:
             await self.infra.db.update_call_status(
                 self.infra.call.id,

--- a/src/rumil/tracing/tracer.py
+++ b/src/rumil/tracing/tracer.py
@@ -38,6 +38,11 @@ def set_trace(trace: "CallTrace") -> contextvars.Token:
     return _trace_var.set(trace)
 
 
+def reset_trace(token: contextvars.Token) -> None:
+    """Restore the task-local CallTrace to its value before ``set_trace``."""
+    _trace_var.reset(token)
+
+
 class CallTrace:
     """Records trace events: persists each to the DB then broadcasts."""
 


### PR DESCRIPTION
Previously only CallInfra.db was repointed to the forked client on call start, while MoveState and CallTrace kept a reference to the parent DB. Tool moves and trace writes therefore ran through the shared parent client, which could be closed underneath them on long runs, producing "Cannot send a request, as the client has been closed" errors mid-call.

Also harden the trace ContextVar lifecycle: capture the set_trace token in run() and reset it in a nested finally so the fork's client always closes even if reset fails, and the ContextVar no longer leaks a completed call's trace to whatever runs next in the task.