### PR TITLE
Tell assess prompt to supply fruit_remaining as a bare integer

### DIFF
--- a/prompts/assess.md
+++ b/prompts/assess.md
@@ -17,7 +17,7 @@ Produce a **Judgement**. It will be automatically linked to the scope question. 
 3. **Conclusion** — your position, stated clearly even if uncertain. Articulate your uncertainty clearly and in a structured way. Very often, it is a good idea to produce a probability breakdown between different possibilities or scenarios, backed by toy probability models where appropriate.
 4. **Key dependencies and sensitivity** — what your conclusion most depends on, and what would shift it
 
-Include the `key_dependencies`, `sensitivity_analysis`, and `fruit_remaining` fields in the judgement. `fruit_remaining` (0-10) estimates how much useful investigation remains on this question: 0 = thoroughly answered with high confidence, 1-2 = close to exhausted, 3-4 = most angles covered, 5-6 = diminishing but real returns, 7-8 = substantial work remains, 9-10 = wide open with many unexplored angles.
+Include the `key_dependencies`, `sensitivity_analysis`, and `fruit_remaining` fields in the judgement. `fruit_remaining` estimates how much useful investigation remains on this question. Supply only the integer value (0-10), not a label or explanation: 0 = thoroughly answered with high confidence, 1-2 = close to exhausted, 3-4 = most angles covered, 5-6 = diminishing but real returns, 7-8 = substantial work remains, 9-10 = wide open with many unexplored angles.
 
 You may also produce sub-questions if important unknowns need further investigation, new claims if the weighing process surfaces something worth recording, or propose a hypothesis if the weighing reveals a compelling candidate answer. Keep generative moves secondary — the judgement is the primary output.
 


### PR DESCRIPTION
## Summary
`create_judgement`'s tool schema has `fruit_remaining: int | None`, but `prompts/assess.md:20` describes the field inline with labeled prose ranges (`"5-6 = diminishing but real returns"`). In a recent run (call `b8996cfc` in the redwood workspace) the model echoed the prompt's label back as the tool-call value — literally `"6 — Diminishing but real returns. ...compress the transition."` — which tripped pydantic int parsing and the whole `create_judgement` call was dropped. The assess call still reported complete because the closing review has its own `_self_assessment` path, but no judgement page was persisted.

The fix is a one-line prompt edit: keep the labeled scale as useful guidance on *what each integer means*, but tell the model explicitly to supply only the integer value.

## Scope check
`assess.md` is only loaded by `AssessCall`'s workspace updater (tool-use path, the vulnerable one) and its closing reviewer (doesn't invoke `create_judgement`). `BigAssessCall` uses `big_assess.md` for its updater (doesn't mention the field, so unaffected). No structured-output / `structured_call` path reads `assess.md` — the scoring pipeline uses separate `score_subquestions.md` / `score_claim_items.md` with a schema-constrained `fruit` field.

## Test plan
- [ ] Re-run an assess call against a redwood question and confirm `create_judgement` succeeds with an integer `fruit_remaining`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)