### PR TITLE
Add missing claude-sonnet-4-6 pricing data

### DIFF
--- a/src/rumil/pricing.json
+++ b/src/rumil/pricing.json
@@ -1,4 +1,10 @@
 {
+  "claude-sonnet-4-6": {
+    "input_tokens_per_mtok": 3.0,
+    "output_tokens_per_mtok": 15.0,
+    "cache_creation_input_tokens_per_mtok": 3.75,
+    "cache_read_input_tokens_per_mtok": 0.30
+  },
   "claude-opus-4-6": {
     "input_tokens_per_mtok": 5.0,
     "output_tokens_per_mtok": 25.0,


### PR DESCRIPTION
## Summary
- Adds `claude-sonnet-4-6` entry to `pricing.json` ($3/$15 input/output, $3.75 cache write, $0.30 cache read)
- This model has been the default `sonnet_model` since the start but was never added to the pricing file, causing "No pricing data for model claude-sonnet-4-6" warnings and $0.00 cost tracking

## Test plan
- [ ] Run a call using sonnet and confirm the warning is gone and costs are non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)