### PR TITLE
Add --global-prio flag to rumil-orchestrate skill

### DIFF
--- a/.claude/lib/rumil_skills/run_orchestrator.py
+++ b/.claude/lib/rumil_skills/run_orchestrator.py
@@ -118,9 +118,7 @@ async def main() -> None:
         global_prio = settings.enable_global_prio
         print(f"workspace:    {ws}")
         print(f"question:     {full_id[:8]}  {truncate(page.headline, 80)}")
-        print(
-            f"orchestrator: {variant}{' (+global_prio, concurrent)' if global_prio else ''}"
-        )
+        print(f"orchestrator: {variant}{' (+global_prio)' if global_prio else ''}")
 
         await open_run(
             db,

--- a/.claude/lib/rumil_skills/run_orchestrator.py
+++ b/.claude/lib/rumil_skills/run_orchestrator.py
@@ -59,6 +59,17 @@ async def main() -> None:
         ),
     )
     parser.add_argument(
+        "--global-prio",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Force settings.enable_global_prio on or off for this invocation "
+            "(overrides the ENABLE_GLOBAL_PRIO env var / .env default). "
+            "When enabled, GlobalPrioOrchestrator wraps the chosen prioritizer "
+            "variant. Omit to inherit the env/settings default."
+        ),
+    )
+    parser.add_argument(
         "--smoke-test",
         action="store_true",
         help="Faster/cheaper model, fewer rounds (for testing)",
@@ -74,6 +85,8 @@ async def main() -> None:
         get_settings().rumil_smoke_test = "1"
     if args.orchestrator:
         get_settings().prioritizer_variant = args.orchestrator
+    if args.global_prio is not None:
+        get_settings().enable_global_prio = args.global_prio
 
     logging.basicConfig(
         level=logging.WARNING,
@@ -100,10 +113,14 @@ async def main() -> None:
         if page.project_id and page.project_id != db.project_id:
             db.project_id = page.project_id
 
-        variant = get_settings().prioritizer_variant
+        settings = get_settings()
+        variant = settings.prioritizer_variant
+        global_prio = settings.enable_global_prio
         print(f"workspace:    {ws}")
         print(f"question:     {full_id[:8]}  {truncate(page.headline, 80)}")
-        print(f"orchestrator: {variant}")
+        print(
+            f"orchestrator: {variant}{' (+global_prio, concurrent)' if global_prio else ''}"
+        )
 
         await open_run(
             db,

--- a/.claude/skills/rumil-orchestrate/SKILL.md
+++ b/.claude/skills/rumil-orchestrate/SKILL.md
@@ -2,7 +2,7 @@
 name: rumil-orchestrate
 description: Fire the rumil orchestrator against an existing question — a full multi-call research loop with a budget. This is the CC-initiated equivalent of `main.py --continue <qid> --budget N`. Use when the user wants real research done on a question, not just a single call. For one targeted call, use /rumil-dispatch instead. Budget defaults to 10; since that's not cheap, confirm with the user before firing if they didn't specify. Trigger when the user says things like "investigate this more", "run some research on this", "give Q# N calls of budget", or right after /rumil-ask when they want to immediately start investigating.
 allowed-tools: Bash
-argument-hint: "<question_id> [--budget N] [--orchestrator two_phase|experimental] [--smoke-test]"
+argument-hint: "<question_id> [--budget N] [--orchestrator two_phase|experimental] [--global-prio|--no-global-prio] [--smoke-test]"
 ---
 
 # rumil-orchestrate
@@ -35,6 +35,23 @@ not a research loop).
 
 The chosen variant is captured in `runs.config.prioritizer_variant` so
 later analyses can filter by orchestrator.
+
+### Global-prio (orthogonal)
+
+`GlobalPrioOrchestrator` runs a cross-cutting global prioritiser
+*concurrently* with the local (variant-selected) orchestrator. It
+splits the remaining budget (default 20% global / 80% local, via
+`global_prio_budget_fraction`) and `asyncio.gather`s both. It doesn't
+replace the variant — it runs beside it. Gated by
+`settings.enable_global_prio`, which comes from the `ENABLE_GLOBAL_PRIO`
+env var / `.env` default (off by default). (Edge case: if the local
+share falls below `MIN_TWOPHASE_BUDGET`, only the global loop runs.)
+
+Use `--global-prio` or `--no-global-prio` to force it on/off for a
+single invocation, overriding the env default. Omit the flag to inherit
+whatever the env/settings say. The flag is tri-state: unset means
+"inherit", `--global-prio` means "force on", `--no-global-prio` means
+"force off" even if the env has it enabled.
 
 ## When to use this vs. /rumil-dispatch
 
@@ -89,6 +106,13 @@ money. One-line check: "Run the orchestrator on `abc12345` with budget
 - **`--orchestrator <variant>`**: `two_phase` or `experimental`. Defaults
   to whatever `settings.prioritizer_variant` is (normally `two_phase`).
   Pass explicitly whenever the user cares which loop is running.
+- **`--global-prio` / `--no-global-prio`**: force the cross-cutting
+  `GlobalPrioOrchestrator` on or off for this invocation. When on, it
+  runs *concurrently* with the variant (budget-split). Overrides the
+  `ENABLE_GLOBAL_PRIO` env var / `.env` default. Tri-state: omit to
+  inherit the env default, pass `--global-prio` to force on, pass
+  `--no-global-prio` to force off. Orthogonal to `--orchestrator` (the
+  variant still runs as the local prioritiser).
 - **`--smoke-test`**: use Haiku and cap rounds — for fast, cheap testing.
 - **`--workspace <name>`**: override the session's active workspace.
 - **`--name <text>`**: optional run name; defaults to the question headline.


### PR DESCRIPTION
## Summary
- Adds tri-state `--global-prio` / `--no-global-prio` to the `/rumil-orchestrate` CC skill, letting invocations force `GlobalPrioOrchestrator` on or off per-run
- Overrides the `ENABLE_GLOBAL_PRIO` env default; omitting the flag inherits env/settings
- Orthogonal to `--orchestrator` since global-prio runs *concurrently* with the variant (budget-split via `global_prio_budget_fraction`), not as a replacement
- Skill docs updated with a "Global-prio (orthogonal)" section clarifying the concurrent/budget-split mechanic

## Test plan
- [x] `--help` renders the new flag as a mutually-exclusive pair
- [x] Fired against redwood's `4a266a32` with `--global-prio --smoke-test --budget 8`; header printed `orchestrator: two_phase (+global_prio, concurrent)` confirming the setting stuck
- [ ] Confirm `--no-global-prio` with `ENABLE_GLOBAL_PRIO=true` in env forces off (not yet exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)