### PR TITLE
Add generate_artefact + critique_artefact calls

### DIFF
--- a/prompts/critique_artefact.md
+++ b/prompts/critique_artefact.md
@@ -1,0 +1,47 @@
+# Critique Artefact Call Instructions
+
+## Your Task
+
+You are critiquing an artefact produced by the generative workflow. The user message will give you three things:
+
+1. **The artefact task** — what the requester asked for.
+2. **The artefact under review** — what the generator produced.
+3. **Broader workspace context** — a distillation of what the workspace knows that bears on this task.
+
+Your job: judge how well this artefact satisfies the request, assuming the workspace context is the ground truth about the situation. Itemise what's wrong or missing, grade the artefact, and summarise overall.
+
+## Important: you are NOT judging spec conformance
+
+You are not shown the spec. That is deliberate. If you saw the spec, you would grade how well the artefact matches it — and you would miss the most valuable kind of finding, which is **gaps in the spec itself**: things the artefact should have done that the spec didn't ask for.
+
+Judge the artefact against the request and against what the workspace context reveals. An issue is worth flagging if it matters to the artefact's fitness for purpose, regardless of whether the artefact was told to attend to it.
+
+## What to produce
+
+Return three structured fields:
+
+- **`grade`** (1–10): your overall fitness score.
+  - 1–3: does not meaningfully satisfy the request.
+  - 4–6: partial — a reviewer would send it back.
+  - 7–8: solid — small edits would ship it.
+  - 9–10: excellent — hard to meaningfully improve.
+- **`overall`** (2–5 sentences): what works, what the biggest issues are, and — importantly — whether the request is converging or is too open-ended to meaningfully improve through further iteration.
+- **`issues`** (list): itemise problems. Each entry should be specific and actionable: what is wrong or missing, and what the artefact should do instead. Order items roughly by severity.
+
+## What makes a useful critique
+
+- **Specific.** "Feels thin" is not useful. "Step 4 says 'set up monitoring' but doesn't name what to monitor — for this kind of system, at minimum X, Y, Z" is useful.
+- **Actionable.** Every issue should be something a writer could address without needing more clarification from you.
+- **Rooted in the workspace.** Prefer issues you can tie to something concrete the workspace context reveals — that's what a spec-only generator couldn't see.
+- **Not a rewrite.** Don't propose a full alternative artefact. Surface issues; leave the fix to refinement.
+- **Calibrated.** Don't pad the list with minor stylistic preferences. If the artefact is genuinely solid, say so and grade high.
+
+## Meta-signal: convergence
+
+In the `overall` field, say honestly whether further iteration looks worthwhile. Signs it's probably NOT worthwhile:
+
+- The issues you're flagging require information the workspace doesn't have.
+- The request is fundamentally under-specified and any plausible artefact would face similar critiques.
+- Successive critiques are naming different issues each round — the spec is churning, not converging.
+
+The refiner uses this signal to decide whether to keep iterating or stop with the current draft.

--- a/prompts/generate_artefact.md
+++ b/prompts/generate_artefact.md
@@ -1,0 +1,27 @@
+# Artefact Writer
+
+You are writing an artefact — a plan, document, design, checklist, or other long-form object — in response to a request.
+
+The user message contains two things in order:
+
+1. **The artefact task**: what the requester wants the artefact to be about.
+2. **The spec**: a numbered list of prescriptive rules the artefact must satisfy. Each rule was written by someone who has seen the broader situation you have not; take them as binding.
+
+Write the artefact. That's your whole job.
+
+## How to write
+
+- Produce the artefact itself — not a description of the artefact, not a meta-summary, not an apology. Produce the thing.
+- Follow every spec rule. If two rules appear to conflict, honour both as literally as possible and prefer the more specific one.
+- Include the connective tissue the spec doesn't explicitly call out: transitions, framing sentences, headings where useful, examples where useful. The spec is a floor, not a ceiling.
+- Use the structure the spec implies (numbered steps, checklist, narrative, sections, etc.). If the spec is silent on structure, choose the structure the artefact type normally takes.
+- Write directly and specifically. Avoid filler openings like "In today's fast-paced world…". Avoid closing paragraphs that recap what was just said.
+
+## What you don't know
+
+- You cannot see any broader context, prior drafts, or anyone else's notes. Everything the artefact needs must be derivable from the task and the spec.
+- If the spec seems incomplete — missing audience, missing scope, missing format detail — make the most helpful assumption a careful writer would make and write accordingly. A later critic will flag spec gaps; your job is to write the best artefact the current spec allows.
+
+## Output
+
+Return a `headline` (10–15 words, self-contained, names the artefact) and a `content` field containing the artefact itself. Write the content in Markdown.

--- a/src/rumil/available_moves.py
+++ b/src/rumil/available_moves.py
@@ -151,6 +151,8 @@ PRESETS: dict[str, AvailableMoves] = {
         CallType.GENERATE_SPEC: [
             MoveType.ADD_SPEC_ITEM,
         ],
+        CallType.GENERATE_ARTEFACT: [],
+        CallType.CRITIQUE_ARTEFACT: [],
     },
     "judge-on-assess": {
         CallType.ASSESS: [
@@ -295,6 +297,8 @@ PRESETS: dict[str, AvailableMoves] = {
         CallType.GENERATE_SPEC: [
             MoveType.ADD_SPEC_ITEM,
         ],
+        CallType.GENERATE_ARTEFACT: [],
+        CallType.CRITIQUE_ARTEFACT: [],
     },
 }
 

--- a/src/rumil/calls/__init__.py
+++ b/src/rumil/calls/__init__.py
@@ -3,7 +3,9 @@
 from rumil.calls.assess import AssessCall, BigAssessCall
 from rumil.calls.call_registry import ASSESS_CALL_CLASSES
 from rumil.calls.create_view import CreateViewCall
+from rumil.calls.critique_artefact import CritiqueArtefactCall
 from rumil.calls.find_considerations import FindConsiderationsCall
+from rumil.calls.generate_artefact import GenerateArtefactCall
 from rumil.calls.generate_spec import GenerateSpecCall
 from rumil.calls.ingest import IngestCall
 from rumil.calls.link_subquestions import LinkSubquestionsCall
@@ -32,7 +34,9 @@ __all__ = [
     "BigAssessCall",
     "CallRunner",
     "CreateViewCall",
+    "CritiqueArtefactCall",
     "FindConsiderationsCall",
+    "GenerateArtefactCall",
     "GenerateSpecCall",
     "IngestCall",
     "LinkSubquestionsCall",

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -1058,15 +1058,7 @@ class SpecOnlyContext(ContextBuilder):
                 f"SpecOnlyContext: artefact-task question {infra.question_id} not found"
             )
 
-        spec_links = await infra.db.get_links_to(infra.question_id)
-        spec_of_links = [l for l in spec_links if l.link_type == LinkType.SPEC_OF]
-        spec_ids = [l.from_page_id for l in spec_of_links]
-        spec_pages_by_id = await infra.db.get_pages_by_ids(spec_ids)
-        spec_pages = [
-            spec_pages_by_id[pid]
-            for pid in spec_ids
-            if pid in spec_pages_by_id and spec_pages_by_id[pid].is_active()
-        ]
+        spec_pages = await active_spec_items_for_task(infra.question_id, infra.db)
 
         parts: list[str] = [
             "# Artefact task",
@@ -1175,3 +1167,22 @@ async def _latest_artefact_for_task(task_id: str, db) -> Page | None:
     if not active:
         return None
     return max(active, key=lambda p: p.created_at)
+
+
+async def active_spec_items_for_task(task_id: str, db) -> list[Page]:
+    """Return active SPEC_ITEM pages SPEC_OF-linked to *task_id*.
+
+    Sorted by ``created_at`` (stable insertion order) so prompt rendering is
+    deterministic across runs — important for prompt caching and for keeping
+    generated artefacts consistent when the spec hasn't actually changed.
+    """
+    links = await db.get_links_to(task_id)
+    spec_of_links = [l for l in links if l.link_type == LinkType.SPEC_OF]
+    if not spec_of_links:
+        return []
+    pages_by_id = await db.get_pages_by_ids([l.from_page_id for l in spec_of_links])
+    active = [
+        p for p in pages_by_id.values() if p.is_active() and p.page_type == PageType.SPEC_ITEM
+    ]
+    active.sort(key=lambda p: (p.created_at, p.id))
+    return active

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -1041,3 +1041,137 @@ class BigAssessContext(ContextBuilder):
             working_page_ids=working_page_ids,
             preloaded_ids=all_extra,
         )
+
+
+class SpecOnlyContext(ContextBuilder):
+    """Context containing ONLY the spec items for an artefact-task question.
+
+    Used by generate_artefact: the generator must produce the artefact from
+    the spec alone, with no access to the broader workspace. Any information
+    the artefact should reflect must be captured in a spec item.
+    """
+
+    async def build_context(self, infra: CallInfra) -> ContextResult:
+        task = await infra.db.get_page(infra.question_id)
+        if task is None:
+            raise ValueError(
+                f"SpecOnlyContext: artefact-task question {infra.question_id} not found"
+            )
+
+        spec_links = await infra.db.get_links_to(infra.question_id)
+        spec_of_links = [l for l in spec_links if l.link_type == LinkType.SPEC_OF]
+        spec_ids = [l.from_page_id for l in spec_of_links]
+        spec_pages_by_id = await infra.db.get_pages_by_ids(spec_ids)
+        spec_pages = [
+            spec_pages_by_id[pid]
+            for pid in spec_ids
+            if pid in spec_pages_by_id and spec_pages_by_id[pid].is_active()
+        ]
+
+        parts: list[str] = [
+            "# Artefact task",
+            "",
+            task.headline,
+            "",
+            task.content or "(no further description)",
+            "",
+            "---",
+            "",
+            f"# Spec ({len(spec_pages)} items)",
+            "",
+        ]
+        if not spec_pages:
+            parts.append("(no spec items yet)")
+        else:
+            for i, spec in enumerate(spec_pages, start=1):
+                parts += [
+                    f"## {i}. {spec.headline}",
+                    "",
+                    spec.content,
+                    "",
+                ]
+        context_text = "\n".join(parts)
+
+        working_page_ids = [task.id] + [p.id for p in spec_pages]
+        await _record_context_built(infra, working_page_ids, [])
+        return ContextResult(
+            context_text=context_text,
+            working_page_ids=working_page_ids,
+            preloaded_ids=[],
+        )
+
+
+class CritiqueContext(ContextBuilder):
+    """Context for critiquing the latest artefact on an artefact-task question.
+
+    Includes the artefact-task question, the latest active Artefact produced
+    for it, and an embedding-based sweep over the broader workspace. Spec
+    items are deliberately EXCLUDED — the critic judges the artefact against
+    the request and what the workspace knows, not against the spec. That is
+    how spec-gaps get surfaced.
+    """
+
+    async def build_context(self, infra: CallInfra) -> ContextResult:
+        task = await infra.db.get_page(infra.question_id)
+        if task is None:
+            raise ValueError(
+                f"CritiqueContext: artefact-task question {infra.question_id} not found"
+            )
+
+        artefact = await _latest_artefact_for_task(infra.question_id, infra.db)
+        if artefact is None:
+            raise ValueError(
+                f"CritiqueContext: no artefact found for task {infra.question_id}; "
+                "run generate_artefact first."
+            )
+
+        query = task.headline or task.content[:200]
+        embedding_result = await build_embedding_based_context(
+            query,
+            infra.db,
+            scope_question_id=infra.question_id,
+        )
+
+        parts: list[str] = [
+            "# Artefact task",
+            "",
+            task.headline,
+            "",
+            task.content or "(no further description)",
+            "",
+            "---",
+            "",
+            "# Artefact under review",
+            "",
+            f"**{artefact.headline}**",
+            "",
+            artefact.content,
+            "",
+            "---",
+            "",
+            "# Broader workspace context",
+            "",
+            embedding_result.context_text,
+        ]
+        context_text = "\n".join(parts)
+
+        working_page_ids = [task.id, artefact.id, *embedding_result.page_ids]
+        await _record_context_built(infra, working_page_ids, [])
+        return ContextResult(
+            context_text=context_text,
+            working_page_ids=working_page_ids,
+            preloaded_ids=[],
+        )
+
+
+async def _latest_artefact_for_task(task_id: str, db) -> Page | None:
+    """Return the most recently-created active Artefact linked ARTEFACT_OF to *task_id*."""
+    links = await db.get_links_to(task_id)
+    artefact_links = [l for l in links if l.link_type == LinkType.ARTEFACT_OF]
+    if not artefact_links:
+        return None
+    pages_by_id = await db.get_pages_by_ids([l.from_page_id for l in artefact_links])
+    active = [p for p in pages_by_id.values() if p.is_active() and p.page_type == PageType.ARTEFACT]
+    if not active:
+        return None
+    return max(active, key=lambda p: p.created_at)

--- a/src/rumil/calls/critique_artefact.py
+++ b/src/rumil/calls/critique_artefact.py
@@ -1,0 +1,186 @@
+"""Critique Artefact call: independently assess the latest artefact on a task.
+
+The critic sees the artefact, the task, and the broader workspace, but NOT
+the spec. That asymmetry is intentional — if the critic saw the spec, it
+would only verify conformance. By seeing the request directly (via workspace
+context) and judging the artefact on its own merits, the critic can surface
+the most valuable kind of finding: gaps in the spec itself.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel, Field
+
+from rumil.calls.closing_reviewers import StandardClosingReview
+from rumil.calls.context_builders import CritiqueContext, _latest_artefact_for_task
+from rumil.calls.stages import (
+    CallInfra,
+    CallRunner,
+    ClosingReviewer,
+    ContextBuilder,
+    ContextResult,
+    UpdateResult,
+    WorkspaceUpdater,
+)
+from rumil.llm import LLMExchangeMetadata, build_system_prompt, structured_call
+from rumil.models import (
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.settings import get_settings
+
+log = logging.getLogger(__name__)
+
+
+class CritiqueOutput(BaseModel):
+    grade: int = Field(
+        description=(
+            "1-10 grade for how well the artefact satisfies the request. "
+            "1 = does not satisfy the request at all; "
+            "5 = partial — a reviewer would ask for substantial changes; "
+            "8 = solid, a few notes but shippable with small edits; "
+            "10 = excellent, could not meaningfully improve."
+        ),
+    )
+    overall: str = Field(
+        description=(
+            "2-5 sentences summarising the artefact's overall fit: what works, "
+            "what the biggest issues are, and whether further iteration looks "
+            "worthwhile versus the request being too open-ended to converge."
+        ),
+    )
+    issues: list[str] = Field(
+        description=(
+            "Itemised problems with the artefact. Each entry should be specific "
+            "and actionable: what is wrong (or missing), and what the artefact "
+            "should do instead. Surface gaps the spec does not cover — that is "
+            "where you add the most value."
+        ),
+    )
+
+
+class CritiqueWriter(WorkspaceUpdater):
+    """Structured-call updater that persists a critique as a hidden JUDGEMENT page.
+
+    Writes one JUDGEMENT page (hidden, with grade+issues stored in ``extra``)
+    linked CRITIQUE_OF to the artefact under review.
+    """
+
+    async def update_workspace(
+        self,
+        infra: CallInfra,
+        context: ContextResult,
+    ) -> UpdateResult:
+        artefact = await _latest_artefact_for_task(infra.question_id, infra.db)
+        if artefact is None:
+            raise RuntimeError(
+                f"critique_artefact: no artefact found for task {infra.question_id[:8]}"
+            )
+
+        system_prompt = build_system_prompt(CallType.CRITIQUE_ARTEFACT.value)
+        result = await structured_call(
+            system_prompt=system_prompt,
+            user_message=context.context_text,
+            response_model=CritiqueOutput,
+            metadata=LLMExchangeMetadata(
+                call_id=infra.call.id,
+                phase="critique_artefact",
+            ),
+            db=infra.db,
+        )
+        parsed = result.parsed
+        if parsed is None:
+            raise RuntimeError(
+                f"critique_artefact: structured call for {infra.call.id[:8]} "
+                "returned no parsed output"
+            )
+
+        issues_md = "\n".join(f"- {issue}" for issue in parsed.issues) or "- (none)"
+        content = (
+            f"**Grade:** {parsed.grade}/10\n\n"
+            f"**Overall:** {parsed.overall}\n\n"
+            f"**Issues:**\n{issues_md}"
+        )
+        headline = f"Critique of {artefact.headline[:80]} (grade {parsed.grade}/10)"
+
+        critique_page = Page(
+            page_type=PageType.JUDGEMENT,
+            layer=PageLayer.SQUIDGY,
+            workspace=Workspace.RESEARCH,
+            content=content,
+            headline=headline,
+            hidden=True,
+            extra={
+                "grade": parsed.grade,
+                "issues": list(parsed.issues),
+            },
+            provenance_model=get_settings().model,
+            provenance_call_type=infra.call.call_type.value,
+            provenance_call_id=infra.call.id,
+        )
+        await infra.db.save_page(critique_page)
+
+        await infra.db.save_link(
+            PageLink(
+                from_page_id=critique_page.id,
+                to_page_id=artefact.id,
+                link_type=LinkType.CRITIQUE_OF,
+            )
+        )
+
+        log.info(
+            "Critique persisted: %s -> artefact %s (grade=%d, issues=%d)",
+            critique_page.id[:8],
+            artefact.id[:8],
+            parsed.grade,
+            len(parsed.issues),
+        )
+
+        infra.state.created_page_ids.append(critique_page.id)
+        infra.state.last_created_id = critique_page.id
+
+        return UpdateResult(
+            created_page_ids=[critique_page.id],
+            moves=[],
+            all_loaded_ids=list(context.working_page_ids),
+            rounds_completed=1,
+        )
+
+
+class CritiqueArtefactCall(CallRunner):
+    """Independently critique the latest artefact on an artefact-task question.
+
+    Sees the artefact, the task, and the workspace via embedding search.
+    Deliberately does NOT see the spec — spec-gaps are the most valuable
+    thing the critic can surface for the refiner.
+    """
+
+    context_builder_cls = CritiqueContext
+    workspace_updater_cls = CritiqueWriter
+    closing_reviewer_cls = StandardClosingReview
+    call_type = CallType.CRITIQUE_ARTEFACT
+
+    def _make_context_builder(self) -> ContextBuilder:
+        return CritiqueContext()
+
+    def _make_workspace_updater(self) -> WorkspaceUpdater:
+        return CritiqueWriter()
+
+    def _make_closing_reviewer(self) -> ClosingReviewer:
+        return StandardClosingReview(self.call_type)
+
+    def task_description(self) -> str:
+        return (
+            "Critique the artefact shown above for how well it satisfies the "
+            "artefact-task request, using your knowledge of the broader workspace. "
+            "Prioritise issues the artefact's spec might not have covered — "
+            "that is where your judgement is most valuable.\n\n"
+            f"Artefact-task question ID: `{self.infra.question_id}`"
+        )

--- a/src/rumil/calls/generate_artefact.py
+++ b/src/rumil/calls/generate_artefact.py
@@ -12,7 +12,7 @@ import logging
 from pydantic import BaseModel, Field
 
 from rumil.calls.closing_reviewers import StandardClosingReview
-from rumil.calls.context_builders import SpecOnlyContext
+from rumil.calls.context_builders import SpecOnlyContext, active_spec_items_for_task
 from rumil.calls.stages import (
     CallInfra,
     CallRunner,
@@ -110,12 +110,12 @@ class ArtefactWriter(WorkspaceUpdater):
             )
         )
 
-        spec_item_ids = [pid for pid in context.working_page_ids if pid != infra.question_id]
-        for spec_id in spec_item_ids:
+        spec_items = await active_spec_items_for_task(infra.question_id, infra.db)
+        for spec in spec_items:
             await infra.db.save_link(
                 PageLink(
                     from_page_id=artefact_page.id,
-                    to_page_id=spec_id,
+                    to_page_id=spec.id,
                     link_type=LinkType.GENERATED_FROM,
                 )
             )
@@ -133,7 +133,7 @@ class ArtefactWriter(WorkspaceUpdater):
             "Artefact generated: %s (task=%s, spec_items=%d)",
             artefact_page.id[:8],
             infra.question_id[:8],
-            len(spec_item_ids),
+            len(spec_items),
         )
 
         infra.state.created_page_ids.append(artefact_page.id)

--- a/src/rumil/calls/generate_artefact.py
+++ b/src/rumil/calls/generate_artefact.py
@@ -1,0 +1,190 @@
+"""Generate Artefact call: write the artefact from the spec alone.
+
+Intentionally domain-neutral — the generator sees only the spec items and the
+artefact-task description, not the rumil preamble, not the broader workspace.
+Any information the artefact should reflect must be captured in a spec item.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel, Field
+
+from rumil.calls.closing_reviewers import StandardClosingReview
+from rumil.calls.context_builders import SpecOnlyContext
+from rumil.calls.stages import (
+    CallInfra,
+    CallRunner,
+    ClosingReviewer,
+    ContextBuilder,
+    ContextResult,
+    UpdateResult,
+    WorkspaceUpdater,
+)
+from rumil.llm import LLMExchangeMetadata, build_system_prompt, structured_call
+from rumil.models import (
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.settings import get_settings
+
+log = logging.getLogger(__name__)
+
+
+class ArtefactOutput(BaseModel):
+    headline: str = Field(
+        description=(
+            "A short, self-contained label for this artefact (10-15 words). "
+            "A reader seeing only the headline should know what the artefact is."
+        ),
+    )
+    content: str = Field(
+        description=(
+            "The artefact itself — the full long-form object the spec describes. "
+            "Produce the artefact; do not meta-comment about it."
+        ),
+    )
+
+
+class ArtefactWriter(WorkspaceUpdater):
+    """Structured-call updater that writes an artefact from the spec.
+
+    Creates one hidden ARTEFACT page. Links the artefact ARTEFACT_OF to the
+    artefact-task question and GENERATED_FROM to each spec item that was live
+    at generation time (the per-iteration snapshot used later to reconstruct
+    past specs even after deletes).
+
+    If an earlier artefact exists for this task, it is superseded.
+    """
+
+    async def update_workspace(
+        self,
+        infra: CallInfra,
+        context: ContextResult,
+    ) -> UpdateResult:
+        system_prompt = build_system_prompt(
+            CallType.GENERATE_ARTEFACT.value,
+            include_preamble=False,
+        )
+        result = await structured_call(
+            system_prompt=system_prompt,
+            user_message=context.context_text,
+            response_model=ArtefactOutput,
+            metadata=LLMExchangeMetadata(
+                call_id=infra.call.id,
+                phase="generate_artefact",
+            ),
+            db=infra.db,
+        )
+        parsed = result.parsed
+        if parsed is None:
+            raise RuntimeError(
+                f"generate_artefact: structured call for {infra.call.id[:8]} "
+                "returned no parsed output"
+            )
+
+        artefact_page = Page(
+            page_type=PageType.ARTEFACT,
+            layer=PageLayer.SQUIDGY,
+            workspace=Workspace.RESEARCH,
+            content=parsed.content,
+            headline=parsed.headline,
+            hidden=True,
+            provenance_model=get_settings().model,
+            provenance_call_type=infra.call.call_type.value,
+            provenance_call_id=infra.call.id,
+        )
+        await infra.db.save_page(artefact_page)
+
+        await infra.db.save_link(
+            PageLink(
+                from_page_id=artefact_page.id,
+                to_page_id=infra.question_id,
+                link_type=LinkType.ARTEFACT_OF,
+            )
+        )
+
+        spec_item_ids = [pid for pid in context.working_page_ids if pid != infra.question_id]
+        for spec_id in spec_item_ids:
+            await infra.db.save_link(
+                PageLink(
+                    from_page_id=artefact_page.id,
+                    to_page_id=spec_id,
+                    link_type=LinkType.GENERATED_FROM,
+                )
+            )
+
+        prior_artefact = await _prior_artefact(infra.question_id, artefact_page.id, infra.db)
+        if prior_artefact is not None:
+            await infra.db.supersede_page(prior_artefact.id, artefact_page.id)
+            log.info(
+                "Superseded prior artefact %s with %s",
+                prior_artefact.id[:8],
+                artefact_page.id[:8],
+            )
+
+        log.info(
+            "Artefact generated: %s (task=%s, spec_items=%d)",
+            artefact_page.id[:8],
+            infra.question_id[:8],
+            len(spec_item_ids),
+        )
+
+        infra.state.created_page_ids.append(artefact_page.id)
+        infra.state.last_created_id = artefact_page.id
+
+        return UpdateResult(
+            created_page_ids=[artefact_page.id],
+            moves=[],
+            all_loaded_ids=list(context.working_page_ids),
+            rounds_completed=1,
+        )
+
+
+async def _prior_artefact(task_id: str, new_artefact_id: str, db) -> Page | None:
+    """Return the most recent active ARTEFACT linked ARTEFACT_OF to the task,
+    excluding *new_artefact_id*. Used to supersede the prior version in place."""
+    links = await db.get_links_to(task_id)
+    artefact_links = [l for l in links if l.link_type == LinkType.ARTEFACT_OF]
+    candidate_ids = [l.from_page_id for l in artefact_links if l.from_page_id != new_artefact_id]
+    if not candidate_ids:
+        return None
+    pages_by_id = await db.get_pages_by_ids(candidate_ids)
+    active = [p for p in pages_by_id.values() if p.is_active() and p.page_type == PageType.ARTEFACT]
+    if not active:
+        return None
+    return max(active, key=lambda p: p.created_at)
+
+
+class GenerateArtefactCall(CallRunner):
+    """Produce the artefact from the current spec on an artefact-task question.
+
+    The generator sees only the spec (via SpecOnlyContext) and writes the
+    artefact in one structured call. No rumil preamble, no broader workspace.
+    """
+
+    context_builder_cls = SpecOnlyContext
+    workspace_updater_cls = ArtefactWriter
+    closing_reviewer_cls = StandardClosingReview
+    call_type = CallType.GENERATE_ARTEFACT
+
+    def _make_context_builder(self) -> ContextBuilder:
+        return SpecOnlyContext()
+
+    def _make_workspace_updater(self) -> WorkspaceUpdater:
+        return ArtefactWriter()
+
+    def _make_closing_reviewer(self) -> ClosingReviewer:
+        return StandardClosingReview(self.call_type)
+
+    def task_description(self) -> str:
+        return (
+            "Produce the artefact described by the spec in your user message. "
+            f"Artefact-task question ID: `{self.infra.question_id}`"
+        )

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -177,15 +177,27 @@ _SCOUT_BUDGET_CALL_TYPES: frozenset[str] = frozenset(
 )
 
 
-def build_system_prompt(call_type: str, *, include_citations: bool = True) -> str:
+def build_system_prompt(
+    call_type: str,
+    *,
+    include_preamble: bool = True,
+    include_citations: bool = True,
+) -> str:
     """Combine preamble + call-type instructions + citations into one system prompt.
 
     Pass ``include_citations=False`` for calls that do not create any content-bearing
     pages (e.g. prioritization, scoring) — the inline-citation rules have nothing to
     attach to in those calls and only add noise.
+
+    Pass ``include_preamble=False`` for calls whose prompts must not assume any
+    rumil-workspace framing (e.g. generate_artefact, where the LLM is acting as
+    a domain-neutral writer with only a spec for context). When preamble is off,
+    citations and grounding are also skipped since they're workspace-specific.
     """
-    preamble = _load_file("preamble.md")
     instructions = _load_file(f"{call_type}.md")
+    if not include_preamble:
+        return instructions
+    preamble = _load_file("preamble.md")
     grounding = _load_file("grounding.md")
     parts = [preamble, instructions]
     if include_citations:

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -32,6 +32,7 @@ class PageType(str, Enum):
     VIEW_ITEM = "view_item"
     VIEW_META = "view_meta"
     SPEC_ITEM = "spec_item"  # prescriptive claim constraining a generated artefact
+    ARTEFACT = "artefact"  # long-form object produced by the generative workflow
 
 
 class PageDetail(str, Enum):
@@ -86,6 +87,8 @@ class CallType(str, Enum):
     GLOBAL_PRIORITIZATION = "global_prioritization"
     UPDATE_VIEW = "update_view"
     GENERATE_SPEC = "generate_spec"
+    GENERATE_ARTEFACT = "generate_artefact"
+    CRITIQUE_ARTEFACT = "critique_artefact"
     # Envelope call for mutations made from Claude Code's broader context
     # (not a rumil-internal call with carefully scoped prompt). Never
     # dispatchable from prioritization — only created by .claude/ skills.
@@ -139,6 +142,11 @@ class LinkType(str, Enum):
     META_FOR = "meta_for"  # view_meta -> view_item or view: meta annotation
     SPEC_OF = (
         "spec_of"  # spec_item -> question: the artefact-task question this spec item constrains
+    )
+    ARTEFACT_OF = "artefact_of"  # artefact -> question: artefact produced for an artefact-task
+    CRITIQUE_OF = "critique_of"  # judgement -> artefact: this judgement critiques that artefact
+    GENERATED_FROM = (
+        "generated_from"  # artefact -> spec_item: spec items the artefact was generated from
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def _block_real_llm_calls(request, monkeypatch):
     test still reaches this chokepoint, it's silently making real API
     calls — raise instead.
     """
-    if request.node.get_closest_marker("llm"):
+    if request.node.get_closest_marker("llm") or request.node.get_closest_marker("integration"):
         return
     from rumil.settings import Settings
 

--- a/tests/test_generate_artefact.py
+++ b/tests/test_generate_artefact.py
@@ -121,6 +121,43 @@ async def test_spec_only_context_renders_task_and_spec(tmp_db, artefact_task):
     assert len(ctx.working_page_ids) == 3
 
 
+async def test_spec_only_context_orders_items_deterministically(tmp_db, artefact_task):
+    """Spec items render in created_at order so prompt caching stays stable."""
+    specs = await _seed_spec_items(
+        tmp_db,
+        artefact_task.id,
+        [
+            ("First rule", "first"),
+            ("Second rule", "second"),
+            ("Third rule", "third"),
+        ],
+    )
+
+    call = Call(
+        call_type=CallType.GENERATE_ARTEFACT,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=artefact_task.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    infra = CallInfra(
+        question_id=artefact_task.id,
+        call=call,
+        db=tmp_db,
+        trace=CallTrace(call.id, tmp_db),
+        state=MoveState(call, tmp_db),
+    )
+    ctx = await SpecOnlyContext().build_context(infra)
+
+    first_pos = ctx.context_text.index("First rule")
+    second_pos = ctx.context_text.index("Second rule")
+    third_pos = ctx.context_text.index("Third rule")
+    assert first_pos < second_pos < third_pos
+
+    assert ctx.working_page_ids[1:] == [s.id for s in specs]
+
+
 async def test_critique_context_errors_when_no_artefact(tmp_db, artefact_task):
     """CritiqueContext requires an artefact; surface a clear error otherwise."""
     call = Call(

--- a/tests/test_generate_artefact.py
+++ b/tests/test_generate_artefact.py
@@ -1,0 +1,282 @@
+"""Tests for generate_artefact and critique_artefact.
+
+- Non-LLM: build_system_prompt(include_preamble=False) skips preamble;
+  SpecOnlyContext renders the task + spec items only; CritiqueContext raises
+  when no artefact exists yet.
+- Integration: end-to-end generate_artefact produces a hidden ARTEFACT page
+  with ARTEFACT_OF + GENERATED_FROM links; critique_artefact produces a
+  hidden JUDGEMENT linked via CRITIQUE_OF.
+"""
+
+import pytest
+import pytest_asyncio
+
+from rumil.calls.context_builders import (
+    CritiqueContext,
+    SpecOnlyContext,
+    _latest_artefact_for_task,
+)
+from rumil.calls.critique_artefact import CritiqueArtefactCall
+from rumil.calls.generate_artefact import GenerateArtefactCall
+from rumil.calls.stages import CallInfra
+from rumil.llm import build_system_prompt
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.moves.base import MoveState
+from rumil.tracing.tracer import CallTrace
+
+
+def test_build_system_prompt_omits_preamble_when_flagged():
+    """include_preamble=False should return just the call-type instructions."""
+    with_preamble = build_system_prompt("generate_artefact", include_preamble=True)
+    without_preamble = build_system_prompt("generate_artefact", include_preamble=False)
+
+    assert len(without_preamble) < len(with_preamble)
+    assert "Rumil" not in without_preamble
+    assert "Artefact Writer" in without_preamble
+
+
+@pytest_asyncio.fixture
+async def artefact_task(tmp_db):
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=(
+            "Write a two-paragraph blurb describing what happens during "
+            "photosynthesis, suitable for a high-school biology poster."
+        ),
+        headline="Photosynthesis blurb for a biology poster",
+        hidden=True,
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+async def _seed_spec_items(db, task_id, items):
+    created = []
+    for headline, content in items:
+        spec = Page(
+            page_type=PageType.SPEC_ITEM,
+            layer=PageLayer.SQUIDGY,
+            workspace=Workspace.RESEARCH,
+            content=content,
+            headline=headline,
+            hidden=True,
+        )
+        await db.save_page(spec)
+        await db.save_link(
+            PageLink(
+                from_page_id=spec.id,
+                to_page_id=task_id,
+                link_type=LinkType.SPEC_OF,
+            )
+        )
+        created.append(spec)
+    return created
+
+
+async def test_spec_only_context_renders_task_and_spec(tmp_db, artefact_task):
+    """SpecOnlyContext output contains the task and every active spec item."""
+    await _seed_spec_items(
+        tmp_db,
+        artefact_task.id,
+        [
+            ("Plain-English diction", "Avoid jargon; define any technical term inline."),
+            ("Two paragraphs", "Exactly two paragraphs, no headings."),
+        ],
+    )
+
+    call = Call(
+        call_type=CallType.GENERATE_ARTEFACT,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=artefact_task.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    infra = CallInfra(
+        question_id=artefact_task.id,
+        call=call,
+        db=tmp_db,
+        trace=CallTrace(call.id, tmp_db),
+        state=MoveState(call, tmp_db),
+    )
+    builder = SpecOnlyContext()
+    ctx = await builder.build_context(infra)
+
+    assert "photosynthesis" in ctx.context_text.lower()
+    assert "Plain-English diction" in ctx.context_text
+    assert "Two paragraphs" in ctx.context_text
+    assert artefact_task.id in ctx.working_page_ids
+    assert len(ctx.working_page_ids) == 3
+
+
+async def test_critique_context_errors_when_no_artefact(tmp_db, artefact_task):
+    """CritiqueContext requires an artefact; surface a clear error otherwise."""
+    call = Call(
+        call_type=CallType.CRITIQUE_ARTEFACT,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=artefact_task.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    infra = CallInfra(
+        question_id=artefact_task.id,
+        call=call,
+        db=tmp_db,
+        trace=CallTrace(call.id, tmp_db),
+        state=MoveState(call, tmp_db),
+    )
+    with pytest.raises(ValueError, match="no artefact"):
+        await CritiqueContext().build_context(infra)
+
+
+async def test_latest_artefact_for_task_returns_most_recent(tmp_db, artefact_task):
+    """Helper selects the most recent active ARTEFACT linked to the task."""
+    assert await _latest_artefact_for_task(artefact_task.id, tmp_db) is None
+
+    older = Page(
+        page_type=PageType.ARTEFACT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="first draft",
+        headline="Draft 1",
+        hidden=True,
+    )
+    await tmp_db.save_page(older)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=older.id,
+            to_page_id=artefact_task.id,
+            link_type=LinkType.ARTEFACT_OF,
+        )
+    )
+
+    newer = Page(
+        page_type=PageType.ARTEFACT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="second draft",
+        headline="Draft 2",
+        hidden=True,
+    )
+    await tmp_db.save_page(newer)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=newer.id,
+            to_page_id=artefact_task.id,
+            link_type=LinkType.ARTEFACT_OF,
+        )
+    )
+
+    latest = await _latest_artefact_for_task(artefact_task.id, tmp_db)
+    assert latest is not None
+    assert latest.id == newer.id
+
+
+@pytest.mark.integration
+async def test_generate_artefact_end_to_end(tmp_db, artefact_task):
+    """generate_artefact creates an ARTEFACT linked ARTEFACT_OF + GENERATED_FROM."""
+    specs = await _seed_spec_items(
+        tmp_db,
+        artefact_task.id,
+        [
+            ("Plain English only", "Avoid jargon; define any technical term inline."),
+            ("Two paragraphs", "Output must be exactly two paragraphs, no headings."),
+            (
+                "Name inputs and outputs",
+                "Mention what goes in (light, CO2, water) and what comes out (sugar, oxygen).",
+            ),
+        ],
+    )
+
+    call = Call(
+        call_type=CallType.GENERATE_ARTEFACT,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=artefact_task.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    runner = GenerateArtefactCall(artefact_task.id, call, tmp_db)
+    await runner.run()
+
+    refreshed = await tmp_db.get_call(call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+
+    artefact = await _latest_artefact_for_task(artefact_task.id, tmp_db)
+    assert artefact is not None
+    assert artefact.page_type == PageType.ARTEFACT
+    assert artefact.hidden is True
+    assert len(artefact.content) > 50
+
+    outgoing = await tmp_db.get_links_from(artefact.id)
+    artefact_of = [l for l in outgoing if l.link_type == LinkType.ARTEFACT_OF]
+    generated_from = [l for l in outgoing if l.link_type == LinkType.GENERATED_FROM]
+    assert len(artefact_of) == 1
+    assert artefact_of[0].to_page_id == artefact_task.id
+    assert {l.to_page_id for l in generated_from} == {s.id for s in specs}
+
+
+@pytest.mark.integration
+async def test_critique_artefact_end_to_end(tmp_db, artefact_task):
+    """critique_artefact creates a JUDGEMENT linked CRITIQUE_OF to the artefact."""
+    artefact = Page(
+        page_type=PageType.ARTEFACT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=(
+            "Photosynthesis is how plants eat light. Leaves take in sunshine, "
+            "drink water from the roots, and breathe in air. Inside the leaf, "
+            "tiny green parts use the light to mix the air and water into food "
+            "for the plant. The plant then lets out fresh oxygen, which is "
+            "what we breathe. Without this, there would be no food and no air "
+            "to breathe."
+        ),
+        headline="A simple blurb on photosynthesis",
+        hidden=True,
+    )
+    await tmp_db.save_page(artefact)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=artefact.id,
+            to_page_id=artefact_task.id,
+            link_type=LinkType.ARTEFACT_OF,
+        )
+    )
+
+    call = Call(
+        call_type=CallType.CRITIQUE_ARTEFACT,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=artefact_task.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    runner = CritiqueArtefactCall(artefact_task.id, call, tmp_db)
+    await runner.run()
+
+    refreshed = await tmp_db.get_call(call.id)
+    assert refreshed.status == CallStatus.COMPLETE
+
+    links_to_artefact = await tmp_db.get_links_to(artefact.id)
+    critique_links = [l for l in links_to_artefact if l.link_type == LinkType.CRITIQUE_OF]
+    assert len(critique_links) >= 1
+
+    critique_pages = await tmp_db.get_pages_by_ids([l.from_page_id for l in critique_links])
+    assert all(p.page_type == PageType.JUDGEMENT for p in critique_pages.values())
+    assert all(p.hidden for p in critique_pages.values())
+    for p in critique_pages.values():
+        assert "grade" in p.extra
+        assert isinstance(p.extra["grade"], int)


### PR DESCRIPTION
## Summary
Second slice of the generative workflow. Builds directly on #356 (`generate_spec` + `SPEC_ITEM`).

- **New enum entries:** `PageType.ARTEFACT`; `LinkType.ARTEFACT_OF` / `CRITIQUE_OF` / `GENERATED_FROM`; `CallType.GENERATE_ARTEFACT` and `CRITIQUE_ARTEFACT`.
- **`build_system_prompt(include_preamble=False)`** — skips the preamble (and citations/grounding) so a call's prompt can be fully workspace-agnostic. Consumed by generate_artefact, available to any future call that wants it.
- **`SpecOnlyContext`** — renders the artefact task + its active `SPEC_OF`-linked spec items. No embedding search. Whatever the artefact should reflect must be in a spec item.
- **`CritiqueContext`** — embedding search + the latest artefact + the task. Deliberately **excludes the spec** so the critic judges the artefact on merits, not on spec conformance. Surfacing spec-gaps is the point.
- **`GenerateArtefactCall`** — structured call, preamble off, domain-neutral prompt. Creates a hidden `ARTEFACT`, links `ARTEFACT_OF` to the task and `GENERATED_FROM` to each live spec item (iteration snapshot for PR 2c). Supersedes any prior artefact for the task.
- **`CritiqueArtefactCall`** — structured call, persists a hidden `JUDGEMENT` with `CRITIQUE_OF` to the artefact; grade (1–10) and issues list stored in `page.extra` so the refiner can read them programmatically.
- Empty move preset entries for both — structured calls, no tools.

### Also: one-line conftest fix

`tests/conftest.py::_block_real_llm_calls` only whitelisted the `llm` marker. Integration-only tests (e.g. `test_call_lifecycle.py`) raised `RuntimeError` when run under `--integration`. CI skips integration tests entirely so nobody caught it. Fixed by treating `integration` the same as `llm` for block-fixture purposes — kept as a separate commit for easy extraction.

## Test plan
- [x] Non-LLM: `build_system_prompt(include_preamble=False)` produces a shorter prompt with no preamble markers
- [x] Non-LLM: `SpecOnlyContext` renders the task + all active spec items (no embedding query)
- [x] Non-LLM: `CritiqueContext` raises when no artefact exists yet
- [x] Non-LLM: `_latest_artefact_for_task` returns the most recently created active `ARTEFACT`
- [x] Integration: `GenerateArtefactCall` end-to-end creates a hidden `ARTEFACT` with `ARTEFACT_OF` + `GENERATED_FROM` links to each seeded spec
- [x] Integration: `CritiqueArtefactCall` end-to-end creates a hidden `JUDGEMENT` linked via `CRITIQUE_OF`, with `grade` + `issues` in `extra`
- [x] Full non-LLM suite: 522 passed, 0 new failures (2 pre-existing `main` flakes deselected)
- [x] `ruff check` / `ruff format --check` / `pyright` clean

## Next
PR 2c: `refine_spec` multi-round call with `REGENERATE_AND_CRITIQUE` + `FINALIZE_ARTEFACT` moves, the `supersede_spec_item` / `delete_spec_item` moves, `RefinementContext` (last-3 triples via `GENERATED_FROM`), the `hidden_changed` mutation event + `DB.set_page_hidden`, and the generative orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)