### PR TITLE
Propagate staged_run_id through all page links

### DIFF
--- a/frontend/src/app/pages/[pageId]/links-container.tsx
+++ b/frontend/src/app/pages/[pageId]/links-container.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import type { LinkedPageOut, PageLink } from "@/api";
+import { withStagedRun } from "@/lib/staged-run-href";
 
 const TYPE_CONFIG: Record<
   string,
@@ -80,9 +81,7 @@ function LinkMeta({ link }: { link: PageLink }) {
 function LinkedCard({ lp, stagedRunId }: { lp: LinkedPageOut; stagedRunId?: string }) {
   const cfg = TYPE_CONFIG[lp.page.page_type] || TYPE_CONFIG.source;
   const isSuperseded = lp.page.is_superseded;
-  const href = stagedRunId
-    ? `/pages/${lp.page.id}?staged_run_id=${stagedRunId}`
-    : `/pages/${lp.page.id}`;
+  const href = withStagedRun(`/pages/${lp.page.id}`, stagedRunId);
   return (
     <Link
       href={href}

--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -10,6 +10,7 @@ import { API_BASE } from "@/lib/api-base";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { fetchProjectName } from "@/lib/fetch-project-name";
 import { truncateHeadline } from "@/lib/page-titles";
+import { withStagedRun } from "@/lib/staged-run-href";
 
 const TYPE_CONFIG: Record<
   string,
@@ -65,16 +66,12 @@ const TYPE_CONFIG: Record<
   },
 };
 
-function stagedQs(stagedRunId?: string): string {
-  return stagedRunId ? `?staged_run_id=${stagedRunId}` : "";
-}
-
 async function getPageDetail(
   pageId: string,
   stagedRunId?: string,
 ): Promise<PageDetailOut | null> {
   const res = await fetch(
-    `${API_BASE}/api/pages/${pageId}/detail${stagedQs(stagedRunId)}`,
+    withStagedRun(`${API_BASE}/api/pages/${pageId}/detail`, stagedRunId),
     { cache: "no-store" },
   );
   if (!res.ok) return null;
@@ -86,7 +83,7 @@ async function getPageHeadline(
   stagedRunId?: string,
 ): Promise<{ headline: string; page_type: string } | null> {
   const res = await fetch(
-    `${API_BASE}/api/pages/${pageId}/detail${stagedQs(stagedRunId)}`,
+    withStagedRun(`${API_BASE}/api/pages/${pageId}/detail`, stagedRunId),
     { cache: "no-store" },
   );
   if (!res.ok) return null;
@@ -95,8 +92,7 @@ async function getPageHeadline(
 }
 
 function pageHref(page: Page, stagedRunId?: string): string {
-  if (stagedRunId) return `/pages/${page.id}?staged_run_id=${stagedRunId}`;
-  return `/pages/${page.id}`;
+  return withStagedRun(`/pages/${page.id}`, stagedRunId);
 }
 
 const ALL_CITATIONS_RE = /\[([a-f0-9]{8}(?:,\s*[a-f0-9]{8})*)\]/g;
@@ -125,11 +121,10 @@ async function buildCitationMap(
   const cited = extractCitedIds(content);
   const missing = [...cited].filter((id) => !map.has(id));
   if (missing.length > 0) {
-    const qs = stagedQs(stagedRunId);
     const results = await Promise.all(
       missing.map(async (shortId) => {
         const res = await fetch(
-          `${API_BASE}/api/pages/short/${shortId}${qs}`,
+          withStagedRun(`${API_BASE}/api/pages/short/${shortId}`, stagedRunId),
           { cache: "no-store" },
         );
         if (!res.ok) return null;
@@ -174,7 +169,7 @@ async function getPageRun(
   stagedRunId?: string,
 ): Promise<RunSummaryOut | null> {
   const res = await fetch(
-    `${API_BASE}/api/pages/${pageId}/run${stagedQs(stagedRunId)}`,
+    withStagedRun(`${API_BASE}/api/pages/${pageId}/run`, stagedRunId),
     { cache: "no-store" },
   );
   if (!res.ok) return null;
@@ -232,7 +227,7 @@ function ViewItemsSection({
                 return (
                   <Link
                     key={lp.page.id}
-                    href={`/pages/${lp.page.id}${stagedRunId ? `?staged_run_id=${stagedRunId}` : ""}`}
+                    href={withStagedRun(`/pages/${lp.page.id}`, stagedRunId)}
                     className={`view-item-card${imp != null && imp >= 5 ? " view-item-important" : ""}`}
                   >
                     <div
@@ -462,7 +457,7 @@ export default async function PageDetailPage({
             <span className="page-id">{page.id.slice(0, 8)}</span>
             {page.is_superseded && page.superseded_by && supersedingPage ? (
               <Link
-                href={`/pages/${page.superseded_by}${stagedRunId ? `?staged_run_id=${stagedRunId}` : ""}`}
+                href={withStagedRun(`/pages/${page.superseded_by}`, stagedRunId)}
                 className="superseded-link"
                 title={supersedingPage.headline}
               >
@@ -477,7 +472,7 @@ export default async function PageDetailPage({
             ) : null}
             {page.page_type === "question" && (
               <Link
-                href={`/pages/${pageId}/stats${stagedRunId ? `?staged_run_id=${stagedRunId}` : ""}`}
+                href={withStagedRun(`/pages/${pageId}/stats`, stagedRunId)}
                 className="page-stats-link"
               >
                 Stats

--- a/frontend/src/app/pages/[pageId]/stats/page.tsx
+++ b/frontend/src/app/pages/[pageId]/stats/page.tsx
@@ -12,10 +12,7 @@ import { StatsView } from "@/components/stats-view";
 import { SubgraphView } from "@/components/subgraph-view";
 import { useDocumentTitle } from "@/lib/use-document-title";
 import { truncateHeadline } from "@/lib/page-titles";
-
-function stagedQs(stagedRunId: string | null): string {
-  return stagedRunId ? `?staged_run_id=${stagedRunId}` : "";
-}
+import { withStagedRun } from "@/lib/staged-run-href";
 
 type LoadState =
   | { kind: "loading" }
@@ -34,7 +31,6 @@ export default function QuestionStatsPage() {
   const pageId = params.pageId;
   const searchParams = useSearchParams();
   const stagedRunId = searchParams.get("staged_run_id");
-  const stagedQ = stagedQs(stagedRunId);
 
   const [projectName, setProjectName] = useState<string>();
   const [projectId, setProjectId] = useState<string>();
@@ -52,7 +48,7 @@ export default function QuestionStatsPage() {
     async function load() {
       try {
         const detailRes = await fetch(
-          `${API_BASE}/api/pages/${pageId}/detail${stagedQ}`,
+          withStagedRun(`${API_BASE}/api/pages/${pageId}/detail`, stagedRunId),
           { cache: "no-store" },
         );
         if (detailRes.status === 404) {
@@ -74,7 +70,7 @@ export default function QuestionStatsPage() {
         }
 
         const statsRes = await fetch(
-          `${API_BASE}/api/pages/${pageId}/stats${stagedQ}`,
+          withStagedRun(`${API_BASE}/api/pages/${pageId}/stats`, stagedRunId),
           { cache: "no-store" },
         );
         if (!statsRes.ok) throw new Error(`stats ${statsRes.status}`);
@@ -96,7 +92,7 @@ export default function QuestionStatsPage() {
     return () => {
       cancelled = true;
     };
-  }, [pageId, stagedQ]);
+  }, [pageId, stagedRunId]);
 
   useEffect(() => {
     if (!projectId) return;
@@ -244,9 +240,9 @@ export default function QuestionStatsPage() {
           <div className="subtitle">question neighborhood · 2 hops</div>
         </div>
         <div className="stats-nav">
-          <Link href={`/pages/${pageId}${stagedQ}`}>Page</Link>
+          <Link href={withStagedRun(`/pages/${pageId}`, stagedRunId)}>Page</Link>
           {projectId && (
-            <Link href={`/projects/${projectId}/stats${stagedQ}`}>
+            <Link href={withStagedRun(`/projects/${projectId}/stats`, stagedRunId)}>
               Project stats
             </Link>
           )}

--- a/frontend/src/app/projects/[projectId]/page.tsx
+++ b/frontend/src/app/projects/[projectId]/page.tsx
@@ -7,6 +7,7 @@ import type { Page, PageType, PaginatedPagesOut, Project, RunListItemOut } from 
 
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
 import { useStagedRun } from "@/lib/staged-run-context";
+import { withStagedRun } from "@/lib/staged-run-href";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { useDocumentTitle } from "@/lib/use-document-title";
 
@@ -68,8 +69,7 @@ const TYPE_CONFIG: Record<
 };
 
 function pageHref(page: Page, stagedRunId?: string | null): string {
-  if (stagedRunId) return `/pages/${page.id}?staged_run_id=${stagedRunId}`;
-  return `/pages/${page.id}`;
+  return withStagedRun(`/pages/${page.id}`, stagedRunId);
 }
 
 function epistemicLabel(page: Page) {

--- a/frontend/src/app/projects/[projectId]/stats/page.tsx
+++ b/frontend/src/app/projects/[projectId]/stats/page.tsx
@@ -10,17 +10,13 @@ import StagedBanner from "@/components/staged-banner";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { StatsView } from "@/components/stats-view";
 import { useDocumentTitle } from "@/lib/use-document-title";
-
-function stagedQs(stagedRunId: string | null): string {
-  return stagedRunId ? `?staged_run_id=${stagedRunId}` : "";
-}
+import { withStagedRun } from "@/lib/staged-run-href";
 
 export default function ProjectStatsPage() {
   const params = useParams<{ projectId: string }>();
   const projectId = params.projectId;
   const searchParams = useSearchParams();
   const stagedRunId = searchParams.get("staged_run_id");
-  const stagedQ = stagedQs(stagedRunId);
 
   const [projectName, setProjectName] = useState<string>();
   const [data, setData] = useState<ProjectStatsOut | null>(null);
@@ -40,7 +36,7 @@ export default function ProjectStatsPage() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    fetch(`${API_BASE}/api/projects/${projectId}/stats${stagedQ}`, {
+    fetch(withStagedRun(`${API_BASE}/api/projects/${projectId}/stats`, stagedRunId), {
       cache: "no-store",
     })
       .then(async (res) => {
@@ -55,7 +51,7 @@ export default function ProjectStatsPage() {
         setError(String(e));
         setLoading(false);
       });
-  }, [projectId, stagedQ]);
+  }, [projectId, stagedRunId]);
 
   return (
     <main className="stats-page">
@@ -137,7 +133,7 @@ export default function ProjectStatsPage() {
           <div className="subtitle">project overview</div>
         </div>
         <div className="stats-nav">
-          <Link href={`/projects/${projectId}${stagedQ}`}>Pages</Link>
+          <Link href={withStagedRun(`/projects/${projectId}`, stagedRunId)}>Pages</Link>
         </div>
       </div>
 

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -14,6 +14,7 @@ import type {
 } from "@/api/types.gen";
 import { CLIENT_API_BASE as QUERY_API_BASE } from "@/api-config";
 import { useStagedRun } from "@/lib/staged-run-context";
+import { withStagedRun } from "@/lib/staged-run-href";
 import { traceKeys } from "@/lib/queries";
 import type { SequenceNode } from "./trace-viewer";
 
@@ -152,9 +153,7 @@ function PageChip({ page }: { page: PageRef }) {
   const short = page.id.slice(0, 8);
   const label = page.headline || short;
   const { activeStagedRunId } = useStagedRun();
-  const href = activeStagedRunId
-    ? `/pages/${page.id}?staged_run_id=${activeStagedRunId}`
-    : `/pages/${page.id}`;
+  const href = withStagedRun(`/pages/${page.id}`, activeStagedRunId);
   return (
     <Link href={href} className="trace-page-chip" title={short}>
       {label}
@@ -1239,12 +1238,9 @@ const EventSection = memo(function EventSection({ event }: { event: TraceEvent }
         <div className="trace-event-body">
           <div className="trace-kv">
             <span className="trace-kv-key">view</span>
-            <Link
-              href={`/pages/${event.view_id}`}
-              className="trace-page-chip"
-            >
-              {event.view_headline || event.view_id.slice(0, 8)}
-            </Link>
+            <span className="trace-kv-value">
+              <PageChip page={{ id: event.view_id, headline: event.view_headline }} />
+            </span>
           </div>
         </div>
       )}

--- a/frontend/src/app/traces/[runId]/page.tsx
+++ b/frontend/src/app/traces/[runId]/page.tsx
@@ -9,6 +9,7 @@ import { API_BASE, serverFetch } from "@/lib/api-base";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { fetchProjectName } from "@/lib/fetch-project-name";
 import { truncateHeadline } from "@/lib/page-titles";
+import { withStagedRun } from "@/lib/staged-run-href";
 
 async function getRunTraceTree(runId: string): Promise<RunTraceTreeOut | null> {
   const res = await serverFetch(`${API_BASE}/api/runs/${runId}/trace-tree`, {
@@ -85,7 +86,10 @@ export default async function TracePage({
       <header className="trace-header">
         {trace.question && (
           <Link
-            href={`/pages/${trace.question.id}`}
+            href={withStagedRun(
+              `/pages/${trace.question.id}`,
+              trace.staged ? runId : null,
+            )}
             className="trace-back-link"
           >
             &larr; {trace.question.headline}

--- a/frontend/src/components/question-focus.tsx
+++ b/frontend/src/components/question-focus.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { CallsForQuestion, Subgraph } from "@/api";
+import { useStagedRun } from "@/lib/staged-run-context";
+import { withStagedRun } from "@/lib/staged-run-href";
 
 export type FocusColorMap = Record<string, string>;
 
@@ -318,6 +320,7 @@ export function SubquestionFocusGrid({
     () => subquestionIdsFromSubgraph(subgraph, anchorId),
     [subgraph, anchorId],
   );
+  const { activeStagedRunId } = useStagedRun();
   const [limit, setLimit] = useState(6);
 
   if (subquestionIds.length === 0) {
@@ -441,7 +444,7 @@ export function SubquestionFocusGrid({
                   ) : null}
                 </div>
                 <div className="subq-headline">
-                  <Link href={`/pages/${qid}/stats`}>{headline}</Link>
+                  <Link href={withStagedRun(`/pages/${qid}/stats`, activeStagedRunId)}>{headline}</Link>
                 </div>
               </div>
               {entry ? (

--- a/frontend/src/components/subgraph-view.tsx
+++ b/frontend/src/components/subgraph-view.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import type { Subgraph, SubgraphNode } from "@/api";
+import { useStagedRun } from "@/lib/staged-run-context";
+import { withStagedRun } from "@/lib/staged-run-href";
 
 // Page types that have dedicated CSS color vars in globals.css. Unknown types
 // fall back to neutral muted colors so the canvas still renders cleanly.
@@ -43,6 +45,7 @@ export function SubgraphView({
   anchorId: string;
 }) {
   const router = useRouter();
+  const { activeStagedRunId } = useStagedRun();
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
   const { laidOut, positions, maxDepth } = useMemo(() => {
@@ -286,7 +289,7 @@ export function SubgraphView({
                   key={n.id}
                   transform={`translate(${n.x}, ${n.y})`}
                   onMouseEnter={() => setHoveredId(n.id)}
-                  onClick={() => router.push(`/pages/${n.id}`)}
+                  onClick={() => router.push(withStagedRun(`/pages/${n.id}`, activeStagedRunId))}
                   style={{
                     cursor: "pointer",
                     opacity: dim ? 0.18 : 1,

--- a/frontend/src/lib/staged-run-href.ts
+++ b/frontend/src/lib/staged-run-href.ts
@@ -1,0 +1,6 @@
+export function withStagedRun(
+  path: string,
+  stagedRunId: string | null | undefined,
+): string {
+  return stagedRunId ? `${path}?staged_run_id=${stagedRunId}` : path;
+}


### PR DESCRIPTION
## Summary
- Fix 404 when clicking a view-page link from a staged run's trace: the `view_created` event used a raw `<Link>` instead of `PageChip`, which drops the active staged-run context.
- Sweep the rest of the frontend for the same pattern (trace back-link, subgraph node clicks, subquestion stats links, two in-file `pageHref`/`stagedQs` duplicates) and consolidate onto one shared `withStagedRun()` helper.
- Helper lives in a server-safe module (`@/lib/staged-run-href`, no `"use client"`) so server components can import it too.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Click view-page link in `view_created` event of a staged-run trace → loads staged view page
- [ ] Back-link (←) at top of staged-run trace page → propagates `staged_run_id`
- [ ] Subgraph node click on staged page → propagates
- [ ] Subquestion stats link on staged page → propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)