### PR TITLE
Make the page→run footer link work for staged pages

### DIFF
--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -169,9 +169,12 @@ function injectCitationLinks(
   });
 }
 
-async function getPageRun(pageId: string): Promise<RunSummaryOut | null> {
+async function getPageRun(
+  pageId: string,
+  stagedRunId?: string,
+): Promise<RunSummaryOut | null> {
   const res = await fetch(
-    `${API_BASE}/api/pages/${pageId}/run`,
+    `${API_BASE}/api/pages/${pageId}/run${stagedQs(stagedRunId)}`,
     { cache: "no-store" },
   );
   if (!res.ok) return null;
@@ -399,7 +402,7 @@ export default async function PageDetailPage({
   const { staged_run_id: stagedRunId } = await searchParams;
   const [detail, run] = await Promise.all([
     getPageDetail(pageId, stagedRunId),
-    getPageRun(pageId),
+    getPageRun(pageId, stagedRunId),
   ]);
 
   if (!detail) {

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -574,7 +574,7 @@ def get_realtime_config():
     "/api/pages/{page_id}/run",
     response_model=RunSummaryOut | None,
 )
-async def get_page_run(page_id: str, db: DB = Depends(_get_db)):
+async def get_page_run(page_id: str, db: DB = Depends(_get_db_maybe_staged)):
     run = await db.get_run_for_page(page_id)
     if not run:
         return None


### PR DESCRIPTION
## Summary
- `GET /api/pages/{page_id}/run` used the non-staged DB dep. Its implementation starts with `db.get_page()`, which applies staged visibility filtering, so for a staged page the endpoint returned `null` and the UI footer silently dropped the "run …" link to the trace.
- Switch the endpoint to `_get_db_maybe_staged` and thread `stagedRunId` through `getPageRun()` in the page detail component so it's appended as `?staged_run_id=…`, mirroring how `getPageDetail` already works.

## Test plan
- [x] Open a staged page in the UI (e.g. judgement `610a9b9d…` on prod): footer now shows `run 6d8cd614` linking to `/traces/6d8cd614…#call-632f85cf`.
- [x] Open a non-staged page: footer link still renders as before.
- [ ] Hitting `/api/pages/<staged-page-id>/run` without `staged_run_id` still returns `null` (expected — baseline readers can't see staged pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)