### PR TITLE
Add generate_spec call + add_spec_item move

### DIFF
--- a/prompts/generate_spec.md
+++ b/prompts/generate_spec.md
@@ -1,0 +1,48 @@
+# Generate Spec Call Instructions
+
+## Your Task
+
+You are performing a **Generate Spec** call — the first step of a generator-refiner workflow that will produce an artefact (a plan, document, design, or other long-form object) in response to the artefact-task question.
+
+Your job here is **not** to write the artefact. Your job is to write a **spec**: a set of atomic prescriptive rules the artefact will be held to. Downstream, a separate call will generate the artefact from this spec alone — seeing no workspace, no context, no broader conversation. Whatever the artefact should contain, avoid, emphasise, or structure: you must make it an explicit spec item here, or it will not appear.
+
+## What to Produce
+
+Call `add_spec_item` once per rule. Each spec item has:
+
+- **headline** — a short, sharp label (10-15 words) naming the rule.
+- **content** — one precise prescriptive statement about the artefact.
+
+Examples of good spec items:
+
+- "The plan should name, for each step, who owns it and the trigger that starts it."
+- "Avoid the phrase 'best practices' anywhere in the artefact; name the specific practice."
+- "Include at least one concrete worked example for each novel concept introduced."
+- "Structure the document as numbered steps, not prose paragraphs."
+- "Cite a source for every quantitative claim."
+
+## What Makes a Good Spec
+
+- **Atomic.** One rule per spec item. If you find yourself writing "and", consider whether you have two items.
+- **Prescriptive, not descriptive.** Spec items are about the artefact, not about the world. "The artefact should X" rather than "X is true".
+- **Actionable by a generator with no context.** If a generator saw only your spec, would it know what shape the artefact takes? What content? What style? What depth? What to leave out?
+- **Grounded in the workspace.** You have full workspace context. Use it to surface rules that a generator could not infer from the artefact-task headline alone — relevant prior considerations, known pitfalls, project-specific conventions, constraints the user has previously voiced.
+- **Specific.** "Be clear" is not a spec item. "Prefer 1-2 sentence paragraphs; never nest lists more than two levels" is.
+
+## Coverage
+
+Aim for a spec rich enough that, handed the spec alone, a capable generator could produce a faithful first draft. This typically means covering:
+
+- **Shape and structure** — what kind of artefact is this, what sections or components must it have?
+- **Content** — what must be included, what must be excluded, what must be addressed?
+- **Style and tone** — how should it read, what voice, what register?
+- **Anchors to the request** — what specific parts of the original request the artefact must directly serve?
+- **Known pitfalls** — failure modes the workspace suggests are worth explicitly guarding against.
+
+Err on the side of more spec items. The downstream refinement loop can prune or supersede what doesn't hold up; it cannot invent what isn't there.
+
+## Not Your Job
+
+- You are **not** writing the artefact itself.
+- You are **not** creating claims, questions, or judgements. Only spec items via `add_spec_item`.
+- You are **not** required to justify each spec item — the item's `content` field is the rule; keep it tight.

--- a/src/rumil/available_moves.py
+++ b/src/rumil/available_moves.py
@@ -148,6 +148,9 @@ PRESETS: dict[str, AvailableMoves] = {
             MoveType.LOAD_PAGE,
             MoveType.UPDATE_EPISTEMIC,
         ],
+        CallType.GENERATE_SPEC: [
+            MoveType.ADD_SPEC_ITEM,
+        ],
     },
     "judge-on-assess": {
         CallType.ASSESS: [
@@ -288,6 +291,9 @@ PRESETS: dict[str, AvailableMoves] = {
         CallType.UPDATE_VIEW: [
             MoveType.LOAD_PAGE,
             MoveType.UPDATE_EPISTEMIC,
+        ],
+        CallType.GENERATE_SPEC: [
+            MoveType.ADD_SPEC_ITEM,
         ],
     },
 }

--- a/src/rumil/calls/__init__.py
+++ b/src/rumil/calls/__init__.py
@@ -4,6 +4,7 @@ from rumil.calls.assess import AssessCall, BigAssessCall
 from rumil.calls.call_registry import ASSESS_CALL_CLASSES
 from rumil.calls.create_view import CreateViewCall
 from rumil.calls.find_considerations import FindConsiderationsCall
+from rumil.calls.generate_spec import GenerateSpecCall
 from rumil.calls.ingest import IngestCall
 from rumil.calls.link_subquestions import LinkSubquestionsCall
 from rumil.calls.scout_analogies import ScoutAnalogiesCall
@@ -32,6 +33,7 @@ __all__ = [
     "CallRunner",
     "CreateViewCall",
     "FindConsiderationsCall",
+    "GenerateSpecCall",
     "IngestCall",
     "LinkSubquestionsCall",
     "ScoutAnalogiesCall",

--- a/src/rumil/calls/generate_spec.py
+++ b/src/rumil/calls/generate_spec.py
@@ -1,0 +1,50 @@
+"""Generate Spec call: produce the initial set of spec items for an artefact task."""
+
+from rumil.calls.closing_reviewers import StandardClosingReview
+from rumil.calls.context_builders import EmbeddingContext
+from rumil.calls.page_creators import SimpleAgentLoop
+from rumil.calls.stages import (
+    CallRunner,
+    ClosingReviewer,
+    ContextBuilder,
+    WorkspaceUpdater,
+)
+from rumil.models import CallType
+
+
+class GenerateSpecCall(CallRunner):
+    """Write the initial spec for an artefact the generative workflow will produce.
+
+    The call runs against a (typically hidden) artefact-task question. It has
+    full workspace context via embedding search and emits spec items via the
+    ADD_SPEC_ITEM move. Each spec item is a hidden SPEC_ITEM page linked to
+    the artefact-task question via SPEC_OF.
+    """
+
+    context_builder_cls = EmbeddingContext
+    workspace_updater_cls = SimpleAgentLoop
+    closing_reviewer_cls = StandardClosingReview
+    call_type = CallType.GENERATE_SPEC
+
+    def _make_context_builder(self) -> ContextBuilder:
+        return EmbeddingContext(self.call_type)
+
+    def _make_workspace_updater(self) -> WorkspaceUpdater:
+        return SimpleAgentLoop(
+            self.call_type,
+            self.task_description(),
+            available_moves=self._resolve_available_moves(),
+        )
+
+    def _make_closing_reviewer(self) -> ClosingReviewer:
+        return StandardClosingReview(self.call_type)
+
+    def task_description(self) -> str:
+        return (
+            "Write the initial spec for the artefact described by the "
+            "artefact-task question below. Emit spec items via `add_spec_item` — "
+            "each one is a single atomic prescriptive rule the artefact will be "
+            "held to. Aim for a spec rich enough that a downstream generator, "
+            "seeing only the spec, could write a faithful artefact.\n\n"
+            f"Artefact-task question ID: `{self.infra.question_id}`"
+        )

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -31,6 +31,7 @@ class PageType(str, Enum):
     VIEW = "view"
     VIEW_ITEM = "view_item"
     VIEW_META = "view_meta"
+    SPEC_ITEM = "spec_item"  # prescriptive claim constraining a generated artefact
 
 
 class PageDetail(str, Enum):
@@ -84,6 +85,7 @@ class CallType(str, Enum):
     CREATE_VIEW = "create_view"
     GLOBAL_PRIORITIZATION = "global_prioritization"
     UPDATE_VIEW = "update_view"
+    GENERATE_SPEC = "generate_spec"
     # Envelope call for mutations made from Claude Code's broader context
     # (not a rumil-internal call with carefully scoped prompt). Never
     # dispatchable from prioritization — only created by .claude/ skills.
@@ -135,6 +137,9 @@ class LinkType(str, Enum):
     VIEW_ITEM = "view_item"  # view -> view_item: item belongs to this view
     VIEW_OF = "view_of"  # view -> question: this view covers this question
     META_FOR = "meta_for"  # view_meta -> view_item or view: meta annotation
+    SPEC_OF = (
+        "spec_of"  # spec_item -> question: the artefact-task question this spec item constrains
+    )
 
 
 class MoveType(str, Enum):
@@ -155,6 +160,7 @@ class MoveType(str, Enum):
     UPDATE_EPISTEMIC = "UPDATE_EPISTEMIC"
     CREATE_VIEW_ITEM = "CREATE_VIEW_ITEM"
     PROPOSE_VIEW_ITEM = "PROPOSE_VIEW_ITEM"
+    ADD_SPEC_ITEM = "ADD_SPEC_ITEM"
 
 
 class CallStage(str, Enum):

--- a/src/rumil/moves/add_spec_item.py
+++ b/src/rumil/moves/add_spec_item.py
@@ -1,0 +1,95 @@
+"""ADD_SPEC_ITEM move: add a prescriptive spec item bearing on the artefact task."""
+
+import logging
+
+from pydantic import BaseModel, Field
+
+from rumil.database import DB
+from rumil.models import (
+    Call,
+    LinkType,
+    MoveType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.moves.base import MoveDef, MoveResult
+from rumil.settings import get_settings
+
+log = logging.getLogger(__name__)
+
+
+class AddSpecItemPayload(BaseModel):
+    headline: str = Field(
+        description=(
+            "Short, sharp label for this spec item — 10-15 words, self-contained. "
+            "Names the prescriptive rule the artefact should satisfy."
+        ),
+    )
+    content: str = Field(
+        description=(
+            "The spec item itself: one precise prescriptive statement about the "
+            "artefact. Prefer atomic rules over bundles — if you're saying two "
+            "independent things, make two spec items. Write in terms of what the "
+            "artefact should or should not do, include, or look like."
+        ),
+    )
+
+
+async def execute(payload: AddSpecItemPayload, call: Call, db: DB) -> MoveResult:
+    artefact_task_id = call.scope_page_id
+    if not artefact_task_id:
+        return MoveResult(
+            message=(
+                "ERROR: add_spec_item requires the call's scope_page_id to be set "
+                "to the artefact-task question. No spec item was created."
+            ),
+            created_page_id=None,
+        )
+
+    page = Page(
+        page_type=PageType.SPEC_ITEM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=payload.content,
+        headline=payload.headline,
+        hidden=True,
+        provenance_model=get_settings().model,
+        provenance_call_type=call.call_type.value,
+        provenance_call_id=call.id,
+    )
+    await db.save_page(page)
+    await db.save_link(
+        PageLink(
+            from_page_id=page.id,
+            to_page_id=artefact_task_id,
+            link_type=LinkType.SPEC_OF,
+        )
+    )
+    log.info(
+        "Spec item added: %s -> artefact task %s",
+        page.id[:8],
+        artefact_task_id[:8],
+    )
+    return MoveResult(
+        message=f"Added spec item [{page.id[:8]}]: {payload.headline}",
+        created_page_id=page.id,
+    )
+
+
+MOVE = MoveDef(
+    move_type=MoveType.ADD_SPEC_ITEM,
+    name="add_spec_item",
+    description=(
+        "Add one atomic prescriptive spec item for the artefact the generative "
+        "workflow will produce. A spec item says what the artefact should or "
+        "should not do, include, or look like — a rule the generator will be "
+        "held to. Prefer sharp, individually-falsifiable rules over broad "
+        "bundles. The spec item is linked to the artefact-task question "
+        "automatically; you do not need to reference it in the payload."
+    ),
+    schema=AddSpecItemPayload,
+    execute=execute,
+)

--- a/src/rumil/moves/add_spec_item.py
+++ b/src/rumil/moves/add_spec_item.py
@@ -49,6 +49,17 @@ async def execute(payload: AddSpecItemPayload, call: Call, db: DB) -> MoveResult
             created_page_id=None,
         )
 
+    scope_page = await db.get_page(artefact_task_id)
+    if scope_page is None or scope_page.page_type != PageType.QUESTION:
+        actual = scope_page.page_type.value if scope_page else "missing"
+        return MoveResult(
+            message=(
+                f"ERROR: add_spec_item scope_page_id must point at a question; "
+                f"got {actual}. No spec item was created."
+            ),
+            created_page_id=None,
+        )
+
     page = Page(
         page_type=PageType.SPEC_ITEM,
         layer=PageLayer.SQUIDGY,

--- a/src/rumil/moves/registry.py
+++ b/src/rumil/moves/registry.py
@@ -1,6 +1,7 @@
 """Move registry: collects all MoveDefs."""
 
 from rumil.models import MoveType
+from rumil.moves.add_spec_item import MOVE as _add_spec_item
 from rumil.moves.base import MoveDef
 from rumil.moves.change_link_role import MOVE as _change_link_role
 from rumil.moves.create_claim import MOVE as _create_claim
@@ -44,5 +45,6 @@ MOVES: dict[MoveType, MoveDef] = {
         _update_epistemic,
         _create_view_item,
         _propose_view_item,
+        _add_spec_item,
     ]
 }

--- a/tests/test_generate_spec.py
+++ b/tests/test_generate_spec.py
@@ -108,6 +108,41 @@ async def test_add_spec_item_errors_without_scope(tmp_db):
     assert spec_items == []
 
 
+async def test_add_spec_item_errors_when_scope_is_not_a_question(tmp_db):
+    """scope_page_id must point at a question — other page types are rejected."""
+    claim = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Some unrelated claim.",
+        headline="Unrelated claim",
+    )
+    await tmp_db.save_page(claim)
+
+    call = Call(
+        call_type=CallType.GENERATE_SPEC,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=claim.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    payload = AddSpecItemPayload(
+        headline="Some rule",
+        content="Some rule about the artefact.",
+    )
+    result = await execute(payload, call, tmp_db)
+
+    assert result.created_page_id is None
+    assert "question" in result.message.lower()
+
+    spec_items = await tmp_db.get_pages(
+        page_type=PageType.SPEC_ITEM,
+        include_hidden=True,
+    )
+    assert spec_items == []
+
+
 @pytest.mark.integration
 async def test_generate_spec_end_to_end(tmp_db, artefact_task, generate_spec_call):
     """GENERATE_SPEC runs to completion and produces at least one SPEC_ITEM

--- a/tests/test_generate_spec.py
+++ b/tests/test_generate_spec.py
@@ -1,0 +1,129 @@
+"""Tests for add_spec_item move and the GENERATE_SPEC call end-to-end.
+
+- Move-level (non-LLM): add_spec_item creates a hidden SPEC_ITEM page and a
+  SPEC_OF link from the spec item to the call's scope_page_id; it errors
+  cleanly when scope is unset.
+- Call-level (LLM-gated): GENERATE_SPEC produces at least one SPEC_ITEM
+  linked via SPEC_OF to the scope question.
+"""
+
+import pytest
+import pytest_asyncio
+
+from rumil.calls.generate_spec import GenerateSpecCall
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+from rumil.moves.add_spec_item import AddSpecItemPayload, execute
+
+
+@pytest_asyncio.fixture
+async def artefact_task(tmp_db):
+    """Hidden question that stands in for an artefact-task anchor."""
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=(
+            "Write a concise onboarding checklist for a new data scientist "
+            "joining a small research team. Cover tooling access, how work is "
+            "prioritised, and where prior analyses live."
+        ),
+        headline="Onboarding checklist for a new data scientist",
+        hidden=True,
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def generate_spec_call(tmp_db, artefact_task):
+    call = Call(
+        call_type=CallType.GENERATE_SPEC,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=artefact_task.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+    return call
+
+
+async def test_add_spec_item_creates_hidden_page_and_spec_of_link(
+    tmp_db, artefact_task, generate_spec_call
+):
+    """The move creates a hidden SPEC_ITEM and links SPEC_OF to the scope question."""
+    payload = AddSpecItemPayload(
+        headline="Name every owner and trigger",
+        content=(
+            "For each onboarding step, name the person who owns it and the "
+            "trigger that starts it (e.g. first-day ticket opened)."
+        ),
+    )
+
+    result = await execute(payload, generate_spec_call, tmp_db)
+    assert result.created_page_id is not None
+
+    created = await tmp_db.get_page(result.created_page_id)
+    assert created is not None
+    assert created.page_type == PageType.SPEC_ITEM
+    assert created.hidden is True
+    assert created.headline == payload.headline
+
+    links_from_spec = await tmp_db.get_links_from(result.created_page_id)
+    spec_of_links = [l for l in links_from_spec if l.link_type == LinkType.SPEC_OF]
+    assert len(spec_of_links) == 1
+    assert spec_of_links[0].to_page_id == artefact_task.id
+
+
+async def test_add_spec_item_errors_without_scope(tmp_db):
+    """The move must error (not create a page) when the call has no scope."""
+    call = Call(
+        call_type=CallType.GENERATE_SPEC,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=None,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    payload = AddSpecItemPayload(
+        headline="Some rule",
+        content="Some rule about the artefact.",
+    )
+    result = await execute(payload, call, tmp_db)
+
+    assert result.created_page_id is None
+    assert "scope_page_id" in result.message
+
+    spec_items = await tmp_db.get_pages(
+        page_type=PageType.SPEC_ITEM,
+        include_hidden=True,
+    )
+    assert spec_items == []
+
+
+@pytest.mark.integration
+async def test_generate_spec_end_to_end(tmp_db, artefact_task, generate_spec_call):
+    """GENERATE_SPEC runs to completion and produces at least one SPEC_ITEM
+    linked via SPEC_OF to the artefact-task question."""
+    call = GenerateSpecCall(artefact_task.id, generate_spec_call, tmp_db)
+    await call.run()
+
+    refreshed = await tmp_db.get_call(generate_spec_call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+
+    links_to_task = await tmp_db.get_links_to(artefact_task.id)
+    spec_of_links = [l for l in links_to_task if l.link_type == LinkType.SPEC_OF]
+    assert len(spec_of_links) >= 1
+
+    spec_item_ids = [l.from_page_id for l in spec_of_links]
+    pages = await tmp_db.get_pages_by_ids(spec_item_ids)
+    for spec in pages.values():
+        assert spec.page_type == PageType.SPEC_ITEM
+        assert spec.hidden is True


### PR DESCRIPTION
## Summary
First slice of the generative-workflow orchestrator (discussed in prior design sessions). Adds:

- **`CallType.GENERATE_SPEC`** + `GenerateSpecCall` — `EmbeddingContext` (full workspace) + `SimpleAgentLoop` + `StandardClosingReview`, with `prompts/generate_spec.md`.
- **`PageType.SPEC_ITEM`**, **`LinkType.SPEC_OF`**, **`MoveType.ADD_SPEC_ITEM`**.
- **`add_spec_item` move** — creates a hidden `SPEC_ITEM` page, links `SPEC_OF` from the spec item to the call's `scope_page_id` (the artefact-task question). Errors cleanly if scope is unset.
- Presets for `GENERATE_SPEC = [ADD_SPEC_ITEM]` in both `default` and `judge-on-assess`.
- Not added to `DISPATCHABLE_CALL_TYPES` — this call is driven by the future generative orchestrator, not by prioritization.

Spec items are hidden-by-default (PR #355 infrastructure) so the lineage never pollutes embedding search or default context rendering.

Scope intentionally tight: no supersede/delete moves, no artefact generation or critique, no orchestrator. Those land in follow-up PRs next to their first consumers so nothing ships as dead code.

## Test plan
- [x] Non-LLM: `add_spec_item` creates hidden `SPEC_ITEM` + `SPEC_OF` link to scope
- [x] Non-LLM: `add_spec_item` errors and creates no page when `scope_page_id` is unset
- [x] Integration (89s, `@pytest.mark.integration`): `GenerateSpecCall` runs end-to-end against a small artefact-task question and produces ≥1 hidden `SPEC_ITEM` linked via `SPEC_OF`
- [x] Full non-LLM suite: 517 passed; 2 failures are pre-existing on `main` (`test_api.py::test_llm_exchange_with_null_round`, `test_big_assess_context.py::test_get_latest_judgement_returns_most_recent`)
- [x] `ruff check` / `ruff format --check` / `pyright` clean

## Next
- PR 2b: `generate_artefact` + `critique_artefact` + `include_preamble` on `CallRunner` + `hidden_changed` mutation event.
- PR 2c: `refine_spec` (multi-round loop with supersede/delete/regenerate/finalize moves) + orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)