### PR TITLE
Skip citations.md in prompts for calls that create no pages

### DIFF
--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -152,9 +152,14 @@ def _load_prompt_sections() -> dict[str, str]:
 
 
 def _build_update_view_system_prompt(context_section: str) -> str:
-    """Build system prompt: preamble + View context framing + citations + grounding."""
+    """Build system prompt: preamble + View context framing + grounding.
+
+    No citations section: update_view only modifies epistemic scores and
+    section/importance on existing items — it cannot create content-bearing
+    pages, so inline-citation rules have nothing to attach to.
+    """
     parts: list[str] = []
-    for name in ("preamble.md", "citations.md", "grounding.md"):
+    for name in ("preamble.md", "grounding.md"):
         p = PROMPTS_DIR / name
         if p.exists():
             parts.append(p.read_text(encoding="utf-8"))

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -145,13 +145,21 @@ def _load_file(name: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def build_system_prompt(call_type: str) -> str:
-    """Combine preamble + call-type instructions + citations into one system prompt."""
+def build_system_prompt(call_type: str, *, include_citations: bool = True) -> str:
+    """Combine preamble + call-type instructions + citations into one system prompt.
+
+    Pass ``include_citations=False`` for calls that do not create any content-bearing
+    pages (e.g. prioritization, scoring) — the inline-citation rules have nothing to
+    attach to in those calls and only add noise.
+    """
     preamble = _load_file("preamble.md")
     instructions = _load_file(f"{call_type}.md")
-    citations = _load_file("citations.md")
     grounding = _load_file("grounding.md")
-    return f"{preamble}\n\n---\n\n{instructions}\n\n---\n\n{citations}\n\n---\n\n{grounding}"
+    parts = [preamble, instructions]
+    if include_citations:
+        parts.append(_load_file("citations.md"))
+    parts.append(grounding)
+    return "\n\n---\n\n".join(parts)
 
 
 def build_user_message(context_text: str, task_description: str) -> str:

--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -373,7 +373,10 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             self.db,
             short_id_map=short_id_map,
             dispatch_types=list(get_available_calls_preset().claim_phase1_scouts),
-            system_prompt=build_system_prompt("claim_investigation_p1"),
+            system_prompt=build_system_prompt(
+                "claim_investigation_p1",
+                include_citations=False,
+            ),
         )
 
         dispatches = list(result.dispatches)
@@ -573,7 +576,10 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             short_id_map=short_id_map,
             dispatch_types=list(get_available_calls_preset().claim_phase2_dispatch),
             extra_dispatch_defs=extra_defs or None,
-            system_prompt=build_system_prompt("claim_investigation_p2"),
+            system_prompt=build_system_prompt(
+                "claim_investigation_p2",
+                include_citations=False,
+            ),
             dispatch_budget=budget,
         )
 

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -271,7 +271,7 @@ async def score_items_sequentially(
             parent_parts.append("")
 
     parent_context = "\n".join(parent_parts)
-    system_prompt = build_system_prompt(system_prompt_name)
+    system_prompt = build_system_prompt(system_prompt_name, include_citations=False)
     messages: list[dict] = []
     results: list[dict] = []
 

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -423,7 +423,10 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             dispatch_types=list(
                 get_available_calls_preset().initial_prioritization_scouts,
             ),
-            system_prompt=build_system_prompt("two_phase_initial_prioritization"),
+            system_prompt=build_system_prompt(
+                "two_phase_initial_prioritization",
+                include_citations=False,
+            ),
         )
 
         dispatches = list(result.dispatches)
@@ -624,6 +627,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             extra_dispatch_defs=extra_defs or None,
             system_prompt=build_system_prompt(
                 "two_phase_main_phase_prioritization",
+                include_citations=False,
             ),
             dispatch_budget=dispatch_budget,
         )

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -399,7 +399,10 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             dispatch_types=list(
                 get_available_calls_preset().initial_prioritization_scouts,
             ),
-            system_prompt=build_system_prompt("two_phase_initial_prioritization"),
+            system_prompt=build_system_prompt(
+                "two_phase_initial_prioritization",
+                include_citations=False,
+            ),
         )
 
         dispatches = list(result.dispatches)
@@ -655,6 +658,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             extra_dispatch_defs=extra_defs or None,
             system_prompt=build_system_prompt(
                 "two_phase_main_phase_prioritization",
+                include_citations=False,
             ),
             dispatch_budget=dispatch_budget,
         )


### PR DESCRIPTION
## Summary
- Add `include_citations: bool = True` flag to `rumil.llm.build_system_prompt` and pass `include_citations=False` at the six `run_prioritization_call` sites across `two_phase`, `experimental`, and `claim_investigation` orchestrators. These calls have `PRIORITIZATION` moves `[]`, so they dispatch but create no content-bearing pages.
- Audit found two more callers that inject the citation rules but cannot cite: `orchestrators/common.py:score_items_sequentially` (structured scoring only, used for `score_subquestions` / `score_claim_items`) and `calls/update_view.py:_build_update_view_system_prompt` (UPDATE_VIEW only has `LOAD_PAGE` + `UPDATE_EPISTEMIC`). Both now omit `citations.md`.
- Left alone: `global_prio` (has CREATE_QUESTION), all scout / assess / find_considerations / ingest / web_research / create_view calls, and the `clean/common.py` reassess paths (supersede claims).

## Test plan
- [ ] `uv run pytest`
- [ ] Smoke-test a prioritization-heavy run and confirm the system prompt no longer contains the `# Inline Citations` section for `two_phase_*_prioritization`, `claim_investigation_p{1,2}`, `score_*`, and `update_view` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)