### PR TITLE
Skip auto-summarise in global-prio when local orch opts out

### DIFF
--- a/src/rumil/orchestrators/global_prio.py
+++ b/src/rumil/orchestrators/global_prio.py
@@ -387,6 +387,12 @@ class GlobalPrioOrchestrator(BaseOrchestrator):
         self._messages: list[dict] = []
         self._turn_count: int = 0
 
+        variant = get_settings().prioritizer_variant
+        if variant == "experimental":
+            self.summarise_before_assess = ExperimentalOrchestrator.summarise_before_assess
+        elif variant == "two_phase":
+            self.summarise_before_assess = TwoPhaseOrchestrator.summarise_before_assess
+
     async def run(self, root_question_id: str) -> None:
         own_db = await self.db.fork()
         self.db = own_db
@@ -1202,6 +1208,7 @@ class GlobalPrioOrchestrator(BaseOrchestrator):
                     parent_call_id=parent_call_id,
                     broadcaster=self.broadcaster,
                     force=True,
+                    summarise=self.summarise_before_assess,
                 )
                 if call_id:
                     self._global_consumed += 1
@@ -1271,6 +1278,7 @@ class GlobalPrioOrchestrator(BaseOrchestrator):
                     parent_call_id=parent_call_id,
                     broadcaster=self.broadcaster,
                     force=True,
+                    summarise=self.summarise_before_assess,
                 )
                 if call_id:
                     self._global_consumed += 1


### PR DESCRIPTION
## Summary

Follow-up to #314. That PR disabled the auto-summarise-before-assess in `ExperimentalOrchestrator`, but runs that use `enable_global_prio=True` were still emitting summarise calls — traced to `GlobalPrioOrchestrator`'s own assess paths (`_assess_stale_questions` and `_propagate_updates`), which call `assess_question(...)` without forwarding the `summarise` flag and so default to `True`.

Fix: `GlobalPrioOrchestrator.__init__` now mirrors the configured local variant's `summarise_before_assess` class attribute onto `self`, and the two assess call sites forward `self.summarise_before_assess`. Net effect:
- `prioritizer_variant="experimental"` → global-prio assesses skip summarise (matches the local orch).
- `prioritizer_variant="two_phase"` → global-prio assesses keep the existing summarise-first behaviour.

Evidence this was the gap: in prod run `6d8cd614-ad95-4fa1-b23c-d729b8aa923c` (experimental local, global-prio on), all 8 summarise calls had a `global_prioritization` parent; none were children of the experimental orch.

## Test plan

- [x] `uv run pytest tests/test_global_prio_loop.py`
- [x] `uv run pyright src/rumil/orchestrators/global_prio.py`
- [ ] Next experimental+global-prio run shows zero summarise calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)