### PR TITLE
Add hidden page flag with read-path filtering

### DIFF
--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -177,6 +177,7 @@ async def list_pages(
     search: str | None = None,
     offset: int = 0,
     limit: int = 50,
+    include_hidden: bool = False,
     db: DB = Depends(_get_db_maybe_staged),
 ):
     pages, total_count = await db.get_pages_paginated(
@@ -186,6 +187,7 @@ async def list_pages(
         search=search,
         offset=offset,
         limit=limit,
+        include_hidden=include_hidden,
     )
     return PaginatedPagesOut(
         items=pages,
@@ -228,16 +230,24 @@ async def get_links_to(page_id: str, db: DB = Depends(_get_db)):
 
 
 @app.get("/api/pages/{page_id}/dependents", response_model=list[LinkedPageOut])
-async def get_dependents(page_id: str, db: DB = Depends(_get_db)):
+async def get_dependents(
+    page_id: str,
+    include_hidden: bool = False,
+    db: DB = Depends(_get_db),
+):
     """Pages that depend on this page (inbound DEPENDS_ON links)."""
-    results = await db.get_dependents(page_id)
+    results = await db.get_dependents(page_id, include_hidden=include_hidden)
     return [LinkedPageOut(page=page, link=link) for page, link in results]
 
 
 @app.get("/api/pages/{page_id}/dependencies", response_model=list[LinkedPageOut])
-async def get_dependencies(page_id: str, db: DB = Depends(_get_db)):
+async def get_dependencies(
+    page_id: str,
+    include_hidden: bool = False,
+    db: DB = Depends(_get_db),
+):
     """Pages that this page depends on (outbound DEPENDS_ON links)."""
-    results = await db.get_dependencies(page_id)
+    results = await db.get_dependencies(page_id, include_hidden=include_hidden)
     return [LinkedPageOut(page=page, link=link) for page, link in results]
 
 
@@ -310,9 +320,10 @@ async def get_question_stats(page_id: str, db: DB = Depends(_get_db_maybe_staged
 async def list_root_questions(
     project_id: str,
     workspace: Workspace = Workspace.RESEARCH,
+    include_hidden: bool = False,
     db: DB = Depends(_get_db),
 ):
-    return await db.get_root_questions(workspace)
+    return await db.get_root_questions(workspace, include_hidden=include_hidden)
 
 
 @app.get(

--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -238,9 +238,7 @@ def _render_item_full(
     uncited = [c for c in related_considerations if c.id not in cited_ids and c.id != page.id]
     if uncited:
         parts.append("")
-        parts.append(
-            "**Related considerations on the parent question (not cited by this item):**"
-        )
+        parts.append("**Related considerations on the parent question (not cited by this item):**")
         for cp in uncited:
             score_parts = []
             if cp.credence is not None:

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -1435,8 +1435,7 @@ class DB:
         return [
             (pages[l.to_page_id], l)
             for l in dep_links
-            if l.to_page_id in pages
-            and (include_hidden or not pages[l.to_page_id].hidden)
+            if l.to_page_id in pages and (include_hidden or not pages[l.to_page_id].hidden)
         ]
 
     async def _get_project_page_ids(self) -> set[str] | None:

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -138,7 +138,7 @@ _SLIM_PAGE_COLUMNS = (
     "id,page_type,layer,workspace,headline,abstract,"
     "epistemic_status,epistemic_type,credence,credence_reasoning,"
     "robustness,robustness_reasoning,extra,is_superseded,"
-    "project_id,created_at,superseded_by,run_id"
+    "project_id,created_at,superseded_by,run_id,hidden"
 )
 
 
@@ -169,6 +169,7 @@ def _row_to_page(row: dict[str, Any]) -> Page:
         sections=row.get("sections"),
         meta_type=row.get("meta_type"),
         run_id=row.get("run_id") or "",
+        hidden=bool(row.get("hidden", False)),
     )
 
 
@@ -524,6 +525,7 @@ class DB:
                     "run_id": self.run_id,
                     "staged": self.staged,
                     "abstract": page.abstract,
+                    "hidden": page.hidden,
                 }
             )
         )
@@ -794,13 +796,19 @@ class DB:
             return f'"{page.headline[:60]}" [{page_id[:8]}]'
         return f"[{page_id[:8]}]"
 
-    async def get_pages_slim(self, active_only: bool = True) -> list[Page]:
+    async def get_pages_slim(
+        self,
+        active_only: bool = True,
+        include_hidden: bool = False,
+    ) -> list[Page]:
         """Fetch all pages without the content field — safe for bulk loads."""
         query = self.client.table("pages").select(_SLIM_PAGE_COLUMNS)
         if self.project_id:
             query = query.eq("project_id", self.project_id)
         if active_only:
             query = query.eq("is_superseded", False)
+        if not include_hidden:
+            query = query.eq("hidden", False)
         query = self._staged_filter(query)
         pages = [
             _row_to_page(r)
@@ -816,6 +824,7 @@ class DB:
         workspace: Workspace | None = None,
         page_type: PageType | None = None,
         active_only: bool = True,
+        include_hidden: bool = False,
     ) -> list[Page]:
         query = self.client.table("pages").select("*")
         if self.project_id:
@@ -826,6 +835,8 @@ class DB:
             query = query.eq("page_type", page_type.value)
         if active_only:
             query = query.eq("is_superseded", False)
+        if not include_hidden:
+            query = query.eq("hidden", False)
         query = self._staged_filter(query)
         pages = [
             _row_to_page(r)
@@ -872,6 +883,7 @@ class DB:
         search: str | None = None,
         offset: int = 0,
         limit: int = 50,
+        include_hidden: bool = False,
     ) -> tuple[Sequence[Page], int]:
         """Return a page of results and the total matching count."""
         query = self.client.table("pages").select("*", count=CountMethod.exact)
@@ -883,6 +895,8 @@ class DB:
             query = query.eq("page_type", page_type.value)
         if active_only:
             query = query.eq("is_superseded", False)
+        if not include_hidden:
+            query = query.eq("hidden", False)
         if search:
             query = query.or_(f"headline.ilike.%{search}%,content.ilike.%{search}%")
         query = self._staged_filter(query)
@@ -1229,6 +1243,7 @@ class DB:
     async def get_considerations_for_question(
         self,
         question_id: str,
+        include_hidden: bool = False,
     ) -> list[tuple[Page, PageLink]]:
         """Return (claim_page, link) pairs for all considerations on a question."""
         links = await self.get_links_to(question_id)
@@ -1239,12 +1254,15 @@ class DB:
         return [
             (pages[l.from_page_id], l)
             for l in consideration_links
-            if l.from_page_id in pages and pages[l.from_page_id].is_active()
+            if l.from_page_id in pages
+            and pages[l.from_page_id].is_active()
+            and (include_hidden or not pages[l.from_page_id].hidden)
         ]
 
     async def get_considerations_for_questions(
         self,
         question_ids: Sequence[str],
+        include_hidden: bool = False,
     ) -> dict[str, list[tuple[Page, PageLink]]]:
         """Bulk-fetch considerations for many questions. Returns {question_id: [(claim, link)]}."""
         result: dict[str, list[tuple[Page, PageLink]]] = {qid: [] for qid in question_ids}
@@ -1263,21 +1281,29 @@ class DB:
         pages = await self.get_pages_by_ids(page_ids)
         for link in consideration_links:
             page = pages.get(link.from_page_id)
-            if page and page.is_active():
+            if page and page.is_active() and (include_hidden or not page.hidden):
                 result[link.to_page_id].append((page, link))
         return result
 
-    async def get_parent_question(self, question_id: str) -> Page | None:
+    async def get_parent_question(
+        self,
+        question_id: str,
+        include_hidden: bool = False,
+    ) -> Page | None:
         """Return the parent question, or None if this is a root question."""
         links = await self.get_links_to(question_id)
         for link in links:
             if link.link_type == LinkType.CHILD_QUESTION:
                 page = await self.get_page(link.from_page_id)
-                if page and page.is_active():
+                if page and page.is_active() and (include_hidden or not page.hidden):
                     return page
         return None
 
-    async def get_child_questions(self, parent_id: str) -> list[Page]:
+    async def get_child_questions(
+        self,
+        parent_id: str,
+        include_hidden: bool = False,
+    ) -> list[Page]:
         """Return sub-questions of a question."""
         links = await self.get_links_from(parent_id)
         child_links = [l for l in links if l.link_type == LinkType.CHILD_QUESTION]
@@ -1287,12 +1313,15 @@ class DB:
         return [
             pages[l.to_page_id]
             for l in child_links
-            if l.to_page_id in pages and pages[l.to_page_id].is_active()
+            if l.to_page_id in pages
+            and pages[l.to_page_id].is_active()
+            and (include_hidden or not pages[l.to_page_id].hidden)
         ]
 
     async def get_child_questions_with_links(
         self,
         parent_id: str,
+        include_hidden: bool = False,
     ) -> list[tuple[Page, PageLink]]:
         """Return (child_page, link) pairs for sub-questions of a question."""
         links = await self.get_links_from(parent_id)
@@ -1303,10 +1332,16 @@ class DB:
         return [
             (pages[l.to_page_id], l)
             for l in child_links
-            if l.to_page_id in pages and pages[l.to_page_id].is_active()
+            if l.to_page_id in pages
+            and pages[l.to_page_id].is_active()
+            and (include_hidden or not pages[l.to_page_id].hidden)
         ]
 
-    async def get_judgements_for_question(self, question_id: str) -> list[Page]:
+    async def get_judgements_for_question(
+        self,
+        question_id: str,
+        include_hidden: bool = False,
+    ) -> list[Page]:
         links = await self.get_links_to(question_id)
         judgement_links = [l for l in links if l.link_type == LinkType.ANSWERS]
         if not judgement_links:
@@ -1318,11 +1353,13 @@ class DB:
             if l.from_page_id in pages
             and pages[l.from_page_id].is_active()
             and pages[l.from_page_id].page_type == PageType.JUDGEMENT
+            and (include_hidden or not pages[l.from_page_id].hidden)
         ]
 
     async def get_judgements_for_questions(
         self,
         question_ids: Sequence[str],
+        include_hidden: bool = False,
     ) -> dict[str, list[Page]]:
         """Bulk-fetch active judgements for many questions. Returns {question_id: [judgements]}.
 
@@ -1356,13 +1393,19 @@ class DB:
         pages = await self.get_pages_by_ids(from_ids)
         for link in applied:
             page = pages.get(link.from_page_id)
-            if page is not None and page.is_active() and page.page_type == PageType.JUDGEMENT:
+            if (
+                page is not None
+                and page.is_active()
+                and page.page_type == PageType.JUDGEMENT
+                and (include_hidden or not page.hidden)
+            ):
                 result.setdefault(link.to_page_id, []).append(page)
         return result
 
     async def get_dependents(
         self,
         page_id: str,
+        include_hidden: bool = False,
     ) -> list[tuple[Page, PageLink]]:
         """Return (dependent_page, link) for all pages that depend on this one."""
         links = await self.get_links_to(page_id)
@@ -1373,12 +1416,15 @@ class DB:
         return [
             (pages[l.from_page_id], l)
             for l in dep_links
-            if l.from_page_id in pages and pages[l.from_page_id].is_active()
+            if l.from_page_id in pages
+            and pages[l.from_page_id].is_active()
+            and (include_hidden or not pages[l.from_page_id].hidden)
         ]
 
     async def get_dependencies(
         self,
         page_id: str,
+        include_hidden: bool = False,
     ) -> list[tuple[Page, PageLink]]:
         """Return (dependency_page, link) for all pages this one depends on."""
         links = await self.get_links_from(page_id)
@@ -1386,7 +1432,12 @@ class DB:
         if not dep_links:
             return []
         pages = await self.get_pages_by_ids([l.to_page_id for l in dep_links])
-        return [(pages[l.to_page_id], l) for l in dep_links if l.to_page_id in pages]
+        return [
+            (pages[l.to_page_id], l)
+            for l in dep_links
+            if l.to_page_id in pages
+            and (include_hidden or not pages[l.to_page_id].hidden)
+        ]
 
     async def _get_project_page_ids(self) -> set[str] | None:
         """Fetch all page IDs belonging to the current project.
@@ -2260,6 +2311,7 @@ class DB:
     async def get_root_questions(
         self,
         workspace: Workspace = Workspace.RESEARCH,
+        include_hidden: bool = False,
     ) -> list[Page]:
         """Return questions that have no parent (top-level questions)."""
         params: dict[str, Any] = {"ws": workspace.value}
@@ -2267,6 +2319,8 @@ class DB:
             params["pid"] = self.project_id
         if self.staged:
             params["p_staged_run_id"] = self.run_id
+        if include_hidden:
+            params["p_include_hidden"] = True
         rows = _rows(await self._execute(self.client.rpc("get_root_questions", params)))
         pages = [_row_to_page(r) for r in rows]
         pages = await self._apply_page_events(pages)
@@ -2275,6 +2329,7 @@ class DB:
     async def get_human_questions(
         self,
         workspace: Workspace = Workspace.RESEARCH,
+        include_hidden: bool = False,
     ) -> list[Page]:
         """Return all active, human-authored questions in *workspace*.
 
@@ -2293,6 +2348,8 @@ class DB:
         )
         if self.project_id:
             query = query.eq("project_id", self.project_id)
+        if not include_hidden:
+            query = query.eq("hidden", False)
         query = self._staged_filter(query)
         rows = _rows(await self._execute(query))
         pages = [_row_to_page(r) for r in rows]

--- a/src/rumil/embeddings.py
+++ b/src/rumil/embeddings.py
@@ -162,11 +162,13 @@ async def search_pages_by_vector(
     match_count: int = 10,
     workspace: Workspace | None = None,
     field_name: str | None = None,
+    include_hidden: bool = False,
 ) -> list[tuple[Page, float]]:
     """Search for pages similar to a given embedding vector.
 
     Returns (page, similarity_score) pairs sorted by descending similarity.
-    Optionally filter to embeddings of a specific field_name.
+    Optionally filter to embeddings of a specific field_name. Hidden pages
+    are excluded unless *include_hidden* is True.
     """
     embedding_str = "[" + ",".join(str(x) for x in query_embedding) + "]"
     params: dict[str, Any] = {
@@ -182,6 +184,8 @@ async def search_pages_by_vector(
         params["filter_field_name"] = field_name
     if db.staged:
         params["filter_staged_run_id"] = db.run_id
+    if include_hidden:
+        params["filter_include_hidden"] = True
     rows: _Rows = _rows(await db.client.rpc("match_pages", params).execute())
     results: list[tuple[Page, float]] = []
     for row in rows:

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -358,6 +358,7 @@ class Page(BaseModel):
     sections: list[str] | None = None  # VIEW pages: ordered section names
     meta_type: str | None = None  # VIEW_META pages: priority/annotation/proposal
     run_id: str = ""
+    hidden: bool = False
 
     def is_active(self) -> bool:
         return not self.is_superseded

--- a/supabase/migrations/20260424132656_add_hidden_to_pages.sql
+++ b/supabase/migrations/20260424132656_add_hidden_to_pages.sql
@@ -1,0 +1,111 @@
+-- Add a `hidden` flag to pages so that generative-workflow lineage
+-- (spec items, superseded artefact versions, critiques) can exist in
+-- the workspace without cluttering embedding search or default context
+-- rendering. Hidden pages are still reachable by direct-id fetch or by
+-- following links from visible pages.
+--
+-- Discovery RPCs (match_pages, get_root_questions) take an
+-- `include_hidden` parameter; when false (the default), hidden rows are
+-- excluded. The existing staged_run_id filter is preserved verbatim.
+
+ALTER TABLE pages ADD COLUMN hidden BOOLEAN NOT NULL DEFAULT false;
+
+DROP FUNCTION IF EXISTS match_pages(
+    extensions.vector, DOUBLE PRECISION, INTEGER, TEXT, UUID, TEXT, TEXT
+);
+
+CREATE OR REPLACE FUNCTION match_pages(
+    query_embedding extensions.vector(1024),
+    match_threshold DOUBLE PRECISION DEFAULT 0.5,
+    match_count INTEGER DEFAULT 10,
+    filter_workspace TEXT DEFAULT NULL,
+    filter_project_id UUID DEFAULT NULL,
+    filter_field_name TEXT DEFAULT NULL,
+    filter_staged_run_id TEXT DEFAULT NULL,
+    filter_include_hidden BOOLEAN DEFAULT false
+)
+RETURNS TABLE(
+    id TEXT,
+    page_type TEXT,
+    layer TEXT,
+    workspace TEXT,
+    content TEXT,
+    headline TEXT,
+    abstract TEXT,
+    project_id UUID,
+    epistemic_status DOUBLE PRECISION,
+    epistemic_type TEXT,
+    credence INTEGER,
+    robustness INTEGER,
+    provenance_model TEXT,
+    provenance_call_type TEXT,
+    provenance_call_id TEXT,
+    created_at TIMESTAMPTZ,
+    superseded_by TEXT,
+    is_superseded BOOLEAN,
+    extra JSONB,
+    run_id TEXT,
+    field_name TEXT,
+    similarity DOUBLE PRECISION
+)
+LANGUAGE sql STABLE
+SET search_path = public, extensions
+AS $$
+    SELECT
+        p.id,
+        p.page_type,
+        p.layer,
+        p.workspace,
+        p.content,
+        p.headline,
+        p.abstract,
+        p.project_id,
+        p.epistemic_status,
+        p.epistemic_type,
+        p.credence,
+        p.robustness,
+        p.provenance_model,
+        p.provenance_call_type,
+        p.provenance_call_id,
+        p.created_at,
+        p.superseded_by,
+        p.is_superseded,
+        p.extra,
+        p.run_id,
+        pe.field_name,
+        1 - (pe.embedding <=> query_embedding) AS similarity
+    FROM page_embeddings pe
+    JOIN pages p ON p.id = pe.page_id
+    WHERE p.is_superseded = FALSE
+      AND 1 - (pe.embedding <=> query_embedding) > match_threshold
+      AND (filter_workspace IS NULL OR p.workspace = filter_workspace)
+      AND (filter_project_id IS NULL OR p.project_id = filter_project_id)
+      AND (filter_field_name IS NULL OR pe.field_name = filter_field_name)
+      AND (p.staged = FALSE OR p.run_id = filter_staged_run_id)
+      AND (filter_include_hidden OR NOT p.hidden)
+    ORDER BY pe.embedding <=> query_embedding
+    LIMIT match_count;
+$$;
+
+DROP FUNCTION IF EXISTS get_root_questions(TEXT, UUID, TEXT);
+
+CREATE OR REPLACE FUNCTION get_root_questions(
+    ws TEXT,
+    pid UUID DEFAULT NULL,
+    p_staged_run_id TEXT DEFAULT NULL,
+    p_include_hidden BOOLEAN DEFAULT false
+)
+RETURNS SETOF pages
+LANGUAGE sql STABLE AS $$
+    SELECT p.* FROM pages p
+    WHERE p.page_type = 'question'
+      AND p.workspace = ws
+      AND p.is_superseded = FALSE
+      AND (pid IS NULL OR p.project_id = pid)
+      AND (p.staged = FALSE OR p.run_id = p_staged_run_id)
+      AND (p_include_hidden OR NOT p.hidden)
+      AND p.id NOT IN (
+          SELECT to_page_id FROM page_links WHERE link_type = 'child_question'
+      )
+    ORDER BY p.created_at DESC;
+$$;

--- a/tests/test_hidden_pages.py
+++ b/tests/test_hidden_pages.py
@@ -1,0 +1,325 @@
+"""Regression tests for the `hidden` page flag and the `include_hidden`
+parameter threaded through discovery DB helpers.
+
+Contract under test:
+- By-ID fetches (``get_page``, ``get_pages_by_ids``) return pages
+  regardless of ``hidden``.
+- Discovery helpers default to excluding hidden pages; passing
+  ``include_hidden=True`` surfaces them.
+- The hidden filter composes correctly with staged-run visibility.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from rumil.database import DB
+from rumil.embeddings import embed_and_store_page, search_pages_by_vector, embed_query
+from rumil.models import (
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+
+
+async def _make_page(
+    db: DB,
+    headline: str,
+    *,
+    page_type: PageType = PageType.CLAIM,
+    hidden: bool = False,
+) -> Page:
+    page = Page(
+        page_type=page_type,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Content for: {headline}",
+        headline=headline,
+        hidden=hidden,
+    )
+    await db.save_page(page)
+    return page
+
+
+async def test_get_page_returns_hidden(tmp_db):
+    """By-id fetch returns a hidden page — `hidden` only filters discovery."""
+    page = await _make_page(tmp_db, "direct-fetch hidden", hidden=True)
+    fetched = await tmp_db.get_page(page.id)
+    assert fetched is not None
+    assert fetched.id == page.id
+    assert fetched.hidden is True
+
+
+async def test_get_pages_by_ids_returns_hidden(tmp_db):
+    """Batched by-id fetch returns hidden pages unchanged."""
+    hidden = await _make_page(tmp_db, "batch hidden", hidden=True)
+    visible = await _make_page(tmp_db, "batch visible", hidden=False)
+    result = await tmp_db.get_pages_by_ids([hidden.id, visible.id])
+    assert hidden.id in result and visible.id in result
+    assert result[hidden.id].hidden is True
+    assert result[visible.id].hidden is False
+
+
+async def test_get_pages_filters_hidden_by_default(tmp_db):
+    """get_pages excludes hidden pages unless include_hidden=True."""
+    visible = await _make_page(tmp_db, "visible claim")
+    hidden = await _make_page(tmp_db, "hidden claim", hidden=True)
+
+    default_ids = {p.id for p in await tmp_db.get_pages(page_type=PageType.CLAIM)}
+    assert visible.id in default_ids
+    assert hidden.id not in default_ids
+
+    all_ids = {
+        p.id
+        for p in await tmp_db.get_pages(
+            page_type=PageType.CLAIM,
+            include_hidden=True,
+        )
+    }
+    assert hidden.id in all_ids
+
+
+async def test_get_pages_slim_filters_hidden_by_default(tmp_db):
+    visible = await _make_page(tmp_db, "slim visible")
+    hidden = await _make_page(tmp_db, "slim hidden", hidden=True)
+    default_ids = {p.id for p in await tmp_db.get_pages_slim()}
+    assert visible.id in default_ids
+    assert hidden.id not in default_ids
+    all_ids = {p.id for p in await tmp_db.get_pages_slim(include_hidden=True)}
+    assert hidden.id in all_ids
+
+
+async def test_get_pages_paginated_filters_hidden_by_default(tmp_db):
+    visible = await _make_page(tmp_db, "paginated visible")
+    hidden = await _make_page(tmp_db, "paginated hidden", hidden=True)
+    pages, _ = await tmp_db.get_pages_paginated()
+    default_ids = {p.id for p in pages}
+    assert visible.id in default_ids
+    assert hidden.id not in default_ids
+    pages_all, _ = await tmp_db.get_pages_paginated(include_hidden=True)
+    assert hidden.id in {p.id for p in pages_all}
+
+
+async def test_get_root_questions_filters_hidden_by_default(tmp_db):
+    """Hidden root questions are invisible by default, visible with the flag."""
+    visible_q = await _make_page(
+        tmp_db,
+        "visible root",
+        page_type=PageType.QUESTION,
+    )
+    hidden_q = await _make_page(
+        tmp_db,
+        "hidden root",
+        page_type=PageType.QUESTION,
+        hidden=True,
+    )
+    default_ids = {p.id for p in await tmp_db.get_root_questions()}
+    assert visible_q.id in default_ids
+    assert hidden_q.id not in default_ids
+
+    all_ids = {p.id for p in await tmp_db.get_root_questions(include_hidden=True)}
+    assert hidden_q.id in all_ids
+
+
+async def test_get_child_questions_filters_hidden_by_default(tmp_db):
+    parent = await _make_page(tmp_db, "parent q", page_type=PageType.QUESTION)
+    visible_child = await _make_page(
+        tmp_db, "visible child", page_type=PageType.QUESTION
+    )
+    hidden_child = await _make_page(
+        tmp_db, "hidden child", page_type=PageType.QUESTION, hidden=True
+    )
+    for child in (visible_child, hidden_child):
+        await tmp_db.save_link(
+            PageLink(
+                from_page_id=parent.id,
+                to_page_id=child.id,
+                link_type=LinkType.CHILD_QUESTION,
+            )
+        )
+
+    default_ids = {p.id for p in await tmp_db.get_child_questions(parent.id)}
+    assert visible_child.id in default_ids
+    assert hidden_child.id not in default_ids
+
+    all_ids = {
+        p.id for p in await tmp_db.get_child_questions(parent.id, include_hidden=True)
+    }
+    assert hidden_child.id in all_ids
+
+
+async def test_get_considerations_filters_hidden_by_default(tmp_db):
+    question = await _make_page(tmp_db, "q for considerations", page_type=PageType.QUESTION)
+    visible_claim = await _make_page(tmp_db, "visible consideration")
+    hidden_claim = await _make_page(tmp_db, "hidden consideration", hidden=True)
+    for claim in (visible_claim, hidden_claim):
+        await tmp_db.save_link(
+            PageLink(
+                from_page_id=claim.id,
+                to_page_id=question.id,
+                link_type=LinkType.CONSIDERATION,
+                strength=3.0,
+                reasoning="t",
+            )
+        )
+
+    default_ids = {
+        p.id for p, _ in await tmp_db.get_considerations_for_question(question.id)
+    }
+    assert visible_claim.id in default_ids
+    assert hidden_claim.id not in default_ids
+
+    all_ids = {
+        p.id
+        for p, _ in await tmp_db.get_considerations_for_question(
+            question.id, include_hidden=True
+        )
+    }
+    assert hidden_claim.id in all_ids
+
+
+async def test_get_judgements_filters_hidden_by_default(tmp_db):
+    question = await _make_page(tmp_db, "q for judgements", page_type=PageType.QUESTION)
+    visible_j = await _make_page(
+        tmp_db, "visible judgement", page_type=PageType.JUDGEMENT
+    )
+    hidden_j = await _make_page(
+        tmp_db, "hidden judgement", page_type=PageType.JUDGEMENT, hidden=True
+    )
+    for j in (visible_j, hidden_j):
+        await tmp_db.save_link(
+            PageLink(
+                from_page_id=j.id,
+                to_page_id=question.id,
+                link_type=LinkType.ANSWERS,
+            )
+        )
+
+    default_ids = {p.id for p in await tmp_db.get_judgements_for_question(question.id)}
+    assert visible_j.id in default_ids
+    assert hidden_j.id not in default_ids
+
+    all_ids = {
+        p.id
+        for p in await tmp_db.get_judgements_for_question(
+            question.id, include_hidden=True
+        )
+    }
+    assert hidden_j.id in all_ids
+
+
+@pytest_asyncio.fixture
+async def staged_project():
+    """Shared project for testing staged vs baseline hidden-page visibility."""
+    setup_db = await DB.create(run_id=str(uuid.uuid4()))
+    project = await setup_db.get_or_create_project(
+        f"test-hidden-staged-{uuid.uuid4().hex[:8]}"
+    )
+    yield project.id
+    await setup_db._execute(
+        setup_db.client.table("projects").delete().eq("id", project.id)
+    )
+
+
+async def test_hidden_filter_composes_with_staged_runs(staged_project):
+    """A staged run's hidden page is invisible to non-staged observers, and
+    invisible by default even to the staged reader until include_hidden=True."""
+    staged = await DB.create(run_id=str(uuid.uuid4()), staged=True)
+    staged.project_id = staged_project
+    await staged.init_budget(10)
+
+    observer = await DB.create(run_id=str(uuid.uuid4()), staged=False)
+    observer.project_id = staged_project
+
+    try:
+        hidden = await _make_page(
+            staged, "staged hidden", page_type=PageType.QUESTION, hidden=True
+        )
+
+        observer_ids = {p.id for p in await observer.get_root_questions()}
+        assert hidden.id not in observer_ids
+        observer_ids_all = {
+            p.id for p in await observer.get_root_questions(include_hidden=True)
+        }
+        assert hidden.id not in observer_ids_all
+
+        staged_default = {p.id for p in await staged.get_root_questions()}
+        assert hidden.id not in staged_default
+        staged_all = {
+            p.id for p in await staged.get_root_questions(include_hidden=True)
+        }
+        assert hidden.id in staged_all
+    finally:
+        await staged.delete_run_data()
+        await observer.close()
+
+
+async def test_baseline_hidden_visible_to_staged_reader_with_flag(staged_project):
+    """A baseline (non-staged) hidden page is visible to a staged reader when
+    include_hidden=True, and filtered out by default — confirming the hidden
+    filter and the staged visibility filter compose in both directions."""
+    baseline = await DB.create(run_id=str(uuid.uuid4()), staged=False)
+    baseline.project_id = staged_project
+    await baseline.init_budget(10)
+
+    staged_reader = await DB.create(run_id=str(uuid.uuid4()), staged=True)
+    staged_reader.project_id = staged_project
+
+    try:
+        hidden = await _make_page(
+            baseline, "baseline hidden", page_type=PageType.QUESTION, hidden=True
+        )
+
+        staged_default = {p.id for p in await staged_reader.get_root_questions()}
+        assert hidden.id not in staged_default
+
+        staged_all = {
+            p.id for p in await staged_reader.get_root_questions(include_hidden=True)
+        }
+        assert hidden.id in staged_all
+    finally:
+        await baseline.delete_run_data()
+        await staged_reader.close()
+
+
+@pytest.mark.llm
+async def test_search_pages_by_vector_filters_hidden_by_default(tmp_db):
+    """Embedding search excludes hidden pages by default; include_hidden surfaces them."""
+    visible = await _make_page(
+        tmp_db,
+        "Photosynthesis converts sunlight into chemical energy in plants.",
+    )
+    hidden = await _make_page(
+        tmp_db,
+        "Photosynthesis underpins food chains by transforming light into sugars.",
+        hidden=True,
+    )
+    await embed_and_store_page(tmp_db, visible)
+    await embed_and_store_page(tmp_db, hidden)
+
+    query_vec = await embed_query("how do plants convert light into energy?")
+
+    default_ids = {
+        p.id
+        for p, _ in await search_pages_by_vector(
+            tmp_db, query_vec, match_threshold=0.2, match_count=10
+        )
+    }
+    assert visible.id in default_ids
+    assert hidden.id not in default_ids
+
+    all_ids = {
+        p.id
+        for p, _ in await search_pages_by_vector(
+            tmp_db,
+            query_vec,
+            match_threshold=0.2,
+            match_count=10,
+            include_hidden=True,
+        )
+    }
+    assert hidden.id in all_ids

--- a/tests/test_hidden_pages.py
+++ b/tests/test_hidden_pages.py
@@ -15,7 +15,7 @@ import pytest
 import pytest_asyncio
 
 from rumil.database import DB
-from rumil.embeddings import embed_and_store_page, search_pages_by_vector, embed_query
+from rumil.embeddings import embed_and_store_page, embed_query, search_pages_by_vector
 from rumil.models import (
     LinkType,
     Page,
@@ -127,9 +127,7 @@ async def test_get_root_questions_filters_hidden_by_default(tmp_db):
 
 async def test_get_child_questions_filters_hidden_by_default(tmp_db):
     parent = await _make_page(tmp_db, "parent q", page_type=PageType.QUESTION)
-    visible_child = await _make_page(
-        tmp_db, "visible child", page_type=PageType.QUESTION
-    )
+    visible_child = await _make_page(tmp_db, "visible child", page_type=PageType.QUESTION)
     hidden_child = await _make_page(
         tmp_db, "hidden child", page_type=PageType.QUESTION, hidden=True
     )
@@ -146,9 +144,7 @@ async def test_get_child_questions_filters_hidden_by_default(tmp_db):
     assert visible_child.id in default_ids
     assert hidden_child.id not in default_ids
 
-    all_ids = {
-        p.id for p in await tmp_db.get_child_questions(parent.id, include_hidden=True)
-    }
+    all_ids = {p.id for p in await tmp_db.get_child_questions(parent.id, include_hidden=True)}
     assert hidden_child.id in all_ids
 
 
@@ -167,26 +163,20 @@ async def test_get_considerations_filters_hidden_by_default(tmp_db):
             )
         )
 
-    default_ids = {
-        p.id for p, _ in await tmp_db.get_considerations_for_question(question.id)
-    }
+    default_ids = {p.id for p, _ in await tmp_db.get_considerations_for_question(question.id)}
     assert visible_claim.id in default_ids
     assert hidden_claim.id not in default_ids
 
     all_ids = {
         p.id
-        for p, _ in await tmp_db.get_considerations_for_question(
-            question.id, include_hidden=True
-        )
+        for p, _ in await tmp_db.get_considerations_for_question(question.id, include_hidden=True)
     }
     assert hidden_claim.id in all_ids
 
 
 async def test_get_judgements_filters_hidden_by_default(tmp_db):
     question = await _make_page(tmp_db, "q for judgements", page_type=PageType.QUESTION)
-    visible_j = await _make_page(
-        tmp_db, "visible judgement", page_type=PageType.JUDGEMENT
-    )
+    visible_j = await _make_page(tmp_db, "visible judgement", page_type=PageType.JUDGEMENT)
     hidden_j = await _make_page(
         tmp_db, "hidden judgement", page_type=PageType.JUDGEMENT, hidden=True
     )
@@ -204,10 +194,7 @@ async def test_get_judgements_filters_hidden_by_default(tmp_db):
     assert hidden_j.id not in default_ids
 
     all_ids = {
-        p.id
-        for p in await tmp_db.get_judgements_for_question(
-            question.id, include_hidden=True
-        )
+        p.id for p in await tmp_db.get_judgements_for_question(question.id, include_hidden=True)
     }
     assert hidden_j.id in all_ids
 
@@ -216,13 +203,9 @@ async def test_get_judgements_filters_hidden_by_default(tmp_db):
 async def staged_project():
     """Shared project for testing staged vs baseline hidden-page visibility."""
     setup_db = await DB.create(run_id=str(uuid.uuid4()))
-    project = await setup_db.get_or_create_project(
-        f"test-hidden-staged-{uuid.uuid4().hex[:8]}"
-    )
+    project = await setup_db.get_or_create_project(f"test-hidden-staged-{uuid.uuid4().hex[:8]}")
     yield project.id
-    await setup_db._execute(
-        setup_db.client.table("projects").delete().eq("id", project.id)
-    )
+    await setup_db._execute(setup_db.client.table("projects").delete().eq("id", project.id))
 
 
 async def test_hidden_filter_composes_with_staged_runs(staged_project):
@@ -236,22 +219,16 @@ async def test_hidden_filter_composes_with_staged_runs(staged_project):
     observer.project_id = staged_project
 
     try:
-        hidden = await _make_page(
-            staged, "staged hidden", page_type=PageType.QUESTION, hidden=True
-        )
+        hidden = await _make_page(staged, "staged hidden", page_type=PageType.QUESTION, hidden=True)
 
         observer_ids = {p.id for p in await observer.get_root_questions()}
         assert hidden.id not in observer_ids
-        observer_ids_all = {
-            p.id for p in await observer.get_root_questions(include_hidden=True)
-        }
+        observer_ids_all = {p.id for p in await observer.get_root_questions(include_hidden=True)}
         assert hidden.id not in observer_ids_all
 
         staged_default = {p.id for p in await staged.get_root_questions()}
         assert hidden.id not in staged_default
-        staged_all = {
-            p.id for p in await staged.get_root_questions(include_hidden=True)
-        }
+        staged_all = {p.id for p in await staged.get_root_questions(include_hidden=True)}
         assert hidden.id in staged_all
     finally:
         await staged.delete_run_data()
@@ -277,9 +254,7 @@ async def test_baseline_hidden_visible_to_staged_reader_with_flag(staged_project
         staged_default = {p.id for p in await staged_reader.get_root_questions()}
         assert hidden.id not in staged_default
 
-        staged_all = {
-            p.id for p in await staged_reader.get_root_questions(include_hidden=True)
-        }
+        staged_all = {p.id for p in await staged_reader.get_root_questions(include_hidden=True)}
         assert hidden.id in staged_all
     finally:
         await baseline.delete_run_data()

--- a/tests/test_update_view.py
+++ b/tests/test_update_view.py
@@ -1,5 +1,7 @@
 """Tests for UpdateViewCall: incremental View updates."""
 
+from datetime import UTC
+
 import pytest
 import pytest_asyncio
 
@@ -260,7 +262,7 @@ def test_render_item_full_omits_related_block_when_all_cited():
 
 async def test_render_claim_investigation_findings_surfaces_new_findings(tmp_db):
     """New considerations on a claim linked to the question should appear."""
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timedelta
 
     from rumil.context import render_claim_investigation_findings
 
@@ -290,10 +292,8 @@ async def test_render_claim_investigation_findings_surfaces_new_findings(tmp_db)
         )
     )
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=365)
-    text, page_ids = await render_claim_investigation_findings(
-        tmp_db, question.id, cutoff
-    )
+    cutoff = datetime.now(UTC) - timedelta(days=365)
+    text, page_ids = await render_claim_investigation_findings(tmp_db, question.id, cutoff)
 
     assert finding.id in page_ids
     assert "Moskovitz" in text
@@ -303,7 +303,7 @@ async def test_render_claim_investigation_findings_surfaces_new_findings(tmp_db)
 
 async def test_render_claim_investigation_findings_filters_old_findings(tmp_db):
     """Findings older than last_view_created_at should be excluded."""
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timedelta
 
     from rumil.context import render_claim_investigation_findings
 
@@ -330,10 +330,8 @@ async def test_render_claim_investigation_findings_filters_old_findings(tmp_db):
         )
     )
 
-    cutoff = datetime.now(timezone.utc) + timedelta(days=1)
-    text, page_ids = await render_claim_investigation_findings(
-        tmp_db, question.id, cutoff
-    )
+    cutoff = datetime.now(UTC) + timedelta(days=1)
+    text, page_ids = await render_claim_investigation_findings(tmp_db, question.id, cutoff)
 
     assert page_ids == []
     assert text == ""


### PR DESCRIPTION
## Summary
- Add `hidden BOOLEAN NOT NULL DEFAULT false` to `pages`; `match_pages` and `get_root_questions` RPCs gain `include_hidden` / `filter_include_hidden` params so discovery queries exclude hidden rows by default.
- Thread `include_hidden: bool = False` through discovery-path DB helpers and `search_pages_by_vector`; by-id fetches (`get_page`, `get_pages_by_ids`) are unchanged — "specifically fetched" returns regardless.
- Add `include_hidden` query param to list-style API endpoints (`list_pages`, `list_root_questions`, `get_dependents`, `get_dependencies`).

Groundwork for the generative-workflow orchestrator: spec items, superseded artefact versions, and critiques need to live in the workspace without polluting embedding search or default context rendering. No writer flips the flag in this PR; the `hidden_changed` mutation event type and public move handlers land with the first consumer.

## Test plan
- [x] `uv run pytest tests/test_hidden_pages.py` — 11 pass, 1 skipped (LLM-gated embedding test)
- [x] Full non-LLM suite: 515 passed, no regressions
- [x] Migration applies cleanly on local Supabase
- [ ] LLM-gated embedding test (`uv run pytest --llm tests/test_hidden_pages.py`) — optional, confirms `match_pages` filter works end-to-end

## Deferred to next PR
- `hidden_changed` mutation event + dual-write, so staged runs can flip the flag safely.
- Public move handlers that create pages with `hidden=true`.
- `compute_project_stats` / `compute_question_stats` — stats RPCs still count hidden rows; will need a follow-up when hidden pages actually exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)