### PR TITLE
Fix cross-phase prompt cache misses in multi-batch calls

### DIFF
--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -286,7 +286,16 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
 
         messages: list[dict] = [
             {"role": "user", "content": context.context_text},
-            {"role": "assistant", "content": "Understood. Ready to review View items."},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Understood. Ready to review View items.",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
         ]
 
         created_page_ids: list[str] = []
@@ -378,7 +387,6 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                 metadata=LLMExchangeMetadata(
                     call_id=infra.call.id,
                     phase=f"score_unscored_batch_{batch_idx}",
-                    user_messages=[{"role": "user", "content": user_content}],
                 ),
                 db=infra.db,
             )
@@ -468,7 +476,6 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                 metadata=LLMExchangeMetadata(
                     call_id=infra.call.id,
                     phase=f"triage_batch_{batch_idx}",
-                    user_messages=[{"role": "user", "content": user_content}],
                 ),
                 db=infra.db,
             )
@@ -563,7 +570,6 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                 metadata=LLMExchangeMetadata(
                     call_id=infra.call.id,
                     phase=f"deep_review_batch_{batch_idx}",
-                    user_messages=[{"role": "user", "content": user_content}],
                 ),
                 db=infra.db,
             )
@@ -670,7 +676,6 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                 metadata=LLMExchangeMetadata(
                     call_id=infra.call.id,
                     phase=f"enforce_caps_i{level}",
-                    user_messages=[{"role": "user", "content": user_content}],
                 ),
                 db=infra.db,
             )
@@ -755,7 +760,6 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             metadata=LLMExchangeMetadata(
                 call_id=infra.call.id,
                 phase="prune",
-                user_messages=[{"role": "user", "content": user_content}],
             ),
             db=infra.db,
         )

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -356,13 +356,17 @@ class LLMExchangeMetadata:
 
     Encapsulates the parameters needed by save_llm_exchange that are not
     already present in the call_api / structured_call signatures.
+
+    `user_message` is only used for single-turn calls (text_call). For
+    multi-turn calls the full message stack is serialized automatically
+    from the `messages` arg and persisted to `user_messages` on the
+    exchange row.
     """
 
     call_id: str
     phase: str
     round_num: int | None = None
     user_message: str | None = None
-    user_messages: list[dict] | None = None
 
 
 async def _save_exchange(
@@ -377,6 +381,7 @@ async def _save_exchange(
     duration_ms: int,
     cache_creation_input_tokens: int = 0,
     cache_read_input_tokens: int = 0,
+    user_messages: Sequence[dict] | None = None,
 ) -> None:
     """Persist an LLM exchange and record a trace event."""
     exchange_id = await db.save_llm_exchange(
@@ -392,7 +397,7 @@ async def _save_exchange(
         round_num=metadata.round_num,
         cache_creation_input_tokens=cache_creation_input_tokens or None,
         cache_read_input_tokens=cache_read_input_tokens or None,
-        user_messages=metadata.user_messages,
+        user_messages=user_messages,
     )
     cost_usd = compute_cost(
         model=model,
@@ -509,8 +514,7 @@ async def call_api(
                         "content": block.model_dump(mode="json")["content"],
                     }
                 )
-        if metadata.user_messages is None and len(messages) > 1:
-            metadata.user_messages = _serialize_messages(messages)
+        serialized = _serialize_messages(messages) if len(messages) > 1 else None
         try:
             await _save_exchange(
                 metadata,
@@ -527,6 +531,7 @@ async def call_api(
                 )
                 or 0,
                 cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
+                user_messages=serialized,
             )
         except Exception as exc:
             log.error(
@@ -779,12 +784,13 @@ async def _structured_call_parse(
         if isinstance(block, TextBlock):
             response_text += block.text
     if metadata and db:
-        if metadata.user_message is None and metadata.user_messages is None:
+        serialized: Sequence[dict] | None = None
+        if metadata.user_message is None:
             if len(msg_list) == 1:
                 content = msg_list[0].get("content", "")
                 metadata.user_message = content if isinstance(content, str) else None
             if len(msg_list) > 1 or metadata.user_message is None:
-                metadata.user_messages = _serialize_messages(msg_list)
+                serialized = _serialize_messages(msg_list)
         await _save_exchange(
             metadata,
             db=db,
@@ -798,6 +804,7 @@ async def _structured_call_parse(
             cache_creation_input_tokens=getattr(response.usage, "cache_creation_input_tokens", 0)
             or 0,
             cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
+            user_messages=serialized,
         )
     if response.parsed_output is not None:
         log.debug(

--- a/src/rumil/orchestrators/common.py
+++ b/src/rumil/orchestrators/common.py
@@ -286,7 +286,19 @@ async def score_items_sequentially(
 
     parent_context = "\n".join(parent_parts)
     system_prompt = build_system_prompt(system_prompt_name, include_citations=False)
-    messages: list[dict] = []
+    messages: list[dict] = [
+        {"role": "user", "content": parent_context},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Understood. Ready to score batches.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+    ]
     results: list[dict] = []
 
     batch_sizes = _split_into_batches(len(items), SCORING_BATCH_SIZE)
@@ -314,9 +326,7 @@ async def score_items_sequentially(
             + "\n\nScore all items in this batch now."
         )
 
-        user_content = parent_context + "\n" + batch_text if batch_idx == 0 else batch_text
-
-        messages.append({"role": "user", "content": user_content})
+        messages.append({"role": "user", "content": batch_text})
 
         result = await structured_call(
             system_prompt,
@@ -326,7 +336,6 @@ async def score_items_sequentially(
             metadata=LLMExchangeMetadata(
                 call_id=call_id,
                 phase=f"score_batch_{batch_idx}",
-                user_messages=[{"role": "user", "content": user_content}],
             ),
             db=db,
         )


### PR DESCRIPTION
## Summary

- `update_view` and `score_items_sequentially` run multiple `structured_call(..., cache=True)` rounds against a growing `messages` list but the schema-injection path (`_inject_into_last_user_message`) only mutated a copy — so each round's sent prefix diverged from prior cached entries and every phase paid full cache-create cost with `cache_read=0`.
- Pre-seed a `[user_context, assistant_ack(cache_control: ephemeral)]` pair at the start of both call sites so the stable context prefix becomes a separately-cached entry that subsequent phases hit on.
- Drop the `user_messages` field from `LLMExchangeMetadata` (and the six call sites that passed it). The field overrode the full-history fallback serialisation in `call_api`, so trace rows only stored the per-phase delta — you couldn't audit what the model actually saw. Now `call_api` / `_structured_call_parse` always serialise the real `messages` list.

## Verification

Verified live on a 13-item `update_view` call in a scratch workspace:

| phase | cache_create | cache_read | n_msgs (trace) |
|---|---|---|---|
| triage_batch_0 | 7757 | 0 | 3 |
| deep_review_batch_0 | 4436 | **6401** | 5 |
| enforce_caps_i5 | 7022 | **6401** | 7 |

Before the fix: `cache_read=0` on every phase and `n_msgs=1` on every row.

## Test plan

- [x] `uv run pyright` clean
- [x] `uv run pytest tests/` — 477 passed, 43 skipped, 2 xfailed
- [x] Live smoke run on `view-abc-scratch` workspace shows expected cache_read values and full message-stack capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)