### PR TITLE
Reduce DB and API retry caps from 60 to 10

### DIFF
--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -87,8 +87,8 @@ class Settings(BaseSettings):
     linker_cache_invalidation_threshold: int = _capture_field(default=100)
     subquestion_linker_enabled: bool = _capture_field(default=True)
 
-    max_db_retries: int = _capture_field(default=60)
-    max_api_retries: int = _capture_field(default=60)
+    max_db_retries: int = _capture_field(default=10)
+    max_api_retries: int = _capture_field(default=10)
     max_api_retries_429: int | None = _capture_field(default=None)
     max_api_retries_500: int | None = _capture_field(default=None)
     max_api_retries_529: int | None = _capture_field(default=None)


### PR DESCRIPTION
## Summary
- Drop `max_db_retries` and `max_api_retries` defaults from 60 to 10 in `src/rumil/settings.py`
- With `wait_exponential(..., max=60)`, 60 retries could hang a run for ~54 minutes before surfacing the failure
- 10 retries still covers ~4 minutes of transient outage (1+2+4+8+16+32+60+60+60+60 s), which comfortably rides out upstream blips without stalling on a dead service
- Audited the rest of the codebase for excessive retries: `max_parse_attempts=2` in `llm.py` and the one-shot prioritization re-prompt are already tight; `max_rounds` values are agent-loop caps, not retries

## Test plan
- [ ] Existing test suite passes (`uv run pytest`)
- [ ] A transient DB/API failure triggers retries and recovers within a handful of attempts in a normal run

🤖 Generated with [Claude Code](https://claude.com/claude-code)