### PR TITLE
Fix update_view closing-review false-negative self-assessments

### DIFF
--- a/src/rumil/calls/closing_reviewers.py
+++ b/src/rumil/calls/closing_reviewers.py
@@ -38,13 +38,22 @@ class StandardClosingReview(ClosingReviewer):
     def __init__(self, call_type: CallType) -> None:
         self._call_type = call_type
 
+    def _review_context(self, creation: UpdateResult) -> str:
+        """Return the main_output string shown to the review LLM.
+
+        Default: render the call's moves. Subclasses override when the
+        call's real work is carried outside of moves (e.g. update_view,
+        whose phases mutate the View page directly).
+        """
+        return format_moves_for_review(creation.moves)
+
     async def closing_review(
         self,
         infra: CallInfra,
         context: ContextResult,
         creation: UpdateResult,
     ) -> None:
-        review_context = format_moves_for_review(creation.moves)
+        review_context = self._review_context(creation)
         review = await run_closing_review(
             infra.call,
             review_context,
@@ -84,6 +93,12 @@ class ViewClosingReview(StandardClosingReview):
     def __init__(self, call_type: CallType, view_id: str) -> None:
         super().__init__(call_type)
         self._view_id = view_id
+
+    def _review_context(self, creation: UpdateResult) -> str:
+        summary = (creation.phase_summary or "").strip()
+        if summary:
+            return "Per-phase summary of work done:\n" + summary
+        return format_moves_for_review(creation.moves)
 
     async def closing_review(
         self,

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -729,7 +729,12 @@ async def run_closing_review(
 def format_moves_for_review(moves: Sequence[Move]) -> str:
     """Format moves as readable text for closing review context."""
     if not moves:
-        return "(no moves)"
+        return (
+            "This call recorded no structural moves. If the call type does "
+            "its work outside of moves (e.g. update_view's per-phase edits), "
+            "that work is not visible here — do not interpret this as a "
+            "failed or empty call on its own."
+        )
     parts = []
     for m in moves:
         headline = getattr(m.payload, "headline", "")

--- a/src/rumil/calls/stages.py
+++ b/src/rumil/calls/stages.py
@@ -56,6 +56,7 @@ class UpdateResult:
     messages: list[dict] = field(default_factory=list)
     last_fruit_score: int | None = None
     rounds_completed: int = 0
+    phase_summary: str = ""
 
 
 class ContextBuilder(ABC):

--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -442,8 +442,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             )
         )
         self._phase_lines.append(
-            f"score_unscored: scored {len(unscored)} item(s), "
-            f"modified {modified_count}"
+            f"score_unscored: scored {len(unscored)} item(s), modified {modified_count}"
         )
         return messages
 
@@ -525,8 +524,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             )
         )
         self._phase_lines.append(
-            f"triage: reviewed {len(scored)} item(s), "
-            f"flagged {len(flagged_ids)} for deep review"
+            f"triage: reviewed {len(scored)} item(s), flagged {len(flagged_ids)} for deep review"
         )
         return messages, flagged_ids
 
@@ -771,9 +769,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
         candidates = _prune_candidates(items)
 
         if not candidates:
-            await infra.trace.record(
-                PhaseSkippedEvent(phase="prune", reason="No prune candidates")
-            )
+            await infra.trace.record(PhaseSkippedEvent(phase="prune", reason="No prune candidates"))
             self._phase_lines.append("prune: skipped (no prune candidates)")
             return messages
 

--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -137,6 +137,22 @@ class PruneDecision(BaseModel):
     reasoning: str = ""
 
 
+def _is_explicit_duplicate(page: Page) -> bool:
+    """True if the item's content is explicitly marked as a duplicate."""
+    return "[Duplicate of" in (page.content or "")
+
+
+def _prune_candidates(
+    items: Sequence[tuple[Page, PageLink]],
+) -> list[tuple[Page, PageLink]]:
+    """Items eligible for the prune phase: low-importance plus explicit duplicates."""
+    return [
+        (p, l)
+        for p, l in items
+        if l.importance is not None and (l.importance <= 2 or _is_explicit_duplicate(p))
+    ]
+
+
 def _parse_prompt_sections(text: str) -> dict[str, str]:
     """Split prompt text on <!-- PHASE:xxx --> markers into {name: content}."""
     parts = PHASE_MARKER_RE.split(text)
@@ -275,6 +291,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
     def __init__(self, view_id: str, call_type: CallType) -> None:
         self._view_id = view_id
         self._call_type = call_type
+        self._phase_lines: list[str] = []
 
     async def update_workspace(
         self,
@@ -319,6 +336,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             moves=[],
             all_loaded_ids=[],
             messages=messages,
+            phase_summary="\n".join(self._phase_lines),
         )
 
     async def _phase_score_unscored(
@@ -335,6 +353,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             await infra.trace.record(
                 PhaseSkippedEvent(phase="score_unscored", reason="No unscored items")
             )
+            self._phase_lines.append("score_unscored: skipped (no unscored items)")
             return messages
 
         link_by_target = {page.id: link for page, link in items}
@@ -422,6 +441,10 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                 items_modified=modified_count,
             )
         )
+        self._phase_lines.append(
+            f"score_unscored: scored {len(unscored)} item(s), "
+            f"modified {modified_count}"
+        )
         return messages
 
     async def _phase_triage(
@@ -436,6 +459,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
 
         if not scored:
             await infra.trace.record(PhaseSkippedEvent(phase="triage", reason="No scored items"))
+            self._phase_lines.append("triage: skipped (no scored items)")
             return messages, []
 
         batch_sizes = _split_into_batches(len(scored), TRIAGE_BATCH_SIZE)
@@ -500,6 +524,10 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                 items_modified=len(flagged_ids),
             )
         )
+        self._phase_lines.append(
+            f"triage: reviewed {len(scored)} item(s), "
+            f"flagged {len(flagged_ids)} for deep review"
+        )
         return messages, flagged_ids
 
     async def _phase_deep_review(
@@ -518,6 +546,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             await infra.trace.record(
                 PhaseSkippedEvent(phase="deep_review", reason="No flagged items found")
             )
+            self._phase_lines.append("deep_review: skipped (no flagged items)")
             return messages, []
 
         link_by_target = {page.id: link for page, link in items}
@@ -535,7 +564,8 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
 
         batch_sizes = _split_into_batches(len(flagged), DEEP_REVIEW_BATCH_SIZE)
         created_page_ids: list[str] = []
-        modified_count = 0
+        adjust_count = 0
+        supersede_count = 0
         offset = 0
 
         for batch_idx, batch_size in enumerate(batch_sizes):
@@ -595,7 +625,10 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                         continue
                     changed = await self._apply_item_review(infra, review, resolved, page, link)
                     if changed:
-                        modified_count += 1
+                        if review.action == "supersede":
+                            supersede_count += 1
+                        elif review.action == "adjust":
+                            adjust_count += 1
                     if review.action == "supersede" and resolved in link_by_target:
                         del link_by_target[resolved]
 
@@ -608,9 +641,14 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             UpdateViewPhaseCompletedEvent(
                 phase="deep_review",
                 items_processed=len(flagged),
-                items_modified=modified_count,
+                items_modified=adjust_count + supersede_count,
                 items_created=len(created_page_ids),
             )
+        )
+        self._phase_lines.append(
+            f"deep_review: reviewed {len(flagged)} item(s), "
+            f"superseded {supersede_count}, adjusted {adjust_count}, "
+            f"proposed {len(created_page_ids)} new item(s)"
         )
         return messages, created_page_ids
 
@@ -631,6 +669,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
 
         any_enforced = False
         first_call = True
+        total_demotions = 0
         for level in [5, 4, 3, 2]:
             items = await infra.db.get_view_items(self._view_id)
             at_level = [
@@ -704,6 +743,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                         )
                         continue
                     await self._apply_demotion(infra.db, demotion, resolved, link)
+                    total_demotions += 1
 
         if not any_enforced:
             await infra.trace.record(
@@ -711,6 +751,11 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                     phase="enforce_caps",
                     reason="All importance levels within caps",
                 )
+            )
+            self._phase_lines.append("enforce_caps: skipped (all levels within caps)")
+        else:
+            self._phase_lines.append(
+                f"enforce_caps: demoted {total_demotions} item(s) to respect importance caps"
             )
 
         return messages
@@ -723,21 +768,33 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
         messages: list[dict],
     ) -> list[dict]:
         items = await infra.db.get_view_items(self._view_id)
-        low = [(p, l) for p, l in items if l.importance is not None and l.importance <= 2]
+        candidates = _prune_candidates(items)
 
-        if not low:
+        if not candidates:
             await infra.trace.record(
-                PhaseSkippedEvent(phase="prune", reason="No I1/I2 items to prune")
+                PhaseSkippedEvent(phase="prune", reason="No prune candidates")
             )
+            self._phase_lines.append("prune: skipped (no prune candidates)")
             return messages
+
+        dup_count = sum(1 for p, _ in candidates if _is_explicit_duplicate(p))
 
         link_by_target = {page.id: link for page, link in items}
 
-        compact_lines = [_render_item_compact(page, link) for page, link in low]
+        compact_lines = [_render_item_compact(page, link) for page, link in candidates]
+        header = (
+            f"## Prune candidates ({len(candidates)} items — "
+            f"low-importance plus {dup_count} marked as duplicates)"
+            if dup_count
+            else f"## Prune candidates ({len(candidates)} items)"
+        )
         batch_text = (
-            f"## Low-importance items ({len(low)} items)\n\n"
+            header
+            + "\n\n"
             + "\n".join(compact_lines)
-            + "\n\nDecide which items to keep and which to remove."
+            + "\n\nDecide which items to keep and which to remove. "
+            "Items whose content explicitly marks them as duplicates "
+            "(e.g. '[Duplicate of ...]') should almost always be removed."
         )
 
         user_content = sections.get("prune", "") + "\n\n" + batch_text
@@ -790,9 +847,14 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
         await infra.trace.record(
             UpdateViewPhaseCompletedEvent(
                 phase="prune",
-                items_processed=len(low),
+                items_processed=len(candidates),
                 items_removed=removed,
             )
+        )
+        self._phase_lines.append(
+            f"prune: considered {len(candidates)} item(s)"
+            + (f" ({dup_count} marked duplicate)" if dup_count else "")
+            + f", removed {removed}"
         )
         return messages
 

--- a/tests/test_update_view.py
+++ b/tests/test_update_view.py
@@ -3,7 +3,9 @@
 import pytest
 import pytest_asyncio
 
-from rumil.calls.stages import CallInfra
+from rumil.calls.closing_reviewers import StandardClosingReview, ViewClosingReview
+from rumil.calls.common import format_moves_for_review
+from rumil.calls.stages import CallInfra, UpdateResult
 from rumil.calls.update_view import (
     DemotionChoice,
     ItemReview,
@@ -11,7 +13,9 @@ from rumil.calls.update_view import (
     UnscoredItemScore,
     UpdateViewCall,
     UpdateViewWorkspaceUpdater,
+    _is_explicit_duplicate,
     _parse_prompt_sections,
+    _prune_candidates,
     _render_item_compact,
     _render_item_full,
 )
@@ -709,6 +713,124 @@ async def test_phase_enforce_caps_skips_within_limits(
         messages,
     )
     assert len(result_messages) == len(messages)
+
+
+def test_is_explicit_duplicate_detects_marker():
+    page_dup = _view_item("Dup", content="[Duplicate of abc123, created in error.]")
+    page_normal = _view_item("Normal", content="Some normal observation.")
+    assert _is_explicit_duplicate(page_dup)
+    assert not _is_explicit_duplicate(page_normal)
+
+
+def test_prune_candidates_includes_duplicates_at_any_importance():
+    """Duplicates should be routed through prune even if their importance is above I2."""
+    dup_high = _view_item("Dup at I5", content="[Duplicate of c9060eb4, created in error.]")
+    dup_link = _view_item_link("view-id", dup_high.id, importance=5, section="confident_views")
+    low = _view_item("Low I1", content="Minor note.")
+    low_link = _view_item_link("view-id", low.id, importance=1, section="other")
+    mid = _view_item("Mid I3", content="Useful background.")
+    mid_link = _view_item_link("view-id", mid.id, importance=3, section="key_evidence")
+    unscored = _view_item("Unscored", content="Not scored yet.")
+    unscored_link = _view_item_link("view-id", unscored.id, importance=None, section="other")
+
+    candidates = _prune_candidates(
+        [(dup_high, dup_link), (low, low_link), (mid, mid_link), (unscored, unscored_link)]
+    )
+    ids = {p.id for p, _ in candidates}
+    assert dup_high.id in ids, "duplicate-marked item must be a prune candidate at any importance"
+    assert low.id in ids, "low-importance item must be a prune candidate"
+    assert mid.id not in ids, "mid-importance non-duplicate must not be a prune candidate"
+    assert unscored.id not in ids, "unscored item must not be a prune candidate"
+
+
+async def test_phase_score_unscored_skip_populates_phase_summary(tmp_db, view_setup, call_infra):
+    """Skipping phase 1 should append a phase_lines entry so closing review can see it."""
+    _, v, _ = view_setup
+    updater = UpdateViewWorkspaceUpdater(v.id, CallType.UPDATE_VIEW)
+
+    messages = [
+        {"role": "user", "content": "context"},
+        {"role": "assistant", "content": "Understood."},
+    ]
+    await updater._phase_score_unscored(call_infra, "system", {}, messages)
+
+    assert len(updater._phase_lines) == 1
+    assert "score_unscored" in updater._phase_lines[0]
+    assert "skipped" in updater._phase_lines[0]
+
+
+async def test_phase_enforce_caps_skip_populates_phase_summary(tmp_db, view_setup, call_infra):
+    _, v, _ = view_setup
+    updater = UpdateViewWorkspaceUpdater(v.id, CallType.UPDATE_VIEW)
+
+    messages = [
+        {"role": "user", "content": "context"},
+        {"role": "assistant", "content": "Understood."},
+    ]
+    await updater._phase_enforce_caps(call_infra, "system", {}, messages)
+
+    assert any("enforce_caps" in line and "skipped" in line for line in updater._phase_lines)
+
+
+async def test_phase_prune_skip_populates_phase_summary(tmp_db, view_setup, call_infra):
+    _, v, _ = view_setup
+    updater = UpdateViewWorkspaceUpdater(v.id, CallType.UPDATE_VIEW)
+
+    messages = [
+        {"role": "user", "content": "context"},
+        {"role": "assistant", "content": "Understood."},
+    ]
+    await updater._phase_prune(call_infra, "system", {}, messages)
+
+    assert any("prune" in line and "skipped" in line for line in updater._phase_lines)
+
+
+def _make_update_result(*, phase_summary: str = "") -> UpdateResult:
+    return UpdateResult(
+        created_page_ids=[],
+        moves=[],
+        all_loaded_ids=[],
+        phase_summary=phase_summary,
+    )
+
+
+def test_format_moves_for_review_empty_flags_out_of_band_work():
+    """Empty moves should not just say '(no moves)'.
+
+    The closing-review LLM previously mistook the literal '(no moves)' for
+    'the call did nothing' — even for update_view, whose real work lives
+    in phase edits rather than moves. The empty-moves message must warn
+    the LLM that absence-of-moves is not absence-of-work.
+    """
+    rendered = format_moves_for_review([])
+    assert "no moves" not in rendered.lower() or "not" in rendered.lower()
+    assert rendered != "(no moves)"
+    assert "phase" in rendered.lower() or "outside" in rendered.lower()
+
+
+def test_view_closing_review_prefers_phase_summary_over_moves():
+    """ViewClosingReview must render phase_summary (not '(no moves)') when moves is empty."""
+    reviewer = ViewClosingReview(CallType.UPDATE_VIEW, view_id="view-id")
+    creation = _make_update_result(
+        phase_summary=(
+            "score_unscored: scored 3 item(s), modified 3\n"
+            "triage: reviewed 5 item(s), flagged 2 for deep review\n"
+            "deep_review: reviewed 2 item(s), superseded 1, adjusted 1, proposed 1 new item(s)"
+        )
+    )
+    rendered = reviewer._review_context(creation)
+    assert "score_unscored" in rendered
+    assert "superseded 1" in rendered
+    assert "(no moves)" not in rendered
+
+
+def test_view_closing_review_falls_back_to_moves_when_no_phase_summary():
+    """If phase_summary is empty, fall back to the default moves rendering."""
+    reviewer = ViewClosingReview(CallType.UPDATE_VIEW, view_id="view-id")
+    creation = _make_update_result(phase_summary="")
+    rendered = reviewer._review_context(creation)
+    default_rendered = StandardClosingReview(CallType.UPDATE_VIEW)._review_context(creation)
+    assert rendered == default_rendered
 
 
 async def test_view_setup_with_unscored_items(tmp_db):


### PR DESCRIPTION
## Summary

Implements three related fixes from the `differential/day-one-structure` self-improvement analysis (§4.1, §4.5, §4.8). Each `update_view` call's closing review was handed the string `"(no moves)"` and self-assessed as having done nothing — even when its phases had superseded, adjusted, proposed, and pruned items.

- **§4.1 (main fix):** `UpdateResult` gains `phase_summary`. `UpdateViewWorkspaceUpdater` now appends one line per phase describing real work done (or explicitly `skipped` with a reason). `ViewClosingReview` overrides a new `_review_context` hook on `StandardClosingReview` to pass that summary to the review LLM instead of the empty moves list.
- **§4.5 (dedup):** The prune phase now also considers items whose content is explicitly marked `[Duplicate of ...]`, regardless of their importance score. The prompt is nudged to remove such items. A dangling duplicate View item won't silently ride along forever.
- **§4.8 (defensive):** `format_moves_for_review([])` no longer returns the curt `"(no moves)"`; instead it warns the LLM that some call types do their work outside of moves. Belt-and-braces if a future call type forgets to populate `phase_summary`.

## Test plan

- [x] Added tests asserting `phase_summary` is populated on skip paths, `_prune_candidates` includes duplicate-marked items at any importance, `ViewClosingReview._review_context` uses `phase_summary` (and falls back to moves when empty), and `format_moves_for_review([])` warns about out-of-band work
- [x] `uv run pytest` — 500 passed, 2 xfailed (one pre-existing flaky test on main unrelated to this PR: `test_get_latest_judgement_returns_most_recent`)
- [x] `uv run pyright` — clean
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)