### PR TITLE
Retry postgrest APIErrors with 5xx status codes

### DIFF
--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -10,12 +10,13 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 import httpx
+from postgrest.exceptions import APIError
 from postgrest.types import CountMethod
 from supabase.lib.client_options import AsyncClientOptions
 from tenacity import (
     RetryCallState,
     retry,
-    retry_if_exception_type,
+    retry_if_exception,
     wait_exponential,
 )
 
@@ -60,6 +61,26 @@ _DB_RETRYABLE_EXCEPTIONS = (
 )
 
 
+def _is_retryable_api_error(exc: BaseException) -> bool:
+    # Gateway/upstream failures (e.g. Cloudflare 502, Supabase 503/504) come back
+    # as APIError because postgrest can't parse the HTML error page as JSON.
+    # Retry these, but not 4xx errors (auth, constraint violations, etc).
+    if not isinstance(exc, APIError):
+        return False
+    code = exc.code
+    if code is None:
+        return False
+    try:
+        status = int(code)
+    except (TypeError, ValueError):
+        return False
+    return 500 <= status < 600
+
+
+def _should_retry_db_exception(exc: BaseException) -> bool:
+    return isinstance(exc, _DB_RETRYABLE_EXCEPTIONS) or _is_retryable_api_error(exc)
+
+
 def _stop_after_db_retries(retry_state: RetryCallState) -> bool:
     return retry_state.attempt_number >= get_settings().max_db_retries
 
@@ -78,7 +99,7 @@ def _log_db_retry(retry_state: RetryCallState) -> None:
 
 
 _db_retry = retry(
-    retry=retry_if_exception_type(_DB_RETRYABLE_EXCEPTIONS),
+    retry=retry_if_exception(_should_retry_db_exception),
     stop=_stop_after_db_retries,
     wait=wait_exponential(multiplier=0.5, min=0.5, max=60),
     before_sleep=_log_db_retry,


### PR DESCRIPTION
## Summary
- Hit a Cloudflare 502 mid-way through an AB eval run; postgrest returned the HTML error page as an `APIError` with `code: 502`, which wasn't in the retryable set and killed the whole run.
- Retry predicate on `DB._execute` now also covers `APIError` with 5xx codes (502/503/504). 4xx errors (auth, constraint violations) still fail fast.

## Test plan
- [x] Unit smoke: verified predicate returns `True` for code 502, `False` for code 401, `False` when no code is present.
- [x] Re-run the failing AB eval and confirm it either succeeds or logs retry warnings instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)