### PR TITLE
Add --self-improve: LLM analyses a run and suggests rumil improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ uv run python main.py "Your question here" --budget 20 --summary
 # Generate a multi-section research report
 uv run python main.py --report QUESTION_ID
 
+# Self-improvement: analyse how an investigation went and get rumil
+# code/prompt improvement suggestions. Read-only; inspects the run plus
+# rumil's own source via LLM tools, then writes a markdown analysis to
+# pages/self-improvement/.
+uv run python main.py --self-improve QUESTION_ID
+
+# Investigate and self-improve in one command (analyses the just-finished run)
+uv run python main.py "Your question here" --budget 20 --self-improve
+
 # Evaluate the judgement quality for a question
 uv run python main.py --evaluate QUESTION_ID
 

--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ from rumil.orchestrators import Orchestrator, create_root_question
 from rumil.report import generate_report, save_report
 from rumil.run_eval import run_run_eval
 from rumil.run_eval.agents import EVAL_AGENTS, EvalAgentSpec
+from rumil.self_improve import run_self_improvement, save_self_improvement
 from rumil.settings import Settings, _settings_var, get_settings
 from rumil.sources import create_source_page, run_ingest_calls
 from rumil.summary import generate_summary, save_summary
@@ -484,6 +485,34 @@ async def cmd_summary(
     print(f"\n---\nSummary saved to: {path}")
 
 
+async def cmd_self_improve(question_id: str, db: DB) -> None:
+    question = await db.get_page(question_id)
+    if not question:
+        resolved = await db.resolve_page_id(question_id)
+        if resolved:
+            question = await db.get_page(resolved)
+    if not question:
+        print(f"Error: question '{question_id}' not found. Run --list to see existing questions.")
+        sys.exit(1)
+
+    if question.project_id and question.project_id != db.project_id:
+        db.project_id = question.project_id
+
+    print(f"\nSelf-improvement analysis for: {question.headline[:80]}")
+    print(
+        "(Uses one or more LLM calls with read-only tools, "
+        "does not count against research budget)\n"
+    )
+
+    text = await run_self_improvement(question.id, db)
+    if not text.strip():
+        print("No analysis produced.")
+        return
+    path = save_self_improvement(text, question.headline)
+    print(text)
+    print(f"\n---\nSelf-improvement analysis saved to: {path}")
+
+
 async def cmd_report(
     question_id: str,
     db: DB,
@@ -859,6 +888,20 @@ async def async_main():
         help="Generate a multi-section research report for a question",
     )
     parser.add_argument(
+        "--self-improve",
+        dest="self_improve_id",
+        metavar="QUESTION_ID",
+        nargs="?",
+        const="__auto__",
+        help=(
+            "Analyse how a completed investigation went and suggest "
+            "rumil code/prompt improvements. Read-only. Pass a "
+            "QUESTION_ID to analyse an existing investigation, or "
+            "combine with a new question to auto-analyse after "
+            "investigation completes."
+        ),
+    )
+    parser.add_argument(
         "--max-depth",
         type=int,
         default=4,
@@ -1220,6 +1263,8 @@ async def async_main():
             db,
             max_depth=args.max_depth,
         )
+    elif args.self_improve_id and args.self_improve_id != "__auto__":
+        await cmd_self_improve(args.self_improve_id, db)
     elif args.continue_id:
         await cmd_continue(
             args.continue_id,
@@ -1236,6 +1281,7 @@ async def async_main():
     elif args.question:
         q = parse_question_input(args.question)
         do_summary = args.summary_id == "__auto__"
+        do_self_improve = args.self_improve_id == "__auto__"
         question_id = await cmd_new(
             q,
             args.budget,
@@ -1251,6 +1297,8 @@ async def async_main():
                 max_depth=args.max_depth,
                 summary_cutoff=args.summarize_after_depth,
             )
+        if do_self_improve:
+            await cmd_self_improve(question_id, db)
     else:
         parser.print_help()
 

--- a/prompts/self_improve.md
+++ b/prompts/self_improve.md
@@ -1,0 +1,76 @@
+# Rumil Self-Improvement Analysis
+
+You are analysing a completed research investigation in **rumil**, an LLM-driven research workspace. Your job is to produce a candid, specific, written analysis of how the investigation went — what worked, what didn't, and concrete ideas for improving rumil itself so future investigations go better.
+
+You are not a participant in the research. You are a reviewer, looking at the investigation from the outside, with full access to everything the system produced and to rumil's own source code.
+
+## How rumil works
+
+A user poses a **question** and gives it a **budget** of LLM calls. An **orchestrator** decides the sequence of calls to dispatch against the question. The orchestrator picks call types and sub-questions based on a prioritization prompt that has access to a map of the workspace.
+
+Each **call** is a structured task the LLM performs with a fixed set of tools ("moves"). There are several call types:
+
+- **find_considerations** — surface claims that bear on a question.
+- **assess** (and variants) — produce a judgement with credence/robustness for a question.
+- **create_view / update_view** — build or revise a structured View page that summarises the current state of a question.
+- **scout_*** — specialised scouts (analogies, cruxes, factchecks, deep_questions, estimates, hypotheses, paradigm_cases, relevant_evidence, stress_test_cases, subquestions, web_questions) that each look for one specific kind of thing.
+- **web_research** — do web searches, read pages, and extract considerations.
+- **ingest** — extract considerations from a user-provided source.
+- **link_subquestions / score_subquestions / score_claim_items** — structural moves.
+- **prioritization** calls (not dispatched as research; internal to the orchestrator) pick what to do next.
+
+Each call produces **pages** — Claims, Questions, Judgements, Concepts, Views, View Items, Sources, Wiki — and links between them (considerations, child-questions, dependencies, etc.). Pages are immutable but can be superseded. The resulting graph is the research output.
+
+Each call records:
+- a **trace** (JSONB event log) of what happened during the call
+- one or more **LLM exchanges** with the full system prompt, user messages, tool calls, and response text
+- a **result_summary** and a **review_json** blob summarising the outcome
+- cost and timing info
+
+All call types share a three-stage architecture: `build_context` → `update_workspace` → `closing_review`. The context builder selects the slice of the workspace to show the LLM; the updater runs the agent loop that issues moves; the closing reviewer persists results and wraps up.
+
+The codebase is in `src/rumil/`. Prompts are in `prompts/`. Call implementations are in `src/rumil/calls/`, moves in `src/rumil/moves/`, orchestrators in `src/rumil/orchestrators/`. The top-level `CLAUDE.md` has more architectural detail.
+
+## What you have access to
+
+You have **read-only** tools for:
+
+- **The research output**: the question and its subtree, every page produced, every call made, every LLM exchange verbatim, every trace event.
+- **Rumil's source code**: any file in the rumil repository — Python source, prompt files, migrations, tests, config.
+
+You cannot modify anything. You can only look and report.
+
+## What to produce
+
+A markdown document — the full text of your final response — structured roughly like:
+
+1. **Overview** — what the question was, how the investigation unfolded in narrative form. Walk through what happened: which calls fired in what order, what each produced, how the picture evolved. Don't just list facts; tell the story. If the orchestrator got stuck in a loop, if a scout came up empty, if an assess produced a judgement that contradicted an earlier one — surface it.
+
+2. **Strengths** — what rumil did well on this investigation. Be specific. "The find_considerations call successfully surfaced a cruxy claim X that reframed the question" beats "the system found some good claims".
+
+3. **Weaknesses** — where the investigation fell short. Look hard. Some things to probe:
+   - Did any LLM exchange show the model confused about its task, the prompt, or the workspace state?
+   - Did calls produce thin, generic, or duplicative output?
+   - Did the orchestrator's prioritization choices make sense given what was already known?
+   - Were considerations linked to the right questions? Were judgements grounded in the actual considerations?
+   - Did the View capture the real state of understanding, or was it shallow?
+   - Were there moments where the system clearly should have done X and instead did Y?
+
+4. **Suggested improvements to rumil** — concrete, actionable proposals for code or prompt changes. For each suggestion:
+   - Name the specific file (and if possible, function or section) you'd change.
+   - Describe the change.
+   - Explain what problem it would fix, citing specific evidence from this run.
+   - Rate your confidence: is this a clear win, a plausible experiment, or a speculative idea?
+
+   **You are suggesting changes, not making them.** Do not write patches. Do not propose to edit anything yourself. Describe what a developer should consider changing and why.
+
+## How to do the analysis
+
+- **Start by orienting.** Use the overview tool to see the shape of the investigation, then skim the high-level call list and the top-level pages. Don't dive into a single LLM exchange before you have a picture of the whole.
+- **Follow the evidence.** When you notice something that seems off, pull on the thread — read the specific exchange, the specific prompt, the specific move. Cite IDs.
+- **Read the relevant source.** When you suspect a prompt or a move is to blame, read the actual prompt file or the move's implementation before proposing a change. Don't suggest changes to code you haven't looked at.
+- **Be specific.** "Improve the assess prompt" is useless. "The assess prompt (`prompts/assess.md`) doesn't mention X, which caused the model to Y in exchange abc12345; adding a paragraph about X would probably fix this" is useful.
+- **Be honest.** If the run went well and you can't find much wrong, say so. Don't invent weaknesses. If you find a real problem that's hard to fix, say that too.
+- **Don't pad.** Length is not a virtue. A short, sharp analysis is better than a long, hedged one.
+
+When you're done exploring and ready to write the final analysis, produce it as your final message — no more tool calls after that. The text of that final message is what gets saved to disk.

--- a/src/rumil/self_improve.py
+++ b/src/rumil/self_improve.py
@@ -1,0 +1,635 @@
+"""
+Self-improvement analysis: an LLM reviews a completed investigation
+against rumil's own source code and produces a markdown narrative of
+strengths, weaknesses, and suggested code/prompt improvements.
+
+One-off utility like --summary: not traced, not budget-counted. The
+final LLM message is saved to pages/self-improvement/.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+import anthropic
+from anthropic.types import TextBlock, ToolUseBlock
+
+from rumil.calls.common import execute_tool_uses, prepare_tools
+from rumil.database import DB, _row_to_call
+from rumil.llm import Tool, call_api
+from rumil.models import Call, Page, PageType
+from rumil.settings import get_settings
+
+log = logging.getLogger(__name__)
+
+PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
+REPO_ROOT = (Path(__file__).parent.parent.parent).resolve()
+OUTPUT_DIR = Path(__file__).parent.parent.parent / "pages" / "self-improvement"
+
+MAX_AGENT_ROUNDS = 60
+MAX_FILE_CHARS = 80_000
+MAX_EXCHANGE_BLOB_CHARS = 120_000
+
+IGNORED_DIR_NAMES = {
+    ".git",
+    "__pycache__",
+    "node_modules",
+    ".next",
+    ".venv",
+    "venv",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    "pages",
+    "reports",
+}
+
+
+def _load_prompt(name: str) -> str:
+    return (PROMPTS_DIR / name).read_text(encoding="utf-8")
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n[... truncated, {len(text) - limit} more chars ...]"
+
+
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _is_full_uuid(s: str) -> bool:
+    return bool(_UUID_RE.match(s))
+
+
+def _safe_repo_path(rel_path: str) -> Path | None:
+    if not rel_path or rel_path.startswith("/"):
+        return None
+    candidate = (REPO_ROOT / rel_path).resolve()
+    try:
+        candidate.relative_to(REPO_ROOT)
+    except ValueError:
+        return None
+    return candidate
+
+
+async def _collect_subtree(
+    root_id: str, db: DB, max_depth: int = 12,
+) -> Sequence[tuple[Page, int]]:
+    """BFS through child questions. Cycle-safe (tracks visited)."""
+    visited: set[str] = set()
+    result: list[tuple[Page, int]] = []
+    root = await db.get_page(root_id)
+    if not root:
+        return result
+    frontier: list[tuple[Page, int]] = [(root, 0)]
+    while frontier:
+        next_frontier: list[tuple[Page, int]] = []
+        for page, depth in frontier:
+            if page.id in visited:
+                continue
+            visited.add(page.id)
+            result.append((page, depth))
+            if depth < max_depth:
+                children = await db.get_child_questions(page.id)
+                for child in children:
+                    if child.id not in visited:
+                        next_frontier.append((child, depth + 1))
+        frontier = next_frontier
+    return result
+
+
+async def _fetch_subtree_calls(
+    subtree_ids: Sequence[str], db: DB,
+) -> Sequence[Call]:
+    """Fetch all calls whose scope_page_id is in the subtree."""
+    if not subtree_ids:
+        return []
+    rows = await db._execute(
+        db.client.table("calls")
+        .select("*")
+        .in_("scope_page_id", list(subtree_ids))
+        .order("created_at")
+    )
+    return [_row_to_call(r) for r in (rows.data or [])]
+
+
+def _format_call_summary(c: Call) -> str:
+    scope = c.scope_page_id[:8] if c.scope_page_id else "none"
+    cost = f"${c.cost_usd:.3f}" if c.cost_usd is not None else "?"
+    return (
+        f"[{c.id[:8]}] {c.call_type.value}  scope={scope}  "
+        f"status={c.status.value}  cost={cost}  budget_used={c.budget_used}"
+    )
+
+
+def _build_tools(
+    root_question_id: str,
+    subtree: Sequence[tuple[Page, int]],
+    calls: Sequence[Call],
+    db: DB,
+) -> Sequence[Tool]:
+    subtree_ids = {p.id for p, _ in subtree}
+    call_ids = {c.id for c in calls}
+
+    async def get_investigation_overview(inp: dict) -> str:
+        parts: list[str] = []
+        root = next((p for p, d in subtree if d == 0), None)
+        if root:
+            parts.append(f"# Root question [{root.id[:8]}]: {root.headline}")
+            if root.content:
+                parts.append(_truncate(root.content, 2000))
+            parts.append("")
+
+        parts.append(f"## Subtree ({len(subtree)} questions)")
+        for p, depth in subtree:
+            indent = "  " * depth
+            parts.append(f"{indent}- [{p.id[:8]}] {p.headline}")
+        parts.append("")
+
+        parts.append(f"## Calls in subtree ({len(calls)})")
+        for c in calls:
+            parts.append(f"- {_format_call_summary(c)}")
+        if not calls:
+            parts.append("(none)")
+        parts.append("")
+
+        page_counts: dict[str, int] = {}
+        total_pages_by_call = 0
+        if call_ids:
+            pages_rows = await db._execute(
+                db.client.table("pages")
+                .select("id, page_type")
+                .in_("provenance_call_id", list(call_ids))
+            )
+            for r in pages_rows.data or []:
+                pt = r["page_type"]
+                page_counts[pt] = page_counts.get(pt, 0) + 1
+                total_pages_by_call += 1
+
+        parts.append(f"## Pages created by these calls ({total_pages_by_call})")
+        for pt, n in sorted(page_counts.items(), key=lambda kv: -kv[1]):
+            parts.append(f"- {pt}: {n}")
+        return "\n".join(parts)
+
+    async def read_page(inp: dict) -> str:
+        page_id = inp.get("page_id", "")
+        resolved = await db.resolve_page_id(page_id)
+        if not resolved:
+            return f"Page '{page_id}' not found."
+        page = await db.get_page(resolved)
+        if not page:
+            return f"Page '{page_id}' not found."
+        lines = [
+            f"ID: {page.id}",
+            f"Type: {page.page_type.value}",
+            f"Headline: {page.headline}",
+        ]
+        if page.abstract:
+            lines.append(f"Abstract: {page.abstract}")
+        if page.credence is not None:
+            lines.append(f"Credence: {page.credence}")
+        if page.robustness is not None:
+            lines.append(f"Robustness: {page.robustness}")
+        if page.is_superseded:
+            lines.append(f"Superseded by: {page.superseded_by}")
+        if page.provenance_call_id:
+            lines.append(
+                f"Provenance: {page.provenance_call_type} "
+                f"call {page.provenance_call_id[:8]} "
+                f"(model: {page.provenance_model})"
+            )
+        lines.append("")
+        lines.append(_truncate(page.content or "", 20_000))
+        if page.extra:
+            lines.append("")
+            lines.append("Extra:")
+            lines.append(_truncate(json.dumps(page.extra, indent=2, default=str), 4000))
+        return "\n".join(lines)
+
+    async def list_pages_for_call(inp: dict) -> str:
+        call_id_arg = inp.get("call_id", "")
+        resolved = await db.resolve_call_id(call_id_arg) or call_id_arg
+        rows = await db._execute(
+            db.client.table("pages")
+            .select("id, page_type, headline, credence, robustness, is_superseded")
+            .eq("provenance_call_id", resolved)
+            .order("created_at")
+        )
+        data = rows.data or []
+        if not data:
+            return f"No pages created by call {resolved[:8]}."
+        lines = [f"{len(data)} page(s) created by call {resolved[:8]}:"]
+        for r in data:
+            bits = [f"[{r['id'][:8]}]", r["page_type"]]
+            if r.get("credence") is not None:
+                bits.append(f"C{r['credence']}")
+            if r.get("robustness") is not None:
+                bits.append(f"R{r['robustness']}")
+            if r.get("is_superseded"):
+                bits.append("(superseded)")
+            lines.append(f"- {' '.join(bits)}  {r['headline']}")
+        return "\n".join(lines)
+
+    async def get_call_details(inp: dict) -> str:
+        call_id_arg = inp.get("call_id", "")
+        resolved = await db.resolve_call_id(call_id_arg)
+        if not resolved:
+            return f"Call '{call_id_arg}' not found."
+        call = await db.get_call(resolved)
+        if not call:
+            return f"Call '{call_id_arg}' not found."
+
+        lines = [
+            f"ID: {call.id}",
+            f"Type: {call.call_type.value}",
+            f"Status: {call.status.value}",
+            f"Scope: {call.scope_page_id or '(none)'}",
+            f"Parent call: {call.parent_call_id or '(none)'}",
+            f"Budget used/allocated: {call.budget_used}/{call.budget_allocated}",
+            f"Cost: ${call.cost_usd:.4f}" if call.cost_usd is not None else "Cost: ?",
+            f"Created: {call.created_at.isoformat()}",
+        ]
+        if call.completed_at:
+            lines.append(f"Completed: {call.completed_at.isoformat()}")
+        if call.result_summary:
+            lines.append("")
+            lines.append("## Result summary")
+            lines.append(_truncate(call.result_summary, 10_000))
+        if call.review_json:
+            lines.append("")
+            lines.append("## Review JSON")
+            lines.append(
+                _truncate(
+                    json.dumps(call.review_json, indent=2, default=str), 10_000
+                )
+            )
+        if call.call_params:
+            lines.append("")
+            lines.append("## Call params")
+            lines.append(
+                _truncate(
+                    json.dumps(call.call_params, indent=2, default=str), 4000
+                )
+            )
+
+        exchanges = await db.get_llm_exchanges(resolved)
+        lines.append("")
+        lines.append(f"## LLM exchanges ({len(exchanges)})")
+        lines.append(
+            "(pass the full exchange id to get_llm_exchange — short "
+            "prefixes aren't accepted here)"
+        )
+        for e in exchanges:
+            lines.append(
+                f"- {e['id']} phase={e.get('phase')} "
+                f"round={e.get('round')} "
+                f"in={e.get('input_tokens')} out={e.get('output_tokens')} "
+                f"ms={e.get('duration_ms')}"
+            )
+
+        trace = await db.get_call_trace(resolved)
+        lines.append("")
+        lines.append(f"## Trace events ({len(trace)})")
+        for ev in trace:
+            etype = ev.get("event", "?")
+            phase = ev.get("phase", "")
+            lines.append(f"- {etype} {phase}".rstrip())
+        return _truncate("\n".join(lines), 40_000)
+
+    async def get_llm_exchange(inp: dict) -> str:
+        exchange_id = inp.get("exchange_id", "").strip()
+        if not exchange_id:
+            return "Error: exchange_id required."
+        if not _is_full_uuid(exchange_id):
+            return (
+                f"Error: '{exchange_id}' is not a full UUID. Call "
+                "get_call_details(call_id) and copy the full exchange id "
+                "from the listing — short prefixes aren't accepted for "
+                "exchanges."
+            )
+        exchange = await db.get_llm_exchange(exchange_id)
+        if not exchange:
+            return f"Exchange '{exchange_id}' not found."
+
+        lines = [
+            f"ID: {exchange['id']}",
+            f"Call: {exchange.get('call_id')}",
+            f"Phase: {exchange.get('phase')}",
+            f"Round: {exchange.get('round')}",
+        ]
+        system_prompt = exchange.get("system_prompt") or ""
+        user_message = exchange.get("user_message") or ""
+        user_messages = exchange.get("user_messages") or []
+        response_text = exchange.get("response_text") or ""
+        tool_calls = exchange.get("tool_calls") or []
+
+        lines.append("")
+        lines.append("## System prompt")
+        lines.append(_truncate(system_prompt, 20_000))
+        lines.append("")
+        lines.append("## User message(s)")
+        if user_messages:
+            lines.append(
+                _truncate(
+                    json.dumps(user_messages, indent=2, default=str), 40_000
+                )
+            )
+        else:
+            lines.append(_truncate(user_message, 20_000))
+        lines.append("")
+        lines.append("## Response text")
+        lines.append(_truncate(response_text, 20_000))
+        if tool_calls:
+            lines.append("")
+            lines.append("## Tool calls")
+            lines.append(
+                _truncate(
+                    json.dumps(tool_calls, indent=2, default=str), 20_000
+                )
+            )
+        return _truncate("\n".join(lines), MAX_EXCHANGE_BLOB_CHARS)
+
+    async def read_repo_file(inp: dict) -> str:
+        rel = inp.get("path", "")
+        path = _safe_repo_path(rel)
+        if path is None:
+            return f"Error: path '{rel}' is outside the rumil repo or invalid."
+        if not path.exists():
+            return f"Error: file '{rel}' does not exist."
+        if not path.is_file():
+            return f"Error: '{rel}' is not a file."
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return f"Error: file '{rel}' is not a text file."
+        return _truncate(text, MAX_FILE_CHARS)
+
+    async def list_repo_dir(inp: dict) -> str:
+        rel = inp.get("path", "").strip() or "."
+        path = _safe_repo_path(rel)
+        if path is None:
+            return f"Error: path '{rel}' is outside the rumil repo or invalid."
+        if not path.exists():
+            return f"Error: directory '{rel}' does not exist."
+        if not path.is_dir():
+            return f"Error: '{rel}' is not a directory."
+        entries = []
+        for child in sorted(path.iterdir()):
+            if child.name.startswith(".") and child.name not in {".env.example"}:
+                continue
+            if child.is_dir() and child.name in IGNORED_DIR_NAMES:
+                continue
+            suffix = "/" if child.is_dir() else ""
+            entries.append(f"{child.name}{suffix}")
+        if not entries:
+            return f"(directory '{rel}' is empty or all entries filtered)"
+        return "\n".join(entries)
+
+    return [
+        Tool(
+            name="get_investigation_overview",
+            description=(
+                "Return a structured overview of the investigation: the root "
+                "question, the full subtree of sub-questions, every call that "
+                "ran against any question in the subtree, and counts of pages "
+                "those calls produced. Start here to orient yourself."
+            ),
+            input_schema={"type": "object", "properties": {}},
+            fn=get_investigation_overview,
+        ),
+        Tool(
+            name="read_page",
+            description=(
+                "Read the full content of any page (claim, question, "
+                "judgement, concept, view, view item, source, wiki) by its "
+                "id (short 8-char prefix or full UUID). Returns headline, "
+                "abstract, content, credence/robustness, provenance, extras."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "page_id": {"type": "string", "description": "Page id."},
+                },
+                "required": ["page_id"],
+            },
+            fn=read_page,
+        ),
+        Tool(
+            name="list_pages_for_call",
+            description=(
+                "List the pages a specific call created (via "
+                "provenance_call_id). Short headlines + ids — use read_page "
+                "to dig into any one."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "call_id": {"type": "string", "description": "Call id."},
+                },
+                "required": ["call_id"],
+            },
+            fn=list_pages_for_call,
+        ),
+        Tool(
+            name="get_call_details",
+            description=(
+                "Read a call's metadata: type, status, scope, budget, cost, "
+                "result_summary, review_json, call_params, list of LLM "
+                "exchange ids, and a summary of trace events. Use "
+                "get_llm_exchange for the verbatim prompt/response of any "
+                "exchange."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "call_id": {"type": "string", "description": "Call id."},
+                },
+                "required": ["call_id"],
+            },
+            fn=get_call_details,
+        ),
+        Tool(
+            name="get_llm_exchange",
+            description=(
+                "Read a single LLM exchange verbatim: system prompt, user "
+                "message(s), response text, and tool calls. Large — only "
+                "fetch one at a time when you want to see exactly what the "
+                "model saw and said. Accepts short id prefix."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "exchange_id": {
+                        "type": "string",
+                        "description": "LLM exchange id (short prefix ok).",
+                    },
+                },
+                "required": ["exchange_id"],
+            },
+            fn=get_llm_exchange,
+        ),
+        Tool(
+            name="read_repo_file",
+            description=(
+                "Read a file from the rumil repository — Python source, "
+                "prompt files, migrations, configs, README, anything. Path "
+                "is relative to the repo root (e.g. "
+                "'prompts/find_considerations.md', "
+                "'src/rumil/orchestrators/two_phase.py'). Read-only. Use "
+                "this to inspect the actual code or prompts you think might "
+                "be worth changing before suggesting edits."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Repo-relative path.",
+                    },
+                },
+                "required": ["path"],
+            },
+            fn=read_repo_file,
+        ),
+        Tool(
+            name="list_repo_dir",
+            description=(
+                "List entries in a directory of the rumil repo. Path is "
+                "relative to repo root; defaults to '.'. Use this to "
+                "discover files before reading them."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Repo-relative directory path.",
+                    },
+                },
+            },
+            fn=list_repo_dir,
+        ),
+    ]
+
+
+async def _run_agent(
+    system_prompt: str,
+    user_message: str,
+    tools: Sequence[Tool],
+) -> str:
+    settings = get_settings()
+    client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
+    model = settings.model
+    tool_defs, tool_fns = prepare_tools(list(tools))
+
+    messages: list[dict] = [{"role": "user", "content": user_message}]
+    final_text = ""
+
+    for round_num in range(MAX_AGENT_ROUNDS):
+        api_resp = await call_api(
+            client,
+            model,
+            system_prompt,
+            messages,
+            tools=tool_defs,
+            cache=True,
+        )
+        response = api_resp.message
+        text_parts: list[str] = []
+        tool_uses: list[ToolUseBlock] = []
+        for block in response.content:
+            if isinstance(block, TextBlock):
+                text_parts.append(block.text)
+            elif isinstance(block, ToolUseBlock):
+                tool_uses.append(block)
+
+        if tool_uses:
+            _, tool_results = await execute_tool_uses(tool_uses, tool_fns)
+            assistant_content = [b.model_dump() for b in response.content]
+            messages.append({"role": "assistant", "content": assistant_content})
+            messages.append({"role": "user", "content": tool_results})
+            if text_parts:
+                preview = " | ".join(t[:120] for t in text_parts)
+                print(
+                    f"  [round {round_num + 1}] "
+                    f"{len(tool_uses)} tool call(s): {preview}"
+                )
+            else:
+                print(
+                    f"  [round {round_num + 1}] "
+                    f"{len(tool_uses)} tool call(s)"
+                )
+            if response.stop_reason == "end_turn":
+                final_text = "\n".join(text_parts)
+                break
+            continue
+
+        final_text = "\n".join(text_parts)
+        break
+    else:
+        log.warning(
+            "Self-improve hit max rounds (%d) without a final text response",
+            MAX_AGENT_ROUNDS,
+        )
+    return final_text
+
+
+async def run_self_improvement(question_id: str, db: DB) -> str:
+    """Run a self-improvement analysis for a question. Returns markdown text."""
+    resolved = await db.resolve_page_id(question_id)
+    if not resolved:
+        raise ValueError(f"Question '{question_id}' not found")
+    question = await db.get_page(resolved)
+    if not question:
+        raise ValueError(f"Question '{question_id}' not found")
+    if question.page_type != PageType.QUESTION:
+        raise ValueError(
+            f"Page '{question_id}' is a {question.page_type.value}, not a question"
+        )
+
+    if question.project_id and question.project_id != db.project_id:
+        db.project_id = question.project_id
+
+    subtree = await _collect_subtree(resolved, db)
+    subtree_ids = [p.id for p, _ in subtree]
+    calls = await _fetch_subtree_calls(subtree_ids, db)
+
+    print(
+        f"Collected subtree: {len(subtree)} question(s), "
+        f"{len(calls)} call(s)."
+    )
+
+    tools = _build_tools(resolved, subtree, calls, db)
+    system_prompt = _load_prompt("self_improve.md")
+    user_message = (
+        f"The investigation to analyse is rooted at question "
+        f"[{resolved[:8]}]: {question.headline}\n\n"
+        "Start by calling get_investigation_overview. Then drill in "
+        "wherever the shape suggests something worth a closer look. "
+        "When you're ready, write the full self-improvement analysis "
+        "as your final message — that text is what gets saved to disk."
+    )
+
+    return await _run_agent(system_prompt, user_message, tools)
+
+
+def save_self_improvement(text: str, question_headline: str) -> Path:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    slug = "".join(
+        c if c.isalnum() or c in " -" else "" for c in question_headline[:50]
+    )
+    slug = slug.strip().replace(" ", "-").lower()
+    filename = f"{timestamp}-{slug}.md"
+    path = OUTPUT_DIR / filename
+    path.write_text(text, encoding="utf-8")
+    return path

--- a/src/rumil/self_improve.py
+++ b/src/rumil/self_improve.py
@@ -82,7 +82,9 @@ def _safe_repo_path(rel_path: str) -> Path | None:
 
 
 async def _collect_subtree(
-    root_id: str, db: DB, max_depth: int = 12,
+    root_id: str,
+    db: DB,
+    max_depth: int = 12,
 ) -> Sequence[tuple[Page, int]]:
     """BFS through child questions. Cycle-safe (tracks visited)."""
     visited: set[str] = set()
@@ -108,7 +110,8 @@ async def _collect_subtree(
 
 
 async def _fetch_subtree_calls(
-    subtree_ids: Sequence[str], db: DB,
+    subtree_ids: Sequence[str],
+    db: DB,
 ) -> Sequence[Call]:
     """Fetch all calls whose scope_page_id is in the subtree."""
     if not subtree_ids:
@@ -137,7 +140,6 @@ def _build_tools(
     calls: Sequence[Call],
     db: DB,
 ) -> Sequence[Tool]:
-    subtree_ids = {p.id for p, _ in subtree}
     call_ids = {c.id for c in calls}
 
     async def get_investigation_overview(inp: dict) -> str:
@@ -267,26 +269,17 @@ def _build_tools(
         if call.review_json:
             lines.append("")
             lines.append("## Review JSON")
-            lines.append(
-                _truncate(
-                    json.dumps(call.review_json, indent=2, default=str), 10_000
-                )
-            )
+            lines.append(_truncate(json.dumps(call.review_json, indent=2, default=str), 10_000))
         if call.call_params:
             lines.append("")
             lines.append("## Call params")
-            lines.append(
-                _truncate(
-                    json.dumps(call.call_params, indent=2, default=str), 4000
-                )
-            )
+            lines.append(_truncate(json.dumps(call.call_params, indent=2, default=str), 4000))
 
         exchanges = await db.get_llm_exchanges(resolved)
         lines.append("")
         lines.append(f"## LLM exchanges ({len(exchanges)})")
         lines.append(
-            "(pass the full exchange id to get_llm_exchange — short "
-            "prefixes aren't accepted here)"
+            "(pass the full exchange id to get_llm_exchange — short prefixes aren't accepted here)"
         )
         for e in exchanges:
             lines.append(
@@ -338,11 +331,7 @@ def _build_tools(
         lines.append("")
         lines.append("## User message(s)")
         if user_messages:
-            lines.append(
-                _truncate(
-                    json.dumps(user_messages, indent=2, default=str), 40_000
-                )
-            )
+            lines.append(_truncate(json.dumps(user_messages, indent=2, default=str), 40_000))
         else:
             lines.append(_truncate(user_message, 20_000))
         lines.append("")
@@ -351,11 +340,7 @@ def _build_tools(
         if tool_calls:
             lines.append("")
             lines.append("## Tool calls")
-            lines.append(
-                _truncate(
-                    json.dumps(tool_calls, indent=2, default=str), 20_000
-                )
-            )
+            lines.append(_truncate(json.dumps(tool_calls, indent=2, default=str), 20_000))
         return _truncate("\n".join(lines), MAX_EXCHANGE_BLOB_CHARS)
 
     async def read_repo_file(inp: dict) -> str:
@@ -559,15 +544,9 @@ async def _run_agent(
             messages.append({"role": "user", "content": tool_results})
             if text_parts:
                 preview = " | ".join(t[:120] for t in text_parts)
-                print(
-                    f"  [round {round_num + 1}] "
-                    f"{len(tool_uses)} tool call(s): {preview}"
-                )
+                print(f"  [round {round_num + 1}] {len(tool_uses)} tool call(s): {preview}")
             else:
-                print(
-                    f"  [round {round_num + 1}] "
-                    f"{len(tool_uses)} tool call(s)"
-                )
+                print(f"  [round {round_num + 1}] {len(tool_uses)} tool call(s)")
             if response.stop_reason == "end_turn":
                 final_text = "\n".join(text_parts)
                 break
@@ -592,9 +571,7 @@ async def run_self_improvement(question_id: str, db: DB) -> str:
     if not question:
         raise ValueError(f"Question '{question_id}' not found")
     if question.page_type != PageType.QUESTION:
-        raise ValueError(
-            f"Page '{question_id}' is a {question.page_type.value}, not a question"
-        )
+        raise ValueError(f"Page '{question_id}' is a {question.page_type.value}, not a question")
 
     if question.project_id and question.project_id != db.project_id:
         db.project_id = question.project_id
@@ -603,10 +580,7 @@ async def run_self_improvement(question_id: str, db: DB) -> str:
     subtree_ids = [p.id for p, _ in subtree]
     calls = await _fetch_subtree_calls(subtree_ids, db)
 
-    print(
-        f"Collected subtree: {len(subtree)} question(s), "
-        f"{len(calls)} call(s)."
-    )
+    print(f"Collected subtree: {len(subtree)} question(s), {len(calls)} call(s).")
 
     tools = _build_tools(resolved, subtree, calls, db)
     system_prompt = _load_prompt("self_improve.md")
@@ -625,9 +599,7 @@ async def run_self_improvement(question_id: str, db: DB) -> str:
 def save_self_improvement(text: str, question_headline: str) -> Path:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
-    slug = "".join(
-        c if c.isalnum() or c in " -" else "" for c in question_headline[:50]
-    )
+    slug = "".join(c if c.isalnum() or c in " -" else "" for c in question_headline[:50])
     slug = slug.strip().replace(" ", "-").lower()
     filename = f"{timestamp}-{slug}.md"
     path = OUTPUT_DIR / filename

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -1,0 +1,634 @@
+"""Tests for self-improvement analysis and its CLI wiring.
+
+Covers:
+- Pure helpers (_truncate, _safe_repo_path, _is_full_uuid,
+  _format_call_summary)
+- Subtree collection + call gathering (cycle-safe)
+- Each tool exposed to the LLM (overview, read_page,
+  list_pages_for_call, get_call_details, get_llm_exchange,
+  read_repo_file, list_repo_dir) — including the regression that
+  get_llm_exchange must reject short prefixes cleanly and
+  get_call_details must print full exchange UUIDs
+- save_self_improvement file naming/writing
+- run_self_improvement precondition checks
+- --self-improve CLI flag: parsed, shown in --help, dispatched
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+import rumil.self_improve as si
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.self_improve import (
+    _build_tools,
+    _collect_subtree,
+    _fetch_subtree_calls,
+    _format_call_summary,
+    _is_full_uuid,
+    _safe_repo_path,
+    _truncate,
+    run_self_improvement,
+    save_self_improvement,
+)
+
+
+def _get_tool(tools, name):
+    return next(t for t in tools if t.name == name)
+
+
+def test_truncate_leaves_short_text_untouched():
+    assert _truncate("short", 100) == "short"
+
+
+def test_truncate_elides_long_text_with_marker():
+    long = "x" * 200
+    out = _truncate(long, 50)
+    assert out.startswith("x" * 50)
+    assert "truncated" in out
+    assert "150 more chars" in out
+
+
+def test_is_full_uuid_accepts_canonical_uuid():
+    assert _is_full_uuid("550e8400-e29b-41d4-a716-446655440000") is True
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "4c493126", "not-a-uuid", "550e8400", "550e8400-e29b-41d4-a716"],
+)
+def test_is_full_uuid_rejects_non_uuids(bad):
+    assert _is_full_uuid(bad) is False
+
+
+def test_safe_repo_path_accepts_repo_file():
+    out = _safe_repo_path("README.md")
+    assert out is not None
+    assert out.name == "README.md"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "/etc/passwd", "../../etc/passwd", "../../../tmp/anything"],
+)
+def test_safe_repo_path_rejects_escapes(bad):
+    assert _safe_repo_path(bad) is None
+
+
+def test_format_call_summary_includes_key_fields():
+    call = Call(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id="abc12345-0000-0000-0000-000000000000",
+        status=CallStatus.COMPLETE,
+        budget_used=2,
+        cost_usd=0.123,
+    )
+    out = _format_call_summary(call)
+    assert "find_considerations" in out
+    assert "status=complete" in out
+    assert "budget_used=2" in out
+    assert "$0.123" in out
+    assert call.id[:8] in out
+
+
+def test_format_call_summary_handles_missing_cost_and_scope():
+    call = Call(
+        call_type=CallType.ASSESS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=None,
+        status=CallStatus.PENDING,
+    )
+    out = _format_call_summary(call)
+    assert "scope=none" in out
+    assert "cost=?" in out
+
+
+async def test_collect_subtree_walks_children(tmp_db, question_page):
+    c1 = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="c1",
+        headline="Child question 1",
+    )
+    c2 = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="c2",
+        headline="Child question 2",
+    )
+    await tmp_db.save_page(c1)
+    await tmp_db.save_page(c2)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=question_page.id,
+            to_page_id=c1.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=question_page.id,
+            to_page_id=c2.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+    result = await _collect_subtree(question_page.id, tmp_db)
+    ids = {p.id for p, _ in result}
+    assert question_page.id in ids
+    assert c1.id in ids
+    assert c2.id in ids
+    root_entries = [entry for entry in result if entry[1] == 0]
+    assert len(root_entries) == 1
+    assert root_entries[0][0].id == question_page.id
+
+
+async def test_collect_subtree_terminates_on_cycles(tmp_db, question_page):
+    child = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="cyclic",
+        headline="Cyclic child",
+    )
+    await tmp_db.save_page(child)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=question_page.id,
+            to_page_id=child.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=child.id,
+            to_page_id=question_page.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+    result = await _collect_subtree(question_page.id, tmp_db)
+    ids = [p.id for p, _ in result]
+    assert len(ids) == len(set(ids))
+    assert set(ids) == {question_page.id, child.id}
+
+
+async def test_collect_subtree_missing_root_returns_empty(tmp_db):
+    fake_id = "00000000-0000-0000-0000-000000000000"
+    assert list(await _collect_subtree(fake_id, tmp_db)) == []
+
+
+async def test_fetch_subtree_calls_returns_scoped_calls(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    other_question = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="other",
+        headline="Other question",
+    )
+    await tmp_db.save_page(other_question)
+    other_call = Call(
+        call_type=CallType.ASSESS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=other_question.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(other_call)
+
+    result = await _fetch_subtree_calls([question_page.id], tmp_db)
+    ids = {c.id for c in result}
+    assert scout_call.id in ids
+    assert other_call.id not in ids
+
+
+async def test_fetch_subtree_calls_empty_input_short_circuits(tmp_db):
+    assert list(await _fetch_subtree_calls([], tmp_db)) == []
+
+
+async def test_overview_lists_root_subtree_and_calls(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    tools = _build_tools(
+        question_page.id,
+        [(question_page, 0)],
+        [scout_call],
+        tmp_db,
+    )
+    out = await _get_tool(tools, "get_investigation_overview").fn({})
+    assert question_page.headline in out
+    assert question_page.id[:8] in out
+    assert scout_call.id[:8] in out
+    assert "find_considerations" in out
+
+
+async def test_overview_counts_pages_produced_by_calls(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="c",
+        headline="A claim produced by the scout",
+        provenance_call_id=scout_call.id,
+    )
+    await tmp_db.save_page(claim)
+    tools = _build_tools(
+        question_page.id,
+        [(question_page, 0)],
+        [scout_call],
+        tmp_db,
+    )
+    out = await _get_tool(tools, "get_investigation_overview").fn({})
+    assert "claim" in out.lower()
+    assert "1" in out
+
+
+async def test_read_page_accepts_short_id(tmp_db, question_page):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "read_page").fn({"page_id": question_page.id[:8]})
+    assert question_page.headline in out
+    assert "question" in out.lower()
+
+
+async def test_read_page_accepts_full_id(tmp_db, question_page):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "read_page").fn({"page_id": question_page.id})
+    assert question_page.headline in out
+
+
+async def test_read_page_missing_id_returns_error(tmp_db, question_page):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "read_page").fn(
+        {"page_id": "zzzzzzzz-0000-0000-0000-000000000000"}
+    )
+    assert "not found" in out.lower()
+
+
+async def test_list_pages_for_call_returns_created_pages(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="c",
+        headline="A discovered claim",
+        provenance_call_id=scout_call.id,
+        credence=7,
+        robustness=3,
+    )
+    await tmp_db.save_page(claim)
+    tools = _build_tools(
+        question_page.id,
+        [(question_page, 0)],
+        [scout_call],
+        tmp_db,
+    )
+    out = await _get_tool(tools, "list_pages_for_call").fn(
+        {"call_id": scout_call.id[:8]}
+    )
+    assert "A discovered claim" in out
+    assert claim.id[:8] in out
+    assert "C7" in out
+    assert "R3" in out
+
+
+async def test_list_pages_for_call_no_results(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    tools = _build_tools(
+        question_page.id,
+        [(question_page, 0)],
+        [scout_call],
+        tmp_db,
+    )
+    out = await _get_tool(tools, "list_pages_for_call").fn({"call_id": scout_call.id})
+    assert "No pages" in out
+
+
+async def test_get_call_details_prints_full_exchange_uuid(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    """Regression: the LLM passes exchange ids it sees in get_call_details
+    directly to get_llm_exchange, which requires full UUIDs (the column is
+    uuid-typed, so LIKE prefix-matching doesn't work). If we showed only
+    a short prefix here, the next tool call would crash."""
+    exchange_id = await tmp_db.save_llm_exchange(
+        call_id=scout_call.id,
+        phase="build_context",
+        system_prompt="sys",
+        user_message="usr",
+        response_text="resp",
+        round_num=0,
+    )
+    tools = _build_tools(
+        question_page.id,
+        [(question_page, 0)],
+        [scout_call],
+        tmp_db,
+    )
+    out = await _get_tool(tools, "get_call_details").fn({"call_id": scout_call.id})
+    assert exchange_id in out
+
+
+async def test_get_call_details_includes_core_metadata(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    tools = _build_tools(
+        question_page.id,
+        [(question_page, 0)],
+        [scout_call],
+        tmp_db,
+    )
+    out = await _get_tool(tools, "get_call_details").fn({"call_id": scout_call.id})
+    assert scout_call.id in out
+    assert scout_call.call_type.value in out
+    assert scout_call.status.value in out
+
+
+async def test_get_call_details_missing_call_returns_error(
+    tmp_db,
+    question_page,
+):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "get_call_details").fn({"call_id": "zzzzzzzz"})
+    assert "not found" in out.lower()
+
+
+async def test_get_llm_exchange_rejects_short_prefix(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    """Regression: previously a short prefix like '4c493126' reached the DB
+    and raised a postgres uuid cast error. Now it must be rejected in
+    Python with a helpful message pointing at get_call_details."""
+    tools = _build_tools(
+        question_page.id,
+        [(question_page, 0)],
+        [scout_call],
+        tmp_db,
+    )
+    out = await _get_tool(tools, "get_llm_exchange").fn({"exchange_id": "4c493126"})
+    assert "not a full UUID" in out
+    assert "get_call_details" in out
+
+
+async def test_get_llm_exchange_reads_full_exchange(
+    tmp_db,
+    question_page,
+    scout_call,
+):
+    exchange_id = await tmp_db.save_llm_exchange(
+        call_id=scout_call.id,
+        phase="update_workspace",
+        system_prompt="YOU-ARE-A-TEST-AGENT",
+        user_message="DO-THE-WORK",
+        response_text="HERE-IS-MY-RESPONSE",
+        round_num=1,
+    )
+    tools = _build_tools(
+        question_page.id,
+        [(question_page, 0)],
+        [scout_call],
+        tmp_db,
+    )
+    out = await _get_tool(tools, "get_llm_exchange").fn({"exchange_id": exchange_id})
+    assert "YOU-ARE-A-TEST-AGENT" in out
+    assert "DO-THE-WORK" in out
+    assert "HERE-IS-MY-RESPONSE" in out
+
+
+async def test_get_llm_exchange_empty_input_returns_error(
+    tmp_db,
+    question_page,
+):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "get_llm_exchange").fn({"exchange_id": ""})
+    assert "required" in out.lower()
+
+
+async def test_get_llm_exchange_unknown_full_uuid_returns_not_found(
+    tmp_db,
+    question_page,
+):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    fake = "00000000-0000-0000-0000-000000000000"
+    out = await _get_tool(tools, "get_llm_exchange").fn({"exchange_id": fake})
+    assert "not found" in out.lower()
+
+
+async def test_read_repo_file_reads_real_file(tmp_db, question_page):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "read_repo_file").fn({"path": "README.md"})
+    assert "rumil" in out.lower() or "research" in out.lower()
+
+
+async def test_read_repo_file_reads_prompt_file(tmp_db, question_page):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "read_repo_file").fn(
+        {"path": "prompts/self_improve.md"}
+    )
+    assert "rumil" in out.lower()
+
+
+@pytest.mark.parametrize("bad", ["/etc/passwd", "../../etc/passwd", ""])
+async def test_read_repo_file_blocks_path_escape(
+    tmp_db,
+    question_page,
+    bad,
+):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "read_repo_file").fn({"path": bad})
+    lowered = out.lower()
+    assert "outside" in lowered or "invalid" in lowered
+
+
+async def test_read_repo_file_missing_file_returns_error(
+    tmp_db,
+    question_page,
+):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "read_repo_file").fn(
+        {"path": "zzz_does_not_exist_xyz.md"}
+    )
+    assert "does not exist" in out.lower()
+
+
+async def test_list_repo_dir_shows_visible_entries(tmp_db, question_page):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "list_repo_dir").fn({"path": "."})
+    assert "src/" in out
+    assert "prompts/" in out
+    assert "main.py" in out
+
+
+async def test_list_repo_dir_filters_ignored_and_hidden(
+    tmp_db,
+    question_page,
+):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "list_repo_dir").fn({"path": "."})
+    assert ".git" not in out
+    assert "pages/" not in out
+    assert "__pycache__" not in out
+
+
+async def test_list_repo_dir_rejects_escape(tmp_db, question_page):
+    tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
+    out = await _get_tool(tools, "list_repo_dir").fn({"path": "/etc"})
+    assert "outside" in out.lower() or "invalid" in out.lower()
+
+
+def test_save_self_improvement_writes_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(si, "OUTPUT_DIR", tmp_path / "out")
+    path = save_self_improvement(
+        "# Analysis\n\nHello world",
+        "Is the sky blue?",
+    )
+    assert path.exists()
+    assert path.read_text() == "# Analysis\n\nHello world"
+    assert "is-the-sky-blue" in path.name
+    assert path.suffix == ".md"
+
+
+def test_save_self_improvement_sanitises_headline(monkeypatch, tmp_path):
+    monkeypatch.setattr(si, "OUTPUT_DIR", tmp_path / "out")
+    path = save_self_improvement(
+        "x",
+        "Weird/characters*and?punctuation: here!",
+    )
+    for bad in "/*?:!":
+        assert bad not in path.name
+
+
+async def test_run_self_improvement_rejects_missing_question(tmp_db):
+    with pytest.raises(ValueError, match="not found"):
+        await run_self_improvement(
+            "00000000-0000-0000-0000-000000000000",
+            tmp_db,
+        )
+
+
+async def test_run_self_improvement_rejects_non_question_page(tmp_db):
+    claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="not a question",
+        headline="A claim",
+    )
+    await tmp_db.save_page(claim)
+    with pytest.raises(ValueError, match="not a question"):
+        await run_self_improvement(claim.id, tmp_db)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_cli_self_improve_flag_in_help():
+    result = subprocess.run(
+        ["uv", "run", "python", "main.py", "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0
+    assert "--self-improve" in result.stdout
+    assert "[QUESTION_ID]" in result.stdout, (
+        "--self-improve must be rendered with an optional argument "
+        "(nargs='?') so it can be combined with a new question for "
+        "auto-analysis"
+    )
+
+
+def test_cli_self_improve_dispatches_and_handles_missing_id():
+    """End-to-end: argparse accepts the flag and cmd_self_improve runs
+    (reports 'not found' for an unknown question id)."""
+    scratch_workspace = f"self-improve-cli-{uuid.uuid4().hex[:8]}"
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "main.py",
+            "--self-improve",
+            "nonexistent-id",
+            "--workspace",
+            scratch_workspace,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    assert "unrecognized" not in combined.lower()
+    assert "not found" in combined.lower()
+
+
+def test_cli_self_improve_bare_flag_does_not_consume_next_flag():
+    """--self-improve without an id should set the sentinel and let the
+    next flag dispatch normally (nargs='?' behaviour). We combine it with
+    --list, which returns early, to confirm argparse didn't consume
+    '--list' as the question id."""
+    scratch_workspace = f"self-improve-bare-{uuid.uuid4().hex[:8]}"
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "main.py",
+            "--self-improve",
+            "--list",
+            "--workspace",
+            scratch_workspace,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    assert "unrecognized" not in combined.lower()
+    assert "expected one argument" not in combined.lower()
+    assert "Self-improvement analysis for" not in combined, (
+        "--list should short-circuit before self-improve runs"
+    )
+    assert (
+        f"No questions in workspace '{scratch_workspace}'" in combined
+        or scratch_workspace in combined
+    )

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -310,9 +310,7 @@ async def test_list_pages_for_call_returns_created_pages(
         [scout_call],
         tmp_db,
     )
-    out = await _get_tool(tools, "list_pages_for_call").fn(
-        {"call_id": scout_call.id[:8]}
-    )
+    out = await _get_tool(tools, "list_pages_for_call").fn({"call_id": scout_call.id[:8]})
     assert "A discovered claim" in out
     assert claim.id[:8] in out
     assert "C7" in out
@@ -458,9 +456,7 @@ async def test_read_repo_file_reads_real_file(tmp_db, question_page):
 
 async def test_read_repo_file_reads_prompt_file(tmp_db, question_page):
     tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
-    out = await _get_tool(tools, "read_repo_file").fn(
-        {"path": "prompts/self_improve.md"}
-    )
+    out = await _get_tool(tools, "read_repo_file").fn({"path": "prompts/self_improve.md"})
     assert "rumil" in out.lower()
 
 
@@ -481,9 +477,7 @@ async def test_read_repo_file_missing_file_returns_error(
     question_page,
 ):
     tools = _build_tools(question_page.id, [(question_page, 0)], [], tmp_db)
-    out = await _get_tool(tools, "read_repo_file").fn(
-        {"path": "zzz_does_not_exist_xyz.md"}
-    )
+    out = await _get_tool(tools, "read_repo_file").fn({"path": "zzz_does_not_exist_xyz.md"})
     assert "does not exist" in out.lower()
 
 


### PR DESCRIPTION
New one-off utility (like --summary) that inspects a completed investigation and writes a markdown narrative of strengths, weaknesses, and concrete code/prompt change suggestions.

The agent has read-only tools for the research output (subtree overview, pages, calls, LLM exchanges verbatim, trace events) plus read-only access to rumil's own source tree. It suggests code changes but does not make them.

Usage:
  uv run python main.py --self-improve QUESTION_ID
  uv run python main.py "Your question" --budget 20 --self-improve