### PR TITLE
Per-question shared budget pool for prioritisation cycles

### DIFF
--- a/prompts/claim_investigation_p1.md
+++ b/prompts/claim_investigation_p1.md
@@ -77,3 +77,9 @@ What NOT to Do
 Do not try to load pages or do any object-level research.
 
 Do not assess or plan follow-up — that happens later.
+
+## Coordinating with other prioritisation cycles
+
+This claim may already have other prioritisation cycles running against it. If so, you'll see them under "Coordination" in your context, listed with their assigned budgets. All cycles on this claim share a single budget pool: each cycle's assigned budget contributes to the pool, and every cycle draws from it. The budget line above already reflects what the pool has remaining — peers' spending is baked in.
+
+- **Don't duplicate work.** If a peer cycle has already dispatched scouts that cover an angle you were considering, pick something else.

--- a/prompts/claim_investigation_p2.md
+++ b/prompts/claim_investigation_p2.md
@@ -135,3 +135,14 @@ Specialized scouts and find\_considerations cost up to max\_rounds (may stop ear
 recurse\_into\_claim\_investigation and recurse\_into\_subquestion cost exactly the budget you assign
 
 dispatch\_web\_factcheck costs exactly 1
+
+## Coordinating with other prioritisation cycles
+
+This claim may already have other prioritisation cycles running against it. If so, you'll see them under "Coordination" in your context, listed with their assigned budgets. All cycles on this claim share a single budget pool: each cycle's assigned budget contributes to the pool, and every cycle draws from it. The budget line above already reflects what the pool has remaining — peers' spending is baked in.
+
+- **Don't duplicate work.** If a peer cycle has already dispatched scouts that cover an angle you were considering, pick something else.
+
+You may also see active prioritisation cycles on subquestions of the current claim, with each subquestion's pool budget remaining. If you want to **wait** for a subquestion's running cycle to finish before reassessing this claim (so the subquestion's results are reflected in your judgement), the way to do this is to **recurse into that subquestion** — the recurse will not return until the subquestion's pool is exhausted.
+
+- To wait *without doing extra work beyond what the running cycle is already doing*, recurse with the minimum allowed budget (4). Your contribution will only marginally extend the running investigation but will block until it returns.
+- To wait *and* contribute additional investigation, recurse with a larger budget — your contribution gets added to the running cycle's pool and you all share the work.

--- a/prompts/two_phase_initial_prioritization.md
+++ b/prompts/two_phase_initial_prioritization.md
@@ -45,3 +45,9 @@ Weight your budget toward scout types that seem most informative for this partic
 
 * Do not try to load pages or do any object-level research.
 * Do not assess or plan follow-up — that happens later.
+
+## Coordinating with other prioritisation cycles
+
+This question may already have other prioritisation cycles running against it. If so, you'll see them under "Coordination" in your context, listed with their assigned budgets. All cycles on this question share a single budget pool: each cycle's assigned budget contributes to the pool, and every cycle draws from it. The budget line above already reflects what the pool has remaining — peers' spending is baked in.
+
+- **Don't duplicate work.** If a peer cycle has already dispatched scouts that cover an angle you were considering, pick something else.

--- a/prompts/two_phase_main_phase_prioritization.md
+++ b/prompts/two_phase_main_phase_prioritization.md
@@ -76,3 +76,14 @@ Your total dispatched budget (worst case) must not exceed your allocated budget:
 - Specialized scouts and find_considerations cost up to `max_rounds` (may stop early, but budget for the worst case)
 - `recurse_into_subquestion` and `recurse_into_claim_investigation` cost exactly the `budget` you assign
 - `dispatch_web_factcheck` costs exactly 1
+
+## Coordinating with other prioritisation cycles
+
+This question may already have other prioritisation cycles running against it. If so, you'll see them under "Coordination" in your context, listed with their assigned budgets. All cycles on this question share a single budget pool: each cycle's assigned budget contributes to the pool, and every cycle draws from it. The budget line above already reflects what the pool has remaining — peers' spending is baked in.
+
+- **Don't duplicate work.** If a peer cycle has already dispatched scouts that cover an angle you were considering, pick something else.
+
+You may also see active prioritisation cycles on subquestions of the current question, with each subquestion's pool budget remaining. If you want to **wait** for a subquestion's running cycle to finish before assessing this question (so the subquestion's results are reflected in your judgement), the way to do this is to **recurse into that subquestion** — the recurse will not return until the subquestion's pool is exhausted.
+
+- To wait *without doing extra work beyond what the running cycle is already doing*, recurse with the minimum allowed budget (4). Your contribution will only marginally extend the running investigation but will block until it returns.
+- To wait *and* contribute additional investigation, recurse with a larger budget — your contribution gets added to the running cycle's pool and you all share the work.

--- a/prompts/two_phase_main_phase_prioritization_experimental.md
+++ b/prompts/two_phase_main_phase_prioritization_experimental.md
@@ -102,3 +102,11 @@ Your total dispatched budget (worst case) must not exceed your allocated budget:
 - Specialized scouts and find_considerations cost up to `max_rounds` (may stop early, but budget for the worst case)
 - `recurse_into_subquestion` costs exactly the `budget` you assign
 - `dispatch_web_factcheck` costs exactly 1
+
+## Coordinating with other prioritisation cycles
+
+This question may already have other prioritisation cycles running against it. If so, you'll see them under "Coordination" in your context, listed with their assigned budgets. All cycles on this question share a single budget pool: each cycle's assigned budget contributes to the pool, and every cycle draws from it. The budget line above already reflects what the pool has remaining — peers' spending is baked in.
+
+- **Don't duplicate work.** If a peer cycle has already dispatched scouts that cover an angle you were considering, pick something else.
+
+You may also see active prioritisation cycles on subquestions of the current question, with each subquestion's pool budget remaining. If you want to **wait** for a subquestion's running cycle to finish before assessing this question, the way to do this is to **recurse into that subquestion** with the minimum allowed budget (4) — your contribution will marginally extend the running investigation but will block until it returns.

--- a/src/rumil/budget.py
+++ b/src/rumil/budget.py
@@ -1,0 +1,43 @@
+"""Per-unit budget consumption helper.
+
+Lives in its own module to break the import cycle between
+``rumil.orchestrators.common`` (which depends on the call modules) and
+``rumil.calls.page_creators`` (which is one of those call modules but also
+needs to debit budget per round).
+"""
+
+import logging
+
+from rumil.database import DB
+
+log = logging.getLogger(__name__)
+
+
+async def _consume_budget(
+    db: DB,
+    force: bool = False,
+    *,
+    pool_question_id: str | None = None,
+) -> bool:
+    """Consume one unit of global budget. Returns False if exhausted.
+
+    When *force* is True the call always succeeds: if normal consumption
+    fails, budget is temporarily expanded so the dispatch can proceed.
+    This is used to guarantee that every dispatch in a committed batch
+    runs, even if it means slightly exceeding the original budget.
+
+    When *pool_question_id* is set, also debit the per-question budget pool
+    for that question. The pool debit never refuses; the run-level budget
+    is the authoritative gate.
+    """
+    ok = await db.consume_budget(1)
+    if not ok:
+        if force:
+            await db.add_budget(1)
+            ok = await db.consume_budget(1)
+        if not ok:
+            remaining = await db.budget_remaining()
+            log.info("Budget exhausted (remaining: %d)", remaining)
+    if ok and pool_question_id is not None:
+        await db.qbp_consume(pool_question_id, 1)
+    return ok

--- a/src/rumil/calls/find_considerations.py
+++ b/src/rumil/calls/find_considerations.py
@@ -34,6 +34,7 @@ class FindConsiderationsCall(CallRunner):
         context_page_ids: Sequence[str] | None = None,
         broadcaster=None,
         up_to_stage: CallStage | None = None,
+        pool_question_id: str | None = None,
     ):
         call.call_params = {
             **(call.call_params or {}),
@@ -43,7 +44,14 @@ class FindConsiderationsCall(CallRunner):
         self._max_rounds = max_rounds
         self._fruit_threshold = fruit_threshold
         self._context_page_ids = context_page_ids
-        super().__init__(question_id, call, db, broadcaster=broadcaster, up_to_stage=up_to_stage)
+        super().__init__(
+            question_id,
+            call,
+            db,
+            broadcaster=broadcaster,
+            up_to_stage=up_to_stage,
+            pool_question_id=pool_question_id,
+        )
 
     @property
     def rounds_completed(self) -> int:

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -10,6 +10,7 @@ import anthropic
 from anthropic.types import ServerToolUseBlock, ToolUseBlock
 from pydantic import BaseModel, Field
 
+from rumil.budget import _consume_budget
 from rumil.calls.common import (
     execute_tool_uses,
     prepare_tools,
@@ -188,8 +189,6 @@ class MultiRoundLoop(WorkspaceUpdater):
         resume_messages: list[dict] = []
         rounds_completed = 0
         last_fruit_score: int | None = None
-
-        from rumil.orchestrators.common import _consume_budget
 
         for i in range(self._max_rounds):
             if not await _consume_budget(infra.db, pool_question_id=infra.pool_question_id):

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -189,8 +189,10 @@ class MultiRoundLoop(WorkspaceUpdater):
         rounds_completed = 0
         last_fruit_score: int | None = None
 
+        from rumil.orchestrators.common import _consume_budget
+
         for i in range(self._max_rounds):
-            if not await infra.db.consume_budget(1):
+            if not await _consume_budget(infra.db, pool_question_id=infra.pool_question_id):
                 log.info(
                     "Budget exhausted, stopping scout session at round %d",
                     i,

--- a/src/rumil/calls/stages.py
+++ b/src/rumil/calls/stages.py
@@ -29,6 +29,10 @@ class CallInfra:
     db: DB
     trace: CallTrace
     state: MoveState
+    # The parent prio cycle's root question — when set, per-round budget
+    # consumption also debits this question's budget pool. Left None for
+    # rumil-mediated dispatch and other paths outside a prio cycle.
+    pool_question_id: str | None = None
 
 
 @dataclass
@@ -100,6 +104,7 @@ class CallRunner(ABC):
         up_to_stage: CallStage | None = None,
         max_rounds: int = 5,
         fruit_threshold: int = 4,
+        pool_question_id: str | None = None,
     ):
         self.infra = CallInfra(
             question_id=question_id,
@@ -107,6 +112,7 @@ class CallRunner(ABC):
             db=db,
             trace=CallTrace(call.id, db, broadcaster=broadcaster),
             state=MoveState(call, db),
+            pool_question_id=pool_question_id,
         )
         self.up_to_stage = up_to_stage
         self._max_rounds = max_rounds

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -640,12 +640,19 @@ async def _build_dependency_signal(db: DB) -> str | None:
 async def build_prioritization_context(
     db: DB,
     scope_question_id: str | None = None,
+    *,
+    current_call_id: str | None = None,
 ) -> tuple[str, dict[str, str]]:
     """Build context for a prioritization call.
 
     Includes the current View (importance 2+) for the scope question,
     then appends the scope question and its direct children (at ABSTRACT
-    detail) and a dependency signal.
+    detail), a dependency signal, and (when ``scope_question_id`` is set)
+    a coordination section listing other in-flight calls on the scope
+    question and active prioritisation pools on its subquestions.
+
+    The coordination section is placed last so it doesn't interfere with
+    the cacheable prefix above it.
 
     Returns (context_text, short_id_map) where short_id_map maps 8-char
     short IDs to full UUIDs.
@@ -688,7 +695,91 @@ async def build_prioritization_context(
         parts.append(dep_section)
         parts.append("")
 
+    if scope_question_id:
+        coord_section = await _build_coordination_section(
+            db,
+            scope_question_id,
+            current_call_id=current_call_id,
+        )
+        if coord_section:
+            parts.append(coord_section)
+            parts.append("")
+
     return "\n".join(parts), short_id_map
+
+
+async def _build_coordination_section(
+    db: DB,
+    scope_question_id: str,
+    *,
+    current_call_id: str | None,
+) -> str:
+    """Render the coordination section for prio prompts.
+
+    Shows in-flight calls on the scope question (with assigned budgets) and
+    active prio pools on subquestions (with remaining budget). Returns an
+    empty string when nothing is in flight, so the section is omitted.
+    """
+    in_flight = await db.get_active_calls_for_question(
+        scope_question_id,
+        exclude_call_id=current_call_id,
+    )
+    sub_pools = await db.get_active_prio_pools_for_subquestions(scope_question_id)
+
+    if not in_flight and not sub_pools:
+        return ""
+
+    lines: list[str] = ["## Coordination: in-flight work on this question and its subquestions", ""]
+
+    if in_flight:
+        lines.append("### Calls in flight against this question")
+        lines.append("")
+        lines.append(
+            "Other calls currently dispatched against this question (excluding "
+            "your own). Their assigned budgets contribute to the same shared "
+            "pool you're drawing from — your budget line above already accounts "
+            "for what they've consumed:"
+        )
+        lines.append("")
+        for c in in_flight:
+            assigned = (
+                f"assigned budget {c.budget_allocated}"
+                if c.budget_allocated is not None
+                else "assigned budget —"
+            )
+            lines.append(f"- `[{c.id[:8]}]` {c.call_type.value.upper()} — {assigned}")
+        lines.append("")
+
+    if sub_pools:
+        sub_ids = [sub_id for sub_id, _ in sub_pools]
+        sub_pages = await db.get_pages_by_ids(sub_ids)
+        lines.append("### Active prioritisation cycles on subquestions")
+        lines.append("")
+        for sub_id, sub_pool in sub_pools:
+            page = sub_pages.get(sub_id)
+            headline = page.headline if page else ""
+            cycles_label = (
+                "1 active cycle"
+                if sub_pool.active_calls == 1
+                else f"{sub_pool.active_calls} active cycles"
+            )
+            lines.append(
+                f'- `[{sub_id[:8]}]` "{headline}" — '
+                f"**{max(sub_pool.remaining, 0)} budget remaining** "
+                f"({cycles_label})"
+            )
+        lines.append("")
+        lines.append(
+            "If you want to wait for one of these subquestion investigations to "
+            "finish before assessing this question, recurse into that "
+            "subquestion. If you want to wait without doing additional work "
+            "beyond what the running cycle is already doing, recurse with the "
+            "minimum allowed budget — your contribution will marginally extend "
+            "the running investigation but will block until the subquestion's "
+            "pool is exhausted."
+        )
+
+    return "\n".join(lines)
 
 
 def _filter_summary_pages(

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import uuid
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, cast
 
@@ -48,6 +49,26 @@ _Rows = list[dict[str, Any]]
 def _rows(response: Any) -> _Rows:
     """Extract rows from a Supabase API response with proper typing."""
     return cast(_Rows, response.data) if response.data else []
+
+
+@dataclass(frozen=True)
+class QuestionBudgetPool:
+    """Per-question shared budget pool state.
+
+    Multiple prioritisation cycles working on the same question contribute
+    their assigned budget to the pool and draw from it together. The pool
+    is the authoritative stop signal for prio loops; the run-level budget
+    remains the authoritative ceiling.
+    """
+
+    question_id: str
+    contributed: int
+    consumed: int
+    active_calls: int
+
+    @property
+    def remaining(self) -> int:
+        return self.contributed - self.consumed
 
 
 _DB_RETRYABLE_EXCEPTIONS = (
@@ -1660,6 +1681,168 @@ class DB:
         total, used = await self.get_budget()
         return max(0, total - used)
 
+    async def qbp_get(self, question_id: str) -> QuestionBudgetPool:
+        """Read the current pool state for a question.
+
+        Returns a zero-default object when no pool row exists.
+        """
+        rows = _rows(
+            await self._execute(
+                self.client.table("question_budget_pool")
+                .select("contributed, consumed, active_calls")
+                .eq("run_id", self.run_id)
+                .eq("question_id", question_id)
+            )
+        )
+        if not rows:
+            return QuestionBudgetPool(
+                question_id=question_id,
+                contributed=0,
+                consumed=0,
+                active_calls=0,
+            )
+        r = rows[0]
+        return QuestionBudgetPool(
+            question_id=question_id,
+            contributed=r["contributed"],
+            consumed=r["consumed"],
+            active_calls=r["active_calls"],
+        )
+
+    async def qbp_get_many(self, question_ids: Sequence[str]) -> dict[str, QuestionBudgetPool]:
+        """Batched pool fetch. Missing IDs are absent from the returned dict."""
+        if not question_ids:
+            return {}
+        rows = _rows(
+            await self._execute(
+                self.client.table("question_budget_pool")
+                .select("question_id, contributed, consumed, active_calls")
+                .eq("run_id", self.run_id)
+                .in_("question_id", list(question_ids))
+            )
+        )
+        return {
+            r["question_id"]: QuestionBudgetPool(
+                question_id=r["question_id"],
+                contributed=r["contributed"],
+                consumed=r["consumed"],
+                active_calls=r["active_calls"],
+            )
+            for r in rows
+        }
+
+    async def qbp_register(self, question_id: str, contribution: int) -> QuestionBudgetPool:
+        """Add a contribution and increment active_calls for the pool."""
+        result = await self._execute(
+            self.client.rpc(
+                "qbp_register",
+                {
+                    "rid": self.run_id,
+                    "qid": question_id,
+                    "contribution": contribution,
+                },
+            )
+        )
+        rows = cast(list[dict[str, Any]], result.data) or []
+        if not rows:
+            return await self.qbp_get(question_id)
+        r = rows[0]
+        return QuestionBudgetPool(
+            question_id=question_id,
+            contributed=r["contributed"],
+            consumed=r["consumed"],
+            active_calls=r["active_calls"],
+        )
+
+    async def qbp_consume(self, question_id: str, amount: int = 1) -> tuple[int, bool]:
+        """Atomically debit the pool. Returns (remaining, exhausted).
+
+        When no pool row exists, returns a sentinel large positive remaining
+        and ``exhausted=False`` — the run-level budget is the authoritative
+        gate; pool consumption never refuses.
+        """
+        result = await self._execute(
+            self.client.rpc(
+                "qbp_consume",
+                {"rid": self.run_id, "qid": question_id, "amount": amount},
+            )
+        )
+        rows = cast(list[dict[str, Any]], result.data) or []
+        if not rows:
+            return 2147483647, False
+        r = rows[0]
+        return int(r["remaining"]), bool(r["exhausted"])
+
+    async def qbp_unregister(self, question_id: str) -> None:
+        """Decrement active_calls (floored at 0). Leaves contributed/consumed."""
+        await self._execute(
+            self.client.rpc(
+                "qbp_unregister",
+                {"rid": self.run_id, "qid": question_id},
+            )
+        )
+
+    async def qbp_recurse(
+        self,
+        parent_question_id: str,
+        child_question_id: str,
+        amount: int,
+    ) -> None:
+        """Charge the parent pool by ``amount`` and register the child contribution.
+
+        Atomic: peer cycles never see momentarily-doubled budget.
+        """
+        await self._execute(
+            self.client.rpc(
+                "qbp_recurse",
+                {
+                    "rid": self.run_id,
+                    "parent_qid": parent_question_id,
+                    "child_qid": child_question_id,
+                    "amount": amount,
+                },
+            )
+        )
+
+    async def get_active_calls_for_question(
+        self,
+        question_id: str,
+        *,
+        exclude_call_id: str | None = None,
+    ) -> list[Call]:
+        """Return pending/running calls of any type targeting a question.
+
+        Scoped to the current ``run_id``. The optional ``exclude_call_id``
+        filters out the caller's own call so a prio context can omit itself.
+        """
+        query = (
+            self.client.table("calls")
+            .select("*")
+            .eq("scope_page_id", question_id)
+            .eq("run_id", self.run_id)
+            .in_("status", [CallStatus.PENDING.value, CallStatus.RUNNING.value])
+            .order("created_at")
+        )
+        rows = _rows(await self._execute(query))
+        calls = [_row_to_call(r) for r in rows]
+        if exclude_call_id is not None:
+            calls = [c for c in calls if c.id != exclude_call_id]
+        return calls
+
+    async def get_active_prio_pools_for_subquestions(
+        self, parent_question_id: str
+    ) -> list[tuple[str, QuestionBudgetPool]]:
+        """For each direct CHILD_QUESTION of ``parent_question_id``, return
+        (child_id, pool) pairs where the child has at least one active prio cycle.
+        """
+        children = await self.get_child_questions(parent_question_id)
+        if not children:
+            return []
+        pools = await self.qbp_get_many([c.id for c in children])
+        return [
+            (c.id, pools[c.id]) for c in children if c.id in pools and pools[c.id].active_calls > 0
+        ]
+
     async def get_links_between(
         self,
         from_page_id: str,
@@ -2768,6 +2951,9 @@ class DB:
         for table in ["calls", "pages"]:
             await self._execute(self.client.table(table).delete().eq("run_id", self.run_id))
         await self._execute(self.client.table("budget").delete().eq("run_id", self.run_id))
+        await self._execute(
+            self.client.table("question_budget_pool").delete().eq("run_id", self.run_id)
+        )
         await self._execute(self.client.table("runs").delete().eq("id", self.run_id))
         if delete_project and self.project_id:
             await self._execute(self.client.table("projects").delete().eq("id", self.project_id))

--- a/src/rumil/orchestrators/base.py
+++ b/src/rumil/orchestrators/base.py
@@ -41,6 +41,10 @@ class BaseOrchestrator(ABC):
         self.broadcaster: Broadcaster | None = broadcaster
         self._owns_broadcaster: bool = False
         self.ingest_hint: str = ""
+        # Set by prio orchestrators to their root question ID. Sub-call
+        # budget consumption debits this question's pool. None for
+        # orchestrators outside a per-question prio cycle.
+        self.pool_question_id: str | None = None
 
     async def _pacing_params(self) -> tuple[int, int]:
         """Return (total, used) for budget pacing.
@@ -115,6 +119,7 @@ class BaseOrchestrator(ABC):
             broadcaster=self.broadcaster,
             max_rounds=max_rounds,
             fruit_threshold=fruit_threshold,
+            pool_question_id=self.pool_question_id,
         )
         await instance.run()
         return call.id
@@ -214,6 +219,7 @@ class BaseOrchestrator(ABC):
                     force=True,
                     sequence_id=seq_id,
                     sequence_position=seq_pos if is_multi_step else None,
+                    pool_question_id=self.pool_question_id,
                 )
                 seq_pos += 1
         return executed

--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -131,10 +131,14 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             )
             self._sequence_id = seq.id
             self._seq_position = 0
+        self.pool_question_id = claim_id
+        contribution = self._budget_cap if self._budget_cap is not None else effective
+        await self.db.qbp_register(claim_id, contribution)
         try:
             while True:
                 remaining = await self.db.budget_remaining()
-                effective = self._effective_budget(remaining)
+                pool = await self.db.qbp_get(claim_id)
+                effective = min(self._effective_budget(remaining), pool.remaining)
                 if effective <= 0:
                     break
 
@@ -208,8 +212,11 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                 if last_call:
                     break
         finally:
-            await self._teardown()
-            await own_db.close()
+            try:
+                await self.db.qbp_unregister(claim_id)
+            finally:
+                await self._teardown()
+                await own_db.close()
 
     async def _run_dispatch_sequence(
         self,
@@ -314,6 +321,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=claim_id,
+            current_call_id=self._initial_call.id if self._initial_call else None,
         )
         if self._initial_call is not None:
             p_call = self._initial_call
@@ -533,9 +541,16 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             fruit_lines.append("")
             scores_text += "\n".join(fruit_lines)
 
+        # Take the authoritative pool snapshot here — between this point and
+        # the LLM dispatching, peer cycles can only consume more from the pool.
+        # Using a fresh snapshot ensures the budget line and the Coordination
+        # context section agree on what's available.
+        fresh_pool = await self.db.qbp_get(claim_id)
+        budget = min(budget, max(fresh_pool.remaining, 0))
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=claim_id,
+            current_call_id=p_call.id,
         )
         budget_line = f"You have a budget of **{budget} budget units** to allocate."
         if last_call:
@@ -594,6 +609,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
+                await self.db.qbp_consume(claim_id, d.payload.budget)
                 child = ClaimInvestigationOrchestrator(
                     self.db,
                     self.broadcaster,
@@ -615,6 +631,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
+                await self.db.qbp_consume(claim_id, d.payload.budget)
                 child = TwoPhaseOrchestrator(
                     self.db,
                     self.broadcaster,

--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -68,6 +68,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         db: DB,
         broadcaster: Broadcaster | None = None,
         budget_cap: int | None = None,
+        pool_pre_registered: bool = False,
     ):
         super().__init__(db, broadcaster)
         self._invocation: int = 0
@@ -80,6 +81,10 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         self._parent_call_id: str | None = None
         self._sequence_id: str | None = None
         self._seq_position: int = 0
+        # See TwoPhaseOrchestrator for why this exists. When True, the
+        # parent already registered our contribution via qbp_recurse, so
+        # run() must not double-register.
+        self._pool_pre_registered: bool = pool_pre_registered
 
     def _effective_budget(self, global_remaining: int) -> int:
         if self._budget_cap is not None:
@@ -132,8 +137,9 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             self._sequence_id = seq.id
             self._seq_position = 0
         self.pool_question_id = claim_id
-        contribution = self._budget_cap if self._budget_cap is not None else effective
-        await self.db.qbp_register(claim_id, contribution)
+        if not self._pool_pre_registered:
+            contribution = self._budget_cap if self._budget_cap is not None else effective
+            await self.db.qbp_register(claim_id, contribution)
         try:
             while True:
                 remaining = await self.db.budget_remaining()
@@ -205,6 +211,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                         force=True,
                         sequence_id=self._sequence_id,
                         sequence_position=self._seq_position,
+                        pool_question_id=self.pool_question_id,
                     )
                     if self._sequence_id is not None:
                         self._seq_position += 1
@@ -547,6 +554,15 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         # context section agree on what's available.
         fresh_pool = await self.db.qbp_get(claim_id)
         budget = min(budget, max(fresh_pool.remaining, 0))
+        # If the pool drained between top-of-loop and now (i.e. peer cycles
+        # consumed our slice), bail before calling the LLM with budget 0.
+        if budget <= 0:
+            await mark_call_completed(
+                p_call,
+                self.db,
+                "Pool drained by peer cycles before this round could plan.",
+            )
+            return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=claim_id,
@@ -609,11 +625,12 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
-                await self.db.qbp_consume(claim_id, d.payload.budget)
+                await self.db.qbp_recurse(claim_id, resolved, d.payload.budget)
                 child = ClaimInvestigationOrchestrator(
                     self.db,
                     self.broadcaster,
                     budget_cap=d.payload.budget,
+                    pool_pre_registered=True,
                 )
                 child._parent_call_id = p_call.id
                 children.append((child, resolved))
@@ -631,11 +648,12 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
-                await self.db.qbp_consume(claim_id, d.payload.budget)
+                await self.db.qbp_recurse(claim_id, resolved, d.payload.budget)
                 child = TwoPhaseOrchestrator(
                     self.db,
                     self.broadcaster,
                     budget_cap=d.payload.budget,
+                    pool_pre_registered=True,
                 )
                 child._parent_call_id = p_call.id
                 children.append((child, resolved))

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -380,34 +380,11 @@ async def create_root_question(
     return page.id
 
 
-async def _consume_budget(
-    db: DB,
-    force: bool = False,
-    *,
-    pool_question_id: str | None = None,
-) -> bool:
-    """Consume one unit of global budget. Returns False if exhausted.
-
-    When *force* is True the call always succeeds: if normal consumption
-    fails, budget is temporarily expanded so the dispatch can proceed.
-    This is used to guarantee that every dispatch in a committed batch
-    runs, even if it means slightly exceeding the original budget.
-
-    When *pool_question_id* is set, also debit the per-question budget pool
-    for that question. The pool debit never refuses; the run-level budget
-    is the authoritative gate.
-    """
-    ok = await db.consume_budget(1)
-    if not ok:
-        if force:
-            await db.add_budget(1)
-            ok = await db.consume_budget(1)
-        if not ok:
-            remaining = await db.budget_remaining()
-            log.info("Budget exhausted (remaining: %d)", remaining)
-    if ok and pool_question_id is not None:
-        await db.qbp_consume(pool_question_id, 1)
-    return ok
+# _consume_budget lives in rumil.budget so that rumil.calls.page_creators
+# can import it without forming a cycle (page_creators is reached *via*
+# this module's own imports of FindConsiderationsCall etc.). Re-exported
+# here for callers that already imported from this location.
+from rumil.budget import _consume_budget  # noqa: E402
 
 
 async def find_considerations_until_done(

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -380,13 +380,22 @@ async def create_root_question(
     return page.id
 
 
-async def _consume_budget(db: DB, force: bool = False) -> bool:
+async def _consume_budget(
+    db: DB,
+    force: bool = False,
+    *,
+    pool_question_id: str | None = None,
+) -> bool:
     """Consume one unit of global budget. Returns False if exhausted.
 
     When *force* is True the call always succeeds: if normal consumption
     fails, budget is temporarily expanded so the dispatch can proceed.
     This is used to guarantee that every dispatch in a committed batch
     runs, even if it means slightly exceeding the original budget.
+
+    When *pool_question_id* is set, also debit the per-question budget pool
+    for that question. The pool debit never refuses; the run-level budget
+    is the authoritative gate.
     """
     ok = await db.consume_budget(1)
     if not ok:
@@ -396,6 +405,8 @@ async def _consume_budget(db: DB, force: bool = False) -> bool:
         if not ok:
             remaining = await db.budget_remaining()
             log.info("Budget exhausted (remaining: %d)", remaining)
+    if ok and pool_question_id is not None:
+        await db.qbp_consume(pool_question_id, 1)
     return ok
 
 
@@ -411,6 +422,7 @@ async def find_considerations_until_done(
     call_id: str | None = None,
     sequence_id: str | None = None,
     sequence_position: int | None = None,
+    pool_question_id: str | None = None,
 ) -> tuple[int, list[str]]:
     """Run a cache-aware find-considerations session.
 
@@ -452,6 +464,7 @@ async def find_considerations_until_done(
         fruit_threshold=fruit_threshold,
         context_page_ids=context_page_ids,
         broadcaster=broadcaster,
+        pool_question_id=pool_question_id,
     )
     await scout.run()
 
@@ -471,6 +484,7 @@ async def ingest_until_done(
     fruit_threshold: int = DEFAULT_INGEST_FRUIT_THRESHOLD,
     parent_call_id: str | None = None,
     broadcaster=None,
+    pool_question_id: str | None = None,
 ) -> int:
     """
     Run Ingest rounds on a source/question pair until remaining_fruit falls below
@@ -492,7 +506,7 @@ async def ingest_until_done(
     )
     rounds = 0
     for i in range(max_rounds):
-        if not await _consume_budget(db):
+        if not await _consume_budget(db, pool_question_id=pool_question_id):
             break
 
         call = await db.create_call(
@@ -537,6 +551,7 @@ async def assess_question(
     sequence_id: str | None = None,
     sequence_position: int | None = None,
     summarise: bool = True,
+    pool_question_id: str | None = None,
 ) -> str | None:
     """Run one Assess call on a question. Returns call ID, or None if no budget.
 
@@ -547,7 +562,7 @@ async def assess_question(
     step is skipped and the assess call sits at ``sequence_position``.
     """
     log.info("assess_question: question=%s", question_id[:8])
-    if not await _consume_budget(db, force=force):
+    if not await _consume_budget(db, force=force, pool_question_id=pool_question_id):
         return None
 
     if summarise:
@@ -587,10 +602,11 @@ async def web_research_question(
     call_id: str | None = None,
     sequence_id: str | None = None,
     sequence_position: int | None = None,
+    pool_question_id: str | None = None,
 ) -> str | None:
     """Run one web research call on a question. Returns call ID, or None if no budget."""
     log.info("web_research_question: question=%s", question_id[:8])
-    if not await _consume_budget(db, force=force):
+    if not await _consume_budget(db, force=force, pool_question_id=pool_question_id):
         return None
 
     call = await db.create_call(

--- a/src/rumil/orchestrators/dispatch_handlers.py
+++ b/src/rumil/orchestrators/dispatch_handlers.py
@@ -86,6 +86,10 @@ class DispatchContext:
     sequence_position: int | None
     d_label: str
 
+    @property
+    def pool_question_id(self) -> str | None:
+        return self.orchestrator.pool_question_id
+
 
 DispatchHandler = Callable[[DispatchContext, BaseDispatchPayload], Awaitable[str | None]]
 
@@ -113,6 +117,7 @@ async def _handle_find_considerations(
         call_id=ctx.call_id,
         sequence_id=ctx.sequence_id,
         sequence_position=ctx.sequence_position,
+        pool_question_id=ctx.pool_question_id,
     )
     return child_ids[0] if child_ids else None
 
@@ -143,6 +148,7 @@ async def _handle_assess(ctx: DispatchContext, payload: BaseDispatchPayload) -> 
             call_id=ctx.call_id,
             sequence_id=ctx.sequence_id,
             sequence_position=ctx.sequence_position,
+            pool_question_id=ctx.pool_question_id,
         )
     log.info("Dispatch: assess on %s — %s", ctx.d_label, payload.reason)
     return await assess_question(
@@ -156,6 +162,7 @@ async def _handle_assess(ctx: DispatchContext, payload: BaseDispatchPayload) -> 
         sequence_id=ctx.sequence_id,
         sequence_position=ctx.sequence_position,
         summarise=ctx.orchestrator.summarise_before_assess,
+        pool_question_id=ctx.pool_question_id,
     )
 
 
@@ -189,6 +196,7 @@ async def _handle_web_research(ctx: DispatchContext, payload: BaseDispatchPayloa
         call_id=ctx.call_id,
         sequence_id=ctx.sequence_id,
         sequence_position=ctx.sequence_position,
+        pool_question_id=ctx.pool_question_id,
     )
 
 

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -142,10 +142,14 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             self._sequence_id = seq.id
             self._seq_position = 0
         budget_token = set_experimental_scout_budget(effective)
+        self.pool_question_id = root_question_id
+        contribution = self._budget_cap if self._budget_cap is not None else effective
+        await self.db.qbp_register(root_question_id, contribution)
         try:
             while True:
                 remaining = await self.db.budget_remaining()
-                effective = self._effective_budget(remaining)
+                pool = await self.db.qbp_get(root_question_id)
+                effective = min(self._effective_budget(remaining), pool.remaining)
                 if effective <= 0:
                     break
                 set_experimental_scout_budget(effective)
@@ -212,9 +216,12 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                     if self._sequence_id is not None:
                         self._seq_position += 1
         finally:
-            reset_experimental_scout_budget(budget_token)
-            await self._teardown()
-            await own_db.close()
+            try:
+                await self.db.qbp_unregister(root_question_id)
+            finally:
+                reset_experimental_scout_budget(budget_token)
+                await self._teardown()
+                await own_db.close()
 
     async def _run_dispatch_sequence(
         self,
@@ -411,6 +418,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=question_id,
+            current_call_id=p_call.id,
         )
         trace = CallTrace(p_call.id, self.db, broadcaster=self.broadcaster)
         set_trace(trace)
@@ -595,9 +603,16 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             fruit_lines.append("")
             scores_text += "\n".join(fruit_lines)
 
+        # Take the authoritative pool snapshot here — between this point and
+        # the LLM dispatching, peer cycles can only consume more from the pool.
+        # Using a fresh snapshot ensures the budget line and the Coordination
+        # context section agree on what's available.
+        fresh_pool = await self.db.qbp_get(question_id)
+        budget = min(budget, max(fresh_pool.remaining, 0))
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=question_id,
+            current_call_id=p_call.id,
         )
         dispatch_budget = budget - 1
         budget_line = f"You have a budget of **{dispatch_budget} budget units** to allocate."
@@ -662,6 +677,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
+                await self.db.qbp_consume(question_id, d.payload.budget)
                 child = ExperimentalOrchestrator(
                     self.db,
                     self.broadcaster,

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -73,6 +73,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         db: DB,
         broadcaster: Broadcaster | None = None,
         budget_cap: int | None = None,
+        pool_pre_registered: bool = False,
     ):
         super().__init__(db, broadcaster)
         self._invocation: int = 0
@@ -86,6 +87,8 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         self._sequence_id: str | None = None
         self._seq_position: int = 0
         self._last_linker_eval_at: datetime | None = None
+        # See TwoPhaseOrchestrator for why this exists.
+        self._pool_pre_registered: bool = pool_pre_registered
 
     def _effective_budget(self, global_remaining: int) -> int:
         if self._budget_cap is not None:
@@ -143,8 +146,9 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             self._seq_position = 0
         budget_token = set_experimental_scout_budget(effective)
         self.pool_question_id = root_question_id
-        contribution = self._budget_cap if self._budget_cap is not None else effective
-        await self.db.qbp_register(root_question_id, contribution)
+        if not self._pool_pre_registered:
+            contribution = self._budget_cap if self._budget_cap is not None else effective
+            await self.db.qbp_register(root_question_id, contribution)
         try:
             while True:
                 remaining = await self.db.budget_remaining()
@@ -212,6 +216,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                         force=True,
                         sequence_id=self._sequence_id,
                         sequence_position=self._seq_position,
+                        pool_question_id=self.pool_question_id,
                     )
                     if self._sequence_id is not None:
                         self._seq_position += 1
@@ -609,6 +614,15 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         # context section agree on what's available.
         fresh_pool = await self.db.qbp_get(question_id)
         budget = min(budget, max(fresh_pool.remaining, 0))
+        # If the pool drained between top-of-loop and now (i.e. peer cycles
+        # consumed our slice), bail before calling the LLM with budget 0/-1.
+        if budget <= 1:
+            await mark_call_completed(
+                p_call,
+                self.db,
+                "Pool drained by peer cycles before this round could plan.",
+            )
+            return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=question_id,
@@ -677,11 +691,12 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
-                await self.db.qbp_consume(question_id, d.payload.budget)
+                await self.db.qbp_recurse(question_id, resolved, d.payload.budget)
                 child = ExperimentalOrchestrator(
                     self.db,
                     self.broadcaster,
                     budget_cap=d.payload.budget,
+                    pool_pre_registered=True,
                 )
                 child._parent_call_id = p_call.id
                 children.append((child, resolved))

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -70,6 +70,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         db: DB,
         broadcaster: Broadcaster | None = None,
         budget_cap: int | None = None,
+        pool_pre_registered: bool = False,
     ):
         super().__init__(db, broadcaster)
         self._invocation: int = 0
@@ -82,6 +83,12 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         self._parent_call_id: str | None = None
         self._sequence_id: str | None = None
         self._seq_position: int = 0
+        # When True, this orchestrator's contribution to the question pool
+        # was already registered atomically by the parent's qbp_recurse call,
+        # so run() must NOT register again (it would double-count). The
+        # finally block still calls qbp_unregister to balance active_calls
+        # (which qbp_recurse incremented via its register half).
+        self._pool_pre_registered: bool = pool_pre_registered
 
     def _effective_budget(self, global_remaining: int) -> int:
         if self._budget_cap is not None:
@@ -138,8 +145,9 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             self._sequence_id = seq.id
             self._seq_position = 0
         self.pool_question_id = root_question_id
-        contribution = self._budget_cap if self._budget_cap is not None else effective
-        await self.db.qbp_register(root_question_id, contribution)
+        if not self._pool_pre_registered:
+            contribution = self._budget_cap if self._budget_cap is not None else effective
+            await self.db.qbp_register(root_question_id, contribution)
         try:
             while True:
                 remaining = await self.db.budget_remaining()
@@ -211,6 +219,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                         force=True,
                         sequence_id=self._sequence_id,
                         sequence_position=self._seq_position,
+                        pool_question_id=self.pool_question_id,
                     )
                     if self._sequence_id is not None:
                         self._seq_position += 1
@@ -592,6 +601,16 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         # context section agree on what's available.
         fresh_pool = await self.db.qbp_get(question_id)
         budget = min(budget, max(fresh_pool.remaining, 0))
+        # If the pool drained between top-of-loop and now (i.e. peer cycles
+        # consumed our slice), bail before calling the LLM with budget 0/-1.
+        # The outer loop will break on the empty result.
+        if budget <= 0:
+            await mark_call_completed(
+                p_call,
+                self.db,
+                "Pool drained by peer cycles before this round could plan.",
+            )
+            return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=question_id,
@@ -675,11 +694,12 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
-                await self.db.qbp_consume(question_id, d.payload.budget)
+                await self.db.qbp_recurse(question_id, resolved, d.payload.budget)
                 child_claim = ClaimInvestigationOrchestrator(
                     self.db,
                     self.broadcaster,
                     budget_cap=d.payload.budget,
+                    pool_pre_registered=True,
                 )
                 child_claim._parent_call_id = p_call.id
                 children.append((child_claim, resolved))
@@ -697,11 +717,12 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
-                await self.db.qbp_consume(question_id, d.payload.budget)
+                await self.db.qbp_recurse(question_id, resolved, d.payload.budget)
                 child = TwoPhaseOrchestrator(
                     self.db,
                     self.broadcaster,
                     budget_cap=d.payload.budget,
+                    pool_pre_registered=True,
                 )
                 child._parent_call_id = p_call.id
                 children.append((child, resolved))

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -137,10 +137,14 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             )
             self._sequence_id = seq.id
             self._seq_position = 0
+        self.pool_question_id = root_question_id
+        contribution = self._budget_cap if self._budget_cap is not None else effective
+        await self.db.qbp_register(root_question_id, contribution)
         try:
             while True:
                 remaining = await self.db.budget_remaining()
-                effective = self._effective_budget(remaining)
+                pool = await self.db.qbp_get(root_question_id)
+                effective = min(self._effective_budget(remaining), pool.remaining)
                 if effective <= 0:
                     break
 
@@ -214,8 +218,11 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 if last_call:
                     break
         finally:
-            await self._teardown()
-            await own_db.close()
+            try:
+                await self.db.qbp_unregister(root_question_id)
+            finally:
+                await self._teardown()
+                await own_db.close()
 
     async def _run_dispatch_sequence(
         self,
@@ -320,6 +327,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=question_id,
+            current_call_id=self._initial_call.id if self._initial_call else None,
         )
         if self._initial_call is not None:
             p_call = self._initial_call
@@ -578,9 +586,16 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             fruit_lines.append("")
             scores_text += "\n".join(fruit_lines)
 
+        # Take the authoritative pool snapshot here — between this point and
+        # the LLM dispatching, peer cycles can only consume more from the pool.
+        # Using a fresh snapshot ensures the budget line and the Coordination
+        # context section agree on what's available.
+        fresh_pool = await self.db.qbp_get(question_id)
+        budget = min(budget, max(fresh_pool.remaining, 0))
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=question_id,
+            current_call_id=p_call.id,
         )
         dispatch_budget = budget if last_call else budget - 1
         budget_line = f"You have a budget of **{dispatch_budget} budget units** to allocate."
@@ -660,6 +675,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
+                await self.db.qbp_consume(question_id, d.payload.budget)
                 child_claim = ClaimInvestigationOrchestrator(
                     self.db,
                     self.broadcaster,
@@ -681,6 +697,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                         d.payload.question_id[:8],
                     )
                     continue
+                await self.db.qbp_consume(question_id, d.payload.budget)
                 child = TwoPhaseOrchestrator(
                     self.db,
                     self.broadcaster,

--- a/src/rumil/views/base.py
+++ b/src/rumil/views/base.py
@@ -34,6 +34,7 @@ class View(ABC):
         call_id: str | None = None,
         sequence_id: str | None = None,
         sequence_position: int | None = None,
+        pool_question_id: str | None = None,
     ) -> str | None:
         """Create-if-missing or update. Single entry point for all refresh sites.
 

--- a/src/rumil/views/judgement.py
+++ b/src/rumil/views/judgement.py
@@ -38,6 +38,7 @@ class JudgementView(View):
         call_id: str | None = None,
         sequence_id: str | None = None,
         sequence_position: int | None = None,
+        pool_question_id: str | None = None,
     ) -> str | None:
         return await assess_question(
             question_id,
@@ -50,6 +51,7 @@ class JudgementView(View):
             sequence_id=sequence_id,
             sequence_position=sequence_position,
             summarise=False,
+            pool_question_id=pool_question_id,
         )
 
     async def render_for_prioritization(self, question_id: str, db: DB) -> str | None:

--- a/src/rumil/views/sectioned.py
+++ b/src/rumil/views/sectioned.py
@@ -38,6 +38,7 @@ class SectionedView(View):
         call_id: str | None = None,
         sequence_id: str | None = None,
         sequence_position: int | None = None,
+        pool_question_id: str | None = None,
     ) -> str | None:
         if await self.exists(question_id, db):
             return await update_view_for_question(
@@ -50,6 +51,7 @@ class SectionedView(View):
                 call_id=call_id,
                 sequence_id=sequence_id,
                 sequence_position=sequence_position,
+                pool_question_id=pool_question_id,
             )
         return await create_view_for_question(
             question_id,
@@ -61,6 +63,7 @@ class SectionedView(View):
             call_id=call_id,
             sequence_id=sequence_id,
             sequence_position=sequence_position,
+            pool_question_id=pool_question_id,
         )
 
     async def render_for_prioritization(self, question_id: str, db: DB) -> str | None:
@@ -137,10 +140,11 @@ async def create_view_for_question(
     call_id: str | None = None,
     sequence_id: str | None = None,
     sequence_position: int | None = None,
+    pool_question_id: str | None = None,
 ) -> str | None:
     """Run a CreateView call. Returns call ID, or None if no budget."""
     log.info("create_view_for_question: question=%s", question_id[:8])
-    if not await _consume_budget(db, force=force):
+    if not await _consume_budget(db, force=force, pool_question_id=pool_question_id):
         return None
 
     call = await db.create_call(
@@ -168,10 +172,11 @@ async def update_view_for_question(
     call_id: str | None = None,
     sequence_id: str | None = None,
     sequence_position: int | None = None,
+    pool_question_id: str | None = None,
 ) -> str | None:
     """Run an UpdateView call. Returns call ID, or None if no budget."""
     log.info("update_view_for_question: question=%s", question_id[:8])
-    if not await _consume_budget(db, force=force):
+    if not await _consume_budget(db, force=force, pool_question_id=pool_question_id):
         return None
 
     call = await db.create_call(

--- a/src/rumil/views/sectioned.py
+++ b/src/rumil/views/sectioned.py
@@ -8,12 +8,12 @@ import logging
 from collections.abc import Sequence
 from datetime import datetime
 
+from rumil.budget import _consume_budget
 from rumil.calls.create_view import CreateViewCall
 from rumil.calls.update_view import UpdateViewCall
 from rumil.context import format_page, render_view
 from rumil.database import DB
 from rumil.models import CallType, PageDetail
-from rumil.orchestrators.common import _consume_budget
 from rumil.tracing.broadcast import Broadcaster
 from rumil.views.base import View
 

--- a/supabase/migrations/20260422110136_question_budget_pool.sql
+++ b/supabase/migrations/20260422110136_question_budget_pool.sql
@@ -1,0 +1,87 @@
+-- Per-question shared budget pool for prioritisation cycles.
+-- Multiple TwoPhase / ClaimInvestigation orchestrators working on the same
+-- question contribute their assigned budget to a shared pool and draw from
+-- it together. The run-level `budget` table remains the authoritative
+-- ceiling; this table is a coordination layer on top.
+
+CREATE TABLE question_budget_pool (
+    run_id        TEXT NOT NULL,
+    question_id   TEXT NOT NULL,
+    contributed   INTEGER NOT NULL DEFAULT 0,
+    consumed      INTEGER NOT NULL DEFAULT 0,
+    active_calls  INTEGER NOT NULL DEFAULT 0,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (run_id, question_id)
+);
+
+ALTER TABLE question_budget_pool ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX idx_qbp_run_id ON question_budget_pool(run_id);
+
+CREATE OR REPLACE FUNCTION qbp_register(rid TEXT, qid TEXT, contribution INTEGER)
+RETURNS TABLE(contributed INTEGER, consumed INTEGER, active_calls INTEGER)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO question_budget_pool (run_id, question_id, contributed, active_calls)
+    VALUES (rid, qid, contribution, 1)
+    ON CONFLICT (run_id, question_id) DO UPDATE
+        SET contributed  = question_budget_pool.contributed + EXCLUDED.contributed,
+            active_calls = question_budget_pool.active_calls + 1,
+            updated_at   = now();
+    RETURN QUERY
+        SELECT p.contributed, p.consumed, p.active_calls
+        FROM question_budget_pool p
+        WHERE p.run_id = rid AND p.question_id = qid;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION qbp_consume(rid TEXT, qid TEXT, amount INTEGER)
+RETURNS TABLE(remaining INTEGER, exhausted BOOLEAN)
+LANGUAGE plpgsql AS $$
+DECLARE
+    cur_c INTEGER;
+    cur_u INTEGER;
+BEGIN
+    SELECT p.contributed, p.consumed INTO cur_c, cur_u
+    FROM question_budget_pool p
+    WHERE p.run_id = rid AND p.question_id = qid
+    FOR UPDATE;
+    IF cur_c IS NULL THEN
+        -- No pool registered. Return sentinel "never exhausted" so callers
+        -- (e.g. legacy / rumil-mediated dispatch lane) don't accidentally
+        -- early-exit. The run-level budget remains the authoritative gate.
+        RETURN QUERY SELECT 2147483647::INTEGER, FALSE;
+        RETURN;
+    END IF;
+    UPDATE question_budget_pool
+        SET consumed = consumed + amount, updated_at = now()
+        WHERE run_id = rid AND question_id = qid;
+    RETURN QUERY
+        SELECT (cur_c - (cur_u + amount))::INTEGER,
+               ((cur_u + amount) >= cur_c);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION qbp_unregister(rid TEXT, qid TEXT)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE question_budget_pool
+        SET active_calls = GREATEST(active_calls - 1, 0),
+            updated_at = now()
+        WHERE run_id = rid AND question_id = qid;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION qbp_recurse(rid TEXT, parent_qid TEXT, child_qid TEXT, amount INTEGER)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    -- Charge the parent pool: the recurse budget is committed against the
+    -- parent cycle. Then register the child contribution. Atomic so peer
+    -- cycles never observe momentarily-doubled budget.
+    PERFORM qbp_consume(rid, parent_qid, amount);
+    PERFORM qbp_register(rid, child_qid, amount);
+END;
+$$;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,7 @@ class PrioHarness:
         **kwargs,
     ) -> str | None:
         force = kwargs.get("force", False)
+        pool_question_id = kwargs.get("pool_question_id")
         ok = await self.db.consume_budget(1)
         if not ok:
             if force:
@@ -253,6 +254,8 @@ class PrioHarness:
                 ok = await self.db.consume_budget(1)
             if not ok:
                 return None
+        if pool_question_id is not None:
+            await self.db.qbp_consume(pool_question_id, 1)
         call = await self.db.create_call(
             call_type,
             scope_page_id=question_id,

--- a/tests/test_question_budget_pool.py
+++ b/tests/test_question_budget_pool.py
@@ -1,0 +1,374 @@
+"""Tests for the per-question shared budget pool.
+
+Covers the DB-level RPC behaviour (register/consume/unregister/recurse),
+the in-flight call queries used by build_prioritization_context, the
+context section rendered for prio prompts, and orchestrator-level
+behaviour (registration, loop stop, recurse handoff).
+"""
+
+import asyncio
+
+import pytest
+
+from rumil.calls.common import RunCallResult
+from rumil.constants import MIN_TWOPHASE_BUDGET
+from rumil.context import build_prioritization_context
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    Dispatch,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    RecurseDispatchPayload,
+    ScoutDispatchPayload,
+    Workspace,
+)
+from rumil.orchestrators.two_phase import TwoPhaseOrchestrator
+
+
+def _scout_dispatch(question_id: str, reason: str = "seed") -> Dispatch:
+    return Dispatch(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        payload=ScoutDispatchPayload(
+            question_id=question_id,
+            max_rounds=1,
+            reason=reason,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_increments_contributed_and_active_calls(tmp_db, question_page):
+    """Two register calls sum contributions and increment active_calls."""
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.contributed == 0
+    assert pool.active_calls == 0
+
+    await tmp_db.qbp_register(question_page.id, 10)
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.contributed == 10
+    assert pool.active_calls == 1
+
+    await tmp_db.qbp_register(question_page.id, 7)
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.contributed == 17
+    assert pool.active_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_consume_drains_pool(tmp_db, question_page):
+    """Consume reports remaining and exhaustion accurately."""
+    await tmp_db.qbp_register(question_page.id, 10)
+
+    remaining, exhausted = await tmp_db.qbp_consume(question_page.id, 7)
+    assert remaining == 3
+    assert exhausted is False
+
+    remaining, exhausted = await tmp_db.qbp_consume(question_page.id, 3)
+    assert remaining == 0
+    assert exhausted is True
+
+    remaining, exhausted = await tmp_db.qbp_consume(question_page.id, 1)
+    assert remaining == -1
+    assert exhausted is True
+
+
+@pytest.mark.asyncio
+async def test_unregister_decrements_active_calls_only(tmp_db, question_page):
+    """Unregister reduces active_calls but leaves contributed/consumed intact."""
+    await tmp_db.qbp_register(question_page.id, 5)
+    await tmp_db.qbp_consume(question_page.id, 2)
+
+    await tmp_db.qbp_unregister(question_page.id)
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.contributed == 5
+    assert pool.consumed == 2
+    assert pool.active_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_unregister_floors_at_zero(tmp_db, question_page):
+    """Extra unregisters don't push active_calls negative."""
+    await tmp_db.qbp_register(question_page.id, 3)
+    await tmp_db.qbp_unregister(question_page.id)
+    await tmp_db.qbp_unregister(question_page.id)
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.active_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_consume_unknown_pool_returns_sentinel(tmp_db, question_page):
+    """Consuming a non-existent pool reports 'never exhausted' and doesn't error."""
+    remaining, exhausted = await tmp_db.qbp_consume(question_page.id, 5)
+    assert exhausted is False
+    assert remaining > 0
+
+
+@pytest.mark.asyncio
+async def test_qbp_get_many_returns_only_existing(tmp_db, question_page, child_question_page):
+    """Batched get returns one entry per existing pool, missing IDs absent."""
+    await tmp_db.qbp_register(question_page.id, 5)
+    pools = await tmp_db.qbp_get_many([question_page.id, child_question_page.id])
+    assert question_page.id in pools
+    assert child_question_page.id not in pools
+    assert pools[question_page.id].contributed == 5
+
+
+@pytest.mark.asyncio
+async def test_recurse_charges_parent_and_registers_child(
+    tmp_db, question_page, child_question_page
+):
+    """qbp_recurse atomically debits parent and registers child."""
+    await tmp_db.qbp_register(question_page.id, 20)
+
+    await tmp_db.qbp_recurse(question_page.id, child_question_page.id, 5)
+
+    parent_pool = await tmp_db.qbp_get(question_page.id)
+    child_pool = await tmp_db.qbp_get(child_question_page.id)
+    assert parent_pool.consumed == 5
+    assert child_pool.contributed == 5
+    assert child_pool.active_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_active_calls_returns_pending_and_running_excludes_self(tmp_db, question_page):
+    """Active call query returns pending+running, filters by exclude_call_id."""
+    pending_call = Call(
+        call_type=CallType.PRIORITIZATION,
+        workspace=Workspace.PRIORITIZATION,
+        scope_page_id=question_page.id,
+        status=CallStatus.PENDING,
+        budget_allocated=12,
+    )
+    running_call = Call(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.RUNNING,
+        budget_allocated=4,
+    )
+    completed_call = Call(
+        call_type=CallType.ASSESS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.COMPLETE,
+    )
+    self_call = Call(
+        call_type=CallType.PRIORITIZATION,
+        workspace=Workspace.PRIORITIZATION,
+        scope_page_id=question_page.id,
+        status=CallStatus.RUNNING,
+    )
+    for c in (pending_call, running_call, completed_call, self_call):
+        await tmp_db.save_call(c)
+
+    active = await tmp_db.get_active_calls_for_question(
+        question_page.id,
+        exclude_call_id=self_call.id,
+    )
+    active_ids = {c.id for c in active}
+    assert pending_call.id in active_ids
+    assert running_call.id in active_ids
+    assert completed_call.id not in active_ids
+    assert self_call.id not in active_ids
+
+
+@pytest.mark.asyncio
+async def test_get_active_prio_pools_for_subquestions(tmp_db, question_page, child_question_page):
+    """Returns only subquestions whose pool has active_calls > 0."""
+    other_child = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Other child",
+        headline="Other child",
+    )
+    await tmp_db.save_page(other_child)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=question_page.id,
+            to_page_id=other_child.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+
+    await tmp_db.qbp_register(child_question_page.id, 8)
+    # other_child has no pool registered
+
+    pools = await tmp_db.get_active_prio_pools_for_subquestions(question_page.id)
+    pool_ids = {sub_id for sub_id, _ in pools}
+    assert child_question_page.id in pool_ids
+    assert other_child.id not in pool_ids
+    sub_pool = next(p for sub_id, p in pools if sub_id == child_question_page.id)
+    assert sub_pool.contributed == 8
+
+
+@pytest.mark.asyncio
+async def test_concurrent_consume_no_overcount(tmp_db, question_page):
+    """50 concurrent consumes drain the pool exactly (FOR UPDATE regression)."""
+    await tmp_db.qbp_register(question_page.id, 100)
+
+    await asyncio.gather(*(tmp_db.qbp_consume(question_page.id, 1) for _ in range(50)))
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.consumed == 50
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_registers_on_run_start_and_unregisters_after(
+    tmp_db, question_page, prio_harness
+):
+    """TwoPhaseOrchestrator registers contribution at run start, unregisters in finally."""
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    parent = TwoPhaseOrchestrator(tmp_db, budget_cap=15)
+    await parent.run(question_page.id)
+
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.contributed == 15
+    assert pool.active_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_context_renders_coordination_section_when_active_work_present(
+    tmp_db, question_page, child_question_page
+):
+    """Coordination section appears when in-flight calls or sub-pools exist."""
+    await tmp_db.qbp_register(question_page.id, 20)
+    await tmp_db.qbp_consume(question_page.id, 3)
+
+    in_flight = Call(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.RUNNING,
+        budget_allocated=4,
+    )
+    await tmp_db.save_call(in_flight)
+
+    await tmp_db.qbp_register(child_question_page.id, 6)
+
+    context_text, _ = await build_prioritization_context(
+        tmp_db,
+        scope_question_id=question_page.id,
+    )
+    assert "Coordination" in context_text
+    assert in_flight.id[:8] in context_text
+    assert child_question_page.id[:8] in context_text
+    assert "6 budget remaining" in context_text
+    # Pool stats line is intentionally not duplicated in the Coordination
+    # section; the orchestrator's budget line is the authoritative number.
+    assert "Shared question pool" not in context_text
+    assert "20 contributed" not in context_text
+
+
+@pytest.mark.asyncio
+async def test_context_omits_coordination_when_nothing_in_flight(tmp_db, question_page):
+    """No active peer calls and no sub-pools → no Coordination section."""
+    context_text, _ = await build_prioritization_context(
+        tmp_db,
+        scope_question_id=question_page.id,
+    )
+    assert "Coordination" not in context_text
+
+
+@pytest.mark.asyncio
+async def test_context_excludes_current_call_from_in_flight_list(tmp_db, question_page):
+    """current_call_id filters self out so the prio doesn't see its own call as a peer."""
+    own_call = Call(
+        call_type=CallType.PRIORITIZATION,
+        workspace=Workspace.PRIORITIZATION,
+        scope_page_id=question_page.id,
+        status=CallStatus.RUNNING,
+        budget_allocated=10,
+    )
+    peer_call = Call(
+        call_type=CallType.PRIORITIZATION,
+        workspace=Workspace.PRIORITIZATION,
+        scope_page_id=question_page.id,
+        status=CallStatus.RUNNING,
+        budget_allocated=4,
+    )
+    for c in (own_call, peer_call):
+        await tmp_db.save_call(c)
+
+    context_text, _ = await build_prioritization_context(
+        tmp_db,
+        scope_question_id=question_page.id,
+        current_call_id=own_call.id,
+    )
+    assert peer_call.id[:8] in context_text
+    assert own_call.id[:8] not in context_text
+
+
+@pytest.mark.asyncio
+async def test_recurse_dispatch_charges_parent_pool_and_registers_child(
+    tmp_db, question_page, child_question_page, prio_harness
+):
+    """A RecurseDispatchPayload debits the parent pool by the recurse budget."""
+    await tmp_db.init_budget(40)
+    recurse = Dispatch(
+        call_type=CallType.PRIORITIZATION,
+        payload=RecurseDispatchPayload(
+            question_id=child_question_page.id,
+            budget=MIN_TWOPHASE_BUDGET,
+            reason="drill into subquestion",
+        ),
+    )
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[recurse]),
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[]),
+        RunCallResult(dispatches=[]),
+    ]
+
+    parent = TwoPhaseOrchestrator(tmp_db, budget_cap=20)
+    await parent.run(question_page.id)
+
+    parent_pool = await tmp_db.qbp_get(question_page.id)
+    # The seed scout consumes 1; the recurse charges MIN_TWOPHASE_BUDGET more.
+    # The child orchestrator also runs and consumes from the *child* pool.
+    assert parent_pool.consumed >= 1 + MIN_TWOPHASE_BUDGET
+    child_pool = await tmp_db.qbp_get(child_question_page.id)
+    # Child orchestrator registered itself with budget=MIN_TWOPHASE_BUDGET when
+    # its run() began.
+    assert child_pool.contributed >= MIN_TWOPHASE_BUDGET
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_when_pool_exhausted_even_if_local_budget_remains(
+    tmp_db, question_page, prio_harness
+):
+    """A peer that drains the pool causes our orchestrator to exit early."""
+    await tmp_db.init_budget(50)
+
+    # Pre-register a peer contribution that's already entirely consumed —
+    # simulating "another cycle ran first and used up the shared pool".
+    await tmp_db.qbp_register(question_page.id, 10)
+    await tmp_db.qbp_consume(question_page.id, 10)
+
+    # Endless dispatch script — we expect to exit before consuming much of
+    # our own budget_cap.
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, f"r{i}")]) for i in range(20)
+    ]
+
+    parent = TwoPhaseOrchestrator(tmp_db, budget_cap=20)
+    await parent.run(question_page.id)
+
+    # The orchestrator should have exited because pool.remaining hit 0,
+    # not because budget_cap (20) was exhausted. Allow for a small bounded
+    # number of consumes from rounds that fired before the loop check tripped.
+    assert parent._consumed < 20
+
+    # Pool active_calls returned to 0 after our orchestrator unregistered
+    # itself (we never unregistered the simulated peer).
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.active_calls == 1


### PR DESCRIPTION
## Summary

- Adds a per-question shared budget pool keyed on `(run_id, question_id)`. When multiple TwoPhase / ClaimInvestigation orchestrators target the same question, they contribute their assigned budget to the pool and draw from it together — stopping when it's exhausted, regardless of which cycle did the spending. The run-level `budget` table remains the authoritative ceiling.
- New atomic RPCs (`qbp_register/consume/unregister/recurse`) and `DB.qbp_*` methods. Recurse dispatches charge the parent pool by the recurse budget; the child orchestrator registers its contribution to the child's pool when it starts.
- Prio prompts gain a Coordination section listing peer calls in flight (with their assigned budgets) and active prio cycles on subquestions (with each subquestion's remaining pool budget). Prompts now explain the "recurse with minimum budget" pattern for waiting on a running subquestion cycle without doing extra work.
- The orchestrator's budget line is taken from a fresh pool snapshot just before context is built, so the budget the LLM sees and the Coordination peer info come from the same view of the pool.

## Test plan

- [x] `uv run pytest tests/test_question_budget_pool.py` — 16 new tests pass (RPC behaviour, in-flight queries, context rendering, orchestrator register/unregister/loop-stop, concurrent consume safety)
- [x] Full non-LLM suite — 493 passed, 2 xfailed, no regressions
- [x] `uv run pyright` — 0 errors
- [x] Smoke test against local Supabase — `uv run python main.py "What jobs will AI automate first?" --workspace pool-scratch2 --smoke-test --budget 8` ran clean; pool table populated with expected register → consume → unregister sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)