### PR TITLE
Give frontend routes dynamic tab titles

### DIFF
--- a/frontend/src/app/ab-evals/[evalId]/page.tsx
+++ b/frontend/src/app/ab-evals/[evalId]/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import type { AbEvalReportOut } from "@/api/types.gen";
 import { API_BASE, serverFetch } from "@/lib/api-base";
 import { EvalDetail } from "./eval-detail";
+import { truncateHeadline } from "@/lib/page-titles";
 import "../ab-evals.css";
 
 async function getABEval(evalId: string): Promise<AbEvalReportOut | null> {
@@ -10,6 +12,19 @@ async function getABEval(evalId: string): Promise<AbEvalReportOut | null> {
   });
   if (!res.ok) return null;
   return res.json();
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ evalId: string }>;
+}): Promise<Metadata> {
+  const { evalId } = await params;
+  const report = await getABEval(evalId);
+  if (!report) return { title: `eval ${evalId.slice(0, 8)}` };
+  const headline = truncateHeadline(report.question_headline, 45);
+  const label = headline || evalId.slice(0, 8);
+  return { title: `eval "${label}"` };
 }
 
 export default async function ABEvalDetailPage({

--- a/frontend/src/app/ab-evals/page.tsx
+++ b/frontend/src/app/ab-evals/page.tsx
@@ -1,7 +1,12 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import type { AbEvalReportListItemOut } from "@/api/types.gen";
 import { API_BASE, serverFetch } from "@/lib/api-base";
 import "./ab-evals.css";
+
+export const metadata: Metadata = {
+  title: "A/B evaluations",
+};
 
 async function getABEvals(): Promise<AbEvalReportListItemOut[]> {
   const res = await serverFetch(`${API_BASE}/api/ab-evals`, {

--- a/frontend/src/app/ab-traces/[abRunId]/page.tsx
+++ b/frontend/src/app/ab-traces/[abRunId]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import type { AbRunTraceOut } from "@/api/types.gen";
 import { ABTraceViewer } from "./ab-trace-viewer";
 import "../../traces/[runId]/trace.css";
@@ -6,6 +7,7 @@ import "../../traces/[runId]/trace.css";
 import { API_BASE, serverFetch } from "@/lib/api-base";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { fetchProjectName } from "@/lib/fetch-project-name";
+import { truncateHeadline } from "@/lib/page-titles";
 
 async function getABRunTrace(abRunId: string): Promise<AbRunTraceOut | null> {
   const res = await serverFetch(`${API_BASE}/api/ab-runs/${abRunId}/trace`, {
@@ -13,6 +15,23 @@ async function getABRunTrace(abRunId: string): Promise<AbRunTraceOut | null> {
   });
   if (!res.ok) return null;
   return res.json();
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ abRunId: string }>;
+}): Promise<Metadata> {
+  const { abRunId } = await params;
+  const trace = await getABRunTrace(abRunId);
+  if (!trace) return { title: `AB ${abRunId.slice(0, 8)}` };
+  const projectName = trace.question?.project_id
+    ? await fetchProjectName(trace.question.project_id)
+    : undefined;
+  const headline = truncateHeadline(trace.question?.headline, 40);
+  const mid = headline ? ` "${headline}"` : ` ${abRunId.slice(0, 8)}`;
+  const suffix = projectName ? ` — ${projectName}` : "";
+  return { title: `AB${mid}${suffix}` };
 }
 
 export default async function ABTracePage({

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,7 +15,10 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Rumil",
+  title: {
+    template: "%s · Rumil",
+    default: "Rumil",
+  },
   description: "Research workspace explorer",
 };
 

--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import type { Metadata } from "next";
 import type { PageDetailOut, LinkedPageOut, Page, RunSummaryOut } from "@/api";
 import LinksContainer from "./links-container";
 import StagedBanner from "./staged-banner";
@@ -8,6 +9,7 @@ import StagedBanner from "./staged-banner";
 import { API_BASE } from "@/lib/api-base";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { fetchProjectName } from "@/lib/fetch-project-name";
+import { truncateHeadline } from "@/lib/page-titles";
 
 const TYPE_CONFIG: Record<
   string,
@@ -360,6 +362,24 @@ function SegmentGauge({ value, max, label }: { value: number; max: number; label
       <span className="ep-value">{label}{value}/{max}</span>
     </div>
   );
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ pageId: string }>;
+  searchParams: Promise<{ staged_run_id?: string; cite?: string }>;
+}): Promise<Metadata> {
+  const { pageId } = await params;
+  const { staged_run_id: stagedRunId } = await searchParams;
+  const detail = await getPageDetail(pageId, stagedRunId);
+  if (!detail) return { title: "Not found" };
+  const { page } = detail;
+  const projectName = await fetchProjectName(page.project_id);
+  const headline = truncateHeadline(page.headline, 50);
+  const suffix = projectName ? ` — ${projectName}` : "";
+  return { title: `${page.page_type} "${headline}"${suffix}` };
 }
 
 export default async function PageDetailPage({

--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -378,8 +378,9 @@ export async function generateMetadata({
   const { page } = detail;
   const projectName = await fetchProjectName(page.project_id);
   const headline = truncateHeadline(page.headline, 50);
+  const mid = headline ? ` "${headline}"` : ` ${pageId.slice(0, 8)}`;
   const suffix = projectName ? ` — ${projectName}` : "";
-  return { title: `${page.page_type} "${headline}"${suffix}` };
+  return { title: `${page.page_type}${mid}${suffix}` };
 }
 
 export default async function PageDetailPage({

--- a/frontend/src/app/pages/[pageId]/stats/page.tsx
+++ b/frontend/src/app/pages/[pageId]/stats/page.tsx
@@ -9,6 +9,8 @@ import { CLIENT_API_BASE as API_BASE } from "@/api-config";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { StatsView } from "@/components/stats-view";
 import { SubgraphView } from "@/components/subgraph-view";
+import { useDocumentTitle } from "@/lib/use-document-title";
+import { truncateHeadline } from "@/lib/page-titles";
 
 type LoadState =
   | { kind: "loading" }
@@ -29,6 +31,12 @@ export default function QuestionStatsPage() {
   const [projectName, setProjectName] = useState<string>();
   const [projectId, setProjectId] = useState<string>();
   const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  const headline =
+    state.kind === "ready" ? state.headline : state.kind === "not-question" ? state.headline : null;
+  const titleLabel = headline ? `question "${truncateHeadline(headline, 45)}" · stats` : null;
+  const wsSuffix = projectName ? ` — ${projectName}` : "";
+  useDocumentTitle(titleLabel ? `${titleLabel}${wsSuffix}` : null);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/app/pages/[pageId]/stats/page.tsx
+++ b/frontend/src/app/pages/[pageId]/stats/page.tsx
@@ -32,9 +32,10 @@ export default function QuestionStatsPage() {
   const [projectId, setProjectId] = useState<string>();
   const [state, setState] = useState<LoadState>({ kind: "loading" });
 
-  const headline =
-    state.kind === "ready" ? state.headline : state.kind === "not-question" ? state.headline : null;
-  const titleLabel = headline ? `question "${truncateHeadline(headline, 45)}" · stats` : null;
+  const titleHeadline = state.kind === "ready" ? state.headline : null;
+  const titleLabel = titleHeadline
+    ? `question "${truncateHeadline(titleHeadline, 45)}" · stats`
+    : null;
   const wsSuffix = projectName ? ` — ${projectName}` : "";
   useDocumentTitle(titleLabel ? `${titleLabel}${wsSuffix}` : null);
 

--- a/frontend/src/app/projects/[projectId]/page.tsx
+++ b/frontend/src/app/projects/[projectId]/page.tsx
@@ -8,6 +8,7 @@ import type { Page, PageType, PaginatedPagesOut, Project, RunListItemOut } from 
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
 import { useStagedRun } from "@/lib/staged-run-context";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
+import { useDocumentTitle } from "@/lib/use-document-title";
 
 const PAGE_TYPES: PageType[] = [
   "question",
@@ -96,6 +97,8 @@ export default function PagesIndexPage() {
   const [showSuperseded, setShowSuperseded] = useState(false);
   const { activeStagedRunId, setActiveStagedRunId } = useStagedRun();
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useDocumentTitle(projectName);
 
   const onSearchChange = useCallback((value: string) => {
     setSearch(value);

--- a/frontend/src/app/projects/[projectId]/stats/page.tsx
+++ b/frontend/src/app/projects/[projectId]/stats/page.tsx
@@ -8,6 +8,7 @@ import type { ProjectStatsOut, Project } from "@/api";
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { StatsView } from "@/components/stats-view";
+import { useDocumentTitle } from "@/lib/use-document-title";
 
 export default function ProjectStatsPage() {
   const params = useParams<{ projectId: string }>();
@@ -15,6 +16,8 @@ export default function ProjectStatsPage() {
 
   const [projectName, setProjectName] = useState<string>();
   const [data, setData] = useState<ProjectStatsOut | null>(null);
+
+  useDocumentTitle(projectName ? `${projectName} · stats` : null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/frontend/src/app/traces/[runId]/page.tsx
+++ b/frontend/src/app/traces/[runId]/page.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
 import type { RunTraceTreeOut, RealtimeConfigOut } from "@/api/types.gen";
 import { TraceViewer } from "./trace-viewer";
 import "./trace.css";
@@ -7,6 +8,7 @@ import "./trace.css";
 import { API_BASE, serverFetch } from "@/lib/api-base";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { fetchProjectName } from "@/lib/fetch-project-name";
+import { truncateHeadline } from "@/lib/page-titles";
 
 async function getRunTraceTree(runId: string): Promise<RunTraceTreeOut | null> {
   const res = await serverFetch(`${API_BASE}/api/runs/${runId}/trace-tree`, {
@@ -26,6 +28,23 @@ async function getRealtimeConfig(): Promise<RealtimeConfigOut | null> {
   } catch {
     return null;
   }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ runId: string }>;
+}): Promise<Metadata> {
+  const { runId } = await params;
+  const trace = await getRunTraceTree(runId);
+  if (!trace) return { title: `trace ${runId.slice(0, 8)}` };
+  const projectName = trace.question?.project_id
+    ? await fetchProjectName(trace.question.project_id)
+    : undefined;
+  const headline = truncateHeadline(trace.question?.headline, 40);
+  const mid = headline ? ` "${headline}"` : ` ${runId.slice(0, 8)}`;
+  const suffix = projectName ? ` — ${projectName}` : "";
+  return { title: `trace${mid}${suffix}` };
 }
 
 export default async function TracePage({

--- a/frontend/src/lib/page-titles.ts
+++ b/frontend/src/lib/page-titles.ts
@@ -1,0 +1,6 @@
+export function truncateHeadline(text: string | null | undefined, max: number): string {
+  if (!text) return "";
+  const clean = text.replace(/\s+/g, " ").trim();
+  if (clean.length <= max) return clean;
+  return clean.slice(0, max - 1).trimEnd() + "…";
+}

--- a/frontend/src/lib/use-document-title.ts
+++ b/frontend/src/lib/use-document-title.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function useDocumentTitle(title: string | null | undefined): void {
+  useEffect(() => {
+    if (!title) return;
+    document.title = `${title} · Rumil`;
+  }, [title]);
+}


### PR DESCRIPTION
## Summary
- Root layout now uses `title.template: '%s · Rumil'` so every route just contributes its own piece.
- Server-component routes (`/pages/[pageId]`, `/traces/[runId]`, `/ab-traces/[abRunId]`, `/ab-evals`, `/ab-evals/[evalId]`) use `generateMetadata` — deduped with the existing fetches.
- Client-component routes (`/projects/[projectId]`, `/projects/[projectId]/stats`, `/pages/[pageId]/stats`) use a new `useDocumentTitle` hook.

## Title formats

| Route | Title |
|---|---|
| `/` | `Rumil` |
| `/projects/[projectId]` | `{ws} · Rumil` |
| `/projects/[projectId]/stats` | `{ws} · stats · Rumil` |
| `/pages/[pageId]` | `{type} "{headline≤50}" — {ws} · Rumil` |
| `/pages/[pageId]/stats` | `question "{headline≤45}" · stats — {ws} · Rumil` |
| `/traces/[runId]` | `trace "{Q.headline≤40}" — {ws} · Rumil` |
| `/ab-traces/[abRunId]` | `AB "{Q.headline≤40}" — {ws} · Rumil` |
| `/ab-evals` | `A/B evaluations · Rumil` |
| `/ab-evals/[evalId]` | `eval "{Q.headline≤45}" · Rumil` |

## Test plan
- [ ] Load each route type fresh — title matches expected format
- [ ] Client-nav from workspace → page detail — title updates (not stuck at "Rumil")
- [ ] Client-nav between sibling pages — title updates correctly
- [ ] Route with no workspace name available drops the `— {ws}` suffix cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)