### PR TITLE
Add vim ignores to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,15 @@ cython_debug/
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
+# Vim
+*.swp
+*.swo
+*.swn
+*~
+.netrwhist
+Session.vim
+.vim/
+
 # Ruff stuff:
 .ruff_cache/
 


### PR DESCRIPTION
## Summary
- Ignore vim swap/backup files, netrw history, session files, and `.vim/`

## Test plan
- [ ] `git status` stays clean when vim creates swap/backup files