### PR TITLE
Make find_considerations prompt agnostic to its downstream call

### DIFF
--- a/prompts/find_considerations.md
+++ b/prompts/find_considerations.md
@@ -2,33 +2,33 @@
 
 ## Your Task
 
-You are performing a **Find Considerations** call. An **assess** call on this question is imminent — likely the next thing that happens after you finish. Your job is to surface the considerations that, added to what's already in view, will most improve the answer that assess is about to produce.
+You are performing a **Find Considerations** call. An **integration step** on this question is imminent — likely the next thing that happens after you finish. That step is either an **assess** call (writing a fresh judgement on the question) or an **update\_view** call (revising the View of the question). Your job is to surface the considerations that, added to what's already in view, will most improve the output the integration step is about to produce.
 
-**Optimise for answer quality per token.** You are not exploring. You are not mapping out the space. You are adding the missing pieces that the next answer most needs — so that the answer written right after you finish is as good as possible.
+**Optimise for output quality per token.** You are not exploring. You are not mapping out the space. You are adding the missing pieces that the next integration step most needs — so that the answer or View written right after you finish is as good as possible.
 
-The context you see now — the existing considerations, the related workspace pages — is the same context the assessor will see when they answer. Read it carefully. Your job is to add what's **missing** from that picture. Anything you produce that duplicates, paraphrases, or closely overlaps with what's already there is wasted: the assessor already has it. Build on top of the existing evidence, don't repeat it.
+The context you see now — the existing considerations, the related workspace pages — is the same context the integrator will see when they produce the next answer or View. Read it carefully. Your job is to add what's **missing** from that picture. Anything you produce that duplicates, paraphrases, or closely overlaps with what's already there is wasted: the integrator already has it. Build on top of the existing evidence, don't repeat it.
 
 Pages you need should already be loaded from the preliminary phase. Proceed directly to generating considerations — only use `load_page` if something genuinely critical turns out to be missing.
 
 ## What earns a consideration its place
 
-A consideration is worth adding if its effect on the next answer is **immediate and obvious**. The assessor should be able to pick it up and use it without further investigation.
+A consideration is worth adding if its effect on the next integration step is **immediate and obvious**. The integrator should be able to pick it up and use it without further investigation.
 
 Strong candidates:
-- **Directly shifts the answer.** A counterweight, a decisive piece of evidence, or a mechanism that would force the answer to change if taken seriously.
-- **Supplies a missing anchor.** A specific number, timeframe, actor, or empirical fact that the answer needs in order to be concrete rather than hand-wavy.
-- **Resolves a live ambiguity in the question.** The current framing admits multiple readings and the answer hinges on which reading is right.
+- **Directly shifts the next output.** A counterweight, a decisive piece of evidence, or a mechanism that would force the answer (or a View item) to change if taken seriously.
+- **Supplies a missing anchor.** A specific number, timeframe, actor, or empirical fact that the answer or View needs in order to be concrete rather than hand-wavy.
+- **Resolves a live ambiguity in the question.** The current framing admits multiple readings and the next output hinges on which reading is right.
 
 Do **not** add considerations that:
 - Open a new angle whose payoff only becomes visible after further research. If the consideration's value depends on someone digging into it before its impact is clear, it's the wrong thing for this call.
-- Represent interesting-but-tangential territory. "This is worth thinking about" is not enough — it must move the immediate answer.
-- Broaden the scope rather than sharpen the answer.
+- Represent interesting-but-tangential territory. "This is worth thinking about" is not enough — it must move the immediate output.
+- Broaden the scope rather than sharpen the next output.
 
-If the best you can produce is "here's an angle someone could explore," produce nothing and let the assessor work with what's already in view.
+If the best you can produce is "here's an angle someone could explore," produce nothing and let the integrator work with what's already in view.
 
 ## What to Produce
 
-Produce **up to 3 new considerations**, prioritising those that will most move the imminent answer. Fewer strong considerations beats more weak ones. Do not duplicate existing considerations.
+Produce **up to 3 new considerations**, prioritising those that will most move the imminent integration step (whether that is a fresh answer or a View revision). Fewer strong considerations beats more weak ones. Do not duplicate existing considerations.
 
 For each consideration, create the claim and link it to the question.
 
@@ -40,7 +40,7 @@ Don't propose a hypothesis if the view is already well-represented in the existi
 
 ## Quality Bar
 
-- **One excellent consideration beats three weak ones.** If you can only find one thing that would meaningfully move the imminent answer, produce one. Produce none if nothing clears the bar.
+- **One excellent consideration beats three weak ones.** If you can only find one thing that would meaningfully move the imminent output, produce one. Produce none if nothing clears the bar.
 - **Specificity is essential.** A claim must be a concrete, falsifiable (or at least evaluable) assertion — specific enough that a credence score (how likely is this to be true) is at least roughly meaningful. If the best you can do is a gesture toward a class of considerations, make it a question or a judgement rather than forcing it into a claim.
 - **Do not restate existing considerations** in different words. Paraphrases don't help.
-- **Immediate payoff only.** If the reader has to squint to see how this would affect the next answer, it doesn't belong here.
+- **Immediate payoff only.** If the reader has to squint to see how this would affect the next output, it doesn't belong here.


### PR DESCRIPTION
## Summary

Implements §4.4 from the `differential/day-one-structure` self-improvement analysis.

`find_considerations` is dispatched in two contexts: on the scope question (followed by `assess`) and on subquestions (followed by an auto `update_view` refresh, see [two_phase.py L644](https://github.com/chaosGuppy/rumil/blob/main/src/rumil/orchestrators/two_phase.py#L644)). The prompt used to hard-code "an **assess** call on this question is imminent" — so when the real downstream call was `update_view`, the scout was being pointed at "the imminent answer" rather than the integration step that was actually about to run.

This PR broadens the prompt to talk about the next **integration step** (either assess or update_view), and replaces "the assessor" with "the integrator" throughout.

No code changes. The scout still does the same thing; it's just no longer lied to about what consumes its output.

## Test plan

- [x] Prompt-only change; existing tests unaffected.
- [ ] Will observe on the next research run whether scouts feeding an update_view produce considerations that land in the View rather than being dropped at synthesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)