### PR TITLE
Show question headlines in page-load stats breakdown

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3748,13 +3748,21 @@
           "total_unique": {
             "type": "integer",
             "title": "Total Unique"
+          },
+          "question_headlines": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Question Headlines"
           }
         },
         "type": "object",
         "required": [
           "events",
           "total",
-          "total_unique"
+          "total_unique",
+          "question_headlines"
         ],
         "title": "PageLoadStatsOut"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1244,6 +1244,12 @@ export type PageLoadStatsOut = {
      * Total Unique
      */
     total_unique: number;
+    /**
+     * Question Headlines
+     */
+    question_headlines: {
+        [key: string]: string;
+    };
 };
 
 /**

--- a/frontend/src/app/traces/[runId]/page-load-stats.tsx
+++ b/frontend/src/app/traces/[runId]/page-load-stats.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { PageLoadStatsOut, PageLoadEventOut } from "@/api/types.gen";
-import { API_BASE } from "@/lib/api-base";
+import { CLIENT_API_BASE } from "@/api-config";
 
 const DETAIL_ORDER = ["content", "abstract", "headline"];
 
@@ -41,6 +41,24 @@ type GroupRow = {
   total: number;
   uniquePages: Set<string>;
 };
+
+function QuestionTagValue({
+  shortId,
+  headline,
+}: {
+  shortId: string;
+  headline: string | undefined;
+}) {
+  if (!headline) {
+    return <span className="pls-question-id-only">{shortId}</span>;
+  }
+  return (
+    <span className="pls-question-value">
+      <span className="pls-question-headline">{headline}</span>
+      <span className="pls-question-short">{shortId}</span>
+    </span>
+  );
+}
 
 function aggregate(
   events: PageLoadEventOut[],
@@ -84,7 +102,7 @@ export function PageLoadStats({ runId }: { runId: string }) {
   const [activeTags, setActiveTags] = useState<string[]>(["call_type"]);
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/runs/${runId}/page-load-stats`)
+    fetch(`${CLIENT_API_BASE}/api/runs/${runId}/page-load-stats`)
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then(setStats)
       .catch(() => setError(true));
@@ -200,13 +218,28 @@ export function PageLoadStats({ runId }: { runId: string }) {
                 {activeTags.length === 0 ? (
                   <td className="pls-call-type">&mdash;</td>
                 ) : (
-                  activeTags.map((t) => (
-                    <td key={t} className="pls-call-type">
-                      {row.tagValues[t] || (
-                        <span className="pls-tag-empty">&empty;</span>
-                      )}
-                    </td>
-                  ))
+                  activeTags.map((t) => {
+                    const raw = row.tagValues[t];
+                    return (
+                      <td
+                        key={t}
+                        className={`pls-call-type ${t === "question" ? "pls-call-type-question" : ""}`}
+                      >
+                        {raw ? (
+                          t === "question" ? (
+                            <QuestionTagValue
+                              shortId={raw}
+                              headline={stats.question_headlines[raw]}
+                            />
+                          ) : (
+                            raw
+                          )
+                        ) : (
+                          <span className="pls-tag-empty">&empty;</span>
+                        )}
+                      </td>
+                    );
+                  })
                 )}
                 {details.map((d) => (
                   <Cell

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -1629,6 +1629,43 @@
 .pls-detail-abstract { color: #4272c4; }
 .pls-detail-headline { color: #8b6cc1; }
 
+.pls-call-type-question {
+  white-space: normal;
+  max-width: 420px;
+  min-width: 220px;
+  padding-right: 16px;
+}
+
+.pls-question-value {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pls-question-headline {
+  color: #222;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.35;
+}
+
+.pls-question-short {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10.5px;
+  color: #aaa;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  flex-shrink: 0;
+}
+
+.pls-question-id-only {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  color: #888;
+  letter-spacing: 0.03em;
+}
+
 @media (prefers-color-scheme: dark) {
   .pls-root { border-top-color: #2a2a2a; }
   .pls-title { color: #6a6a6a; }
@@ -1676,4 +1713,7 @@
     border-color: transparent;
   }
   .pls-tag-empty { color: #555; }
+  .pls-question-headline { color: #e5e5e5; }
+  .pls-question-short { color: #5c5c5c; }
+  .pls-question-id-only { color: #777; }
 }

--- a/scripts/generate-api-types.sh
+++ b/scripts/generate-api-types.sh
@@ -11,6 +11,7 @@ import json
 schema = app.openapi()
 with open('frontend/openapi.json', 'w') as f:
     json.dump(schema, f, indent=2, default=str)
+    f.write('\n')
 "
 
 echo "Generating TypeScript types..."

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -600,8 +600,21 @@ async def get_page_load_stats(run_id: str, db: DB = Depends(_get_db)):
     ]
     unique_pages = {r["page_id"] for r in rows}
 
+    question_shorts = {q for ev in events if (q := ev.tags.get("question"))}
+    question_headlines: dict[str, str] = {}
+    if question_shorts:
+        resolved = await db.resolve_page_ids(list(question_shorts))
+        full_ids = list(set(resolved.values()))
+        if full_ids:
+            page_by_id = await db.get_pages_by_ids(full_ids)
+            for short_id, full_id in resolved.items():
+                page = page_by_id.get(full_id)
+                if page and page.headline:
+                    question_headlines[short_id] = page.headline
+
     return PageLoadStatsOut(
         events=events,
         total=len(rows),
         total_unique=len(unique_pages),
+        question_headlines=question_headlines,
     )

--- a/src/rumil/api/schemas.py
+++ b/src/rumil/api/schemas.py
@@ -427,3 +427,4 @@ class PageLoadStatsOut(BaseModel):
     events: list[PageLoadEventOut]
     total: int
     total_unique: int
+    question_headlines: dict[str, str]


### PR DESCRIPTION
## Summary

- Resolve `question` short IDs to headlines in the `/api/runs/{run_id}/page-load-stats` response and surface them in the trace viewer's Page Loads table — the "group by question" row now shows the full question headline with the 8-char ID as a muted mono suffix instead of the bare ID.
- Fix a pre-existing bug where `PageLoadStats` fetched via `API_BASE` (a server-only `API_BASE_URL` env var) and silently hit the wrong host from the browser — switched to `CLIENT_API_BASE` (`NEXT_PUBLIC_API_URL`).
- Make `scripts/generate-api-types.sh` write a trailing newline into `frontend/openapi.json` so the regen hook stops fighting with `end-of-file-fixer`.

## Test plan

- [x] Backend: `uv run pyright` clean.
- [x] Frontend: `npx tsc --noEmit` clean.
- [x] Hit `/api/runs/<run_id>/page-load-stats` directly — `question_headlines` map returned correctly.
- [x] Load the trace viewer in the browser, toggle "group by → question", confirm the headline renders with the short ID below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)