### PR TITLE
Add pre-rearch test coverage for prioritization/budget/dispatch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,16 +11,20 @@ _SKILLS_LIB = Path(__file__).resolve().parent.parent / ".claude" / "lib"
 if str(_SKILLS_LIB) not in sys.path:
     sys.path.insert(0, str(_SKILLS_LIB))
 
+from rumil.calls.common import RunCallResult
 from rumil.database import DB
 from rumil.models import (
     Call,
     CallStatus,
     CallType,
+    LinkType,
     Page,
     PageLayer,
+    PageLink,
     PageType,
     Workspace,
 )
+from rumil.orchestrators.base import BaseOrchestrator
 from rumil.settings import override_settings
 
 
@@ -167,3 +171,172 @@ async def prioritization_call(tmp_db, question_page):
     )
     await tmp_db.save_call(call)
     return call
+
+
+@pytest_asyncio.fixture
+async def child_question_page(tmp_db, question_page):
+    """Create a child question linked under question_page via CHILD_QUESTION."""
+    child = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Which cognitive tasks will be automated first?",
+        headline="Which cognitive tasks will be automated first?",
+    )
+    await tmp_db.save_page(child)
+    link = PageLink(
+        from_page_id=question_page.id,
+        to_page_id=child.id,
+        link_type=LinkType.CHILD_QUESTION,
+    )
+    await tmp_db.save_link(link)
+    return child
+
+
+class PrioHarness:
+    """Captures prio call invocations and simulates dispatch handlers.
+
+    Tests set ``prio_queue`` to a list of RunCallResult values; each call to
+    the mocked ``run_prioritization_call`` pops the next one (or returns an
+    empty result when the queue is drained). Each simulated dispatch
+    realistically consumes 1 unit of budget (respecting ``force``) and
+    creates a call row so tests can inspect DB state.
+
+    Attributes:
+        prio_queue: RunCallResult values to return on successive prio calls.
+        prio_calls: kwargs of each run_prioritization_call invocation.
+        dispatched: dicts describing each dispatched call, in order.
+    """
+
+    def __init__(self, db: DB):
+        self.db = db
+        self.prio_queue: list[RunCallResult] = []
+        self.prio_calls: list[dict] = []
+        self.dispatched: list[dict] = []
+
+    async def simulate_dispatch(
+        self,
+        call_type: CallType,
+        question_id: str,
+        workspace: Workspace = Workspace.RESEARCH,
+        **kwargs,
+    ) -> str | None:
+        force = kwargs.get("force", False)
+        ok = await self.db.consume_budget(1)
+        if not ok:
+            if force:
+                await self.db.add_budget(1)
+                ok = await self.db.consume_budget(1)
+            if not ok:
+                return None
+        call = await self.db.create_call(
+            call_type,
+            scope_page_id=question_id,
+            parent_call_id=kwargs.get("parent_call_id"),
+            call_id=kwargs.get("call_id"),
+            sequence_id=kwargs.get("sequence_id"),
+            sequence_position=kwargs.get("sequence_position"),
+            workspace=workspace,
+        )
+        call.status = CallStatus.COMPLETE
+        await self.db.save_call(call)
+        self.dispatched.append(
+            {
+                "question_id": question_id,
+                "call_type": call_type.value,
+                "sequence_id": call.sequence_id,
+                "sequence_position": call.sequence_position,
+                "call_id": call.id,
+                "parent_call_id": kwargs.get("parent_call_id"),
+                "force": force,
+            }
+        )
+        return call.id
+
+
+@pytest_asyncio.fixture
+async def prio_harness(tmp_db, mocker):
+    """Mock LLM-dependent plumbing so TwoPhaseOrchestrator can run without a real LLM.
+
+    Mocks:
+    - ``run_prioritization_call`` at its two_phase.py import site — returns
+      scripted RunCallResult objects from ``harness.prio_queue``.
+    - The 5 dispatch-handler helpers + ``_run_simple_call_dispatch`` to
+      consume 1 unit of budget and create a call row per dispatch, honoring
+      ``force``.
+    - ``score_items_sequentially`` to return empty score lists (scoring is
+      an independent LLM call path we don't test here).
+
+    Returns the ``PrioHarness`` instance.
+    """
+    harness = PrioHarness(tmp_db)
+
+    async def _fake_prio(task, context_text, call, db, **kwargs):
+        harness.prio_calls.append({"task": task, "call": call, **kwargs})
+        if harness.prio_queue:
+            return harness.prio_queue.pop(0)
+        return RunCallResult()
+
+    mocker.patch(
+        "rumil.orchestrators.two_phase.run_prioritization_call",
+        side_effect=_fake_prio,
+    )
+
+    async def _fake_fc(question_id, db, **kwargs):
+        cid = await harness.simulate_dispatch(CallType.FIND_CONSIDERATIONS, question_id, **kwargs)
+        return (0, [cid] if cid else [])
+
+    async def _fake_assess(question_id, db, **kwargs):
+        kwargs.pop("summarise", None)
+        return await harness.simulate_dispatch(CallType.ASSESS, question_id, **kwargs)
+
+    async def _fake_create_view(question_id, db, **kwargs):
+        return await harness.simulate_dispatch(CallType.CREATE_VIEW, question_id, **kwargs)
+
+    async def _fake_update_view(question_id, db, **kwargs):
+        return await harness.simulate_dispatch(CallType.UPDATE_VIEW, question_id, **kwargs)
+
+    async def _fake_web(question_id, db, **kwargs):
+        return await harness.simulate_dispatch(CallType.WEB_RESEARCH, question_id, **kwargs)
+
+    mocker.patch(
+        "rumil.orchestrators.dispatch_handlers.find_considerations_until_done",
+        side_effect=_fake_fc,
+    )
+    mocker.patch(
+        "rumil.orchestrators.dispatch_handlers.assess_question",
+        side_effect=_fake_assess,
+    )
+    mocker.patch(
+        "rumil.orchestrators.dispatch_handlers.create_view_for_question",
+        side_effect=_fake_create_view,
+    )
+    mocker.patch(
+        "rumil.orchestrators.dispatch_handlers.update_view_for_question",
+        side_effect=_fake_update_view,
+    )
+    mocker.patch(
+        "rumil.orchestrators.dispatch_handlers.web_research_question",
+        side_effect=_fake_web,
+    )
+    mocker.patch(
+        "rumil.orchestrators.two_phase.update_view_for_question",
+        side_effect=_fake_update_view,
+    )
+    mocker.patch(
+        "rumil.orchestrators.two_phase.create_view_for_question",
+        side_effect=_fake_create_view,
+    )
+    mocker.patch(
+        "rumil.orchestrators.two_phase.score_items_sequentially",
+        return_value=[],
+    )
+
+    async def _fake_simple(self, question_id, call_type, cls, parent_call_id, **kwargs):
+        kwargs.setdefault("parent_call_id", parent_call_id)
+        kwargs["parent_call_id"] = parent_call_id
+        return await harness.simulate_dispatch(call_type, question_id, **kwargs)
+
+    mocker.patch.object(BaseOrchestrator, "_run_simple_call_dispatch", _fake_simple)
+
+    return harness

--- a/tests/test_budget_pacing.py
+++ b/tests/test_budget_pacing.py
@@ -3,6 +3,7 @@
 import pytest
 
 from rumil.constants import compute_round_budget
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
 
 
 @pytest.mark.parametrize(
@@ -47,3 +48,27 @@ def test_base_allocation_scaling() -> None:
         assert steady > 0
         assert steady >= prev or total <= 20
         prev = steady
+
+
+@pytest.mark.asyncio
+async def test_paced_budget_uses_budget_cap_in_nested_orchestrator(tmp_db):
+    """When budget_cap is set, _pacing_params returns the local cap/consumed, not global.
+
+    Nested orchestrators pace against their own allocation; a child with cap=20
+    paces like a 20-budget run regardless of the global pool size.
+    """
+    await tmp_db.init_budget(100)
+    await tmp_db.consume_budget(40)
+
+    capped = TwoPhaseOrchestrator(tmp_db, budget_cap=20)
+    capped._consumed = 5
+    total, used = await capped._pacing_params()
+    assert (total, used) == (20, 5), (
+        f"capped orch should pace from (budget_cap, _consumed); got ({total}, {used})"
+    )
+
+    uncapped = TwoPhaseOrchestrator(tmp_db)
+    g_total, g_used = await uncapped._pacing_params()
+    assert (g_total, g_used) == (100, 40), (
+        f"uncapped orch should pace from global budget; got ({g_total}, {g_used})"
+    )

--- a/tests/test_parallel_investigations.py
+++ b/tests/test_parallel_investigations.py
@@ -2,20 +2,29 @@
 
 import asyncio
 import time
+from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from rumil.calls.common import RunCallResult
 from rumil.clean.feedback import _make_investigation_tools
 from rumil.models import (
     Call,
     CallStatus,
     CallType,
+    Dispatch,
+    FindConsiderationsMode,
+    LinkType,
     Page,
     PageLayer,
+    PageLink,
     PageType,
+    RecurseDispatchPayload,
+    ScoutDispatchPayload,
     Workspace,
 )
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
 
 
 def _fake_page(page_id: str = "aaaa1111", headline: str = "Test Q") -> Page:
@@ -213,3 +222,168 @@ async def test_budget_deducted_across_dispatches(investigation_tools):
         )
 
         await collect_tool.handler({})
+
+
+def _scout_dispatch(question_id: str, reason: str = "") -> Dispatch:
+    return Dispatch(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        payload=ScoutDispatchPayload(
+            question_id=question_id,
+            mode=FindConsiderationsMode.ALTERNATE,
+            max_rounds=1,
+            reason=reason,
+        ),
+    )
+
+
+async def _make_question(db, headline: str) -> Page:
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+    )
+    await db.save_page(page)
+    return page
+
+
+async def test_concurrent_recursive_children_dont_overspend_global_budget(tmp_db, mocker):
+    """Two concurrent recurse children with caps summing above remaining must not overspend.
+
+    Pins the invariant that ``_consumed`` tracked locally per orchestrator
+    does not allow siblings to collectively overdraw the shared global pool.
+    If a future rearch holds stale per-orchestrator consumption counters, this
+    test should fail.
+    """
+    parent_q = await _make_question(tmp_db, "Parent Q")
+    child_a = await _make_question(tmp_db, "Child A")
+    child_b = await _make_question(tmp_db, "Child B")
+    for child in (child_a, child_b):
+        await tmp_db.save_link(
+            PageLink(
+                from_page_id=parent_q.id,
+                to_page_id=child.id,
+                link_type=LinkType.CHILD_QUESTION,
+            )
+        )
+
+    await tmp_db.init_budget(15)
+    initial_total = 15
+
+    scripts_by_scope: dict[str, list[RunCallResult]] = {
+        parent_q.id: [
+            RunCallResult(dispatches=[_scout_dispatch(parent_q.id, "seed")]),
+            RunCallResult(
+                dispatches=[
+                    Dispatch(
+                        call_type=CallType.PRIORITIZATION,
+                        payload=RecurseDispatchPayload(
+                            question_id=child_a.id,
+                            budget=10,
+                            reason="drill A",
+                        ),
+                    ),
+                    Dispatch(
+                        call_type=CallType.PRIORITIZATION,
+                        payload=RecurseDispatchPayload(
+                            question_id=child_b.id,
+                            budget=10,
+                            reason="drill B",
+                        ),
+                    ),
+                ]
+            ),
+            RunCallResult(dispatches=[]),
+        ],
+        child_a.id: [
+            RunCallResult(dispatches=[_scout_dispatch(child_a.id, f"a{i}") for i in range(10)]),
+            RunCallResult(dispatches=[]),
+        ],
+        child_b.id: [
+            RunCallResult(dispatches=[_scout_dispatch(child_b.id, f"b{i}") for i in range(10)]),
+            RunCallResult(dispatches=[]),
+        ],
+    }
+    call_counts: dict[str, int] = defaultdict(int)
+    dispatched: list[dict] = []
+
+    async def _fake_prio(task, context_text, call, db, **kwargs):
+        scope = call.scope_page_id
+        idx = call_counts[scope]
+        call_counts[scope] += 1
+        scripts = scripts_by_scope.get(scope, [])
+        if idx < len(scripts):
+            return scripts[idx]
+        return RunCallResult()
+
+    mocker.patch(
+        "rumil.orchestrators.two_phase.run_prioritization_call",
+        side_effect=_fake_prio,
+    )
+
+    async def _simulate(call_type, question_id, **kwargs):
+        force = kwargs.get("force", False)
+        ok = await tmp_db.consume_budget(1)
+        if not ok:
+            if force:
+                await tmp_db.add_budget(1)
+                ok = await tmp_db.consume_budget(1)
+            if not ok:
+                return None
+        call = await tmp_db.create_call(
+            call_type,
+            scope_page_id=question_id,
+            parent_call_id=kwargs.get("parent_call_id"),
+            call_id=kwargs.get("call_id"),
+            sequence_id=kwargs.get("sequence_id"),
+            sequence_position=kwargs.get("sequence_position"),
+            workspace=Workspace.RESEARCH,
+        )
+        call.status = CallStatus.COMPLETE
+        await tmp_db.save_call(call)
+        dispatched.append(
+            {"question_id": question_id, "force": force, "call_type": call_type.value}
+        )
+        return call.id
+
+    async def _fake_fc(question_id, db, **kwargs):
+        cid = await _simulate(CallType.FIND_CONSIDERATIONS, question_id, **kwargs)
+        return (0, [cid] if cid else [])
+
+    mocker.patch(
+        "rumil.orchestrators.dispatch_handlers.find_considerations_until_done",
+        side_effect=_fake_fc,
+    )
+    mocker.patch(
+        "rumil.orchestrators.two_phase.score_items_sequentially",
+        return_value=[],
+    )
+
+    async def _noop_view(*args, **kwargs):
+        return None
+
+    mocker.patch(
+        "rumil.orchestrators.two_phase.create_view_for_question",
+        side_effect=_noop_view,
+    )
+    mocker.patch(
+        "rumil.orchestrators.two_phase.update_view_for_question",
+        side_effect=_noop_view,
+    )
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(parent_q.id)
+
+    non_forced = [d for d in dispatched if not d["force"]]
+    assert len(non_forced) <= initial_total, (
+        f"non-forced dispatches ({len(non_forced)}) exceeded initial global pool "
+        f"({initial_total}) — concurrent children overdrew the shared budget"
+    )
+
+    total, used = await tmp_db.get_budget()
+    assert used <= total, f"used={used} exceeded total={total}"
+    forced_count = sum(1 for d in dispatched if d["force"])
+    assert total == initial_total + forced_count, (
+        f"total={total} should equal initial {initial_total} + forced {forced_count}"
+    )

--- a/tests/test_prioritization_call.py
+++ b/tests/test_prioritization_call.py
@@ -1,0 +1,228 @@
+"""Contract tests for ``run_prioritization_call``.
+
+These tests couple deliberately to the function's interface: they verify
+status transitions, return shape, the under-allocation retry, and the
+extra-dispatch-def wiring. When the prioritizer rearchitect replaces this
+interface, these tests are expected to be rewritten to target the
+successor.
+
+LLM plumbing is mocked at the ``run_single_call`` import site inside
+``rumil.calls.prioritization``; the real retry branch in
+``run_prioritization_call`` executes unchanged.
+"""
+
+import pytest
+
+from rumil.calls.dispatches import RECURSE_DISPATCH_DEF
+from rumil.calls.prioritization import run_prioritization_call
+from rumil.llm import AgentResult
+from rumil.models import (
+    AssessDispatchPayload,
+    CallStatus,
+    Dispatch,
+    FindConsiderationsMode,
+    ScoutDispatchPayload,
+)
+
+
+def _agent_result() -> AgentResult:
+    return AgentResult(messages=[{"role": "assistant", "content": "ok"}])
+
+
+def _make_side_effect(dispatches_per_call: list[list[Dispatch]]):
+    """Return a coroutine that scripts successive run_single_call invocations.
+
+    Each element of ``dispatches_per_call`` is the list of dispatches to
+    append to ``state.dispatches`` on that invocation.
+    """
+    calls: list[dict] = []
+
+    async def _side_effect(system_prompt, user_message="", tools=None, **kwargs):
+        idx = len(calls)
+        calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_message": user_message,
+                "tools": tools,
+                **kwargs,
+            }
+        )
+        to_add = dispatches_per_call[idx] if idx < len(dispatches_per_call) else []
+        state = kwargs["state"]
+        for d in to_add:
+            state.dispatches.append(d)
+        return _agent_result()
+
+    return _side_effect, calls
+
+
+@pytest.mark.asyncio
+async def test_run_prioritization_call_sets_status_running(
+    tmp_db, prioritization_call, question_page, mocker
+):
+    side_effect, _ = _make_side_effect([[]])
+    mocker.patch(
+        "rumil.calls.prioritization.run_single_call",
+        side_effect=side_effect,
+    )
+
+    await run_prioritization_call(
+        "task",
+        "context",
+        prioritization_call,
+        tmp_db,
+        system_prompt="sys",
+    )
+
+    refreshed = await tmp_db.get_call(prioritization_call.id)
+    assert refreshed is not None
+    assert refreshed.status == CallStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_run_prioritization_call_returns_dispatches(
+    tmp_db, prioritization_call, question_page, mocker
+):
+    scripted = [
+        Dispatch(
+            call_type=prioritization_call.call_type.ASSESS,
+            payload=AssessDispatchPayload(question_id=question_page.id, reason="r1"),
+        ),
+        Dispatch(
+            call_type=prioritization_call.call_type.ASSESS,
+            payload=AssessDispatchPayload(question_id=question_page.id, reason="r2"),
+        ),
+    ]
+    side_effect, _ = _make_side_effect([scripted])
+    mocker.patch(
+        "rumil.calls.prioritization.run_single_call",
+        side_effect=side_effect,
+    )
+
+    result = await run_prioritization_call(
+        "task",
+        "context",
+        prioritization_call,
+        tmp_db,
+        system_prompt="sys",
+    )
+
+    assert len(result.dispatches) == 2
+    reasons = [d.payload.reason for d in result.dispatches]
+    assert reasons == ["r1", "r2"]
+
+
+@pytest.mark.asyncio
+async def test_under_allocation_triggers_retry(tmp_db, prioritization_call, question_page, mocker):
+    """Cost=1 with budget=10 is under 50% → retry fires in phase prioritization_retry."""
+    first_round = [
+        Dispatch(
+            call_type=prioritization_call.call_type.ASSESS,
+            payload=AssessDispatchPayload(question_id=question_page.id),
+        ),
+    ]
+    side_effect, calls = _make_side_effect([first_round, []])
+    mocker.patch(
+        "rumil.calls.prioritization.run_single_call",
+        side_effect=side_effect,
+    )
+
+    await run_prioritization_call(
+        "task",
+        "context",
+        prioritization_call,
+        tmp_db,
+        system_prompt="sys",
+        dispatch_budget=10,
+    )
+
+    assert len(calls) == 2
+    assert calls[0]["phase"] == "prioritization"
+    assert calls[1]["phase"] == "prioritization_retry"
+    assert calls[1].get("messages") is not None
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_allocation_sufficient(
+    tmp_db, prioritization_call, question_page, mocker
+):
+    """Scout dispatch with max_rounds=5 against budget=10 is exactly 50% → no retry."""
+    first_round = [
+        Dispatch(
+            call_type=prioritization_call.call_type.FIND_CONSIDERATIONS,
+            payload=ScoutDispatchPayload(
+                question_id=question_page.id,
+                mode=FindConsiderationsMode.ALTERNATE,
+                max_rounds=5,
+            ),
+        ),
+    ]
+    side_effect, calls = _make_side_effect([first_round])
+    mocker.patch(
+        "rumil.calls.prioritization.run_single_call",
+        side_effect=side_effect,
+    )
+
+    await run_prioritization_call(
+        "task",
+        "context",
+        prioritization_call,
+        tmp_db,
+        system_prompt="sys",
+        dispatch_budget=10,
+    )
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_dispatch_budget_none(
+    tmp_db, prioritization_call, question_page, mocker
+):
+    """Dispatch budget unset → the retry branch never evaluates."""
+    first_round = [
+        Dispatch(
+            call_type=prioritization_call.call_type.ASSESS,
+            payload=AssessDispatchPayload(question_id=question_page.id),
+        ),
+    ]
+    side_effect, calls = _make_side_effect([first_round])
+    mocker.patch(
+        "rumil.calls.prioritization.run_single_call",
+        side_effect=side_effect,
+    )
+
+    await run_prioritization_call(
+        "task",
+        "context",
+        prioritization_call,
+        tmp_db,
+        system_prompt="sys",
+        dispatch_budget=None,
+    )
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_recurse_defs_included_when_passed_as_extra(
+    tmp_db, prioritization_call, question_page, mocker
+):
+    """extra_dispatch_defs add tools to the list handed to run_single_call."""
+    side_effect, calls = _make_side_effect([[]])
+    mocker.patch(
+        "rumil.calls.prioritization.run_single_call",
+        side_effect=side_effect,
+    )
+
+    await run_prioritization_call(
+        "task",
+        "context",
+        prioritization_call,
+        tmp_db,
+        system_prompt="sys",
+        extra_dispatch_defs=[RECURSE_DISPATCH_DEF],
+    )
+
+    tool_names = {t.name for t in calls[0]["tools"]}
+    assert RECURSE_DISPATCH_DEF.name in tool_names

--- a/tests/test_two_phase_auto_assess.py
+++ b/tests/test_two_phase_auto_assess.py
@@ -1,0 +1,139 @@
+"""Auto-assess atomicity invariants for ``TwoPhaseOrchestrator``.
+
+When main-phase prioritization dispatches a scout onto a **subquestion**
+(not the scope question), the orchestrator silently appends an
+``AssessDispatchPayload`` so the subquestion ends with a fresh judgement.
+The orchestrator also guarantees that this trailing assess runs even if
+budget runs out mid-sequence (force-consume). These invariants are easy
+for a rewrite to drop; pinning them here protects against that.
+"""
+
+import pytest
+
+from rumil.calls.common import RunCallResult
+from rumil.models import (
+    CallType,
+    Dispatch,
+    FindConsiderationsMode,
+    ScoutDispatchPayload,
+)
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
+
+
+def _scout_dispatch(question_id: str, reason: str = "") -> Dispatch:
+    return Dispatch(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        payload=ScoutDispatchPayload(
+            question_id=question_id,
+            mode=FindConsiderationsMode.ALTERNATE,
+            max_rounds=1,
+            reason=reason,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_subquestion_dispatch_gets_auto_assess_appended(
+    tmp_db, question_page, child_question_page, prio_harness
+):
+    """Main-phase scout on a subquestion runs as a [scout, assess] sequence."""
+    await tmp_db.init_budget(20)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed initial")]),
+        RunCallResult(dispatches=[_scout_dispatch(child_question_page.id, "target child")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    sub_dispatches = [
+        d for d in prio_harness.dispatched if d["question_id"] == child_question_page.id
+    ]
+    call_types = [d["call_type"] for d in sub_dispatches]
+    assert call_types == [
+        CallType.FIND_CONSIDERATIONS.value,
+        CallType.ASSESS.value,
+    ], f"expected [scout, assess] on subquestion, got {call_types}"
+
+    assert sub_dispatches[0]["sequence_id"] is not None
+    assert sub_dispatches[0]["sequence_id"] == sub_dispatches[1]["sequence_id"]
+
+
+@pytest.mark.asyncio
+async def test_scope_dispatch_does_not_get_auto_assess(tmp_db, question_page, prio_harness):
+    """A scout targeting the scope question runs alone — no trailing assess."""
+    await tmp_db.init_budget(20)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed initial")]),
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "main-phase scope scout")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    scope_dispatches = [d for d in prio_harness.dispatched if d["question_id"] == question_page.id]
+    assess_on_scope = [d for d in scope_dispatches if d["call_type"] == CallType.ASSESS.value]
+    assert assess_on_scope == [], (
+        f"scope dispatches unexpectedly got an assess appended: {assess_on_scope}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_assess_runs_even_when_budget_exhausts_mid_sequence(
+    tmp_db, question_page, child_question_page, prio_harness
+):
+    """When the scout consumes the last unit, the trailing assess force-consumes and still runs.
+
+    init_budget=13 lets initial prio drain 12 units, leaving 1 for the main-phase
+    scout; the trailing assess hits budget_remaining==0 and must force-consume.
+    """
+    await tmp_db.init_budget(13)
+    seed_scouts = [_scout_dispatch(question_page.id, f"seed {i}") for i in range(12)]
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=seed_scouts),
+        RunCallResult(dispatches=[_scout_dispatch(child_question_page.id, "subq scout")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    sub_dispatches = [
+        d for d in prio_harness.dispatched if d["question_id"] == child_question_page.id
+    ]
+    sub_call_types = [d["call_type"] for d in sub_dispatches]
+    assert CallType.FIND_CONSIDERATIONS.value in sub_call_types
+    assert CallType.ASSESS.value in sub_call_types, "auto-assess was skipped when budget was tight"
+    assess_entries = [d for d in sub_dispatches if d["call_type"] == CallType.ASSESS.value]
+    assert any(d["force"] for d in assess_entries), (
+        "trailing assess did not force-consume despite exhausted budget"
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_consume_expands_global_budget(
+    tmp_db, question_page, child_question_page, prio_harness
+):
+    """Force-consume grows ``total`` by 1 per forced unit, so we never overdraw."""
+    initial_total = 13
+    await tmp_db.init_budget(initial_total)
+    seed_scouts = [_scout_dispatch(question_page.id, f"seed {i}") for i in range(12)]
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=seed_scouts),
+        RunCallResult(dispatches=[_scout_dispatch(child_question_page.id, "subq scout")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    total, used = await tmp_db.get_budget()
+    forced_count = sum(1 for d in prio_harness.dispatched if d["force"])
+    assert forced_count > 0, "expected at least one force-consume in this setup"
+    assert total >= initial_total + forced_count, (
+        f"total={total} should have grown by ≥ {forced_count} forced units "
+        f"from initial {initial_total}"
+    )
+    assert used <= total

--- a/tests/test_two_phase_budget.py
+++ b/tests/test_two_phase_budget.py
@@ -1,0 +1,132 @@
+"""Budget invariants for ``TwoPhaseOrchestrator.run()``.
+
+These tests pin the budget accounting guarantees most likely to silently
+break when prioritization moves from "one prioritizer traversing the
+graph" to "a prioritizer at every node" with subscriptions and budget
+transfers. They target the public ``run()`` entry point so they survive
+internal refactors.
+
+LLM plumbing is mocked via the shared ``prio_harness`` fixture; the
+orchestrator's control-flow, budget bookkeeping, and dispatch routing
+all execute for real.
+"""
+
+import pytest
+
+from rumil.calls.common import RunCallResult
+from rumil.constants import MIN_TWOPHASE_BUDGET
+from rumil.models import (
+    CallType,
+    Dispatch,
+    FindConsiderationsMode,
+    ScoutDispatchPayload,
+)
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
+
+
+def _scout_dispatch(question_id: str, reason: str = "") -> Dispatch:
+    return Dispatch(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        payload=ScoutDispatchPayload(
+            question_id=question_id,
+            mode=FindConsiderationsMode.ALTERNATE,
+            max_rounds=1,
+            reason=reason,
+        ),
+    )
+
+
+async def _count_calls_of_type(db, call_type: CallType, project_id: str) -> int:
+    rows = (
+        await db._execute(
+            db.client.table("calls")
+            .select("id")
+            .eq("call_type", call_type.value)
+            .eq("project_id", project_id)
+        )
+    ).data
+    return len(rows)
+
+
+@pytest.mark.asyncio
+async def test_twophase_raises_when_below_min_budget(tmp_db, question_page, prio_harness):
+    await tmp_db.init_budget(MIN_TWOPHASE_BUDGET - 1)
+    orch = TwoPhaseOrchestrator(tmp_db)
+    with pytest.raises(ValueError, match="budget"):
+        await orch.run(question_page.id)
+
+
+def test_twophase_effective_budget_respects_cap(tmp_db):
+    """Pins the _effective_budget formula: min(global_remaining, cap - consumed)."""
+    orch = TwoPhaseOrchestrator(tmp_db, budget_cap=5)
+    assert orch._effective_budget(100) == 5
+    orch._consumed = 3
+    assert orch._effective_budget(100) == 2
+    orch._consumed = 5
+    assert orch._effective_budget(100) == 0
+    orch._consumed = 10
+    assert orch._effective_budget(100) < 0
+
+
+@pytest.mark.asyncio
+async def test_twophase_budget_cap_limits_rounds(tmp_db, question_page, prio_harness):
+    """budget_cap bounds total dispatch rounds even when global budget is plentiful.
+
+    With global budget = 200 but cap = 20, the loop must terminate long before
+    exhausting the scripted prio queue. Consumption also stays bounded by the cap.
+    """
+    await tmp_db.init_budget(200)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id)]) for _ in range(50)
+    ]
+
+    budget_cap = 20
+    orch = TwoPhaseOrchestrator(tmp_db, budget_cap=budget_cap)
+    await orch.run(question_page.id)
+
+    assert orch._consumed <= budget_cap, f"_consumed={orch._consumed} exceeded cap={budget_cap}"
+    assert len(prio_harness.prio_queue) > 0, (
+        "prio queue was fully drained — budget_cap did not bound the number of rounds"
+    )
+
+
+@pytest.mark.asyncio
+async def test_twophase_stops_loop_when_budget_hits_zero(tmp_db, question_page, prio_harness):
+    """When every prio plans many dispatches but budget is tight, the loop still terminates."""
+    await tmp_db.init_budget(5)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id) for _ in range(15)]),
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id) for _ in range(15)]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    scout_calls = await _count_calls_of_type(
+        tmp_db, CallType.FIND_CONSIDERATIONS, tmp_db.project_id
+    )
+    assert scout_calls <= 5
+
+    prio_calls = await _count_calls_of_type(tmp_db, CallType.PRIORITIZATION, tmp_db.project_id)
+    assert prio_calls <= 2, f"prioritization loop ran {prio_calls} times — should terminate quickly"
+
+
+@pytest.mark.asyncio
+async def test_twophase_budget_conservation(tmp_db, question_page, prio_harness):
+    """After run(), total/used bookkeeping stays consistent (total - used == remaining, ≥ 0)."""
+    await tmp_db.init_budget(20)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id) for _ in range(3)]),
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id) for _ in range(3)]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    total, used = await tmp_db.get_budget()
+    remaining = await tmp_db.budget_remaining()
+    assert total - used == remaining
+    assert remaining >= 0
+    assert used >= 0
+    assert used <= total

--- a/tests/test_two_phase_multi_parent.py
+++ b/tests/test_two_phase_multi_parent.py
@@ -1,0 +1,187 @@
+"""Multi-parent behaviour pins.
+
+Today, a question with two parents gets dispatched twice when each
+parent's prioritizer independently targets it — there is no
+subscription or dedup layer. The prioritizer rearch will introduce
+subscriptions so that one investigation can reuse another's result.
+
+These tests split into two groups:
+* **Current behaviour (non-xfail)** — pins duplicate dispatch so we
+  notice if it silently changes.
+* **Rearch target (xfail)** — specifies the post-rearch semantics.
+  When the rearch lands, these should start passing; the rearch
+  author should flip ``strict=False`` → ``strict=True``.
+"""
+
+import pytest
+
+from rumil.calls.common import RunCallResult
+from rumil.models import (
+    CallType,
+    Dispatch,
+    FindConsiderationsMode,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    ScoutDispatchPayload,
+    Workspace,
+)
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
+
+
+def _scout_dispatch(question_id: str, reason: str = "") -> Dispatch:
+    return Dispatch(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        payload=ScoutDispatchPayload(
+            question_id=question_id,
+            mode=FindConsiderationsMode.ALTERNATE,
+            max_rounds=1,
+            reason=reason,
+        ),
+    )
+
+
+async def _make_question(db, headline: str) -> Page:
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+    )
+    await db.save_page(page)
+    return page
+
+
+async def _link_child(db, parent: Page, child: Page) -> None:
+    await db.save_link(
+        PageLink(
+            from_page_id=parent.id,
+            to_page_id=child.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_parent_child_gets_dispatched_twice_today(tmp_db, prio_harness):
+    """Two parents each prioritizing the same child → two scout calls on that child.
+
+    This pins *current* behavior. When the rearch introduces subscriptions,
+    this test will start failing — at which point the rearch author should
+    delete this test and un-xfail the sibling target-behavior test.
+    """
+    p1 = await _make_question(tmp_db, "Parent one.")
+    p2 = await _make_question(tmp_db, "Parent two.")
+    child = await _make_question(tmp_db, "Shared child.")
+    await _link_child(tmp_db, p1, child)
+    await _link_child(tmp_db, p2, child)
+
+    await tmp_db.init_budget(30)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(p1.id, "seed p1")]),
+        RunCallResult(dispatches=[_scout_dispatch(child.id, "p1 targets child")]),
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[_scout_dispatch(p2.id, "seed p2")]),
+        RunCallResult(dispatches=[_scout_dispatch(child.id, "p2 targets child")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch_p1 = TwoPhaseOrchestrator(tmp_db)
+    await orch_p1.run(p1.id)
+    orch_p2 = TwoPhaseOrchestrator(tmp_db)
+    await orch_p2.run(p2.id)
+
+    child_scouts = [
+        d
+        for d in prio_harness.dispatched
+        if d["question_id"] == child.id and d["call_type"] == CallType.FIND_CONSIDERATIONS.value
+    ]
+    assert len(child_scouts) >= 2, (
+        f"expected ≥2 scout dispatches on shared child (today's behavior), got {len(child_scouts)}"
+    )
+
+
+@pytest.mark.xfail(
+    reason="rearch target: subscriptions should dedup cross-parent dispatches",
+    strict=False,
+)
+@pytest.mark.asyncio
+async def test_multi_parent_dedup_across_parents(tmp_db, prio_harness):
+    """Post-rearch target: a shared child should be investigated exactly once across parents.
+
+    Both parents' prioritizers should observe the single investigation's
+    result via a subscription rather than each dispatching their own.
+    """
+    p1 = await _make_question(tmp_db, "Parent one.")
+    p2 = await _make_question(tmp_db, "Parent two.")
+    child = await _make_question(tmp_db, "Shared child.")
+    await _link_child(tmp_db, p1, child)
+    await _link_child(tmp_db, p2, child)
+
+    await tmp_db.init_budget(30)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(p1.id, "seed p1")]),
+        RunCallResult(dispatches=[_scout_dispatch(child.id, "p1 targets child")]),
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[_scout_dispatch(p2.id, "seed p2")]),
+        RunCallResult(dispatches=[_scout_dispatch(child.id, "p2 targets child")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch_p1 = TwoPhaseOrchestrator(tmp_db)
+    await orch_p1.run(p1.id)
+    orch_p2 = TwoPhaseOrchestrator(tmp_db)
+    await orch_p2.run(p2.id)
+
+    child_scouts = [
+        d
+        for d in prio_harness.dispatched
+        if d["question_id"] == child.id and d["call_type"] == CallType.FIND_CONSIDERATIONS.value
+    ]
+    assert len(child_scouts) == 1, (
+        f"post-rearch: expected single scout on shared child, got {len(child_scouts)}"
+    )
+
+
+@pytest.mark.xfail(
+    reason="rearch target: concurrent prio on the same question should subscribe, not duplicate",
+    strict=False,
+)
+@pytest.mark.asyncio
+async def test_prio_on_question_with_running_prio_uses_subscription(
+    tmp_db, question_page, prio_harness
+):
+    """Post-rearch: a second prioritizer targeting an in-flight question subscribes to the first.
+
+    Exact subscription shape is TBD by the rearch. This placeholder asserts
+    the minimum required invariant: no duplicate PRIORITIZATION call row is
+    created on the same question when one is already running.
+    """
+    await tmp_db.init_budget(30)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch_a = TwoPhaseOrchestrator(tmp_db)
+    await orch_a.run(question_page.id)
+    orch_b = TwoPhaseOrchestrator(tmp_db)
+    await orch_b.run(question_page.id)
+
+    rows = (
+        await tmp_db._execute(
+            tmp_db.client.table("calls")
+            .select("id")
+            .eq("call_type", CallType.PRIORITIZATION.value)
+            .eq("scope_page_id", question_page.id)
+            .eq("project_id", tmp_db.project_id)
+        )
+    ).data
+    assert len(rows) <= 2, (
+        f"post-rearch: expected ≤2 prio call rows on the same question (one per run), got {len(rows)}"
+    )

--- a/tests/test_two_phase_phase_skip.py
+++ b/tests/test_two_phase_phase_skip.py
@@ -1,0 +1,159 @@
+"""Phase-skip invariants for ``TwoPhaseOrchestrator``.
+
+When the scope question already has a judgement or a view, the
+orchestrator must skip ``_initial_prioritization`` and proceed directly
+to main-phase on the next loop iteration. An eagerly-created initial
+call is marked complete with a ``PhaseSkippedEvent`` rather than left
+PENDING. These invariants are easy to break during a rewrite because
+they straddle the two-phase entry logic and the eager-call-creation
+optimization.
+"""
+
+import pytest
+
+from rumil.calls.common import RunCallResult
+from rumil.models import (
+    CallStatus,
+    CallType,
+    Dispatch,
+    FindConsiderationsMode,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    ScoutDispatchPayload,
+    Workspace,
+)
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
+
+
+def _scout_dispatch(question_id: str, reason: str = "") -> Dispatch:
+    return Dispatch(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        payload=ScoutDispatchPayload(
+            question_id=question_id,
+            mode=FindConsiderationsMode.ALTERNATE,
+            max_rounds=1,
+            reason=reason,
+        ),
+    )
+
+
+async def _seed_judgement(db, question_id: str) -> Page:
+    judgement = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="A provisional judgement.",
+        headline="A provisional judgement.",
+    )
+    await db.save_page(judgement)
+    await db.save_link(
+        PageLink(
+            from_page_id=judgement.id,
+            to_page_id=question_id,
+            link_type=LinkType.ANSWERS,
+        )
+    )
+    return judgement
+
+
+async def _seed_view(db, question_id: str) -> Page:
+    view = Page(
+        page_type=PageType.VIEW,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="A view page.",
+        headline="A view page.",
+    )
+    await db.save_page(view)
+    await db.save_link(
+        PageLink(
+            from_page_id=view.id,
+            to_page_id=question_id,
+            link_type=LinkType.VIEW_OF,
+        )
+    )
+    return view
+
+
+@pytest.mark.asyncio
+async def test_initial_prio_skipped_when_judgement_exists(tmp_db, question_page, prio_harness):
+    """A pre-existing judgement on the scope question causes initial prio to be skipped."""
+    await _seed_judgement(tmp_db, question_page.id)
+    await tmp_db.init_budget(20)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "main-phase")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    tasks_from_prio = [c.get("task", "") for c in prio_harness.prio_calls]
+    initial_tasks = [t for t in tasks_from_prio if "fan out exploratory research" in t]
+    assert initial_tasks == [], "initial_prioritization ran even though a judgement already exists"
+
+
+@pytest.mark.asyncio
+async def test_initial_prio_skipped_when_view_exists(tmp_db, question_page, prio_harness):
+    """A pre-existing view on the scope question causes initial prio to be skipped."""
+    await _seed_view(tmp_db, question_page.id)
+    await tmp_db.init_budget(20)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "main-phase")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    tasks_from_prio = [c.get("task", "") for c in prio_harness.prio_calls]
+    initial_tasks = [t for t in tasks_from_prio if "fan out exploratory research" in t]
+    assert initial_tasks == []
+
+
+@pytest.mark.asyncio
+async def test_main_phase_proceeds_after_skipped_initial(tmp_db, question_page, prio_harness):
+    """Initial-prio skip still allows main-phase to run and dispatch."""
+    await _seed_judgement(tmp_db, question_page.id)
+    await tmp_db.init_budget(20)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "post-skip")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    post_skip_scouts = [
+        d
+        for d in prio_harness.dispatched
+        if d["call_type"] == CallType.FIND_CONSIDERATIONS.value
+        and d["question_id"] == question_page.id
+    ]
+    assert len(post_skip_scouts) >= 1, "main phase did not dispatch after the skip"
+
+
+@pytest.mark.asyncio
+async def test_eagerly_created_initial_call_is_marked_complete_on_skip(
+    tmp_db, question_page, prio_harness
+):
+    """The pre-created initial_prioritization call must be marked COMPLETE, not left PENDING."""
+    await _seed_judgement(tmp_db, question_page.id)
+    await tmp_db.init_budget(20)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "post-skip")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    eager_id = await orch.create_initial_call(question_page.id)
+    await orch.run(question_page.id)
+
+    refreshed = await tmp_db.get_call(eager_id)
+    assert refreshed is not None
+    assert refreshed.status == CallStatus.COMPLETE, (
+        f"eagerly-created initial call was left in {refreshed.status}, expected COMPLETE"
+    )

--- a/tests/test_two_phase_recurse.py
+++ b/tests/test_two_phase_recurse.py
@@ -1,0 +1,200 @@
+"""Recurse → child-orchestrator-spawn invariants.
+
+The recurse path is the closest analog of what the prioritizer rearch
+replaces: today, a recurse dispatch spawns a new ``TwoPhaseOrchestrator``
+(or ``ClaimInvestigationOrchestrator``) with its own ``budget_cap``.
+These tests pin the current contract so the rearch author can tell when
+they've accidentally dropped it.
+"""
+
+import pytest
+
+from rumil.calls.common import RunCallResult
+from rumil.constants import MIN_TWOPHASE_BUDGET
+from rumil.models import (
+    CallType,
+    Dispatch,
+    FindConsiderationsMode,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    RecurseClaimDispatchPayload,
+    RecurseDispatchPayload,
+    ScoutDispatchPayload,
+    Workspace,
+)
+from rumil.orchestrators.claim_investigation import ClaimInvestigationOrchestrator
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
+
+
+def _scout_dispatch(question_id: str, reason: str = "") -> Dispatch:
+    return Dispatch(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        payload=ScoutDispatchPayload(
+            question_id=question_id,
+            mode=FindConsiderationsMode.ALTERNATE,
+            max_rounds=1,
+            reason=reason,
+        ),
+    )
+
+
+def _patch_init(mocker, cls):
+    """Wrap ``cls.__init__`` to capture every instance created."""
+    instances: list = []
+    original_init = cls.__init__
+
+    def capturing_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        instances.append(
+            {
+                "instance": self,
+                "budget_cap": kwargs.get("budget_cap"),
+            }
+        )
+
+    mocker.patch.object(cls, "__init__", capturing_init)
+    return instances
+
+
+@pytest.mark.asyncio
+async def test_recurse_dispatch_spawns_child_twophase_with_budget_cap(
+    tmp_db, question_page, child_question_page, prio_harness, mocker
+):
+    """A RecurseDispatchPayload → a new TwoPhaseOrchestrator with the right budget_cap."""
+    instances = _patch_init(mocker, TwoPhaseOrchestrator)
+    await tmp_db.init_budget(30)
+    recurse = Dispatch(
+        call_type=CallType.PRIORITIZATION,
+        payload=RecurseDispatchPayload(
+            question_id=child_question_page.id,
+            budget=MIN_TWOPHASE_BUDGET,
+            reason="drill into subquestion",
+        ),
+    )
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[recurse]),
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    parent = TwoPhaseOrchestrator(tmp_db)
+    await parent.run(question_page.id)
+
+    child_entries = [i for i in instances if i["instance"] is not parent]
+    assert len(child_entries) >= 1
+    assert child_entries[0]["budget_cap"] == MIN_TWOPHASE_BUDGET
+
+
+@pytest.mark.asyncio
+async def test_recurse_claim_dispatch_spawns_claim_investigation_orchestrator(
+    tmp_db, question_page, prio_harness, mocker
+):
+    """A RecurseClaimDispatchPayload → a new ClaimInvestigationOrchestrator with budget_cap."""
+    claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Claim under investigation.",
+        headline="Claim under investigation.",
+    )
+    await tmp_db.save_page(claim)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=claim.id,
+            to_page_id=question_page.id,
+            link_type=LinkType.CONSIDERATION,
+        )
+    )
+
+    claim_instances = _patch_init(mocker, ClaimInvestigationOrchestrator)
+    _patch_init(mocker, TwoPhaseOrchestrator)
+
+    await tmp_db.init_budget(30)
+    recurse_claim = Dispatch(
+        call_type=CallType.PRIORITIZATION,
+        payload=RecurseClaimDispatchPayload(
+            question_id=claim.id,
+            budget=MIN_TWOPHASE_BUDGET,
+            reason="investigate claim",
+        ),
+    )
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[recurse_claim]),
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    parent = TwoPhaseOrchestrator(tmp_db)
+    await parent.run(question_page.id)
+
+    assert len(claim_instances) >= 1
+    assert claim_instances[0]["budget_cap"] == MIN_TWOPHASE_BUDGET
+
+
+@pytest.mark.asyncio
+async def test_recurse_with_missing_question_id_skips_cleanly(
+    tmp_db, question_page, prio_harness, mocker
+):
+    """Unresolvable recurse target → no child orchestrator spawned, no exception."""
+    instances = _patch_init(mocker, TwoPhaseOrchestrator)
+    await tmp_db.init_budget(30)
+    recurse = Dispatch(
+        call_type=CallType.PRIORITIZATION,
+        payload=RecurseDispatchPayload(
+            question_id="00000000-0000-0000-0000-000000000000",
+            budget=MIN_TWOPHASE_BUDGET,
+            reason="bogus target",
+        ),
+    )
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[recurse]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    parent = TwoPhaseOrchestrator(tmp_db)
+    await parent.run(question_page.id)
+
+    children = [i for i in instances if i["instance"] is not parent]
+    assert children == [], f"child orchestrator was spawned for unresolvable id: {children}"
+
+
+@pytest.mark.asyncio
+async def test_recurse_below_min_budget_not_offered_as_tool(tmp_db, question_page, prio_harness):
+    """When dispatch_budget < MIN_TWOPHASE_BUDGET, recurse tools must not be offered.
+
+    Main-phase prio sees extra_dispatch_defs=None in that regime (two_phase.py:641-644).
+    """
+    await tmp_db.init_budget(14)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed1")]),
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed2")]),
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed3")]),
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed4")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    parent = TwoPhaseOrchestrator(tmp_db)
+    await parent.run(question_page.id)
+
+    main_phase_calls = [
+        c for c in prio_harness.prio_calls if c.get("extra_dispatch_defs") is not None
+    ]
+    low_budget_calls = [
+        c
+        for c in prio_harness.prio_calls
+        if c.get("dispatch_budget") is not None and c["dispatch_budget"] < MIN_TWOPHASE_BUDGET
+    ]
+    for c in low_budget_calls:
+        assert c.get("extra_dispatch_defs") is None, (
+            "recurse was offered when dispatch_budget was below MIN_TWOPHASE_BUDGET: "
+            f"dispatch_budget={c['dispatch_budget']}"
+        )
+    assert low_budget_calls or main_phase_calls, (
+        "neither low- nor high-budget main-phase calls observed — scenario did not exercise recurse gating"
+    )

--- a/tests/test_two_phase_trace_events.py
+++ b/tests/test_two_phase_trace_events.py
@@ -1,0 +1,139 @@
+"""Trace event shape & ordering invariants.
+
+The frontend reads these events directly (via the typed API envelope),
+so their shape and relative ordering is downstream-visible. When the
+prioritizer rearch reshapes the event stream, these tests make the
+impact explicit instead of silent.
+"""
+
+import pytest
+
+from rumil.calls.common import RunCallResult
+from rumil.models import (
+    CallType,
+    Dispatch,
+    FindConsiderationsMode,
+    RecurseDispatchPayload,
+    ScoutDispatchPayload,
+)
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
+
+
+def _scout_dispatch(question_id: str, reason: str = "") -> Dispatch:
+    return Dispatch(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        payload=ScoutDispatchPayload(
+            question_id=question_id,
+            mode=FindConsiderationsMode.ALTERNATE,
+            max_rounds=1,
+            reason=reason,
+        ),
+    )
+
+
+async def _trace_events(db, call_id: str) -> list[dict]:
+    rows = (await db._execute(db.client.table("calls").select("trace_json").eq("id", call_id))).data
+    if not rows:
+        return []
+    return list(rows[0].get("trace_json") or [])
+
+
+async def _prio_call_ids(db, project_id: str) -> list[str]:
+    rows = (
+        await db._execute(
+            db.client.table("calls")
+            .select("id, created_at")
+            .eq("call_type", CallType.PRIORITIZATION.value)
+            .eq("project_id", project_id)
+            .order("created_at")
+        )
+    ).data
+    return [r["id"] for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_initial_prio_trace_sequence(tmp_db, question_page, prio_harness):
+    """Initial prioritization trace must open with context_built, then dispatches_planned."""
+    await tmp_db.init_budget(20)
+    scouts = [_scout_dispatch(question_page.id, f"s{i}") for i in range(3)]
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=scouts),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    prio_ids = await _prio_call_ids(tmp_db, tmp_db.project_id)
+    assert prio_ids, "no prioritization call rows were created"
+    events = await _trace_events(tmp_db, prio_ids[0])
+    kinds = [e.get("event") for e in events]
+    assert "context_built" in kinds
+    assert "dispatches_planned" in kinds
+    assert kinds.index("context_built") < kinds.index("dispatches_planned")
+
+    planned = next(e for e in events if e.get("event") == "dispatches_planned")
+    assert len(planned.get("dispatches", [])) == 3
+
+
+@pytest.mark.asyncio
+async def test_main_phase_prio_trace_includes_scoring(tmp_db, question_page, prio_harness):
+    """Main-phase trace must include scoring_completed with both score arrays present."""
+    await tmp_db.init_budget(20)
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "main")]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    prio_ids = await _prio_call_ids(tmp_db, tmp_db.project_id)
+    assert len(prio_ids) >= 2, "expected at least initial + main-phase prio calls"
+    main_events = await _trace_events(tmp_db, prio_ids[1])
+    kinds = [e.get("event") for e in main_events]
+    assert "scoring_completed" in kinds, f"main-phase trace missing scoring_completed: {kinds}"
+
+    scoring = next(e for e in main_events if e.get("event") == "scoring_completed")
+    assert "subquestion_scores" in scoring
+    assert "claim_scores" in scoring
+
+
+@pytest.mark.asyncio
+async def test_recurse_dispatch_executed_event_has_recurse_call_type(
+    tmp_db, question_page, child_question_page, prio_harness
+):
+    """Recurse dispatches must surface as DispatchExecutedEvent(child_call_type='recurse')."""
+    await tmp_db.init_budget(30)
+    recurse = Dispatch(
+        call_type=CallType.PRIORITIZATION,
+        payload=RecurseDispatchPayload(
+            question_id=child_question_page.id,
+            budget=4,
+            reason="drill into subquestion",
+        ),
+    )
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[recurse]),
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    orch = TwoPhaseOrchestrator(tmp_db)
+    await orch.run(question_page.id)
+
+    prio_ids = await _prio_call_ids(tmp_db, tmp_db.project_id)
+    assert len(prio_ids) >= 2
+    main_events = await _trace_events(tmp_db, prio_ids[1])
+    recurse_events = [
+        e
+        for e in main_events
+        if e.get("event") == "dispatch_executed" and e.get("child_call_type") == "recurse"
+    ]
+    assert recurse_events, (
+        f"no recurse DispatchExecutedEvent in main-phase trace — kinds: "
+        f"{[(e.get('event'), e.get('child_call_type')) for e in main_events]}"
+    )
+    assert recurse_events[0].get("child_call_id") is not None


### PR DESCRIPTION
## Summary
- We're about to rearchitect prioritization to decouple **communication** (subscription to another call's result) from **budget allocation**, moving from one prioritizer recursing the graph to a prioritizer at every node with subscriptions and budget transfers. Before that, pin the current behaviour of the code most likely to silently break.
- Adds 7 new test files + extensions to 2 existing ones (49 tests; 2 xfail). All LLM and dispatch-handler plumbing is mocked at the boundary so tests stay fast and don't require `--llm`/`--integration`.
- New shared fixtures (`PrioHarness`, `prio_harness`, `child_question_page`) in `tests/conftest.py` let orchestrator tests run the real two-phase loop while scripting `run_prioritization_call` and simulating dispatches against the real DB.

**Coverage added:**
- `test_prioritization_call.py` — `run_prioritization_call` contract: status=RUNNING, returns dispatches, under-allocation retry (50% threshold, `phase="prioritization_retry"`), recurse defs inclusion.
- `test_two_phase_budget.py` — `TwoPhaseOrchestrator.run()` budget invariants: min-budget guard, `_effective_budget` formula, `budget_cap` bounds rounds, global-budget-zero loop termination, conservation.
- `test_two_phase_recurse.py` — Recurse → child-orchestrator spawn with correct `budget_cap`; `RecurseClaimDispatchPayload` → `ClaimInvestigationOrchestrator`; unresolvable recurse skips cleanly; recurse not offered below `MIN_TWOPHASE_BUDGET`.
- `test_two_phase_auto_assess.py` — `[scout, assess]` atomicity on subquestion dispatches; scope dispatch has no trailing assess; trailing assess force-consumes when budget is exhausted; force-consume grows `total`.
- `test_two_phase_phase_skip.py` — Initial prio skipped when judgement/view exists; main-phase proceeds post-skip; eagerly-created initial call is marked COMPLETE.
- `test_two_phase_multi_parent.py` — Pins current duplicate-dispatch on shared children (1 passing) + xfails specifying post-rearch subscription targets (2 xfail, `strict=False`).
- `test_two_phase_trace_events.py` — Trace event shape/ordering: `context_built` before `dispatches_planned`, `scoring_completed` in main phase, recurse `DispatchExecutedEvent(child_call_type="recurse")`.
- `test_budget_pacing.py` — Nested orchestrator paces against `(budget_cap, _consumed)`, not global budget.
- `test_parallel_investigations.py` — Two sibling recurse children with caps summing above remaining don't overdraw the shared global pool.

## Test plan
- [x] `uv run pytest tests/test_two_phase_budget.py tests/test_two_phase_recurse.py tests/test_two_phase_auto_assess.py tests/test_prioritization_call.py tests/test_two_phase_phase_skip.py tests/test_two_phase_multi_parent.py tests/test_two_phase_trace_events.py tests/test_budget_pacing.py tests/test_parallel_investigations.py` — 47 passed, 2 xfail.
- [x] Full suite: no regressions introduced by these changes. (5 pre-existing failures in `test_n_plus_one_batching.py` and `test_workspace_isolation.py` are unrelated — they concern `get_stale_dependencies()` / change-magnitude tracking.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)