### PR TITLE
Workspace-aware Views: merge graph derivation with stored VIEW_ITEMs

### DIFF
--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 from rumil.database import DB
 from rumil.embeddings import embed_query, search_pages_by_vector
-from rumil.models import Page, PageDetail, PageLink, PageType
+from rumil.models import Page, PageDetail, PageType
 from rumil.settings import get_settings
 from rumil.tracing.page_load_tracking import get_page_track_tags
 from rumil.tracing.tracer import get_trace

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -17,7 +17,7 @@ from rumil.models import Page, PageDetail, PageType
 from rumil.settings import get_settings
 from rumil.tracing.page_load_tracking import get_page_track_tags
 from rumil.tracing.tracer import get_trace
-from rumil.views import View, build_view
+from rumil.views import View, build_view, build_views_many
 
 log = logging.getLogger(__name__)
 
@@ -471,12 +471,11 @@ async def render_child_investigation_results(
         return "", []
 
     child_ids = [c.id for c in children]
-    child_views_list, summaries_map, judgements_map = await asyncio.gather(
-        asyncio.gather(*(build_view(db, cid) for cid in child_ids)),
+    child_views_by_id, summaries_map, judgements_map = await asyncio.gather(
+        build_views_many(db, child_ids),
         db.get_latest_summaries_for_questions(child_ids),
         db.get_judgements_for_questions(child_ids),
     )
-    child_views_by_id: dict[str, View] = dict(zip(child_ids, child_views_list))
 
     def _is_new(page: Page) -> bool:
         if last_view_created_at is None:

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -501,6 +501,8 @@ async def render_child_investigation_results(
             if stored:
                 new = _is_new(stored)
                 page_ids.append(stored.id)
+            else:
+                new = True
             lines.append(f"**Status:** View available{' [NEW]' if new else ''}")
             view_text = render_view(child_view, min_importance=4 if new else 5)
             if view_text.strip():

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -17,6 +17,7 @@ from rumil.models import Page, PageDetail, PageLink, PageType
 from rumil.settings import get_settings
 from rumil.tracing.page_load_tracking import get_page_track_tags
 from rumil.tracing.tracer import get_trace
+from rumil.views import View, build_view
 
 log = logging.getLogger(__name__)
 
@@ -414,69 +415,39 @@ async def format_page(
     return "\n".join(lines)
 
 
-async def render_view(
-    view: Page,
-    items_with_links: Sequence[tuple[Page, PageLink]],
-    min_importance: int = 5,
-) -> str:
-    """Render a View page at the given importance threshold.
+def render_view(view: View, *, min_importance: int = 3) -> str:
+    """Render a structured View as markdown for LLM context injection.
 
-    - min_importance=5: NL summary only (no individual items)
-    - min_importance=4: NL summary + programmatic rendering of all items at 4+
-    - min_importance=3: NL summary + all items at 3+
-    - min_importance=2: NL summary + all items at 2+
-
-    Whenever items are rendered programmatically, importance-5 items are
-    always included alongside lower-tier ones.
+    Items below *min_importance* are omitted. Curated VIEW_ITEM content
+    is rendered inline; graph items show headline + scores only. Returns
+    empty string when no sections have items clearing the threshold.
     """
-    parts: list[str] = [f"## View: {view.headline}", ""]
-
-    if view.content:
-        parts.append(view.content)
-        parts.append("")
-
-    if min_importance >= 5:
-        return "\n".join(parts)
-
-    filtered = [
-        (page, link)
-        for page, link in items_with_links
-        if link.importance is not None and link.importance >= min_importance
-    ]
-    if not filtered:
-        return "\n".join(parts)
-
-    sections_order = view.sections or []
-    section_index = {s: i for i, s in enumerate(sections_order)}
-
-    by_section: dict[str, list[tuple[Page, PageLink]]] = {}
-    for page, link in filtered:
-        sec = link.section or "other"
-        by_section.setdefault(sec, []).append((page, link))
-
-    ordered_sections = sorted(
-        by_section.keys(),
-        key=lambda s: section_index.get(s, 999),
-    )
-
-    parts.append("### View Items")
-    parts.append("")
-    for sec in ordered_sections:
-        label = sec.replace("_", " ").title()
-        parts.append(f"#### {label}")
-        parts.append("")
-        items = by_section[sec]
-        items.sort(key=lambda pair: pair[1].position or 0)
-        for page, link in items:
-            imp = link.importance or 0
+    rendered_sections: list[str] = []
+    for section in view.sections:
+        filtered = [
+            item
+            for item in section.items
+            if item.effective_importance is not None and item.effective_importance >= min_importance
+        ]
+        if not filtered:
+            continue
+        lines = [f"#### {section.name.replace('_', ' ').title()}", ""]
+        for item in filtered:
+            page = item.page
             r = page.robustness if page.robustness is not None else "?"
-            parts.append(f"- [R{r} I{imp}] `{page.id[:8]}` — {page.headline}")
-            if page.content:
-                for line in page.content.strip().split("\n"):
-                    parts.append(f"  {line}")
-            parts.append("")
+            imp = item.effective_importance or 0
+            lines.append(f"- [R{r} I{imp}] `{page.id[:8]}` — {page.headline}")
+            if item.source == "view_item" and page.content:
+                for content_line in page.content.strip().split("\n"):
+                    lines.append(f"  {content_line}")
+        rendered_sections.append("\n".join(lines))
 
-    return "\n".join(parts)
+    if not rendered_sections:
+        return ""
+
+    parts = [f"## View: {view.question.headline}", "", "### View Items", ""]
+    parts.append("\n\n".join(rendered_sections))
+    return "\n".join(parts).rstrip() + "\n"
 
 
 async def render_child_investigation_results(
@@ -500,34 +471,22 @@ async def render_child_investigation_results(
         return "", []
 
     child_ids = [c.id for c in children]
-    views_map, summaries_map, judgements_map = await asyncio.gather(
-        db.get_views_for_questions(child_ids),
+    child_views_list, summaries_map, judgements_map = await asyncio.gather(
+        asyncio.gather(*(build_view(db, cid) for cid in child_ids)),
         db.get_latest_summaries_for_questions(child_ids),
         db.get_judgements_for_questions(child_ids),
     )
+    child_views_by_id: dict[str, View] = dict(zip(child_ids, child_views_list))
 
     def _is_new(page: Page) -> bool:
         if last_view_created_at is None:
             return True
         return page.created_at > last_view_created_at
 
-    new_view_ids: list[str] = []
-    for cid in child_ids:
-        v = views_map.get(cid)
-        if v and _is_new(v):
-            new_view_ids.append(v.id)
-    view_items_map: dict[str, list[tuple[Page, PageLink]]] = {}
-    if new_view_ids:
-        items_results = await asyncio.gather(
-            *(db.get_view_items(vid, min_importance=4) for vid in new_view_ids)
-        )
-        for vid, items in zip(new_view_ids, items_results):
-            view_items_map[vid] = items
-
     entries: list[tuple[bool, str, list[str]]] = []
     for child in children:
         cid = child.id
-        view = views_map.get(cid)
+        child_view = child_views_by_id[cid]
         summary = summaries_map.get(cid)
         judgements = judgements_map.get(cid, [])
         latest_judgement = max(judgements, key=lambda p: p.created_at) if judgements else None
@@ -536,32 +495,21 @@ async def render_child_investigation_results(
         page_ids: list[str] = []
         lines: list[str] = [f"### `{cid[:8]}` — {child.headline}"]
 
-        if view:
-            new = _is_new(view)
-            page_ids.append(view.id)
+        has_view_content = bool(child_view.sections) or child_view.stored_view is not None
+
+        if has_view_content:
+            stored = child_view.stored_view
+            if stored:
+                new = _is_new(stored)
+                page_ids.append(stored.id)
             lines.append(f"**Status:** View available{' [NEW]' if new else ''}")
-            if view.content:
-                detail = PageDetail.CONTENT if new else PageDetail.ABSTRACT
-                formatted_view = await format_page(
-                    view,
-                    detail,
-                    linked_detail=None,
-                    db=db,
-                    track=True,
-                    track_tags={"source": "child_investigation"},
-                )
+            view_text = render_view(child_view, min_importance=4 if new else 5)
+            if view_text.strip():
                 lines.append("")
-                lines.append(formatted_view)
-            if new and view.id in view_items_map:
-                items = view_items_map[view.id]
-                if items:
-                    lines.append("")
-                    lines.append("**Key items:**")
-                    for page, link in items:
-                        imp = link.importance or 0
-                        r = page.robustness if page.robustness is not None else "?"
-                        lines.append(f"- [R{r} I{imp}] `{page.id[:8]}` — {page.headline}")
-                        page_ids.append(page.id)
+                lines.append(view_text)
+            for section in child_view.sections:
+                for item in section.items:
+                    page_ids.append(item.page.id)
         elif summary:
             new = _is_new(summary)
             page_ids.append(summary.id)
@@ -683,22 +631,13 @@ async def build_prioritization_context(
     if scope_question_id:
         question = await db.get_page(scope_question_id)
         if question:
-            view = await db.get_view_for_question(scope_question_id)
-            if view:
-                view_items = await db.get_view_items(
-                    view.id,
-                    min_importance=2,
-                )
-                view_text = await render_view(
-                    view,
-                    view_items,
-                    min_importance=2,
-                )
-                if view_text.strip():
-                    parts.append(view_text)
-                    parts.append("")
-                    parts.append("---")
-                    parts.append("")
+            view = await build_view(db, scope_question_id)
+            view_text = render_view(view, min_importance=2)
+            if view_text.strip():
+                parts.append(view_text)
+                parts.append("")
+                parts.append("---")
+                parts.append("")
 
             direct_children = await db.get_child_questions(scope_question_id)
             full_page_ids = {scope_question_id} | {c.id for c in direct_children}

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -28,6 +28,7 @@ from rumil.constants import (
     SMOKE_TEST_INGEST_MAX_ROUNDS,
     SMOKE_TEST_MAX_ROUNDS,
 )
+from rumil.context import render_view
 from rumil.database import DB
 from rumil.embeddings import embed_and_store_page
 from rumil.models import (
@@ -43,6 +44,7 @@ from rumil.models import (
 )
 from rumil.settings import get_settings
 from rumil.tracing.broadcast import Broadcaster
+from rumil.views import build_view
 
 log = logging.getLogger(__name__)
 
@@ -260,15 +262,11 @@ async def score_items_sequentially(
             parent_parts.append(parent_judgement.headline)
         parent_parts.append("")
 
-    view = await db.get_view_for_question(parent_page.id)
-    if view:
-        from rumil.context import render_view
-
-        view_items = await db.get_view_items(view.id, min_importance=2)
-        view_text = await render_view(view, view_items, min_importance=2)
-        if view_text.strip():
-            parent_parts.append(view_text)
-            parent_parts.append("")
+    view = await build_view(db, parent_page.id)
+    view_text = render_view(view, min_importance=2)
+    if view_text.strip():
+        parent_parts.append(view_text)
+        parent_parts.append("")
 
     parent_context = "\n".join(parent_parts)
     system_prompt = build_system_prompt(system_prompt_name)

--- a/src/rumil/views.py
+++ b/src/rumil/views.py
@@ -1,0 +1,338 @@
+"""
+View construction for research questions.
+
+Builds a structured View of research on a question as a function of
+workspace state: graph-derived items (considerations, child questions,
+judgements) merged with stored VIEW_ITEM pages from update_view when
+available. Always works — no update_view pass required — but honors
+curation where it exists.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from rumil.constants import DEFAULT_VIEW_SECTIONS
+from rumil.database import DB
+from rumil.models import (
+    CallType,
+    LinkRole,
+    LinkType,
+    Page,
+    PageLink,
+    PageType,
+)
+
+ViewSource = str  # "graph" | "view_item"
+
+
+@dataclass
+class ViewItem:
+    page: Page
+    links: list[PageLink]
+    section: str
+    source: ViewSource = "graph"
+
+    @property
+    def effective_importance(self) -> int | None:
+        """Integer 1-5 importance for ranking/filtering.
+
+        VIEW_ITEM pages: from the VIEW_ITEM link (set by update_view).
+        Judgements: implicit 5 (they're the question's current answer).
+        Considerations: from link.strength (0-5 float).
+        Child questions: from link.impact_on_parent_question (0-10 → 1-5).
+        """
+        for link in self.links:
+            if link.link_type == LinkType.VIEW_ITEM and link.importance is not None:
+                return link.importance
+        if self.page.page_type == PageType.JUDGEMENT:
+            return 5
+        for link in self.links:
+            if link.link_type == LinkType.CONSIDERATION:
+                return max(1, min(5, round(link.strength)))
+            if link.link_type == LinkType.CHILD_QUESTION:
+                if link.impact_on_parent_question is not None:
+                    return max(1, min(5, round(link.impact_on_parent_question / 2)))
+                return None
+        return None
+
+    @property
+    def sort_key(self) -> tuple[int, int, int, int]:
+        """Lower tuple = shown first. Curated beats derived at same importance."""
+        imp = self.effective_importance
+        inv_importance = -(imp if imp is not None else -99)
+        source_priority = 0 if self.source == "view_item" else 1
+        inv_credence = 10 - (self.page.credence or 5)
+        inv_robustness = 6 - (self.page.robustness or 3)
+        return (inv_importance, source_priority, inv_credence, inv_robustness)
+
+
+@dataclass
+class ViewSection:
+    name: str
+    items: list[ViewItem] = field(default_factory=list)
+
+
+@dataclass
+class ViewHealth:
+    total_pages: int
+    missing_credence: int
+    child_questions_without_judgements: int
+    max_depth: int
+
+
+@dataclass
+class View:
+    question: Page
+    sections: list[ViewSection]
+    health: ViewHealth
+    stored_view: Page | None = None
+
+
+_SECTION_ORDER = {name: i for i, name in enumerate(DEFAULT_VIEW_SECTIONS)}
+
+
+def _section_order(name: str) -> int:
+    return _SECTION_ORDER.get(name, len(DEFAULT_VIEW_SECTIONS))
+
+
+_INGEST_CALL_TYPES = {
+    CallType.INGEST.value,
+    CallType.WEB_RESEARCH.value,
+}
+
+
+async def build_view(db: DB, question_id: str) -> View:
+    """Build a structured View of research on a question.
+
+    Merges graph-derived items with stored VIEW_ITEMs when available.
+    Graph items that are cited by a VIEW_ITEM are hidden in favour of
+    the curated version.
+    """
+    question = await db.get_page(question_id)
+    if not question:
+        raise ValueError(f"Question {question_id} not found")
+    if question.page_type != PageType.QUESTION:
+        raise ValueError(f"Page {question_id[:8]} is {question.page_type.value}, not a question")
+
+    considerations, child_questions_with_links, judgements = await _fetch_direct(db, question_id)
+
+    child_question_ids = [p.id for p, _ in child_questions_with_links]
+    child_judgements_by_q = await db.get_judgements_for_questions(child_question_ids)
+
+    consideration_page_ids = [p.id for p, _ in considerations]
+    outgoing_by_page = await db.get_links_from_many(consideration_page_ids)
+    cites_page_ids = {
+        pid
+        for pid, links in outgoing_by_page.items()
+        if any(l.link_type == LinkType.CITES for l in links)
+    }
+
+    stored_view = await db.get_view_for_question(question_id)
+    stored_items_with_links: list[tuple[Page, PageLink]] = []
+    cited_by_view_items: set[str] = set()
+    if stored_view:
+        stored_items_with_links = await db.get_view_items(stored_view.id)
+        view_item_page_ids = [p.id for p, _ in stored_items_with_links]
+        view_item_outgoing = await db.get_links_from_many(view_item_page_ids)
+        for links in view_item_outgoing.values():
+            for link in links:
+                if link.link_type in (LinkType.CITES, LinkType.DEPENDS_ON):
+                    cited_by_view_items.add(link.to_page_id)
+
+    max_depth = await _measure_child_depth(db, question_id)
+
+    sections_dict: dict[str, ViewSection] = {
+        name: ViewSection(name=name) for name in DEFAULT_VIEW_SECTIONS
+    }
+
+    all_scored_pages: list[Page] = []
+
+    active_judgements = [j for j in judgements if j.is_active()]
+    if active_judgements:
+        latest = max(active_judgements, key=lambda j: j.created_at)
+        judgement_links = [
+            link for p, link in await _get_answers_links(db, question_id) if p.id == latest.id
+        ]
+        sections_dict["assessments"].items.append(
+            ViewItem(
+                page=latest,
+                links=judgement_links,
+                section="assessments",
+                source="graph",
+            )
+        )
+        all_scored_pages.append(latest)
+
+    for claim, link in considerations:
+        if not claim.is_active():
+            continue
+        all_scored_pages.append(claim)
+        if claim.id in cited_by_view_items:
+            continue
+        section = _classify_consideration(
+            claim,
+            link,
+            has_cites=claim.id in cites_page_ids,
+        )
+        sections_dict[section].items.append(
+            ViewItem(page=claim, links=[link], section=section, source="graph")
+        )
+
+    for child, link in child_questions_with_links:
+        if not child.is_active():
+            continue
+        all_scored_pages.append(child)
+        if child.id in cited_by_view_items:
+            continue
+        child_js = child_judgements_by_q.get(child.id, [])
+        section = _classify_child_question(child, link, child_js)
+        sections_dict[section].items.append(
+            ViewItem(page=child, links=[link], section=section, source="graph")
+        )
+
+    for item_page, link in stored_items_with_links:
+        if not item_page.is_active():
+            continue
+        section = link.section if link.section in sections_dict else "other"
+        sections_dict[section].items.append(
+            ViewItem(
+                page=item_page,
+                links=[link],
+                section=section,
+                source="view_item",
+            )
+        )
+
+    sections = [s for s in sections_dict.values() if s.items]
+    sections.sort(key=lambda s: _section_order(s.name))
+    for section in sections:
+        section.items.sort(key=lambda item: item.sort_key)
+
+    health = _compute_health(
+        all_scored_pages,
+        child_questions_with_links,
+        child_judgements_by_q,
+        max_depth,
+    )
+
+    return View(
+        question=question,
+        sections=sections,
+        health=health,
+        stored_view=stored_view,
+    )
+
+
+async def _fetch_direct(
+    db: DB, question_id: str
+) -> tuple[
+    list[tuple[Page, PageLink]],
+    list[tuple[Page, PageLink]],
+    list[Page],
+]:
+    considerations = await db.get_considerations_for_question(question_id)
+    child_questions_with_links = await db.get_child_questions_with_links(question_id)
+    judgements = await db.get_judgements_for_question(question_id)
+    return considerations, child_questions_with_links, judgements
+
+
+async def _get_answers_links(db: DB, question_id: str) -> list[tuple[Page, PageLink]]:
+    links = await db.get_links_to(question_id)
+    answers_links = [lk for lk in links if lk.link_type == LinkType.ANSWERS]
+    if not answers_links:
+        return []
+    pages = await db.get_pages_by_ids([lk.from_page_id for lk in answers_links])
+    return [(pages[lk.from_page_id], lk) for lk in answers_links if lk.from_page_id in pages]
+
+
+def _classify_consideration(claim: Page, link: PageLink, *, has_cites: bool) -> str:
+    """Return the single section this consideration belongs in."""
+    cred = claim.credence
+    rob = claim.robustness
+
+    if link.role == LinkRole.STRUCTURAL:
+        return "broader_context"
+
+    if has_cites or claim.provenance_call_type in _INGEST_CALL_TYPES:
+        return "key_evidence"
+
+    if cred is not None and cred >= 7 and rob is not None and rob >= 3:
+        return "confident_views"
+
+    if rob is not None and rob <= 2:
+        return "live_hypotheses"
+
+    if cred is not None and 4 <= cred <= 6:
+        if rob is not None and rob >= 3:
+            return "key_uncertainties"
+        return "live_hypotheses"
+
+    return "other"
+
+
+def _classify_child_question(
+    child: Page,
+    link: PageLink,
+    judgements: Sequence[Page],
+) -> str:
+    if link.role == LinkRole.STRUCTURAL:
+        return "broader_context"
+
+    active_judgements = [j for j in judgements if j.is_active()]
+    if not active_judgements:
+        return "key_uncertainties"
+
+    return "assessments"
+
+
+async def _measure_child_depth(
+    db: DB,
+    question_id: str,
+    *,
+    max_depth: int = 20,
+) -> int:
+    """BFS to measure maximum child question nesting depth. Cycle-safe."""
+    visited: set[str] = {question_id}
+    frontier = [question_id]
+    depth = 0
+
+    for level in range(max_depth):
+        if not frontier:
+            break
+        links_by_parent = await db.get_links_from_many(frontier)
+        next_frontier: list[str] = []
+        for parent_id in frontier:
+            for link in links_by_parent.get(parent_id, []):
+                if link.link_type == LinkType.CHILD_QUESTION and link.to_page_id not in visited:
+                    visited.add(link.to_page_id)
+                    next_frontier.append(link.to_page_id)
+        if next_frontier:
+            depth = level + 1
+        frontier = next_frontier
+
+    return depth
+
+
+def _compute_health(
+    all_pages: Sequence[Page],
+    child_questions_with_links: Sequence[tuple[Page, PageLink]],
+    child_judgements_by_q: dict[str, list[Page]],
+    max_depth: int,
+) -> ViewHealth:
+    missing_credence = sum(
+        1
+        for p in all_pages
+        if p.page_type in (PageType.CLAIM, PageType.JUDGEMENT) and p.credence is None
+    )
+    child_without_judgements = sum(
+        1
+        for child, _ in child_questions_with_links
+        if child.is_active()
+        and not any(j.is_active() for j in child_judgements_by_q.get(child.id, []))
+    )
+    return ViewHealth(
+        total_pages=len(all_pages),
+        missing_credence=missing_credence,
+        child_questions_without_judgements=child_without_judgements,
+        max_depth=max_depth,
+    )

--- a/src/rumil/views.py
+++ b/src/rumil/views.py
@@ -8,6 +8,7 @@ available. Always works — no update_view pass required — but honors
 curation where it exists.
 """
 
+import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
@@ -28,7 +29,7 @@ ViewSource = str  # "graph" | "view_item"
 @dataclass
 class ViewItem:
     page: Page
-    links: list[PageLink]
+    links: Sequence[PageLink]
     section: str
     source: ViewSource = "graph"
 
@@ -83,7 +84,7 @@ class ViewHealth:
 @dataclass
 class View:
     question: Page
-    sections: list[ViewSection]
+    sections: Sequence[ViewSection]
     health: ViewHealth
     stored_view: Page | None = None
 
@@ -104,55 +105,142 @@ _INGEST_CALL_TYPES = {
 async def build_view(db: DB, question_id: str) -> View:
     """Build a structured View of research on a question.
 
-    Merges graph-derived items with stored VIEW_ITEMs when available.
-    Graph items that are cited by a VIEW_ITEM are hidden in favour of
-    the curated version.
+    Thin wrapper around :func:`build_views_many` — prefer that for batched
+    use to avoid per-qid query fan-out.
     """
-    question = await db.get_page(question_id)
-    if not question:
-        raise ValueError(f"Question {question_id} not found")
-    if question.page_type != PageType.QUESTION:
-        raise ValueError(f"Page {question_id[:8]} is {question.page_type.value}, not a question")
+    result = await build_views_many(db, [question_id])
+    return result[question_id]
 
-    considerations, child_questions_with_links, judgements = await _fetch_direct(db, question_id)
 
-    child_question_ids = [p.id for p, _ in child_questions_with_links]
-    child_judgements_by_q = await db.get_judgements_for_questions(child_question_ids)
+async def build_views_many(
+    db: DB,
+    question_ids: Sequence[str],
+) -> dict[str, View]:
+    """Build Views for many questions with batched DB fetches.
 
-    consideration_page_ids = [p.id for p, _ in considerations]
-    outgoing_by_page = await db.get_links_from_many(consideration_page_ids)
+    Round trips are O(1) in the number of questions for the bulk fetches
+    (questions, considerations, child questions, judgements, views, and
+    cross-page outgoing links). View items per stored view and depth BFS
+    per root remain O(N) calls, fired in parallel via ``asyncio.gather``.
+    """
+    if not question_ids:
+        return {}
+
+    qids = list(dict.fromkeys(question_ids))
+
+    questions_map = await db.get_pages_by_ids(qids)
+    for qid in qids:
+        q = questions_map.get(qid)
+        if not q:
+            raise ValueError(f"Question {qid} not found")
+        if q.page_type != PageType.QUESTION:
+            raise ValueError(f"Page {qid[:8]} is {q.page_type.value}, not a question")
+
+    (
+        considerations_by_q,
+        child_qs_with_links_by_q,
+        judgements_by_q,
+        stored_view_by_q,
+    ) = await asyncio.gather(
+        db.get_considerations_for_questions(qids),
+        _get_child_questions_with_links_many(db, qids),
+        db.get_judgements_for_questions(qids),
+        db.get_views_for_questions(qids),
+    )
+
+    all_child_ids: list[str] = []
+    for q_list in child_qs_with_links_by_q.values():
+        all_child_ids.extend(c.id for c, _ in q_list)
+    child_judgements_by_q: dict[str, list[Page]] = {}
+    if all_child_ids:
+        child_judgements_by_q = await db.get_judgements_for_questions(all_child_ids)
+
+    all_consideration_ids: list[str] = []
+    for q_list in considerations_by_q.values():
+        all_consideration_ids.extend(p.id for p, _ in q_list)
+    outgoing_by_consideration = (
+        await db.get_links_from_many(all_consideration_ids) if all_consideration_ids else {}
+    )
     cites_page_ids = {
         pid
-        for pid, links in outgoing_by_page.items()
+        for pid, links in outgoing_by_consideration.items()
         if any(l.link_type == LinkType.CITES for l in links)
     }
 
-    stored_view = await db.get_view_for_question(question_id)
-    stored_items_with_links: list[tuple[Page, PageLink]] = []
-    cited_by_view_items: set[str] = set()
-    if stored_view:
-        stored_items_with_links = await db.get_view_items(stored_view.id)
-        view_item_page_ids = [p.id for p, _ in stored_items_with_links]
-        view_item_outgoing = await db.get_links_from_many(view_item_page_ids)
+    views_with_items = [v for v in stored_view_by_q.values() if v is not None]
+    stored_items_by_view: dict[str, Sequence[tuple[Page, PageLink]]] = {}
+    cited_by_view_items_all: set[str] = set()
+    if views_with_items:
+        items_results = await asyncio.gather(*(db.get_view_items(v.id) for v in views_with_items))
+        stored_items_by_view = dict(zip([v.id for v in views_with_items], items_results))
+        all_view_item_ids = [p.id for items in stored_items_by_view.values() for p, _ in items]
+        view_item_outgoing = (
+            await db.get_links_from_many(all_view_item_ids) if all_view_item_ids else {}
+        )
         for links in view_item_outgoing.values():
             for link in links:
                 if link.link_type in (LinkType.CITES, LinkType.DEPENDS_ON):
-                    cited_by_view_items.add(link.to_page_id)
+                    cited_by_view_items_all.add(link.to_page_id)
 
-    max_depth = await _measure_child_depth(db, question_id)
+    qs_with_active_judgements = [
+        qid for qid in qids if any(j.is_active() for j in judgements_by_q.get(qid, []))
+    ]
+    answers_links_by_q: dict[str, Sequence[tuple[Page, PageLink]]] = {qid: [] for qid in qids}
+    if qs_with_active_judgements:
+        answers_results = await asyncio.gather(
+            *(_get_answers_links(db, qid) for qid in qs_with_active_judgements)
+        )
+        answers_links_by_q.update(dict(zip(qs_with_active_judgements, answers_results)))
 
+    depths = await asyncio.gather(*(_measure_child_depth(db, qid) for qid in qids))
+    depth_by_q = dict(zip(qids, depths))
+
+    result: dict[str, View] = {}
+    for qid in qids:
+        question = questions_map[qid]
+        result[qid] = _assemble_view(
+            question=question,
+            considerations=considerations_by_q.get(qid, []),
+            child_questions_with_links=child_qs_with_links_by_q.get(qid, []),
+            judgements=judgements_by_q.get(qid, []),
+            child_judgements_by_q=child_judgements_by_q,
+            cites_page_ids=cites_page_ids,
+            stored_view=stored_view_by_q.get(qid),
+            stored_items_with_links=(
+                stored_items_by_view.get(stored_view_by_q.get(qid).id, [])  # type: ignore[union-attr]
+                if stored_view_by_q.get(qid)
+                else []
+            ),
+            cited_by_view_items=cited_by_view_items_all,
+            answers_links=answers_links_by_q.get(qid, []),
+            max_depth=depth_by_q[qid],
+        )
+    return result
+
+
+def _assemble_view(
+    *,
+    question: Page,
+    considerations: Sequence[tuple[Page, PageLink]],
+    child_questions_with_links: Sequence[tuple[Page, PageLink]],
+    judgements: Sequence[Page],
+    child_judgements_by_q: dict[str, list[Page]],
+    cites_page_ids: set[str],
+    stored_view: Page | None,
+    stored_items_with_links: Sequence[tuple[Page, PageLink]],
+    cited_by_view_items: set[str],
+    answers_links: Sequence[tuple[Page, PageLink]],
+    max_depth: int,
+) -> View:
     sections_dict: dict[str, ViewSection] = {
         name: ViewSection(name=name) for name in DEFAULT_VIEW_SECTIONS
     }
-
     all_scored_pages: list[Page] = []
 
     active_judgements = [j for j in judgements if j.is_active()]
     if active_judgements:
         latest = max(active_judgements, key=lambda j: j.created_at)
-        judgement_links = [
-            link for p, link in await _get_answers_links(db, question_id) if p.id == latest.id
-        ]
+        judgement_links = [link for p, link in answers_links if p.id == latest.id]
         sections_dict["assessments"].items.append(
             ViewItem(
                 page=latest,
@@ -169,11 +257,7 @@ async def build_view(db: DB, question_id: str) -> View:
         all_scored_pages.append(claim)
         if claim.id in cited_by_view_items:
             continue
-        section = _classify_consideration(
-            claim,
-            link,
-            has_cites=claim.id in cites_page_ids,
-        )
+        section = _classify_consideration(claim, link, has_cites=claim.id in cites_page_ids)
         sections_dict[section].items.append(
             ViewItem(page=claim, links=[link], section=section, source="graph")
         )
@@ -223,20 +307,31 @@ async def build_view(db: DB, question_id: str) -> View:
     )
 
 
-async def _fetch_direct(
-    db: DB, question_id: str
-) -> tuple[
-    list[tuple[Page, PageLink]],
-    list[tuple[Page, PageLink]],
-    list[Page],
-]:
-    considerations = await db.get_considerations_for_question(question_id)
-    child_questions_with_links = await db.get_child_questions_with_links(question_id)
-    judgements = await db.get_judgements_for_question(question_id)
-    return considerations, child_questions_with_links, judgements
+async def _get_child_questions_with_links_many(
+    db: DB,
+    question_ids: Sequence[str],
+) -> dict[str, Sequence[tuple[Page, PageLink]]]:
+    """Batched equivalent of get_child_questions_with_links across many parents."""
+    result: dict[str, Sequence[tuple[Page, PageLink]]] = {qid: [] for qid in question_ids}
+    if not question_ids:
+        return result
+    links_by_parent = await db.get_links_from_many(list(question_ids))
+    child_ids: list[str] = []
+    child_links_by_parent: dict[str, list[PageLink]] = {}
+    for qid in question_ids:
+        kids = [l for l in links_by_parent.get(qid, []) if l.link_type == LinkType.CHILD_QUESTION]
+        if kids:
+            child_links_by_parent[qid] = kids
+            child_ids.extend(l.to_page_id for l in kids)
+    if not child_ids:
+        return result
+    pages = await db.get_pages_by_ids(list(dict.fromkeys(child_ids)))
+    for qid, kids in child_links_by_parent.items():
+        result[qid] = [(pages[l.to_page_id], l) for l in kids if l.to_page_id in pages]
+    return result
 
 
-async def _get_answers_links(db: DB, question_id: str) -> list[tuple[Page, PageLink]]:
+async def _get_answers_links(db: DB, question_id: str) -> Sequence[tuple[Page, PageLink]]:
     links = await db.get_links_to(question_id)
     answers_links = [lk for lk in links if lk.link_type == LinkType.ANSWERS]
     if not answers_links:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,487 @@
+"""Tests for src/rumil/views.py."""
+
+import pytest
+import pytest_asyncio
+
+from rumil.models import (
+    CallType,
+    ConsiderationDirection,
+    LinkRole,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.views import build_view
+
+
+@pytest_asyncio.fixture
+async def question(tmp_db):
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Why is the sky blue?",
+        headline="Why is the sky blue?",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+async def _make_claim(
+    tmp_db,
+    question,
+    headline,
+    *,
+    credence=None,
+    robustness=None,
+    direction=ConsiderationDirection.SUPPORTS,
+    role=LinkRole.DIRECT,
+    strength=3.0,
+    provenance_call_type="",
+):
+    claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+        credence=credence,
+        robustness=robustness,
+        provenance_call_type=provenance_call_type,
+    )
+    await tmp_db.save_page(claim)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=claim.id,
+            to_page_id=question.id,
+            link_type=LinkType.CONSIDERATION,
+            strength=strength,
+            direction=direction,
+            role=role,
+        )
+    )
+    return claim
+
+
+async def _make_child_question(tmp_db, parent, headline, *, role=LinkRole.DIRECT):
+    child = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+    )
+    await tmp_db.save_page(child)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=parent.id,
+            to_page_id=child.id,
+            link_type=LinkType.CHILD_QUESTION,
+            reasoning="Sub-question",
+            role=role,
+        )
+    )
+    return child
+
+
+async def _make_judgement(tmp_db, question, headline, *, robustness=3):
+    judgement = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+        robustness=robustness,
+    )
+    await tmp_db.save_page(judgement)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=judgement.id,
+            to_page_id=question.id,
+            link_type=LinkType.ANSWERS,
+        )
+    )
+    return judgement
+
+
+async def _make_stored_view(tmp_db, question):
+    view = Page(
+        page_type=PageType.VIEW,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        content="",
+        headline=f"View: {question.headline}",
+    )
+    await tmp_db.save_page(view)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=view.id,
+            to_page_id=question.id,
+            link_type=LinkType.VIEW_OF,
+        )
+    )
+    return view
+
+
+async def _make_view_item(
+    tmp_db,
+    view,
+    headline,
+    *,
+    section="key_evidence",
+    importance=4,
+    robustness=3,
+    cites_page_ids=(),
+):
+    item = Page(
+        page_type=PageType.VIEW_ITEM,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+        robustness=robustness,
+    )
+    await tmp_db.save_page(item)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=view.id,
+            to_page_id=item.id,
+            link_type=LinkType.VIEW_ITEM,
+            importance=importance,
+            section=section,
+        )
+    )
+    for cited_id in cites_page_ids:
+        await tmp_db.save_link(
+            PageLink(
+                from_page_id=item.id,
+                to_page_id=cited_id,
+                link_type=LinkType.CITES,
+            )
+        )
+    return item
+
+
+async def test_build_view_basic_structure(tmp_db, question):
+    await _make_claim(tmp_db, question, "Rayleigh scattering", credence=7, robustness=4)
+    await _make_child_question(tmp_db, question, "What wavelengths scatter most?")
+    await _make_judgement(tmp_db, question, "Probably Rayleigh scattering")
+
+    view = await build_view(tmp_db, question.id)
+
+    assert view.question.id == question.id
+    assert len(view.sections) > 0
+    section_names = [s.name for s in view.sections]
+    assert "assessments" in section_names
+    assert view.health.total_pages > 0
+
+
+async def test_assessments_contains_judgement(tmp_db, question):
+    judgement = await _make_judgement(tmp_db, question, "Likely Rayleigh")
+
+    view = await build_view(tmp_db, question.id)
+
+    assessments = next(s for s in view.sections if s.name == "assessments")
+    assert any(item.page.id == judgement.id for item in assessments.items)
+
+
+async def test_confident_views_high_credence_high_robustness(tmp_db, question):
+    claim = await _make_claim(
+        tmp_db, question, "Well-established finding", credence=8, robustness=4
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    confident = next(s for s in view.sections if s.name == "confident_views")
+    assert [item.page.id for item in confident.items] == [claim.id]
+
+
+async def test_live_hypotheses_low_robustness(tmp_db, question):
+    claim = await _make_claim(tmp_db, question, "Fragile hypothesis", credence=7, robustness=2)
+
+    view = await build_view(tmp_db, question.id)
+
+    hyp = next(s for s in view.sections if s.name == "live_hypotheses")
+    assert [item.page.id for item in hyp.items] == [claim.id]
+
+
+async def test_live_hypotheses_mid_credence_no_robustness(tmp_db, question):
+    claim = await _make_claim(tmp_db, question, "Uncertain claim", credence=5, robustness=None)
+
+    view = await build_view(tmp_db, question.id)
+
+    hyp = next(s for s in view.sections if s.name == "live_hypotheses")
+    assert claim.id in {item.page.id for item in hyp.items}
+
+
+async def test_key_evidence_cites_link(tmp_db, question):
+    claim = await _make_claim(tmp_db, question, "Evidence-backed claim", credence=8, robustness=4)
+    source = Page(
+        page_type=PageType.SOURCE,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="A scientific paper",
+        headline="Paper on scattering",
+    )
+    await tmp_db.save_page(source)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=claim.id,
+            to_page_id=source.id,
+            link_type=LinkType.CITES,
+        )
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    evidence = next(s for s in view.sections if s.name == "key_evidence")
+    assert claim.id in {item.page.id for item in evidence.items}
+
+
+async def test_key_evidence_ingest_provenance(tmp_db, question):
+    claim = await _make_claim(
+        tmp_db,
+        question,
+        "Ingested finding",
+        credence=7,
+        robustness=3,
+        provenance_call_type=CallType.INGEST.value,
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    evidence = next(s for s in view.sections if s.name == "key_evidence")
+    assert claim.id in {item.page.id for item in evidence.items}
+
+
+async def test_key_uncertainties_unjudged_child_question(tmp_db, question):
+    child = await _make_child_question(tmp_db, question, "Unresolved sub-question")
+
+    view = await build_view(tmp_db, question.id)
+
+    uncert = next(s for s in view.sections if s.name == "key_uncertainties")
+    assert [item.page.id for item in uncert.items] == [child.id]
+
+
+async def test_key_uncertainties_mid_credence_robust(tmp_db, question):
+    claim = await _make_claim(tmp_db, question, "Robust but uncertain", credence=5, robustness=4)
+
+    view = await build_view(tmp_db, question.id)
+
+    uncert = next(s for s in view.sections if s.name == "key_uncertainties")
+    assert claim.id in {item.page.id for item in uncert.items}
+
+
+async def test_broader_context_structural_claim(tmp_db, question):
+    claim = await _make_claim(
+        tmp_db,
+        question,
+        "Structural framing claim",
+        credence=7,
+        robustness=4,
+        role=LinkRole.STRUCTURAL,
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    ctx = next(s for s in view.sections if s.name == "broader_context")
+    assert [item.page.id for item in ctx.items] == [claim.id]
+
+
+async def test_broader_context_structural_child_question(tmp_db, question):
+    child = await _make_child_question(
+        tmp_db, question, "Structural sub-question", role=LinkRole.STRUCTURAL
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    ctx = next(s for s in view.sections if s.name == "broader_context")
+    assert [item.page.id for item in ctx.items] == [child.id]
+
+
+async def test_child_question_with_judgement_goes_to_assessments(tmp_db, question):
+    child = await _make_child_question(tmp_db, question, "Judged child")
+    await _make_judgement(tmp_db, child, "Answer to child")
+
+    view = await build_view(tmp_db, question.id)
+
+    assessments = next(s for s in view.sections if s.name == "assessments")
+    assert child.id in {item.page.id for item in assessments.items}
+
+
+async def test_stored_view_items_included(tmp_db, question):
+    stored = await _make_stored_view(tmp_db, question)
+    item = await _make_view_item(
+        tmp_db, stored, "Curated summary", section="confident_views", importance=5
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    assert view.stored_view is not None
+    assert view.stored_view.id == stored.id
+    confident = next(s for s in view.sections if s.name == "confident_views")
+    assert item.id in {i.page.id for i in confident.items}
+
+
+async def test_graph_item_hidden_when_cited_by_view_item(tmp_db, question):
+    claim = await _make_claim(
+        tmp_db, question, "Underlying consideration", credence=8, robustness=4
+    )
+    stored = await _make_stored_view(tmp_db, question)
+    await _make_view_item(
+        tmp_db,
+        stored,
+        "Summary of consideration",
+        section="confident_views",
+        importance=5,
+        cites_page_ids=[claim.id],
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    all_item_page_ids = {item.page.id for s in view.sections for item in s.items}
+    assert claim.id not in all_item_page_ids
+
+
+async def test_graph_only_when_no_stored_view(tmp_db, question):
+    claim = await _make_claim(tmp_db, question, "Raw consideration", credence=8, robustness=4)
+
+    view = await build_view(tmp_db, question.id)
+
+    assert view.stored_view is None
+    all_item_page_ids = {item.page.id for s in view.sections for item in s.items}
+    assert claim.id in all_item_page_ids
+
+
+async def test_view_item_sorts_before_graph_at_same_importance(tmp_db, question):
+    stored = await _make_stored_view(tmp_db, question)
+    curated = await _make_view_item(
+        tmp_db, stored, "Curated item", section="confident_views", importance=3
+    )
+    graph_claim = await _make_claim(
+        tmp_db, question, "Graph claim", credence=8, robustness=4, strength=3.0
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    confident = next(s for s in view.sections if s.name == "confident_views")
+    ids_in_order = [item.page.id for item in confident.items]
+    assert curated.id in ids_in_order
+    assert graph_claim.id in ids_in_order
+    assert ids_in_order.index(curated.id) < ids_in_order.index(graph_claim.id)
+
+
+async def test_stored_view_item_uses_link_importance(tmp_db, question):
+    stored = await _make_stored_view(tmp_db, question)
+    item = await _make_view_item(tmp_db, stored, "Curated", section="confident_views", importance=5)
+
+    view = await build_view(tmp_db, question.id)
+
+    confident = next(s for s in view.sections if s.name == "confident_views")
+    view_item = next(i for i in confident.items if i.page.id == item.id)
+    assert view_item.effective_importance == 5
+
+
+async def test_health_missing_credence(tmp_db, question):
+    await _make_claim(tmp_db, question, "No credence", credence=None, robustness=3)
+
+    view = await build_view(tmp_db, question.id)
+
+    assert view.health.missing_credence == 1
+
+
+async def test_health_child_questions_without_judgements(tmp_db, question):
+    await _make_child_question(tmp_db, question, "Unjudged child 1")
+    await _make_child_question(tmp_db, question, "Unjudged child 2")
+
+    view = await build_view(tmp_db, question.id)
+
+    assert view.health.child_questions_without_judgements == 2
+
+
+async def test_health_judged_child_not_counted(tmp_db, question):
+    child = await _make_child_question(tmp_db, question, "Judged child")
+    await _make_judgement(tmp_db, child, "Answer to child")
+
+    view = await build_view(tmp_db, question.id)
+
+    assert view.health.child_questions_without_judgements == 0
+
+
+async def test_superseded_pages_excluded(tmp_db, question):
+    claim = await _make_claim(tmp_db, question, "Old superseded claim", credence=8, robustness=4)
+    claim.is_superseded = True
+    await tmp_db.save_page(claim)
+
+    view = await build_view(tmp_db, question.id)
+
+    all_page_ids = {item.page.id for s in view.sections for item in s.items}
+    assert claim.id not in all_page_ids
+
+
+async def test_build_view_raises_for_nonexistent_page(tmp_db):
+    with pytest.raises(ValueError, match="not found"):
+        await build_view(tmp_db, "00000000-0000-0000-0000-000000000000")
+
+
+async def test_build_view_raises_for_non_question(tmp_db):
+    claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Not a question",
+        headline="Not a question",
+    )
+    await tmp_db.save_page(claim)
+
+    with pytest.raises(ValueError, match="not a question"):
+        await build_view(tmp_db, claim.id)
+
+
+async def test_max_depth_with_nested_children(tmp_db, question):
+    child1 = await _make_child_question(tmp_db, question, "Level 1")
+    await _make_child_question(tmp_db, child1, "Level 2")
+
+    view = await build_view(tmp_db, question.id)
+
+    assert view.health.max_depth == 2
+
+
+async def test_max_depth_cycle_safe(tmp_db, question):
+    child1 = await _make_child_question(tmp_db, question, "Level 1")
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=child1.id,
+            to_page_id=question.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+
+    view = await build_view(tmp_db, question.id)
+
+    assert view.health.max_depth < 20
+
+
+async def test_sections_ordered_by_definition(tmp_db, question):
+    await _make_child_question(tmp_db, question, "Unresolved child")
+    await _make_claim(tmp_db, question, "Confident", credence=8, robustness=4)
+    await _make_judgement(tmp_db, question, "Current answer")
+
+    view = await build_view(tmp_db, question.id)
+
+    section_names = [s.name for s in view.sections]
+    expected_canonical = ["confident_views", "assessments", "key_uncertainties"]
+    present_canonical = [n for n in expected_canonical if n in section_names]
+    indices = [section_names.index(n) for n in present_canonical]
+    assert indices == sorted(indices)
+
+
+async def test_empty_view_no_research(tmp_db, question):
+    view = await build_view(tmp_db, question.id)
+
+    assert view.question.id == question.id
+    assert len(view.sections) == 0
+    assert view.health.total_pages == 0


### PR DESCRIPTION
Meant to illustrate an idea rather than being a strong bid to switch to this. I do like that this kind of substrate would allow for UIs and context-consumers to have a view-like representation regardless of whether a view-constructing orchestrator has run on a particular part of the workspace.

claude:

## What it does

- New `src/rumil/views.py`: `View` dataclass + `build_view(db, qid)` that derives sections from workspace state — considerations, child questions, judgements classified into the canonical taxonomy, merged with stored `VIEW_ITEM` pages from `update_view` when present. Graph items cited by a VIEW_ITEM are hidden in favour of the curated version.
- Refactors three call sites (`orchestrators/common.py` parent view, `context.py` prioritization view, `context.py` child-investigation view) to use `build_view` + a new `render_view(view: View, *, min_importance)` signature.
- `update_view` still runs and still writes VIEW_ITEMs; those are no longer the exclusive context source.

## The shift

Views in LLM context went from "whatever `update_view` last wrote" to "graph projection + curated overlay, always available, always fresh."

## Wins

- Child questions at depth used to render empty when `update_view` hadn't reached them. Now they always have content.
- Graph additions between `update_view` passes are visible immediately.
- `update_view`'s curation is honored where it exists — VIEW_ITEM content renders inline; their cited considerations get hidden to avoid double-rendering.
- One rendering path instead of three ad-hoc variants.

## Tradeoffs

- Context is larger. Prioritization / parent / child-investigation prompts now include graph items on top of VIEW_ITEMs, and child-investigation additionally renders VIEW_ITEM content where it previously showed only headlines.
- Graph items get rule-based section classification (from credence/robustness/role), which is coarser than update_view's LLM placement. A consideration might land in `other` where an LLM would have chosen `live_hypotheses`.
- Pruning doesn't propagate. If `update_view` deleted a VIEW_ITEM link as noise, the underlying consideration still surfaces as a graph item. That signal lives only on VIEW_ITEM links.
- Stale child views previously rendered nothing; now they render I5+ items.

## Open questions

- Does `update_view` still earn its budget? Most of what it produced is visible via derivation now. Its synthesized prose and LLM-chosen section labels remain uniquely valuable, but the cost/benefit shifts.
- Thresholds at call sites (2, 4, 5) are hand-picked. Watch context sizes in real runs.
- Frontend still reads VIEW_ITEMs directly.

## Out of scope

- No changes to `update_view` itself.
- No hybrid rule where VIEW_ITEM scores override graph classification.
- No migration — existing rows work unchanged.

## Test plan

- [x] 27 new tests in `tests/test_views.py` covering classification, merge semantics, cite-based dedup, cycle safety, health, error cases
- [x] Full suite passes (472 passed; 1 pre-existing `test_stats.py` failure unrelated to this PR)
- [x] Smoke run on a fresh question (confirms empty-view path renders cleanly with no dangling header)
- [x] Manual inspection of `build_view` output on a real question with `update_view` history (confirms merged graph + VIEW_ITEM rendering)
- [x] Runtime exercise of `render_child_investigation_results` on a real parent (`metr` project, parent `37d88504`) — surfaced a bug where derived-only child views (sections but no stored View) rendered empty status headers because `new=False` forced `min_importance=5`; fixed by treating derived-only views as NEW

🤖 Generated with [Claude Code](https://claude.com/claude-code)
