### PR TITLE
Batch page-id resolution in report section collection

### DIFF
--- a/src/rumil/report.py
+++ b/src/rumil/report.py
@@ -105,9 +105,10 @@ async def _collect_section_pages(section: OutlineSection, db: DB) -> str:
     if not all_ids:
         return "(No source pages specified for this section.)"
 
+    resolved_map = await db.resolve_page_ids(all_ids)
     resolved_ids: list[str] = []
     for pid in all_ids:
-        full_id = await db.resolve_page_id(pid)
+        full_id = resolved_map.get(pid)
         if full_id:
             resolved_ids.append(full_id)
         else:


### PR DESCRIPTION
## Summary
- `_collect_section_pages` in `src/rumil/report.py` was calling `db.resolve_page_id` once per ID, making O(N) DB round trips per report section.
- Swapped to the existing batched `db.resolve_page_ids`, which issues at most two queries regardless of input size. Same semantics — unresolved IDs still log a warning and are dropped.

## Test plan
- [ ] Generate a report that exercises `_collect_section_pages` and confirm the rendered section pages are unchanged
- [ ] Spot-check logs for the "Could not resolve page ID" warning on a deliberately-bad short ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)