### PR TITLE
Read worktree-local .env.local in addition to .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ activemq-data/
 
 # Environments
 .env
+.env.local
 .envrc
 .venv
 env/

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -32,7 +32,15 @@ def _capture_field(**kwargs: Any) -> Any:
 
 
 class Settings(BaseSettings):
-    model_config = {"env_file": ".env", "extra": "ignore", "validate_assignment": True}
+    # ".env" is the shared (often symlinked) project env; ".env.local" is a
+    # worktree-local override file written by the workmux post_create hook
+    # (see /Users/chaos-guppy/differential/.workmux.yaml). Later files in the
+    # tuple override earlier ones, so .env.local wins.
+    model_config = {
+        "env_file": (".env", ".env.local"),
+        "extra": "ignore",
+        "validate_assignment": True,
+    }
 
     anthropic_api_key: str = ""
     rumil_test_mode: str = ""


### PR DESCRIPTION
## Summary

The workmux pane that runs the `main` window uses `tmux set-environment` to publish per-worktree `SUPABASE_LOCAL_URL` and `FRONTEND_URL`. That only takes effect in panes/processes spawned *after* it runs — other panes that started concurrently, fresh subshells, and any subprocess that doesn't inherit the tmux session env all fall back to rumil's default (`http://127.0.0.1:54321`), which doesn't exist on a non-default-offset worktree.

This change makes rumil's `Settings` read `.env.local` after `.env`, so a worktree-local override file is the source of truth. The companion change (uncommitted in this repo, lives in the user's `~/differential/.workmux.yaml`) is a `post_create` hook that writes `.env.local` on worktree creation with the offset-derived URLs:

```yaml
post_create:
  - |
    cd "$WM_WORKTREE_PATH"
    OFFSET=$(./scripts/workmux-offset.sh)
    SUPA_OFFSET=$((OFFSET + 1))
    cat > .env.local <<EOF
    SUPABASE_LOCAL_URL=http://127.0.0.1:\$((54321 + SUPA_OFFSET * 100))
    FRONTEND_URL=http://127.0.0.1:\$((3000 + OFFSET))
    EOF
```

Existing worktrees (including this one) need a one-time `.env.local` written manually — the same `cd … && OFFSET=… && cat > .env.local <<EOF …` block does the job.

`.env.local` is added to `.gitignore` alongside `.env`.

## Test plan

- [x] With my pane's `SUPABASE_LOCAL_URL` env var explicitly stripped (`env -u SUPABASE_LOCAL_URL …`), `Settings()` resolves to the worktree's port (`http://127.0.0.1:55121`) and `DB.create()` connects successfully.
- [x] `uv run pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)