### PR TITLE
Skip auto-summarise before assess in experimental orchestrator

### DIFF
--- a/src/rumil/orchestrators/base.py
+++ b/src/rumil/orchestrators/base.py
@@ -32,6 +32,8 @@ log = logging.getLogger(__name__)
 
 
 class BaseOrchestrator(ABC):
+    summarise_before_assess: bool = True
+
     def __init__(self, db: DB, broadcaster: Broadcaster | None = None):
         self.db = db
         self.broadcaster: Broadcaster | None = broadcaster
@@ -177,7 +179,7 @@ class BaseOrchestrator(ABC):
                 sequence_position=seq_pos if is_multi_step else None,
             )
             if isinstance(dispatch.payload, AssessDispatchPayload):
-                seq_pos += 2
+                seq_pos += 2 if self.summarise_before_assess else 1
             else:
                 seq_pos += 1
             executed = True

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -531,26 +531,32 @@ async def assess_question(
     call_id: str | None = None,
     sequence_id: str | None = None,
     sequence_position: int | None = None,
+    summarise: bool = True,
 ) -> str | None:
     """Run one Assess call on a question. Returns call ID, or None if no budget.
 
-    When ``sequence_id`` is provided, the summarise call is placed at
-    ``sequence_position`` and the assess call at ``sequence_position + 1``.
-    Callers should account for two positions being consumed.
+    When ``summarise`` is True (the default), a summarise call runs first;
+    with ``sequence_id`` provided it is placed at ``sequence_position`` and
+    the assess call at ``sequence_position + 1`` — callers should account for
+    two positions being consumed. When ``summarise`` is False, the summarise
+    step is skipped and the assess call sits at ``sequence_position``.
     """
     log.info("assess_question: question=%s", question_id[:8])
     if not await _consume_budget(db, force=force):
         return None
 
-    await summarize_question(
-        question_id,
-        db,
-        parent_call_id=parent_call_id,
-        sequence_id=sequence_id,
-        sequence_position=sequence_position,
-    )
+    if summarise:
+        await summarize_question(
+            question_id,
+            db,
+            parent_call_id=parent_call_id,
+            sequence_id=sequence_id,
+            sequence_position=sequence_position,
+        )
+        assess_position = sequence_position + 1 if sequence_position is not None else None
+    else:
+        assess_position = sequence_position
 
-    assess_position = sequence_position + 1 if sequence_position is not None else None
     call = await db.create_call(
         CallType.ASSESS,
         scope_page_id=question_id,

--- a/src/rumil/orchestrators/dispatch_handlers.py
+++ b/src/rumil/orchestrators/dispatch_handlers.py
@@ -157,6 +157,7 @@ async def _handle_assess(ctx: DispatchContext, payload: BaseDispatchPayload) -> 
         call_id=ctx.call_id,
         sequence_id=ctx.sequence_id,
         sequence_position=ctx.sequence_position,
+        summarise=ctx.orchestrator.summarise_before_assess,
     )
 
 

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -63,6 +63,8 @@ class ExperimentalOrchestrator(BaseOrchestrator):
     or recurse).
     """
 
+    summarise_before_assess = False
+
     def __init__(
         self,
         db: DB,
@@ -200,9 +202,10 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                         force=True,
                         sequence_id=self._sequence_id,
                         sequence_position=self._seq_position,
+                        summarise=False,
                     )
                     if self._sequence_id is not None:
-                        self._seq_position += 2
+                        self._seq_position += 1
         finally:
             await self._teardown()
             await own_db.close()


### PR DESCRIPTION
## Summary
- Adds a `summarise: bool = True` kwarg to `assess_question`; when `False`, the summarise step is skipped and the assess call sits at `sequence_position` directly.
- Introduces `BaseOrchestrator.summarise_before_assess` (defaults to `True`). `_run_dispatch_sequence` bumps `seq_pos` by 1 (not 2) for assess payloads when `False`, and `_handle_assess` threads the flag through.
- `ExperimentalOrchestrator` sets `summarise_before_assess = False` and updates its direct `assess_question` call site accordingly. Other orchestrators (two-phase, claim-investigation, robustify, global-prio) inherit the default and keep existing behavior.

## Test plan
- [x] `uv run pyright` clean on modified files
- [x] `uv run pytest tests/test_orchestrator_dispatch.py tests/test_call_sequences.py`
- [ ] Manual smoke run of experimental orchestrator to confirm no summarise calls precede assess

🤖 Generated with [Claude Code](https://claude.com/claude-code)