### PR TITLE
Add refine_spec call + generative orchestrator

### DIFF
--- a/prompts/refine_spec.md
+++ b/prompts/refine_spec.md
@@ -1,0 +1,49 @@
+# Refine Spec Call Instructions
+
+## Your Task
+
+You are refining the spec for a generated artefact. The user message shows you:
+
+1. **The artefact task** — what the requester asked for.
+2. **The current spec** — the set of prescriptive rules currently in force.
+3. **Last-N iteration triples** — for each recent generation pass, the spec items the artefact was generated from (captured as a snapshot at generation time, so deleted items still appear here), the artefact itself, and a critique of it.
+
+Your job is to edit the spec so that the next regeneration produces a better artefact — or to decide refinement is done.
+
+## Your toolbox
+
+- **`add_spec_item`** — add a new prescriptive rule the artefact should satisfy.
+- **`supersede_spec_item`** — replace an existing rule with a revised version. Use when the rule is pointed in the right direction but needs sharpening.
+- **`delete_spec_item`** — drop a rule entirely with no replacement. Use when the rule was simply wrong and is making the artefact worse, or redundant with another.
+- **`regenerate_and_critique`** — regenerate the artefact from the current spec and get a fresh independent critique. Costs 2 units of budget. Use after a batch of edits when you want to see whether the changes actually helped.
+- **`finalize_artefact`** — end the loop and promote the latest artefact from hidden to visible. Use when (a) the artefact is good enough, (b) the request is too open-ended to converge further through spec edits, or (c) the issues surfaced by the critic require signal the current spec can't capture.
+
+## Reading the critique
+
+Each critique has a grade (1–10), an overall note, and a list of issues. The critic does NOT see the spec — it judges the artefact on its own merits against the request and workspace context. That asymmetry is deliberate and valuable: issues the critic raises are often **spec-gaps** — things the artefact should have done that the spec never told it to do.
+
+When you see a critique issue, ask: *is the corresponding rule in the spec?* If no, add it. If yes but ambiguously worded, supersede it. If yes and the artefact still ignored it, supersede to be sharper or louder.
+
+## How to iterate
+
+- Make edits in coherent batches. Don't regenerate after every single add/delete — make 2–4 targeted changes, then regenerate.
+- Attend to whether successive critiques converge (fewer, smaller issues each round → keep going) or churn (different issues each round → consider whether the spec is playing whack-a-mole, and whether finalizing is wiser).
+- If a critique issue seems unfixable through spec edits (e.g. "the request is genuinely ambiguous about X"), surface this by finalizing rather than spinning.
+- Trust your budget. Each regeneration costs 2; spec edits are free. Favour a thought-through batch of edits over rapid regen cycles.
+
+## When to finalize
+
+Call `finalize_artefact` when any of these hold:
+
+- The grade is high (8+) and the remaining issues are stylistic nits you'd rather not over-engineer for.
+- Two consecutive critiques are raising different sets of issues (non-convergence — likely the spec is over-fit to the last critique).
+- The critic explicitly says iteration won't help further (the request is open-ended, or issues need information the spec can't give).
+- You can see a further-improving edit but the budget won't cover another regeneration — finalize now with the current version rather than regenerate and leave the critique unread.
+
+The `note` field on `finalize_artefact` is where to record *why* you stopped, for later audit.
+
+## Quality bar
+
+- **Every spec edit should be justifiable by a specific critique issue or a spec-gap you identified.** If you're tempted to add a rule "just in case", you're probably speculating — spec items should be load-bearing.
+- **Prefer sharpening over adding.** Many issues come from under-specified rules, not missing ones. Supersede before add.
+- **Delete ruthlessly.** Rules that are never violated by the artefact aren't doing work; rules that the artefact can't satisfy make everything else worse. If a rule isn't pulling its weight, delete it.

--- a/src/rumil/available_moves.py
+++ b/src/rumil/available_moves.py
@@ -153,6 +153,13 @@ PRESETS: dict[str, AvailableMoves] = {
         ],
         CallType.GENERATE_ARTEFACT: [],
         CallType.CRITIQUE_ARTEFACT: [],
+        CallType.REFINE_SPEC: [
+            MoveType.ADD_SPEC_ITEM,
+            MoveType.SUPERSEDE_SPEC_ITEM,
+            MoveType.DELETE_SPEC_ITEM,
+            MoveType.REGENERATE_AND_CRITIQUE,
+            MoveType.FINALIZE_ARTEFACT,
+        ],
     },
     "judge-on-assess": {
         CallType.ASSESS: [
@@ -299,6 +306,13 @@ PRESETS: dict[str, AvailableMoves] = {
         ],
         CallType.GENERATE_ARTEFACT: [],
         CallType.CRITIQUE_ARTEFACT: [],
+        CallType.REFINE_SPEC: [
+            MoveType.ADD_SPEC_ITEM,
+            MoveType.SUPERSEDE_SPEC_ITEM,
+            MoveType.DELETE_SPEC_ITEM,
+            MoveType.REGENERATE_AND_CRITIQUE,
+            MoveType.FINALIZE_ARTEFACT,
+        ],
     },
 }
 

--- a/src/rumil/calls/__init__.py
+++ b/src/rumil/calls/__init__.py
@@ -9,6 +9,7 @@ from rumil.calls.generate_artefact import GenerateArtefactCall
 from rumil.calls.generate_spec import GenerateSpecCall
 from rumil.calls.ingest import IngestCall
 from rumil.calls.link_subquestions import LinkSubquestionsCall
+from rumil.calls.refine_spec import RefineSpecCall
 from rumil.calls.scout_analogies import ScoutAnalogiesCall
 from rumil.calls.scout_c_cruxes import ScoutCCruxesCall
 from rumil.calls.scout_c_how_false import ScoutCHowFalseCall
@@ -40,6 +41,7 @@ __all__ = [
     "GenerateSpecCall",
     "IngestCall",
     "LinkSubquestionsCall",
+    "RefineSpecCall",
     "ScoutAnalogiesCall",
     "ScoutCCruxesCall",
     "ScoutCHowFalseCall",

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -1173,3 +1173,134 @@ async def active_spec_items_for_task(task_id: str, db) -> list[Page]:
     ]
     active.sort(key=lambda p: (p.created_at, p.id))
     return active
+
+
+class RefinementContext(ContextBuilder):
+    """Context for the refine_spec call.
+
+    Shows the refiner:
+    1. The original artefact-task request.
+    2. The current spec (same format as SpecOnlyContext).
+    3. The last-3 iteration triples — for each of the three most recent
+       artefact versions linked ARTEFACT_OF to the task: the spec items it
+       was generated from (via GENERATED_FROM — captured at generation time
+       so deleted spec items still appear in historical triples), the
+       artefact itself, and its critique.
+
+    Does NOT do a main-workspace embedding sweep — refinement operates on
+    the closed feedback loop of spec → artefact → critique.
+    """
+
+    def __init__(self, window: int = 3) -> None:
+        self._window = window
+
+    async def build_context(self, infra: CallInfra) -> ContextResult:
+        task = await infra.db.get_page(infra.question_id)
+        if task is None:
+            raise ValueError(
+                f"RefinementContext: artefact-task question {infra.question_id} not found"
+            )
+
+        current_spec = await active_spec_items_for_task(infra.question_id, infra.db)
+
+        links = await infra.db.get_links_to(infra.question_id)
+        artefact_links = [l for l in links if l.link_type == LinkType.ARTEFACT_OF]
+        artefact_ids = [l.from_page_id for l in artefact_links]
+        artefacts_by_id = await infra.db.get_pages_by_ids(artefact_ids)
+        artefacts = [p for p in artefacts_by_id.values() if p.page_type == PageType.ARTEFACT]
+        artefacts.sort(key=lambda p: (p.created_at, p.id))
+        recent = artefacts[-self._window :]
+
+        triples: list[tuple[Page, list[Page], Page | None]] = []
+        for artefact in recent:
+            snapshot_links = await infra.db.get_links_from(artefact.id)
+            spec_ids = [
+                l.to_page_id for l in snapshot_links if l.link_type == LinkType.GENERATED_FROM
+            ]
+            snapshot_pages_by_id = await infra.db.get_pages_by_ids(spec_ids) if spec_ids else {}
+            snapshot_specs = [
+                snapshot_pages_by_id[pid] for pid in spec_ids if pid in snapshot_pages_by_id
+            ]
+            snapshot_specs.sort(key=lambda p: (p.created_at, p.id))
+
+            inbound = await infra.db.get_links_to(artefact.id)
+            critique_link_ids = [
+                l.from_page_id for l in inbound if l.link_type == LinkType.CRITIQUE_OF
+            ]
+            critique_pages_by_id = (
+                await infra.db.get_pages_by_ids(critique_link_ids) if critique_link_ids else {}
+            )
+            critiques = [
+                p
+                for p in critique_pages_by_id.values()
+                if p.is_active() and p.page_type == PageType.JUDGEMENT
+            ]
+            latest_critique = max(critiques, key=lambda p: p.created_at) if critiques else None
+
+            triples.append((artefact, snapshot_specs, latest_critique))
+
+        parts: list[str] = [
+            "# Artefact task",
+            "",
+            task.headline,
+            "",
+            task.content or "(no further description)",
+            "",
+            "---",
+            "",
+            f"# Current spec ({len(current_spec)} items)",
+            "",
+        ]
+        if current_spec:
+            for i, spec in enumerate(current_spec, start=1):
+                parts += [
+                    f"## {i}. [{spec.id[:8]}] {spec.headline}",
+                    "",
+                    spec.content,
+                    "",
+                ]
+        else:
+            parts.append("(no spec items)")
+
+        parts += ["", "---", "", f"# Last {len(triples)} iterations (oldest first)", ""]
+        if not triples:
+            parts.append("(no iterations yet — call regenerate_and_critique to start)")
+        else:
+            for iter_index, (artefact, snapshot_specs, critique) in enumerate(triples, start=1):
+                parts += [f"## Iteration {iter_index} — artefact [{artefact.id[:8]}]", ""]
+                parts.append(f"### Spec used ({len(snapshot_specs)} items)")
+                parts.append("")
+                if snapshot_specs:
+                    for spec in snapshot_specs:
+                        parts.append(f"- [{spec.id[:8]}] **{spec.headline}** — {spec.content}")
+                else:
+                    parts.append("(none captured)")
+                parts += ["", f"### Artefact: {artefact.headline}", "", artefact.content, ""]
+                if critique is not None:
+                    grade = critique.extra.get("grade")
+                    issues = critique.extra.get("issues") or []
+                    grade_label = f"**Grade:** {grade}/10" if grade is not None else ""
+                    parts += ["### Critique", "", grade_label]
+                    if issues:
+                        parts.append("")
+                        parts.append("**Issues:**")
+                        for issue in issues:
+                            parts.append(f"- {issue}")
+                    parts.append("")
+                else:
+                    parts += ["### Critique", "", "(no critique recorded for this iteration)", ""]
+                parts.append("---")
+                parts.append("")
+
+        context_text = "\n".join(parts)
+        working_page_ids = [
+            task.id,
+            *[p.id for p in current_spec],
+            *[a.id for a, _, _ in triples],
+        ]
+        await _record_context_built(infra, working_page_ids, [])
+        return ContextResult(
+            context_text=context_text,
+            working_page_ids=working_page_ids,
+            preloaded_ids=[],
+        )

--- a/src/rumil/calls/refine_spec.py
+++ b/src/rumil/calls/refine_spec.py
@@ -1,0 +1,54 @@
+"""Refine Spec call: iterate on the spec in response to artefact + critique.
+
+This is the driver of the generative workflow. Reads the current spec and
+the last-3 iteration triples (spec → artefact → critique), edits the spec
+via add/supersede/delete moves, and fires regenerate_and_critique when
+ready to see how the artefact has moved. Exits by calling
+finalize_artefact when further iteration is unlikely to help, or when
+the outer orchestrator exhausts its budget.
+"""
+
+from rumil.calls.closing_reviewers import StandardClosingReview
+from rumil.calls.context_builders import RefinementContext
+from rumil.calls.page_creators import SimpleAgentLoop
+from rumil.calls.stages import (
+    CallRunner,
+    ClosingReviewer,
+    ContextBuilder,
+    WorkspaceUpdater,
+)
+from rumil.models import CallType
+
+
+class RefineSpecCall(CallRunner):
+    """Iterate the spec via an agent loop until the artefact converges or budget runs out."""
+
+    context_builder_cls = RefinementContext
+    workspace_updater_cls = SimpleAgentLoop
+    closing_reviewer_cls = StandardClosingReview
+    call_type = CallType.REFINE_SPEC
+
+    def _make_context_builder(self) -> ContextBuilder:
+        return RefinementContext()
+
+    def _make_workspace_updater(self) -> WorkspaceUpdater:
+        return SimpleAgentLoop(
+            self.call_type,
+            self.task_description(),
+            available_moves=self._resolve_available_moves(),
+            max_rounds=self._max_rounds,
+        )
+
+    def _make_closing_reviewer(self) -> ClosingReviewer:
+        return StandardClosingReview(self.call_type)
+
+    def task_description(self) -> str:
+        return (
+            "Refine the spec for this artefact-task. You may add, supersede, "
+            "or delete spec items, then call `regenerate_and_critique` to see "
+            "how the artefact moves. Call `finalize_artefact` when further "
+            "iteration is unlikely to help — the artefact is good enough, or "
+            "the request is too open-ended to converge, or the remaining "
+            "issues need workspace signal the current spec can't capture.\n\n"
+            f"Artefact-task question ID: `{self.infra.question_id}`"
+        )

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -89,6 +89,7 @@ class CallType(str, Enum):
     GENERATE_SPEC = "generate_spec"
     GENERATE_ARTEFACT = "generate_artefact"
     CRITIQUE_ARTEFACT = "critique_artefact"
+    REFINE_SPEC = "refine_spec"
     # Envelope call for mutations made from Claude Code's broader context
     # (not a rumil-internal call with carefully scoped prompt). Never
     # dispatchable from prioritization — only created by .claude/ skills.
@@ -172,6 +173,7 @@ class MoveType(str, Enum):
     SUPERSEDE_SPEC_ITEM = "SUPERSEDE_SPEC_ITEM"
     DELETE_SPEC_ITEM = "DELETE_SPEC_ITEM"
     FINALIZE_ARTEFACT = "FINALIZE_ARTEFACT"
+    REGENERATE_AND_CRITIQUE = "REGENERATE_AND_CRITIQUE"
 
 
 class CallStage(str, Enum):

--- a/src/rumil/moves/finalize_artefact.py
+++ b/src/rumil/moves/finalize_artefact.py
@@ -72,7 +72,7 @@ async def execute(payload: FinalizeArtefactPayload, call: Call, db: DB) -> MoveR
     return MoveResult(
         message=(f"Finalized artefact [{artefact.id[:8]}]: now visible to the workspace."),
         created_page_id=None,
-        trace_extra={"artefact_id": artefact.id, "note": payload.note},
+        trace_extra={"artefact_id": artefact.id},
     )
 
 

--- a/src/rumil/moves/regenerate_and_critique.py
+++ b/src/rumil/moves/regenerate_and_critique.py
@@ -50,12 +50,12 @@ async def execute(payload: RegenerateAndCritiquePayload, call: Call, db: DB) -> 
             created_page_id=None,
         )
 
-    gen_ok = await db.consume_budget(1)
-    if not gen_ok:
+    if not await db.consume_budget(2):
         return MoveResult(
             message=(
-                "ERROR: budget exhausted before generate_artefact could run. "
-                "No sub-calls fired. Consider calling finalize_artefact."
+                "ERROR: regenerate_and_critique needs 2 units of budget and "
+                "fewer are available. No sub-calls fired. Consider calling "
+                "finalize_artefact to ship the latest artefact instead."
             ),
             created_page_id=None,
         )
@@ -67,16 +67,6 @@ async def execute(payload: RegenerateAndCritiquePayload, call: Call, db: DB) -> 
     )
     gen_runner = GenerateArtefactCall(artefact_task_id, gen_call, db)
     await gen_runner.run()
-
-    crit_ok = await db.consume_budget(1)
-    if not crit_ok:
-        return MoveResult(
-            message=(
-                "Budget ran out after regeneration — no critique produced this "
-                "round. The new artefact is available; consider finalize_artefact."
-            ),
-            created_page_id=None,
-        )
 
     crit_call = await db.create_call(
         CallType.CRITIQUE_ARTEFACT,

--- a/src/rumil/moves/regenerate_and_critique.py
+++ b/src/rumil/moves/regenerate_and_critique.py
@@ -1,0 +1,153 @@
+"""REGENERATE_AND_CRITIQUE: fire generate_artefact + critique_artefact in sequence.
+
+Called from the refine_spec agent loop. Regenerating without a fresh critique,
+or critiquing without a fresh artefact, would desynchronise the signal the
+refiner reads — so the two sub-calls are bundled into a single atomic tool.
+"""
+
+import logging
+
+from pydantic import BaseModel, Field
+
+from rumil.database import DB
+from rumil.models import Call, CallType, LinkType, MoveType, PageType
+from rumil.moves.base import MoveDef, MoveResult
+
+log = logging.getLogger(__name__)
+
+
+class RegenerateAndCritiquePayload(BaseModel):
+    reason: str = Field(
+        default="",
+        description=(
+            "Optional one-sentence note on what the spec change was meant to "
+            "fix. Stored for audit only; the critic does not see it."
+        ),
+    )
+
+
+async def execute(payload: RegenerateAndCritiquePayload, call: Call, db: DB) -> MoveResult:
+    # Deferred imports: moves.registry loads every MoveDef at import time,
+    # which transitively pulls in closing_reviewers → moves.registry. Keeping
+    # the CallRunner imports inside execute() breaks the cycle.
+    from rumil.calls.critique_artefact import CritiqueArtefactCall
+    from rumil.calls.generate_artefact import GenerateArtefactCall
+
+    artefact_task_id = call.scope_page_id
+    if not artefact_task_id:
+        return MoveResult(
+            message=(
+                "ERROR: regenerate_and_critique requires call.scope_page_id "
+                "set to the artefact-task question. No sub-calls fired."
+            ),
+            created_page_id=None,
+        )
+    scope_page = await db.get_page(artefact_task_id)
+    if scope_page is None or scope_page.page_type != PageType.QUESTION:
+        actual = scope_page.page_type.value if scope_page else "missing"
+        return MoveResult(
+            message=(f"ERROR: regenerate_and_critique scope must be a question; got {actual}."),
+            created_page_id=None,
+        )
+
+    gen_ok = await db.consume_budget(1)
+    if not gen_ok:
+        return MoveResult(
+            message=(
+                "ERROR: budget exhausted before generate_artefact could run. "
+                "No sub-calls fired. Consider calling finalize_artefact."
+            ),
+            created_page_id=None,
+        )
+
+    gen_call = await db.create_call(
+        CallType.GENERATE_ARTEFACT,
+        scope_page_id=artefact_task_id,
+        parent_call_id=call.id,
+    )
+    gen_runner = GenerateArtefactCall(artefact_task_id, gen_call, db)
+    await gen_runner.run()
+
+    crit_ok = await db.consume_budget(1)
+    if not crit_ok:
+        return MoveResult(
+            message=(
+                "Budget ran out after regeneration — no critique produced this "
+                "round. The new artefact is available; consider finalize_artefact."
+            ),
+            created_page_id=None,
+        )
+
+    crit_call = await db.create_call(
+        CallType.CRITIQUE_ARTEFACT,
+        scope_page_id=artefact_task_id,
+        parent_call_id=call.id,
+    )
+    crit_runner = CritiqueArtefactCall(artefact_task_id, crit_call, db)
+    await crit_runner.run()
+
+    new_artefact = await db.latest_artefact_for_task(artefact_task_id)
+    if new_artefact is None:
+        return MoveResult(
+            message="ERROR: after regenerate_and_critique, no artefact exists for the task.",
+            created_page_id=None,
+        )
+
+    critique_links = await db.get_links_to(new_artefact.id)
+    critique_pages_by_id: dict = {}
+    critique_link_ids = [
+        l.from_page_id for l in critique_links if l.link_type == LinkType.CRITIQUE_OF
+    ]
+    if critique_link_ids:
+        critique_pages_by_id = await db.get_pages_by_ids(critique_link_ids)
+    critiques = [
+        p
+        for p in critique_pages_by_id.values()
+        if p.is_active() and p.page_type == PageType.JUDGEMENT
+    ]
+    latest_critique = max(critiques, key=lambda p: p.created_at) if critiques else None
+
+    grade = latest_critique.extra.get("grade") if latest_critique else None
+    issues = latest_critique.extra.get("issues") if latest_critique else []
+    issue_lines = "\n".join(f"- {issue}" for issue in (issues or []))
+
+    summary_parts = [
+        f"Regenerated artefact [{new_artefact.id[:8]}]: {new_artefact.headline}",
+    ]
+    if grade is not None:
+        summary_parts.append(f"Critique grade: {grade}/10")
+    if issue_lines:
+        summary_parts.append("Issues surfaced:")
+        summary_parts.append(issue_lines)
+    summary = "\n\n".join(summary_parts)
+
+    log.info(
+        "regenerate_and_critique complete: artefact=%s, grade=%s, issue_count=%d",
+        new_artefact.id[:8],
+        grade,
+        len(issues or []),
+    )
+    return MoveResult(
+        message=summary,
+        created_page_id=None,
+        trace_extra={
+            "artefact_id": new_artefact.id,
+            "critique_id": latest_critique.id if latest_critique else None,
+            "grade": grade,
+        },
+    )
+
+
+MOVE = MoveDef(
+    move_type=MoveType.REGENERATE_AND_CRITIQUE,
+    name="regenerate_and_critique",
+    description=(
+        "Regenerate the artefact from the current spec and produce a fresh, "
+        "independent critique of it. Fires both sub-calls atomically so the "
+        "critique you see always matches the latest artefact. Use after a "
+        "batch of spec edits when you want to see how the artefact has moved. "
+        "Each invocation consumes 2 units of budget (one per sub-call)."
+    ),
+    schema=RegenerateAndCritiquePayload,
+    execute=execute,
+)

--- a/src/rumil/moves/registry.py
+++ b/src/rumil/moves/registry.py
@@ -23,6 +23,7 @@ from rumil.moves.link_related import MOVE as _link_related
 from rumil.moves.link_variant import MOVE as _link_variant
 from rumil.moves.load_page import MOVE as _load_page
 from rumil.moves.propose_view_item import MOVE as _propose_view_item
+from rumil.moves.regenerate_and_critique import MOVE as _regenerate_and_critique
 from rumil.moves.remove_link import MOVE as _remove_link
 from rumil.moves.report_duplicate import MOVE as _report_duplicate
 from rumil.moves.supersede_spec_item import MOVE as _supersede_spec_item
@@ -52,5 +53,6 @@ MOVES: dict[MoveType, MoveDef] = {
         _supersede_spec_item,
         _delete_spec_item,
         _finalize_artefact,
+        _regenerate_and_critique,
     ]
 }

--- a/src/rumil/orchestrators/generative.py
+++ b/src/rumil/orchestrators/generative.py
@@ -1,0 +1,166 @@
+"""Generative orchestrator: spec → refine → final artefact.
+
+Drives the generator-refiner workflow end to end:
+
+1. Create a hidden artefact-task question for the user's request.
+2. Run generate_spec to produce the initial set of spec items.
+3. Run refine_spec, which internally reads the spec + last-3 artefact/critique
+   triples, edits the spec via add/supersede/delete, fires regenerate_and_critique
+   to see how the artefact moves, and calls finalize_artefact when iteration
+   is no longer worthwhile.
+4. If the refiner hasn't finalized (e.g. budget ran out), the orchestrator
+   falls back to force-finalizing the latest artefact so the caller always
+   ends up with a visible artefact page.
+
+Budget is allocated at the orchestrator level. generate_spec costs 1 unit;
+each regenerate_and_critique inside refine_spec costs 2; refine_spec's own
+agent-loop turns cost 1 each (run_agent_loop does not charge budget — budget
+is only debited by explicit consume_budget calls, which the move does).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from rumil.calls.critique_artefact import CritiqueArtefactCall
+from rumil.calls.generate_artefact import GenerateArtefactCall
+from rumil.calls.generate_spec import GenerateSpecCall
+from rumil.calls.refine_spec import RefineSpecCall
+from rumil.database import DB
+from rumil.models import (
+    CallType,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class GenerativeResult:
+    """Return value of GenerativeOrchestrator.run."""
+
+    task_id: str
+    artefact_id: str | None
+    finalized: bool
+
+
+class GenerativeOrchestrator:
+    """Drive the generator-refiner loop to produce a visible artefact."""
+
+    def __init__(
+        self,
+        db: DB,
+        *,
+        refine_max_rounds: int = 10,
+    ) -> None:
+        self.db = db
+        self.refine_max_rounds = refine_max_rounds
+
+    async def run(self, request: str, *, headline: str | None = None) -> GenerativeResult:
+        """Produce an artefact for *request*. Returns the result's IDs.
+
+        The orchestrator creates its own hidden artefact-task question,
+        drives generate_spec + refine_spec to completion (or budget
+        exhaustion), and ensures an artefact exists and is visible.
+        """
+        task = await self._create_task(request, headline=headline)
+        log.info(
+            "Generative orchestrator: task=%s, headline=%s",
+            task.id[:8],
+            task.headline[:70],
+        )
+
+        await self._run_generate_spec(task.id)
+
+        await self._run_refine_spec(task.id)
+
+        artefact = await self.db.latest_artefact_for_task(task.id)
+        finalized = False
+        # Refiner never produced an artefact (budget exhausted before the
+        # first regenerate_and_critique, or the model never fired one).
+        # Try to produce one now with a direct generate+critique so the
+        # caller at least has something.
+        if artefact is None and await self.db.consume_budget(1):
+            await self._one_off_regenerate(task.id, parent_call_id=None)
+            artefact = await self.db.latest_artefact_for_task(task.id)
+
+        if artefact is not None and artefact.hidden:
+            await self.db.set_page_hidden(artefact.id, False)
+            finalized = True
+            log.info("Orchestrator force-finalized artefact %s", artefact.id[:8])
+        elif artefact is not None and not artefact.hidden:
+            finalized = True
+
+        return GenerativeResult(
+            task_id=task.id,
+            artefact_id=artefact.id if artefact else None,
+            finalized=finalized,
+        )
+
+    async def _create_task(self, request: str, *, headline: str | None) -> Page:
+        task = Page(
+            page_type=PageType.QUESTION,
+            layer=PageLayer.SQUIDGY,
+            workspace=Workspace.RESEARCH,
+            content=request,
+            headline=headline or request[:120],
+            hidden=True,
+        )
+        await self.db.save_page(task)
+        return task
+
+    async def _run_generate_spec(self, task_id: str) -> None:
+        if not await self.db.consume_budget(1):
+            log.warning("Budget exhausted before generate_spec could run")
+            return
+        call = await self.db.create_call(
+            CallType.GENERATE_SPEC,
+            scope_page_id=task_id,
+        )
+        runner = GenerateSpecCall(task_id, call, self.db)
+        await runner.run()
+
+    async def _run_refine_spec(self, task_id: str) -> None:
+        if not await self.db.consume_budget(1):
+            log.warning("Budget exhausted before refine_spec could run")
+            return
+        call = await self.db.create_call(
+            CallType.REFINE_SPEC,
+            scope_page_id=task_id,
+        )
+        runner = RefineSpecCall(task_id, call, self.db, max_rounds=self.refine_max_rounds)
+        await runner.run()
+
+    async def _one_off_regenerate(self, task_id: str, parent_call_id: str | None) -> None:
+        """Run a single generate_artefact + critique_artefact as a fallback."""
+        gen_call = await self.db.create_call(
+            CallType.GENERATE_ARTEFACT,
+            scope_page_id=task_id,
+            parent_call_id=parent_call_id,
+        )
+        await GenerateArtefactCall(task_id, gen_call, self.db).run()
+
+        if not await self.db.consume_budget(1):
+            return
+        crit_call = await self.db.create_call(
+            CallType.CRITIQUE_ARTEFACT,
+            scope_page_id=task_id,
+            parent_call_id=parent_call_id,
+        )
+        await CritiqueArtefactCall(task_id, crit_call, self.db).run()
+
+
+async def run_generative_workflow(
+    db: DB,
+    request: str,
+    *,
+    headline: str | None = None,
+    refine_max_rounds: int = 10,
+) -> GenerativeResult:
+    """One-shot convenience wrapper for the generative orchestrator."""
+    orchestrator = GenerativeOrchestrator(db, refine_max_rounds=refine_max_rounds)
+    return await orchestrator.run(request, headline=headline)

--- a/tests/test_generative_workflow.py
+++ b/tests/test_generative_workflow.py
@@ -24,6 +24,8 @@ from rumil.models import (
     Workspace,
 )
 from rumil.moves.base import MoveState
+from rumil.moves.regenerate_and_critique import RegenerateAndCritiquePayload
+from rumil.moves.regenerate_and_critique import execute as regenerate_and_critique
 from rumil.orchestrators.generative import GenerativeOrchestrator
 from rumil.tracing.tracer import CallTrace
 
@@ -192,6 +194,82 @@ async def test_refinement_context_respects_window(tmp_db, refinement_task):
     assert "v4" in ctx.context_text
     assert "v1" not in ctx.context_text
     assert "v2" not in ctx.context_text
+
+
+async def test_regenerate_and_critique_errors_when_budget_is_one(tmp_db, refinement_task):
+    """Budget guard must be atomic — budget=1 means no sub-calls fire and no
+    partial artefact is produced. Exercised without the LLM by setting a
+    tight budget before calling."""
+    await _seed_spec(tmp_db, refinement_task, ["Rule A"])
+
+    parent = Call(
+        call_type=CallType.REFINE_SPEC,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=refinement_task.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(parent)
+
+    total, used = await tmp_db.get_budget()
+    await tmp_db.consume_budget(total - used - 1)  # leave exactly 1 unit
+
+    result = await regenerate_and_critique(
+        RegenerateAndCritiquePayload(reason="should be rejected"),
+        parent,
+        tmp_db,
+    )
+    assert "budget" in result.message.lower()
+    assert result.created_page_id is None
+
+    artefacts = await tmp_db.get_pages(page_type=PageType.ARTEFACT, include_hidden=True)
+    assert artefacts == []
+
+
+@pytest.mark.integration
+async def test_regenerate_and_critique_produces_artefact_and_critique(tmp_db, refinement_task):
+    """Happy path: the move fires both sub-calls and links them up."""
+    await tmp_db.init_budget(6)
+    await _seed_spec(
+        tmp_db,
+        refinement_task,
+        [
+            "Keep it short",
+            "Use plain language",
+            "No headings, prose only",
+        ],
+    )
+
+    parent = Call(
+        call_type=CallType.REFINE_SPEC,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=refinement_task.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(parent)
+
+    _total, used_before = await tmp_db.get_budget()
+    result = await regenerate_and_critique(
+        RegenerateAndCritiquePayload(reason="initial"),
+        parent,
+        tmp_db,
+    )
+    _total, used_after = await tmp_db.get_budget()
+    assert used_after - used_before == 2
+
+    assert "Regenerated artefact" in result.message
+
+    artefact = await tmp_db.latest_artefact_for_task(refinement_task.id)
+    assert artefact is not None
+    assert artefact.page_type == PageType.ARTEFACT
+
+    inbound = await tmp_db.get_links_to(artefact.id)
+    critique_links = [l for l in inbound if l.link_type == LinkType.CRITIQUE_OF]
+    assert len(critique_links) == 1
+
+    critiques = await tmp_db.get_pages_by_ids([l.from_page_id for l in critique_links])
+    (crit,) = list(critiques.values())
+    assert crit.page_type == PageType.JUDGEMENT
+    assert "grade" in crit.extra
 
 
 @pytest.mark.integration

--- a/tests/test_generative_workflow.py
+++ b/tests/test_generative_workflow.py
@@ -1,0 +1,226 @@
+"""Tests for RefinementContext and the end-to-end generative orchestrator.
+
+Non-LLM: RefinementContext rendering contains the current spec plus the
+last-N iteration triples reconstructed via GENERATED_FROM + CRITIQUE_OF.
+
+Integration: GenerativeOrchestrator.run produces a visible artefact given
+a small, well-scoped request.
+"""
+
+import pytest
+import pytest_asyncio
+
+from rumil.calls.context_builders import RefinementContext
+from rumil.calls.stages import CallInfra
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.moves.base import MoveState
+from rumil.orchestrators.generative import GenerativeOrchestrator
+from rumil.tracing.tracer import CallTrace
+
+
+async def _make_page(tmp_db, headline, *, page_type=PageType.CLAIM, hidden=False, extra=None):
+    page = Page(
+        page_type=page_type,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Content for: {headline}",
+        headline=headline,
+        hidden=hidden,
+        extra=extra or {},
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def refinement_task(tmp_db):
+    return await _make_page(
+        tmp_db,
+        "Refinement task",
+        page_type=PageType.QUESTION,
+        hidden=True,
+    )
+
+
+async def _seed_spec(tmp_db, task, headlines):
+    specs = []
+    for h in headlines:
+        spec = await _make_page(tmp_db, h, page_type=PageType.SPEC_ITEM, hidden=True)
+        await tmp_db.save_link(
+            PageLink(
+                from_page_id=spec.id,
+                to_page_id=task.id,
+                link_type=LinkType.SPEC_OF,
+            )
+        )
+        specs.append(spec)
+    return specs
+
+
+async def _seed_iteration(tmp_db, task, spec_items, *, artefact_headline, grade, issues):
+    artefact = await _make_page(
+        tmp_db,
+        artefact_headline,
+        page_type=PageType.ARTEFACT,
+        hidden=True,
+    )
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=artefact.id,
+            to_page_id=task.id,
+            link_type=LinkType.ARTEFACT_OF,
+        )
+    )
+    for spec in spec_items:
+        await tmp_db.save_link(
+            PageLink(
+                from_page_id=artefact.id,
+                to_page_id=spec.id,
+                link_type=LinkType.GENERATED_FROM,
+            )
+        )
+    critique = await _make_page(
+        tmp_db,
+        f"Critique of {artefact_headline}",
+        page_type=PageType.JUDGEMENT,
+        hidden=True,
+        extra={"grade": grade, "issues": issues},
+    )
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=critique.id,
+            to_page_id=artefact.id,
+            link_type=LinkType.CRITIQUE_OF,
+        )
+    )
+    return artefact, critique
+
+
+def _make_infra(tmp_db, task_id):
+    call = Call(
+        call_type=CallType.REFINE_SPEC,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=task_id,
+        status=CallStatus.PENDING,
+    )
+    return CallInfra(
+        question_id=task_id,
+        call=call,
+        db=tmp_db,
+        trace=CallTrace(call.id, tmp_db),
+        state=MoveState(call, tmp_db),
+    )
+
+
+async def test_refinement_context_with_no_iterations(tmp_db, refinement_task):
+    await _seed_spec(tmp_db, refinement_task, ["Rule A", "Rule B"])
+
+    infra = _make_infra(tmp_db, refinement_task.id)
+    ctx = await RefinementContext().build_context(infra)
+
+    assert "Current spec (2 items)" in ctx.context_text
+    assert "Rule A" in ctx.context_text
+    assert "Rule B" in ctx.context_text
+    assert "no iterations yet" in ctx.context_text.lower()
+
+
+async def test_refinement_context_renders_past_triples(tmp_db, refinement_task):
+    current = await _seed_spec(tmp_db, refinement_task, ["Current rule A", "Current rule B"])
+
+    older_spec = await _make_page(
+        tmp_db, "Old rule superseded", page_type=PageType.SPEC_ITEM, hidden=True
+    )
+    await _seed_iteration(
+        tmp_db,
+        refinement_task,
+        [older_spec, current[0]],
+        artefact_headline="Draft v1",
+        grade=4,
+        issues=["Missing key detail", "Too long"],
+    )
+
+    await _seed_iteration(
+        tmp_db,
+        refinement_task,
+        current,
+        artefact_headline="Draft v2",
+        grade=7,
+        issues=["Minor wording"],
+    )
+
+    infra = _make_infra(tmp_db, refinement_task.id)
+    ctx = await RefinementContext().build_context(infra)
+
+    v1_pos = ctx.context_text.index("Draft v1")
+    v2_pos = ctx.context_text.index("Draft v2")
+    assert v1_pos < v2_pos
+
+    assert "Old rule superseded" in ctx.context_text
+    assert "**Grade:** 4/10" in ctx.context_text
+    assert "**Grade:** 7/10" in ctx.context_text
+    assert "Missing key detail" in ctx.context_text
+    assert "Minor wording" in ctx.context_text
+
+
+async def test_refinement_context_respects_window(tmp_db, refinement_task):
+    """With more artefacts than the window, only the most recent N render."""
+    current = await _seed_spec(tmp_db, refinement_task, ["Rule A"])
+    for label in ("v1", "v2", "v3", "v4"):
+        await _seed_iteration(
+            tmp_db,
+            refinement_task,
+            current,
+            artefact_headline=label,
+            grade=5,
+            issues=[],
+        )
+
+    infra = _make_infra(tmp_db, refinement_task.id)
+    ctx = await RefinementContext(window=2).build_context(infra)
+
+    assert "v3" in ctx.context_text
+    assert "v4" in ctx.context_text
+    assert "v1" not in ctx.context_text
+    assert "v2" not in ctx.context_text
+
+
+@pytest.mark.integration
+async def test_generative_orchestrator_produces_visible_artefact(tmp_db):
+    """Tight request → visible ARTEFACT at the end, even if the refiner runs
+    out of moves. Uses a concrete request small enough for Haiku to handle
+    reliably within a modest budget."""
+    await tmp_db.init_budget(15)
+
+    orchestrator = GenerativeOrchestrator(tmp_db, refine_max_rounds=4)
+    result = await orchestrator.run(
+        (
+            "Write a three-bullet checklist for a team introducing a new "
+            "intern to their first dataset: what files to open first, "
+            "who to talk to, and where to put their first analysis. "
+            "Keep it to three bullets, one line each."
+        ),
+        headline="Intern onboarding checklist",
+    )
+
+    assert result.task_id
+    assert result.artefact_id is not None
+
+    artefact = await tmp_db.get_page(result.artefact_id)
+    assert artefact is not None
+    assert artefact.page_type == PageType.ARTEFACT
+    assert artefact.hidden is False
+    assert len(artefact.content) > 30
+
+    task = await tmp_db.get_page(result.task_id)
+    assert task is not None
+    assert task.hidden is True


### PR DESCRIPTION
## Summary
Completes the generator-refiner workflow (final slice of PR 2). Builds on #355 (hidden flag), #356 (generate_spec), #357 (generate/critique_artefact), and #358 (move primitives + set_hidden).

- **`CallType.REFINE_SPEC`** + `RefineSpecCall` — `SimpleAgentLoop`-based call with the five-move toolbox (add/supersede/delete spec item, regenerate_and_critique, finalize_artefact).
- **`RefinementContext`** — renders (a) the current active spec, (b) the last-N iteration triples reconstructed from `ARTEFACT_OF` + `GENERATED_FROM` + `CRITIQUE_OF`. Deleted spec items still appear in historical triples because `GENERATED_FROM` is a per-artefact snapshot, so the refiner can see the full lineage even after aggressive pruning. Configurable window (default 3).
- **`MoveType.REGENERATE_AND_CRITIQUE`** — atomic tool that fires `generate_artefact` + `critique_artefact` in sequence and returns a summary (artefact short-id + grade + issues) to the refiner's conversation. Budget: 2 per invocation. Using deferred imports of the sub-call runners to avoid the `closing_reviewers → registry → calls` circular import.
- **`prompts/refine_spec.md`** — teaches the refiner to read critiques as spec-gap signal, when to regenerate vs finalize, and how to distinguish convergence from churn.
- **`GenerativeOrchestrator`** (`src/rumil/orchestrators/generative.py`) — takes a user request, creates a hidden artefact-task question, runs `generate_spec` then `refine_spec`, and falls back to force-finalizing the latest artefact if the refiner didn't finalize. Always ends with a visible artefact when one could be produced.

### Bundled fix (separate commit `8d99075`)

`finalize_artefact` stored `note` in both its Pydantic payload and `trace_extra`, which crashed move-trace formatting with `TypeError: multiple values for 'note'` when a refiner actually called it. Removed from `trace_extra`; the payload field is what `format_moves_for_review` serialises. Discovered when the integration test below first tried to run.

## Test plan
- [x] Non-LLM: `RefinementContext` with no iterations yet shows the current spec + "no iterations" marker.
- [x] Non-LLM: `RefinementContext` with two past triples renders them in chronological order with grades + issues.
- [x] Non-LLM: window parameter trims older iterations.
- [x] Integration (200s, `@pytest.mark.integration`): `GenerativeOrchestrator.run(<tight request>)` produces a visible `ARTEFACT` linked to a hidden task.
- [x] Full non-LLM suite: 540 passed, 0 new failures.
- [x] `ruff check` / `ruff format --check` / `pyright` clean.

## Next
- Surface via CLI (`main.py --generate <request>`) and possibly via a `.claude/skills/` entry.
- Consider a dedicated `PageType.CRITIQUE` — `JUDGEMENT` works, but the semantic overload ("answers a question" vs "assesses an artefact") has been called out in earlier reviews.
- Stats RPCs (`compute_project_stats`, `compute_question_stats`) still count hidden rows — revisit when generative-workflow usage actually lands in a project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)