### PR TITLE
Add question-focused panels to the question stats page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ db/
 frontend/package-lock.json
 .claude/settings.local.json
 .claude/state/
-CLAUDE.md.local
+CLAUDE.local.md
 
 # macOS
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,5 +166,3 @@ You must always invoke the relevant skill when doing certain types of work
 - **Writing unit tests** Always invoke the write-tests skill
 - **Writing frontend code** Always invoke the frontend-design skill
 When you write a plan that involes either of these things, always include a reminder to invoke the appropriate skill.
-
-@CLAUDE.md.local

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2283,6 +2283,18 @@
           "total": {
             "type": "integer",
             "title": "Total"
+          },
+          "child_questions": {
+            "type": "integer",
+            "title": "Child Questions"
+          },
+          "considerations": {
+            "type": "integer",
+            "title": "Considerations"
+          },
+          "judgements": {
+            "type": "integer",
+            "title": "Judgements"
           }
         },
         "type": "object",
@@ -2290,7 +2302,10 @@
           "question_id",
           "headline",
           "by_type",
-          "total"
+          "total",
+          "child_questions",
+          "considerations",
+          "judgements"
         ],
         "title": "CallsForQuestion"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -411,6 +411,18 @@ export type CallsForQuestion = {
      * Total
      */
     total: number;
+    /**
+     * Child Questions
+     */
+    child_questions: number;
+    /**
+     * Considerations
+     */
+    considerations: number;
+    /**
+     * Judgements
+     */
+    judgements: number;
 };
 
 /**

--- a/frontend/src/app/pages/[pageId]/stats/page.tsx
+++ b/frontend/src/app/pages/[pageId]/stats/page.tsx
@@ -260,7 +260,11 @@ export default function QuestionStatsPage() {
         <div className="stats-error">Failed to load stats: {state.message}</div>
       )}
       {state.kind === "ready" && (
-        <StatsView data={state.data} leadingPanel={leadingPanel} />
+        <StatsView
+          data={state.data}
+          leadingPanel={leadingPanel}
+          anchorId={pageId}
+        />
       )}
     </main>
   );

--- a/frontend/src/components/question-focus.tsx
+++ b/frontend/src/components/question-focus.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import type { CallsForQuestion, Subgraph } from "@/api";
+
+export type FocusColorMap = Record<string, string>;
+
+type FocusBarSegment = {
+  callType: string;
+  n: number;
+  color: string;
+};
+
+type FocusBar =
+  | {
+      kind: "calls";
+      label: string;
+      total: number;
+      segments: FocusBarSegment[];
+    }
+  | {
+      kind: "count";
+      key: "child_questions" | "considerations" | "judgements";
+      label: string;
+      total: number;
+      color: string;
+      hatchColor?: string;
+    };
+
+function buildFocusBars(
+  entry: CallsForQuestion,
+  callTypes: string[],
+  hiddenCallTypes: Set<string>,
+  callTypeColor: (ct: string, i: number) => string,
+): FocusBar[] {
+  const visibleTypes = callTypes.filter((ct) => !hiddenCallTypes.has(ct));
+  const segments: FocusBarSegment[] = [];
+  let callsTotal = 0;
+  for (const ct of visibleTypes) {
+    const n = entry.by_type[ct] ?? 0;
+    if (n > 0) {
+      segments.push({
+        callType: ct,
+        n,
+        color: callTypeColor(ct, callTypes.indexOf(ct)),
+      });
+      callsTotal += n;
+    }
+  }
+  return [
+    {
+      kind: "calls",
+      label: "calls",
+      total: callsTotal,
+      segments,
+    },
+    {
+      kind: "count",
+      key: "child_questions",
+      label: "child questions",
+      total: entry.child_questions,
+      color: "var(--type-question)",
+      hatchColor: "var(--type-question-border)",
+    },
+    {
+      kind: "count",
+      key: "considerations",
+      label: "considerations",
+      total: entry.considerations,
+      color: "var(--type-claim)",
+      hatchColor: "var(--type-claim-border)",
+    },
+    {
+      kind: "count",
+      key: "judgements",
+      label: "judgements",
+      total: entry.judgements,
+      color: "var(--type-judgement)",
+      hatchColor: "var(--type-judgement-border)",
+    },
+  ];
+}
+
+function maxFromBars(bars: FocusBar[]): number {
+  let max = 0;
+  for (const b of bars) if (b.total > max) max = b.total;
+  return max;
+}
+
+// Shared renderer for a single focus bar row.
+function FocusBarRow({
+  bar,
+  max,
+  compact = false,
+  animationDelayMs = 0,
+}: {
+  bar: FocusBar;
+  max: number;
+  compact?: boolean;
+  animationDelayMs?: number;
+}) {
+  const pct = max === 0 ? 0 : (bar.total / max) * 100;
+  return (
+    <div className={`focus-row${compact ? " compact" : ""}`}>
+      <span
+        className="focus-label"
+        style={{
+          color: bar.kind === "count" ? bar.color : "var(--color-foreground)",
+        }}
+      >
+        {bar.label}
+      </span>
+      <div className="focus-track">
+        <div
+          className="focus-fill"
+          style={{
+            width: `${pct}%`,
+            animationDelay: `${animationDelayMs}ms`,
+          }}
+        >
+          {bar.kind === "calls" ? (
+            <CallsStack segments={bar.segments} total={bar.total} />
+          ) : (
+            <div
+              className="count-fill"
+              style={{
+                background: bar.hatchColor ?? bar.color,
+                borderRight: `2px solid ${bar.color}`,
+              }}
+            />
+          )}
+        </div>
+      </div>
+      <span className="focus-count">{bar.total}</span>
+    </div>
+  );
+}
+
+function CallsStack({
+  segments,
+  total,
+}: {
+  segments: FocusBarSegment[];
+  total: number;
+}) {
+  if (total === 0 || segments.length === 0) {
+    return <div className="count-fill empty" />;
+  }
+  return (
+    <div className="calls-stack">
+      {segments.map((s) => {
+        const pct = (s.n / total) * 100;
+        return (
+          <div
+            key={s.callType}
+            className="calls-seg"
+            style={{ width: `${pct}%`, background: s.color }}
+            title={`${s.callType} · ${s.n}`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export function QuestionFocusBars({
+  entry,
+  callTypes,
+  hiddenCallTypes,
+  callTypeColor,
+  compact = false,
+}: {
+  entry: CallsForQuestion;
+  callTypes: string[];
+  hiddenCallTypes: Set<string>;
+  callTypeColor: (ct: string, i: number) => string;
+  compact?: boolean;
+}) {
+  const bars = useMemo(
+    () => buildFocusBars(entry, callTypes, hiddenCallTypes, callTypeColor),
+    [entry, callTypes, hiddenCallTypes, callTypeColor],
+  );
+  const max = maxFromBars(bars);
+
+  return (
+    <div className={`focus-bars${compact ? " compact" : ""}`}>
+      <FocusBarStyles />
+      {bars.map((bar, i) => (
+        <FocusBarRow
+          key={bar.kind === "calls" ? "calls" : bar.key}
+          bar={bar}
+          max={max}
+          compact={compact}
+          animationDelayMs={i * 60}
+        />
+      ))}
+    </div>
+  );
+}
+
+function FocusBarStyles() {
+  return (
+    <style>{`
+      .focus-bars {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+      .focus-bars.compact {
+        gap: 0.3rem;
+      }
+      .focus-row {
+        display: grid;
+        grid-template-columns: 7.5rem 1fr 3rem;
+        align-items: center;
+        gap: 0.75rem;
+        font-family: var(--font-geist-mono), monospace;
+        font-size: 0.75rem;
+      }
+      .focus-row.compact {
+        grid-template-columns: 5.5rem 1fr 2rem;
+        gap: 0.5rem;
+        font-size: 0.68rem;
+      }
+      .focus-label {
+        text-align: right;
+        letter-spacing: 0.02em;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .focus-track {
+        position: relative;
+        height: 0.95rem;
+        background: var(--color-background);
+        border: 1px solid var(--color-border);
+      }
+      .focus-row.compact .focus-track {
+        height: 0.72rem;
+      }
+      .focus-fill {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        transform-origin: left;
+        animation: focusBarGrow 0.55s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+      }
+      @keyframes focusBarGrow {
+        from { transform: scaleX(0); }
+        to { transform: scaleX(1); }
+      }
+      .count-fill {
+        width: 100%;
+        height: 100%;
+      }
+      .count-fill.empty {
+        background: transparent;
+      }
+      .calls-stack {
+        display: flex;
+        width: 100%;
+        height: 100%;
+      }
+      .calls-seg {
+        height: 100%;
+      }
+      .calls-seg + .calls-seg {
+        border-left: 1px solid var(--color-background);
+      }
+      .focus-count {
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+        opacity: 0.85;
+      }
+    `}</style>
+  );
+}
+
+// Extract the set of direct child questions of the anchor from the subgraph.
+// We walk edges for (anchor --child_question--> dst).
+function subquestionIdsFromSubgraph(
+  subgraph: Subgraph,
+  anchorId: string,
+): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const e of subgraph.edges) {
+    if (
+      e.link_type === "child_question" &&
+      e.from_page_id === anchorId &&
+      !seen.has(e.to_page_id)
+    ) {
+      seen.add(e.to_page_id);
+      ids.push(e.to_page_id);
+    }
+  }
+  return ids;
+}
+
+export function SubquestionFocusGrid({
+  anchorId,
+  subgraph,
+  callsByQuestion,
+  callTypes,
+  hiddenCallTypes,
+  callTypeColor,
+}: {
+  anchorId: string;
+  subgraph: Subgraph;
+  callsByQuestion: Record<string, CallsForQuestion>;
+  callTypes: string[];
+  hiddenCallTypes: Set<string>;
+  callTypeColor: (ct: string, i: number) => string;
+}) {
+  const subquestionIds = useMemo(
+    () => subquestionIdsFromSubgraph(subgraph, anchorId),
+    [subgraph, anchorId],
+  );
+  const [limit, setLimit] = useState(6);
+
+  if (subquestionIds.length === 0) {
+    return (
+      <div className="empty-panel">
+        this question has no child questions
+      </div>
+    );
+  }
+
+  const visibleIds = subquestionIds.slice(0, limit);
+  const hiddenCount = subquestionIds.length - visibleIds.length;
+
+  return (
+    <div className="subq-grid-wrap">
+      <style>{`
+        .subq-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+          gap: 1px;
+          background: var(--color-border);
+          border: 1px solid var(--color-border);
+        }
+        .subq-cell {
+          background: var(--color-background);
+          padding: 0.9rem 1rem 1rem 1rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.6rem;
+          animation: subqFadeIn 0.35s ease both;
+        }
+        @keyframes subqFadeIn {
+          from { opacity: 0; transform: translateY(3px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        .subq-header {
+          display: flex;
+          flex-direction: column;
+          gap: 0.2rem;
+          min-height: 2.4rem;
+        }
+        .subq-index {
+          font-family: var(--font-geist-mono), monospace;
+          font-size: 0.62rem;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          color: var(--type-question);
+          opacity: 0.75;
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          gap: 0.5rem;
+        }
+        .subq-index .total-pill {
+          font-family: var(--font-geist-mono), monospace;
+          font-size: 0.62rem;
+          letter-spacing: 0.04em;
+          text-transform: none;
+          color: var(--color-muted);
+          opacity: 0.85;
+        }
+        .subq-headline {
+          font-size: 0.82rem;
+          line-height: 1.3;
+          color: var(--color-foreground);
+          font-weight: 500;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+        .subq-headline a {
+          color: inherit;
+          text-decoration: none;
+          border-bottom: 1px solid transparent;
+          transition: border-color 0.12s ease;
+        }
+        .subq-headline a:hover {
+          border-color: var(--type-question);
+        }
+        .subq-missing {
+          font-family: var(--font-geist-mono), monospace;
+          font-size: 0.7rem;
+          color: var(--color-muted);
+          letter-spacing: 0.03em;
+          padding: 0.5rem 0;
+        }
+        .subq-more {
+          margin-top: 0.75rem;
+          padding: 0.5rem 0.75rem;
+          background: transparent;
+          border: 1px solid var(--color-border);
+          color: var(--color-muted);
+          font-family: var(--font-geist-mono), monospace;
+          font-size: 0.68rem;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          cursor: pointer;
+          transition: all 0.12s ease;
+        }
+        .subq-more:hover {
+          color: var(--color-foreground);
+          border-color: var(--color-accent);
+        }
+      `}</style>
+
+      <div className="subq-grid">
+        {visibleIds.map((qid, idx) => {
+          const entry = callsByQuestion[qid];
+          const headline =
+            entry?.headline ?? inferHeadline(subgraph, qid) ?? "(no headline)";
+          return (
+            <div key={qid} className="subq-cell">
+              <div className="subq-header">
+                <div className="subq-index">
+                  <span>SQ{String(idx + 1).padStart(2, "0")}</span>
+                  {entry ? (
+                    <span className="total-pill">
+                      {entry.total} call{entry.total === 1 ? "" : "s"}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="subq-headline">
+                  <Link href={`/pages/${qid}/stats`}>{headline}</Link>
+                </div>
+              </div>
+              {entry ? (
+                <QuestionFocusBars
+                  entry={entry}
+                  callTypes={callTypes}
+                  hiddenCallTypes={hiddenCallTypes}
+                  callTypeColor={callTypeColor}
+                  compact
+                />
+              ) : (
+                <div className="subq-missing">
+                  no stats available for this subquestion
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          className="subq-more"
+          onClick={() => setLimit((n) => n + 6)}
+        >
+          show {Math.min(hiddenCount, 6)} more · {hiddenCount} hidden
+        </button>
+      )}
+    </div>
+  );
+}
+
+function inferHeadline(subgraph: Subgraph, qid: string): string | null {
+  const node = subgraph.nodes.find((n) => n.id === qid);
+  return node?.headline ?? null;
+}

--- a/frontend/src/components/stats-view.tsx
+++ b/frontend/src/components/stats-view.tsx
@@ -12,7 +12,11 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { CallsForQuestion, DegreeCell } from "@/api";
+import type { CallsForQuestion, DegreeCell, Subgraph } from "@/api";
+import {
+  QuestionFocusBars,
+  SubquestionFocusGrid,
+} from "@/components/question-focus";
 
 type Histogram = { [key: string]: number };
 
@@ -25,6 +29,7 @@ export type StatsViewData = {
   robustness_histogram: Histogram;
   credence_histogram: Histogram;
   calls_per_question: Array<CallsForQuestion>;
+  subgraph?: Subgraph;
 };
 
 const TYPE_ORDER = [
@@ -215,9 +220,11 @@ function binCallsPerQuestion(
 export function StatsView({
   data,
   leadingPanel,
+  anchorId,
 }: {
   data: StatsViewData;
   leadingPanel?: React.ReactNode;
+  anchorId?: string;
 }) {
   const pageTypeKeys = useMemo(
     () => orderedTypeKeys(data.pages_by_type),
@@ -254,6 +261,17 @@ export function StatsView({
     () => collectCallTypes(data.calls_per_question),
     [data.calls_per_question],
   );
+  const callsByQuestion = useMemo(() => {
+    const m: Record<string, CallsForQuestion> = {};
+    for (const e of data.calls_per_question) m[e.question_id] = e;
+    return m;
+  }, [data.calls_per_question]);
+  const anchorEntry = anchorId ? callsByQuestion[anchorId] : undefined;
+  const focusAvailable = Boolean(anchorId && anchorEntry);
+  const [callsView, setCallsView] = useState<"distribution" | "focus">(
+    focusAvailable ? "focus" : "distribution",
+  );
+  const activeCallsView = focusAvailable ? callsView : "distribution";
   const [hiddenCallTypes, setHiddenCallTypes] = useState<Set<string>>(
     () => new Set(),
   );
@@ -314,6 +332,55 @@ export function StatsView({
           color: var(--color-muted);
           font-family: var(--font-geist-mono), monospace;
           margin-bottom: 0.9rem;
+        }
+        .stats-view .panel-header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 1rem;
+          margin-bottom: 0.9rem;
+          flex-wrap: wrap;
+        }
+        .stats-view .panel-header .panel-label {
+          margin-bottom: 0.25rem;
+        }
+        .panel-sublabel {
+          font-size: 0.7rem;
+          color: var(--color-muted);
+          font-family: var(--font-geist-mono), monospace;
+          letter-spacing: 0.02em;
+          opacity: 0.8;
+        }
+        .view-toggle {
+          display: inline-flex;
+          border: 1px solid var(--color-border);
+          background: var(--color-background);
+        }
+        .view-toggle .toggle-chip {
+          background: transparent;
+          border: none;
+          color: var(--color-muted);
+          font-family: var(--font-geist-mono), monospace;
+          font-size: 0.65rem;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          padding: 0.4rem 0.75rem;
+          cursor: pointer;
+          transition: all 0.14s ease;
+          border-right: 1px solid var(--color-border);
+        }
+        .view-toggle .toggle-chip:last-child {
+          border-right: none;
+        }
+        .view-toggle .toggle-chip:hover {
+          color: var(--color-foreground);
+        }
+        .view-toggle .toggle-chip.active {
+          background: var(--color-foreground);
+          color: var(--color-background);
+        }
+        .focus-panel {
+          padding: 0.4rem 0 0.2rem 0;
         }
 
         .summary-row {
@@ -849,14 +916,101 @@ export function StatsView({
       {allHistEmpty && null}
 
       <div className="panel">
-        <div className="panel-label">
-          Calls per question &nbsp;
-          <span style={{ opacity: 0.7, fontWeight: 400 }}>
-            questions binned by total calls, stacked by call type
-          </span>
+        <div className="panel-header">
+          <div>
+            <div className="panel-label">
+              {activeCallsView === "focus"
+                ? "Question focus"
+                : "Calls per question"}
+            </div>
+            <div className="panel-sublabel">
+              {activeCallsView === "focus"
+                ? "calls, child questions, considerations and judgements for this question"
+                : "questions binned by total calls, stacked by call type"}
+            </div>
+          </div>
+          {focusAvailable && (
+            <div
+              className="view-toggle"
+              role="tablist"
+              aria-label="Calls view mode"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeCallsView === "focus"}
+                className={`toggle-chip${activeCallsView === "focus" ? " active" : ""}`}
+                onClick={() => setCallsView("focus")}
+              >
+                this question
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeCallsView === "distribution"}
+                className={`toggle-chip${activeCallsView === "distribution" ? " active" : ""}`}
+                onClick={() => setCallsView("distribution")}
+              >
+                neighbourhood
+              </button>
+            </div>
+          )}
         </div>
-        {callTypes.length === 0 ? (
+
+        {callTypes.length === 0 && !focusAvailable ? (
           <div className="empty-panel">no calls recorded</div>
+        ) : activeCallsView === "focus" && anchorEntry ? (
+          <>
+            <div className="focus-panel">
+              <QuestionFocusBars
+                entry={anchorEntry}
+                callTypes={callTypes}
+                hiddenCallTypes={hiddenCallTypes}
+                callTypeColor={callTypeColor}
+              />
+            </div>
+            {callTypes.length > 0 && (
+              <div className="legend-row">
+                <button
+                  type="button"
+                  className="legend-chip legend-all"
+                  onClick={toggleAllCallTypes}
+                  title={
+                    anyHidden ? "Show all call types" : "Hide all call types"
+                  }
+                >
+                  {anyHidden ? "show all" : "hide all"}
+                </button>
+                {callTypes.map((ct, i) => {
+                  const hidden = hiddenCallTypes.has(ct);
+                  return (
+                    <button
+                      key={ct}
+                      type="button"
+                      className={`legend-chip${hidden ? " hidden" : ""}`}
+                      onClick={() => toggleCallType(ct)}
+                      title={hidden ? `Show ${ct}` : `Hide ${ct}`}
+                    >
+                      <span
+                        className="legend-swatch"
+                        style={{
+                          background: hidden
+                            ? "transparent"
+                            : callTypeColor(ct, i),
+                          borderColor: callTypeColor(ct, i),
+                        }}
+                      />
+                      {ct}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            <div className="hist-caption">
+              bars share a common scale · click a call type to toggle its
+              contribution
+            </div>
+          </>
         ) : (
           <>
             <div className="calls-wrap">
@@ -955,6 +1109,27 @@ export function StatsView({
           </>
         )}
       </div>
+
+      {focusAvailable && anchorId && data.subgraph && (
+        <div className="panel">
+          <div className="panel-header">
+            <div>
+              <div className="panel-label">Per subquestion</div>
+              <div className="panel-sublabel">
+                direct children of this question
+              </div>
+            </div>
+          </div>
+          <SubquestionFocusGrid
+            anchorId={anchorId}
+            subgraph={data.subgraph}
+            callsByQuestion={callsByQuestion}
+            callTypes={callTypes}
+            hiddenCallTypes={hiddenCallTypes}
+            callTypeColor={callTypeColor}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/scripts/generate-api-types.sh
+++ b/scripts/generate-api-types.sh
@@ -11,6 +11,7 @@ import json
 schema = app.openapi()
 with open('frontend/openapi.json', 'w') as f:
     json.dump(schema, f, indent=2, default=str)
+    f.write('\n')
 "
 
 echo "Generating TypeScript types..."

--- a/src/rumil/api/schemas.py
+++ b/src/rumil/api/schemas.py
@@ -368,6 +368,9 @@ class CallsForQuestion(BaseModel):
     headline: str | None
     by_type: dict[str, int]
     total: int
+    child_questions: int
+    considerations: int
+    judgements: int
 
 
 class StatsOut(BaseModel):

--- a/supabase/migrations/20260418103529_add_question_focus_counts.sql
+++ b/supabase/migrations/20260418103529_add_question_focus_counts.sql
@@ -1,0 +1,446 @@
+-- Augment calls_per_question entries in the stats RPCs with three
+-- per-question composition counts so the dashboard can render a
+-- "question-focused" view without additional round trips.
+--
+-- Added fields (per question in calls_per_question):
+--   child_questions: active outgoing 'child_question' links to an active question page
+--   considerations:  active incoming 'consideration' links from an active source page
+--   judgements:      active judgement pages linked (any link type) to the question
+--
+-- Counts are global (not subgraph-scoped) because they describe an
+-- intrinsic property of the question itself, not its 2-hop neighborhood.
+-- v1 is baseline-only: staged = FALSE, is_superseded = FALSE.
+
+CREATE OR REPLACE FUNCTION compute_project_stats(p_project_id UUID)
+RETURNS jsonb
+LANGUAGE sql STABLE AS $$
+    WITH active_pages AS (
+        SELECT id, page_type, credence, robustness, headline
+        FROM pages
+        WHERE project_id = p_project_id
+          AND staged = FALSE
+          AND is_superseded = FALSE
+    ),
+    active_links AS (
+        SELECT l.id,
+               pf.page_type AS from_type,
+               pt.page_type AS to_type,
+               l.link_type
+        FROM page_links l
+        JOIN active_pages pf ON pf.id = l.from_page_id
+        JOIN active_pages pt ON pt.id = l.to_page_id
+        WHERE l.staged = FALSE
+    ),
+    pages_by_type AS (
+        SELECT page_type, COUNT(*)::int AS n
+        FROM active_pages
+        GROUP BY page_type
+    ),
+    links_by_type AS (
+        SELECT link_type, COUNT(*)::int AS n
+        FROM active_links
+        GROUP BY link_type
+    ),
+    out_counts AS (
+        SELECT from_type AS page_type, link_type, COUNT(*)::float AS n
+        FROM active_links
+        GROUP BY from_type, link_type
+    ),
+    in_counts AS (
+        SELECT to_type AS page_type, link_type, COUNT(*)::float AS n
+        FROM active_links
+        GROUP BY to_type, link_type
+    ),
+    degree_pairs AS (
+        SELECT page_type, link_type FROM out_counts
+        UNION
+        SELECT page_type, link_type FROM in_counts
+    ),
+    degree_cells AS (
+        SELECT
+            dp.page_type,
+            dp.link_type,
+            COALESCE(oc.n, 0) / pbt.n::float AS avg_out,
+            COALESCE(ic.n, 0) / pbt.n::float AS avg_in
+        FROM degree_pairs dp
+        JOIN pages_by_type pbt ON pbt.page_type = dp.page_type
+        LEFT JOIN out_counts oc
+               ON oc.page_type = dp.page_type AND oc.link_type = dp.link_type
+        LEFT JOIN in_counts ic
+               ON ic.page_type = dp.page_type AND ic.link_type = dp.link_type
+    ),
+    robustness_hist AS (
+        SELECT robustness AS bucket, COUNT(*)::int AS n
+        FROM active_pages
+        WHERE robustness IS NOT NULL
+        GROUP BY robustness
+    ),
+    credence_hist AS (
+        SELECT credence AS bucket, COUNT(*)::int AS n
+        FROM active_pages
+        WHERE credence IS NOT NULL
+        GROUP BY credence
+    ),
+    question_pages AS (
+        SELECT id, headline
+        FROM active_pages
+        WHERE page_type = 'question'
+    ),
+    calls_by_qt AS (
+        SELECT c.scope_page_id AS question_id,
+               c.call_type,
+               COUNT(*)::int AS n
+        FROM calls c
+        WHERE c.project_id = p_project_id
+          AND c.scope_page_id IN (SELECT id FROM question_pages)
+        GROUP BY c.scope_page_id, c.call_type
+    ),
+    child_question_counts AS (
+        SELECT l.from_page_id AS question_id, COUNT(*)::int AS n
+        FROM page_links l
+        JOIN pages cq ON cq.id = l.to_page_id
+        WHERE l.link_type = 'child_question'
+          AND l.staged = FALSE
+          AND cq.staged = FALSE
+          AND cq.is_superseded = FALSE
+          AND cq.page_type = 'question'
+          AND l.from_page_id IN (SELECT id FROM question_pages)
+        GROUP BY l.from_page_id
+    ),
+    consideration_counts AS (
+        SELECT l.to_page_id AS question_id, COUNT(*)::int AS n
+        FROM page_links l
+        JOIN pages src ON src.id = l.from_page_id
+        WHERE l.link_type = 'consideration'
+          AND l.staged = FALSE
+          AND src.staged = FALSE
+          AND src.is_superseded = FALSE
+          AND l.to_page_id IN (SELECT id FROM question_pages)
+        GROUP BY l.to_page_id
+    ),
+    judgement_counts AS (
+        SELECT l.to_page_id AS question_id, COUNT(DISTINCT j.id)::int AS n
+        FROM page_links l
+        JOIN pages j ON j.id = l.from_page_id
+        WHERE j.page_type = 'judgement'
+          AND j.staged = FALSE
+          AND j.is_superseded = FALSE
+          AND l.staged = FALSE
+          AND l.to_page_id IN (SELECT id FROM question_pages)
+        GROUP BY l.to_page_id
+    ),
+    calls_per_question AS (
+        SELECT
+            qp.id AS question_id,
+            qp.headline,
+            COALESCE(
+                (SELECT jsonb_object_agg(cbt.call_type, cbt.n)
+                 FROM calls_by_qt cbt WHERE cbt.question_id = qp.id),
+                '{}'::jsonb
+            ) AS by_type,
+            COALESCE(
+                (SELECT SUM(cbt.n)::int FROM calls_by_qt cbt WHERE cbt.question_id = qp.id),
+                0
+            ) AS total,
+            COALESCE(
+                (SELECT n FROM child_question_counts cqc WHERE cqc.question_id = qp.id),
+                0
+            ) AS child_questions,
+            COALESCE(
+                (SELECT n FROM consideration_counts cc WHERE cc.question_id = qp.id),
+                0
+            ) AS considerations,
+            COALESCE(
+                (SELECT n FROM judgement_counts jc WHERE jc.question_id = qp.id),
+                0
+            ) AS judgements
+        FROM question_pages qp
+    )
+    SELECT jsonb_build_object(
+        'pages_total', COALESCE((SELECT SUM(n)::int FROM pages_by_type), 0),
+        'pages_by_type', COALESCE(
+            (SELECT jsonb_object_agg(page_type, n) FROM pages_by_type),
+            '{}'::jsonb
+        ),
+        'links_total', COALESCE((SELECT SUM(n)::int FROM links_by_type), 0),
+        'links_by_type', COALESCE(
+            (SELECT jsonb_object_agg(link_type, n) FROM links_by_type),
+            '{}'::jsonb
+        ),
+        'degree_matrix', COALESCE(
+            (SELECT jsonb_object_agg(page_type, per_link)
+             FROM (
+                 SELECT page_type,
+                        jsonb_object_agg(
+                            link_type,
+                            jsonb_build_object('avg_out', avg_out, 'avg_in', avg_in)
+                        ) AS per_link
+                 FROM degree_cells
+                 GROUP BY page_type
+             ) _grouped),
+            '{}'::jsonb
+        ),
+        'robustness_histogram', COALESCE(
+            (SELECT jsonb_object_agg(bucket::text, n) FROM robustness_hist),
+            '{}'::jsonb
+        ),
+        'credence_histogram', COALESCE(
+            (SELECT jsonb_object_agg(bucket::text, n) FROM credence_hist),
+            '{}'::jsonb
+        ),
+        'calls_per_question', COALESCE(
+            (SELECT jsonb_agg(
+                jsonb_build_object(
+                    'question_id', question_id,
+                    'headline', headline,
+                    'by_type', by_type,
+                    'total', total,
+                    'child_questions', child_questions,
+                    'considerations', considerations,
+                    'judgements', judgements
+                ) ORDER BY total DESC
+             ) FROM calls_per_question),
+            '[]'::jsonb
+        )
+    );
+$$;
+
+
+CREATE OR REPLACE FUNCTION compute_question_stats(p_question_id TEXT)
+RETURNS jsonb
+LANGUAGE sql STABLE AS $$
+    WITH RECURSIVE hood(page_id, depth) AS (
+        SELECT p_question_id, 0
+        UNION
+        SELECT
+            CASE WHEN l.from_page_id = h.page_id
+                 THEN l.to_page_id
+                 ELSE l.from_page_id END,
+            h.depth + 1
+        FROM hood h
+        JOIN page_links l
+          ON (l.from_page_id = h.page_id OR l.to_page_id = h.page_id)
+        WHERE h.depth < 2
+          AND l.staged = FALSE
+    ),
+    hood_depths AS (
+        SELECT page_id, MIN(depth)::int AS depth
+        FROM hood
+        GROUP BY page_id
+    ),
+    active_pages AS (
+        SELECT p.id, p.page_type, p.credence, p.robustness, p.headline,
+               hd.depth
+        FROM pages p
+        JOIN hood_depths hd ON hd.page_id = p.id
+        WHERE p.staged = FALSE
+          AND p.is_superseded = FALSE
+    ),
+    active_links AS (
+        SELECT l.id,
+               l.from_page_id,
+               l.to_page_id,
+               pf.page_type AS from_type,
+               pt.page_type AS to_type,
+               l.link_type
+        FROM page_links l
+        JOIN active_pages pf ON pf.id = l.from_page_id
+        JOIN active_pages pt ON pt.id = l.to_page_id
+        WHERE l.staged = FALSE
+    ),
+    pages_by_type AS (
+        SELECT page_type, COUNT(*)::int AS n
+        FROM active_pages
+        GROUP BY page_type
+    ),
+    links_by_type AS (
+        SELECT link_type, COUNT(*)::int AS n
+        FROM active_links
+        GROUP BY link_type
+    ),
+    out_counts AS (
+        SELECT from_type AS page_type, link_type, COUNT(*)::float AS n
+        FROM active_links
+        GROUP BY from_type, link_type
+    ),
+    in_counts AS (
+        SELECT to_type AS page_type, link_type, COUNT(*)::float AS n
+        FROM active_links
+        GROUP BY to_type, link_type
+    ),
+    degree_pairs AS (
+        SELECT page_type, link_type FROM out_counts
+        UNION
+        SELECT page_type, link_type FROM in_counts
+    ),
+    degree_cells AS (
+        SELECT
+            dp.page_type,
+            dp.link_type,
+            COALESCE(oc.n, 0) / pbt.n::float AS avg_out,
+            COALESCE(ic.n, 0) / pbt.n::float AS avg_in
+        FROM degree_pairs dp
+        JOIN pages_by_type pbt ON pbt.page_type = dp.page_type
+        LEFT JOIN out_counts oc
+               ON oc.page_type = dp.page_type AND oc.link_type = dp.link_type
+        LEFT JOIN in_counts ic
+               ON ic.page_type = dp.page_type AND ic.link_type = dp.link_type
+    ),
+    robustness_hist AS (
+        SELECT robustness AS bucket, COUNT(*)::int AS n
+        FROM active_pages
+        WHERE robustness IS NOT NULL
+        GROUP BY robustness
+    ),
+    credence_hist AS (
+        SELECT credence AS bucket, COUNT(*)::int AS n
+        FROM active_pages
+        WHERE credence IS NOT NULL
+        GROUP BY credence
+    ),
+    question_pages AS (
+        SELECT id, headline
+        FROM active_pages
+        WHERE page_type = 'question'
+    ),
+    calls_by_qt AS (
+        SELECT c.scope_page_id AS question_id,
+               c.call_type,
+               COUNT(*)::int AS n
+        FROM calls c
+        WHERE c.scope_page_id IN (SELECT id FROM question_pages)
+        GROUP BY c.scope_page_id, c.call_type
+    ),
+    child_question_counts AS (
+        SELECT l.from_page_id AS question_id, COUNT(*)::int AS n
+        FROM page_links l
+        JOIN pages cq ON cq.id = l.to_page_id
+        WHERE l.link_type = 'child_question'
+          AND l.staged = FALSE
+          AND cq.staged = FALSE
+          AND cq.is_superseded = FALSE
+          AND cq.page_type = 'question'
+          AND l.from_page_id IN (SELECT id FROM question_pages)
+        GROUP BY l.from_page_id
+    ),
+    consideration_counts AS (
+        SELECT l.to_page_id AS question_id, COUNT(*)::int AS n
+        FROM page_links l
+        JOIN pages src ON src.id = l.from_page_id
+        WHERE l.link_type = 'consideration'
+          AND l.staged = FALSE
+          AND src.staged = FALSE
+          AND src.is_superseded = FALSE
+          AND l.to_page_id IN (SELECT id FROM question_pages)
+        GROUP BY l.to_page_id
+    ),
+    judgement_counts AS (
+        SELECT l.to_page_id AS question_id, COUNT(DISTINCT j.id)::int AS n
+        FROM page_links l
+        JOIN pages j ON j.id = l.from_page_id
+        WHERE j.page_type = 'judgement'
+          AND j.staged = FALSE
+          AND j.is_superseded = FALSE
+          AND l.staged = FALSE
+          AND l.to_page_id IN (SELECT id FROM question_pages)
+        GROUP BY l.to_page_id
+    ),
+    calls_per_question AS (
+        SELECT
+            qp.id AS question_id,
+            qp.headline,
+            COALESCE(
+                (SELECT jsonb_object_agg(cbt.call_type, cbt.n)
+                 FROM calls_by_qt cbt WHERE cbt.question_id = qp.id),
+                '{}'::jsonb
+            ) AS by_type,
+            COALESCE(
+                (SELECT SUM(cbt.n)::int FROM calls_by_qt cbt WHERE cbt.question_id = qp.id),
+                0
+            ) AS total,
+            COALESCE(
+                (SELECT n FROM child_question_counts cqc WHERE cqc.question_id = qp.id),
+                0
+            ) AS child_questions,
+            COALESCE(
+                (SELECT n FROM consideration_counts cc WHERE cc.question_id = qp.id),
+                0
+            ) AS considerations,
+            COALESCE(
+                (SELECT n FROM judgement_counts jc WHERE jc.question_id = qp.id),
+                0
+            ) AS judgements
+        FROM question_pages qp
+    )
+    SELECT jsonb_build_object(
+        'subgraph_page_count', (SELECT COUNT(*)::int FROM active_pages),
+        'pages_total', COALESCE((SELECT SUM(n)::int FROM pages_by_type), 0),
+        'pages_by_type', COALESCE(
+            (SELECT jsonb_object_agg(page_type, n) FROM pages_by_type),
+            '{}'::jsonb
+        ),
+        'links_total', COALESCE((SELECT SUM(n)::int FROM links_by_type), 0),
+        'links_by_type', COALESCE(
+            (SELECT jsonb_object_agg(link_type, n) FROM links_by_type),
+            '{}'::jsonb
+        ),
+        'degree_matrix', COALESCE(
+            (SELECT jsonb_object_agg(page_type, per_link)
+             FROM (
+                 SELECT page_type,
+                        jsonb_object_agg(
+                            link_type,
+                            jsonb_build_object('avg_out', avg_out, 'avg_in', avg_in)
+                        ) AS per_link
+                 FROM degree_cells
+                 GROUP BY page_type
+             ) _grouped),
+            '{}'::jsonb
+        ),
+        'robustness_histogram', COALESCE(
+            (SELECT jsonb_object_agg(bucket::text, n) FROM robustness_hist),
+            '{}'::jsonb
+        ),
+        'credence_histogram', COALESCE(
+            (SELECT jsonb_object_agg(bucket::text, n) FROM credence_hist),
+            '{}'::jsonb
+        ),
+        'calls_per_question', COALESCE(
+            (SELECT jsonb_agg(
+                jsonb_build_object(
+                    'question_id', question_id,
+                    'headline', headline,
+                    'by_type', by_type,
+                    'total', total,
+                    'child_questions', child_questions,
+                    'considerations', considerations,
+                    'judgements', judgements
+                ) ORDER BY total DESC
+             ) FROM calls_per_question),
+            '[]'::jsonb
+        ),
+        'subgraph', jsonb_build_object(
+            'nodes', COALESCE(
+                (SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'id', id,
+                        'page_type', page_type,
+                        'headline', headline,
+                        'depth', depth
+                    ) ORDER BY depth, id
+                 ) FROM active_pages),
+                '[]'::jsonb
+            ),
+            'edges', COALESCE(
+                (SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'from_page_id', from_page_id,
+                        'to_page_id', to_page_id,
+                        'link_type', link_type
+                    ) ORDER BY from_page_id, to_page_id
+                 ) FROM active_links),
+                '[]'::jsonb
+            )
+        )
+    );
+$$;

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -169,10 +169,17 @@ async def test_project_stats_calls_per_question(tmp_db, small_project):
     q_a_entry = by_qid[small_project["q_a"].id]
     assert q_a_entry["total"] == 3
     assert q_a_entry["by_type"] == {"find_considerations": 2, "assess": 1}
+    # q_a has 1 child question (q_b), 2 considerations (c_1, c_2), 1 judgement (j_1)
+    assert q_a_entry["child_questions"] == 1
+    assert q_a_entry["considerations"] == 2
+    assert q_a_entry["judgements"] == 1
 
     q_b_entry = by_qid[small_project["q_b"].id]
     assert q_b_entry["total"] == 1
     assert q_b_entry["by_type"] == {"find_considerations": 1}
+    assert q_b_entry["child_questions"] == 0
+    assert q_b_entry["considerations"] == 0
+    assert q_b_entry["judgements"] == 0
 
 
 @pytest.mark.asyncio
@@ -251,7 +258,15 @@ async def test_question_stats_isolated(tmp_db):
     assert blob["pages_by_type"] == {"question": 1}
     assert blob["links_total"] == 0
     assert blob["calls_per_question"] == [
-        {"question_id": q.id, "headline": "lonely", "by_type": {}, "total": 0}
+        {
+            "question_id": q.id,
+            "headline": "lonely",
+            "by_type": {},
+            "total": 0,
+            "child_questions": 0,
+            "considerations": 0,
+            "judgements": 0,
+        }
     ]
 
 


### PR DESCRIPTION
## Summary
- Extends `compute_{project,question}_stats` RPCs with per-question `child_question`, `consideration`, and `judgement` counts (global, not subgraph-scoped) and surfaces them on `CallsForQuestion`.
- Adds a **Question focus** panel to the per-question stats page: a calls bar stacked by call type alongside child-question / consideration / judgement bars, with a `this question | neighbourhood` toggle that swaps between the focus view and the existing cross-question histogram, plus call-type toggles ("hide all" + per-type chips) that recompute the calls bar.
- Adds a **Per subquestion** grid that renders each direct child question with its own compact focus chart, linking through to that subquestion's stats page.
- Drive-by: `generate-api-types.sh` now writes a trailing newline on `openapi.json` so `end-of-file-fixer` stops rewriting it on every commit.
- Drive-by: rename `CLAUDE.md.local` → canonical `CLAUDE.local.md` (auto-loaded by Claude Code, no import needed).

## Test plan
- [x] `uv run pytest tests/test_stats.py` — 13 passed (includes new assertions for `child_questions`, `considerations`, `judgements` on both RPC outputs).
- [x] `npx tsc --noEmit` clean in `frontend/`.
- [x] Browser-tested at `/pages/<qid>/stats` against a question with 2 direct children, 17 considerations, and 7 dispatched calls — both toggle states render correctly, call-type toggles recompute the calls bar, subquestion cards link to the right stats pages.
- [ ] Migration `20260418103529_add_question_focus_counts.sql` pushed to prod before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)