### PR TITLE
Migrate deployment to fresh GCP project on GKE Autopilot

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - path_regex: deploy/chart/secrets(\.enc)?\.yaml$
+    gcp_kms: projects/project-fe559f0f-d011-4af4-bf0/locations/global/keyRings/sops/cryptoKeys/sops-key

--- a/deploy/chart/secrets.enc.yaml
+++ b/deploy/chart/secrets.enc.yaml
@@ -1,0 +1,20 @@
+#ENC[AES256_GCM,data:Qu6gHwvTE4aIBrA5y+cHbcbMNCkJxkc1GEsLKWXdemI7+QJ1PFNjuMoIAtIQeGfuxZ8ayd+v720OTmjz,iv:Iso8RmF1GzgYUsN5LY75L3BLX+T6dOIOmdh/wuEbLaE=,tag:pfEZBsEmuVMkOEfJNKXLFQ==,type:comment]
+#ENC[AES256_GCM,data:9JCUBxV2CZZ8o7HIFmtDfq473H9EBlW/n4aTAP6tvPyDhICBpOQdaNmGGzmvR1/GmwOwZjdHAtX4V2g38yi2/xTFFoOseLYBgMcFj+UdDw==,iv:vE/okS/eehHs412Nrz5saw0fnyh08oH+GiNTVO+GCgg=,tag:l4MBTgzXlGqACCakv4tyzQ==,type:comment]
+#ENC[AES256_GCM,data:8NQmrs3Asvyw3cu2D36LbNJF8x1vliuZIJjbgxrqieFX7+ktP3ofzPuhdirS84+2r1z4Arts8vPV8NEmT8WeCGvX,iv:xiMGb4uI63eOgCWHIjFFXG4GOveK3YLz0Ih9QsHQ0PM=,tag:v1LFxAT2Qx0egzwu8dv2KQ==,type:comment]
+secrets:
+    api:
+        SUPABASE_PROD_KEY: ENC[AES256_GCM,data:pcvNbUBGZKEIBQWQyowAV9exOXqip4vuo19clXMlGTylyI6i8DCDrV8=,iv:JlACdZLGee96/11WR9kDBGK0Ix90nbwZWmLVUOj93vs=,tag:P9f3Z9BD9nLny+88Zkzc1A==,type:str]
+        ANTHROPIC_API_KEY: ENC[AES256_GCM,data:YKJ/M6tL02x5f+DNH5ZsUTo8Gh7zCAzH0++UQ50Sp/HCSORyWQZBf/UbOGRW6oy6En3pSYsdeSUISn192Y1FtwrmT+jazqU94llWixBccGLPEeYLsPEGrw/GDfbyTlQcu/S1zT+BMvIal4ON,iv:rEsuzY92zDsi3tcOCfkYdhplb5k2RYMp31Q2fjKq6GE=,tag:xCgBR7dAxqwF3AqksJjT2Q==,type:str]
+        VOYAGE_AI_API_KEY: ENC[AES256_GCM,data:BJ2ZgsYD2pAAXFMmRMEQsxS6L54d0hMtSxi5sCzWugIqdDZn/KdI1o0mzUaayA==,iv:4BFc4oWLOnseftARAPB/vd1Pj00aTec/vy/roHXXUmg=,tag:6WcZYM+AzqdtQ8DvAPsurg==,type:str]
+        JINA_API_KEY: ENC[AES256_GCM,data:ypDGnljHYmHfpIW6PRW38xBlaKTFPryzl2In/mabjQYgV8v0cbHG/ODnjJQFWaF7qFtAAw3LVG5d+da9VgXgUSk=,iv:skfPatD2Sx5yhOe/HCgQ96KBoaQl/QnICn35fbhf0ek=,tag:BexlftTQAvb7PYl60EcAzQ==,type:str]
+    frontend:
+        AUTH_PASSWORD: ENC[AES256_GCM,data:CMGTHHZmMFwS3LtZRUCZ3g==,iv:KxNRcglV2ZRhyUB8f/Ad9Hp+pKjC4Q6jLuSUrCBWVnI=,tag:A/NRcHOeSFKc+pTeD9DTOQ==,type:str]
+sops:
+    gcp_kms:
+        - resource_id: projects/project-fe559f0f-d011-4af4-bf0/locations/global/keyRings/sops/cryptoKeys/sops-key
+          created_at: "2026-04-24T17:00:18Z"
+          enc: CiQAjT8VB/HCvkKXfDS3lbNLy1UlNdt2LyiyEPjz16f9k3K2rsgSSQDATLUF7bREVUk1jnQayf/uHIzouj3cZrZalQj8GWCkTyoKbVRqGsnsTd4GYxaQU41R4HDoAOHhGKadZkzgYf8C8t3IQ1enFTs=
+    lastmodified: "2026-04-24T17:00:18Z"
+    mac: ENC[AES256_GCM,data:V9bkxuWeQhJCSY/8OZv7xUcHumOyVolQe8bz/srf5ML7JHsbocxHxjohshf8UR4gz3Zwm4QnASiD6hQ6BMv/JDMzJYee0Fk607Xz64zW2gtvQxE/tFR+T79RDEXop6xIhd0SGuDcQXZcJT7d+MeV+VREFpfIZLjwk1ZuNAgxLmg=,iv:zZMtYu+qBPSijH1qXmo+qGxrT+eaUo4HZGS4ot5Isbc=,tag:vRnGUOSK6jRCHbmj+J+xVw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/deploy/chart/templates/api-healthcheckpolicy.yaml
+++ b/deploy/chart/templates/api-healthcheckpolicy.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.api.httproute.enabled }}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ include "rumil.fullname" . }}-api
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "rumil.fullname" . }}-api
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz
+        port: {{ .Values.api.service.port }}
+{{- end }}

--- a/deploy/chart/templates/api-httproute.yaml
+++ b/deploy/chart/templates/api-httproute.yaml
@@ -10,6 +10,7 @@ spec:
   parentRefs:
   - name: shared-tls-gateway
     namespace: cert-manager
+    sectionName: https
   hostnames:
   - {{ .Values.api.httproute.host | quote }}
   rules:

--- a/deploy/chart/templates/frontend-healthcheckpolicy.yaml
+++ b/deploy/chart/templates/frontend-healthcheckpolicy.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.frontend.httproute.enabled }}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ include "rumil.fullname" . }}-frontend
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "rumil.fullname" . }}-frontend
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz
+        port: {{ .Values.frontend.service.port }}
+{{- end }}

--- a/deploy/chart/templates/frontend-httproute.yaml
+++ b/deploy/chart/templates/frontend-httproute.yaml
@@ -10,6 +10,7 @@ spec:
   parentRefs:
   - name: shared-tls-gateway
     namespace: cert-manager
+    sectionName: https
   hostnames:
   - {{ .Values.frontend.httproute.host | quote }}
   rules:

--- a/deploy/chart/templates/http-redirect-httproute.yaml
+++ b/deploy/chart/templates/http-redirect-httproute.yaml
@@ -1,0 +1,26 @@
+{{- if or .Values.api.httproute.enabled .Values.frontend.httproute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "rumil.fullname" . }}-http-redirect
+  labels:
+    {{- include "rumil.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+  - name: shared-tls-gateway
+    namespace: cert-manager
+    sectionName: http
+  hostnames:
+    {{- if .Values.frontend.httproute.enabled }}
+    - {{ .Values.frontend.httproute.host | quote }}
+    {{- end }}
+    {{- if .Values.api.httproute.enabled }}
+    - {{ .Values.api.httproute.host | quote }}
+    {{- end }}
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301
+{{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -7,7 +7,7 @@ api:
   replicaCount: 1
 
   image:
-    repository: us-central1-docker.pkg.dev/varuna-400921/delphos/rumil-api
+    repository: us-central1-docker.pkg.dev/project-fe559f0f-d011-4af4-bf0/rumil/rumil-api
     pullPolicy: IfNotPresent
 
   service:
@@ -53,17 +53,18 @@ api:
     SUPABASE_PROD_URL: https://aesjaehibxrzearctiqp.supabase.co
 
   httproute:
-    enabled: false
+    enabled: true
+    host: api.rumil.ink
 
 frontend:
   replicaCount: 1
 
   image:
-    repository: us-central1-docker.pkg.dev/varuna-400921/delphos/rumil-frontend
+    repository: us-central1-docker.pkg.dev/project-fe559f0f-d011-4af4-bf0/rumil/rumil-frontend
     pullPolicy: IfNotPresent
 
   service:
-    type: LoadBalancer
+    type: ClusterIP
     port: 3000
 
   resources:
@@ -104,23 +105,8 @@ frontend:
     API_BASE_URL: http://rumil-api.rumil.svc.cluster.local:8000
 
   httproute:
-    enabled: false
+    enabled: true
+    host: rumil.ink
 
 secrets:
   enabled: true
-
-tolerations:
-  - key: "hyperdiskonly"
-    operator: "Equal"
-    value: "true"
-    effect: "NoSchedule"
-
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: hyperdiskonly
-              operator: In
-              values:
-                - "true"

--- a/deploy/infra/create-cluster.sh
+++ b/deploy/infra/create-cluster.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Provision the Differential Labs GKE Autopilot cluster and surrounding GCP
+# resources in a fresh GCP project. Idempotent — safe to re-run.
+#
+# What this creates:
+#   - Enables the GCP APIs we need
+#   - A custom-mode VPC + regional subnet with pod/service secondary ranges
+#   - A Cloud Router + Cloud NAT so private-node workloads can egress
+#   - A dedicated node service account with minimum required roles
+#   - A Docker-format Artifact Registry repo (rumil) in the cluster's region
+#   - A regional GKE Autopilot cluster with Workload Identity + private nodes
+#   - A Cloud DNS public managed zone for rumil.ink
+#   - A kubectl context pointed at the new cluster
+#
+# Prereqs:
+#   - gcloud authed as an identity with Owner on the target project
+#   - Billing linked to the project
+#
+# Usage:
+#   bash deploy/infra/create-cluster.sh
+
+set -euo pipefail
+
+PROJECT="project-fe559f0f-d011-4af4-bf0"
+REGION="us-central1"
+ACCOUNT="lawrence.gab.phillips@gmail.com"
+
+CLUSTER_NAME="differential"
+NETWORK_NAME="differential-vpc"
+SUBNET_NAME="differential-subnet-${REGION}"
+ROUTER_NAME="differential-router-${REGION}"
+NAT_NAME="differential-nat-${REGION}"
+
+NODE_SA_NAME="gke-differential-nodes"
+NODE_SA="${NODE_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+
+AR_REPO="rumil"
+
+DNS_ZONE_NAME="rumil-ink"
+DNS_NAME="rumil.ink."
+
+SUBNET_CIDR="10.0.0.0/20"
+PODS_CIDR="10.4.0.0/14"
+SERVICES_CIDR="10.8.0.0/20"
+
+GC() { gcloud --project="$PROJECT" --account="$ACCOUNT" "$@"; }
+
+log() { printf '\n[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+
+exists() {
+  # Run a `gcloud ... describe` as an existence check. Returns 0 if the
+  # resource exists, nonzero otherwise.
+  GC "$@" >/dev/null 2>&1
+}
+
+log "Target: project=$PROJECT region=$REGION cluster=$CLUSTER_NAME"
+
+log "Enabling required GCP APIs"
+GC services enable \
+  container.googleapis.com \
+  compute.googleapis.com \
+  artifactregistry.googleapis.com \
+  dns.googleapis.com \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com
+
+log "VPC: $NETWORK_NAME"
+if exists compute networks describe "$NETWORK_NAME"; then
+  echo "  already exists — skipping"
+else
+  GC compute networks create "$NETWORK_NAME" \
+    --subnet-mode=custom \
+    --bgp-routing-mode=regional
+fi
+
+log "Subnet: $SUBNET_NAME ($SUBNET_CIDR, pods=$PODS_CIDR, services=$SERVICES_CIDR)"
+if exists compute networks subnets describe "$SUBNET_NAME" --region="$REGION"; then
+  echo "  already exists — skipping"
+else
+  GC compute networks subnets create "$SUBNET_NAME" \
+    --network="$NETWORK_NAME" \
+    --region="$REGION" \
+    --range="$SUBNET_CIDR" \
+    --secondary-range="pods=$PODS_CIDR" \
+    --secondary-range="services=$SERVICES_CIDR" \
+    --enable-private-ip-google-access
+fi
+
+log "Cloud Router: $ROUTER_NAME"
+if exists compute routers describe "$ROUTER_NAME" --region="$REGION"; then
+  echo "  already exists — skipping"
+else
+  GC compute routers create "$ROUTER_NAME" \
+    --network="$NETWORK_NAME" \
+    --region="$REGION"
+fi
+
+log "Cloud NAT: $NAT_NAME"
+if exists compute routers nats describe "$NAT_NAME" \
+    --router="$ROUTER_NAME" --region="$REGION"; then
+  echo "  already exists — skipping"
+else
+  GC compute routers nats create "$NAT_NAME" \
+    --router="$ROUTER_NAME" \
+    --region="$REGION" \
+    --nat-all-subnet-ip-ranges \
+    --auto-allocate-nat-external-ips
+fi
+
+log "Node service account: $NODE_SA"
+if exists iam service-accounts describe "$NODE_SA"; then
+  echo "  already exists — skipping create"
+else
+  GC iam service-accounts create "$NODE_SA_NAME" \
+    --display-name="GKE differential node SA" \
+    --description="Runtime identity for GKE Autopilot nodes in the differential cluster"
+fi
+
+log "Granting roles to node SA (idempotent)"
+for role in \
+  roles/logging.logWriter \
+  roles/monitoring.metricWriter \
+  roles/monitoring.viewer \
+  roles/stackdriver.resourceMetadata.writer \
+  roles/autoscaling.metricsWriter \
+  roles/artifactregistry.reader; do
+  echo "  $role"
+  GC projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:$NODE_SA" \
+    --role="$role" \
+    --condition=None \
+    --quiet >/dev/null
+done
+
+log "Artifact Registry: $AR_REPO ($REGION, docker)"
+if exists artifacts repositories describe "$AR_REPO" --location="$REGION"; then
+  echo "  already exists — skipping"
+else
+  GC artifacts repositories create "$AR_REPO" \
+    --repository-format=docker \
+    --location="$REGION" \
+    --description="Rumil container images"
+fi
+
+log "GKE Autopilot cluster: $CLUSTER_NAME (this takes ~5-10 minutes)"
+if exists container clusters describe "$CLUSTER_NAME" --region="$REGION"; then
+  echo "  already exists — skipping"
+else
+  GC container clusters create-auto "$CLUSTER_NAME" \
+    --region="$REGION" \
+    --release-channel=regular \
+    --network="$NETWORK_NAME" \
+    --subnetwork="$SUBNET_NAME" \
+    --cluster-secondary-range-name=pods \
+    --services-secondary-range-name=services \
+    --service-account="$NODE_SA" \
+    --enable-private-nodes
+fi
+
+log "Fetching kubectl credentials"
+GC container clusters get-credentials "$CLUSTER_NAME" --region="$REGION"
+
+log "Cloud DNS zone: $DNS_ZONE_NAME ($DNS_NAME)"
+if exists dns managed-zones describe "$DNS_ZONE_NAME"; then
+  echo "  already exists — skipping"
+else
+  GC dns managed-zones create "$DNS_ZONE_NAME" \
+    --dns-name="$DNS_NAME" \
+    --description="Public DNS zone for rumil.ink" \
+    --visibility=public
+fi
+
+log "Done."
+echo
+echo "Cluster endpoint + current state:"
+GC container clusters describe "$CLUSTER_NAME" --region="$REGION" \
+  --format='value(endpoint,status,currentMasterVersion)'
+echo
+echo "Cloud DNS nameservers for rumil.ink (set these at your registrar):"
+GC dns managed-zones describe "$DNS_ZONE_NAME" \
+  --format='value(nameServers.list())' | tr ';' '\n' | sed 's/^/  /'
+echo
+echo "Next steps:"
+echo "  1. Point the rumil.ink registrar at the nameservers above."
+echo "  2. Verify: kubectl get nodes"
+echo "  3. Install cert-manager + Gateway + HTTPRoutes and deploy the helm chart."

--- a/deploy/infra/install-platform.sh
+++ b/deploy/infra/install-platform.sh
@@ -153,6 +153,12 @@ metadata:
 spec:
   gatewayClassName: gke-l7-global-external-managed
   listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
     - name: https
       protocol: HTTPS
       port: 443

--- a/deploy/infra/install-platform.sh
+++ b/deploy/infra/install-platform.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Install the platform pieces that the rumil helm chart expects:
+#   - cert-manager (via helm)
+#   - Workload Identity so cert-manager can edit the Cloud DNS zone
+#   - A Let's Encrypt ClusterIssuer using the Cloud DNS DNS-01 solver
+#   - A reserved global external IP for the shared Gateway
+#   - Cloud DNS A records for rumil.ink / api.rumil.ink
+#   - A Certificate covering both hostnames
+#   - A shared Gateway (gke-l7-global-external-managed) in the cert-manager ns
+#
+# The existing chart's HTTPRoutes already target `shared-tls-gateway` in the
+# `cert-manager` namespace, so once this script completes and DNS propagates,
+# enabling httproute.enabled=true on the chart is all that's needed.
+#
+# Idempotent — safe to re-run.
+#
+# Usage:
+#   bash deploy/infra/install-platform.sh
+
+set -euo pipefail
+
+PROJECT="project-fe559f0f-d011-4af4-bf0"
+REGION="us-central1"
+ACCOUNT="lawrence.gab.phillips@gmail.com"
+
+DNS_ZONE_NAME="rumil-ink"
+APEX_DOMAIN="rumil.ink"
+API_HOST="api.rumil.ink"
+
+CERT_MANAGER_VERSION="1.19.2"
+CERT_MANAGER_NS="cert-manager"
+
+DNS_GSA_NAME="cert-manager-dns01"
+DNS_GSA="${DNS_GSA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+
+GATEWAY_NAME="shared-tls-gateway"
+
+CERT_NAME="rumil-ink-certificate"
+CERT_SECRET_NAME="rumil-ink-tls"
+CLUSTER_ISSUER_NAME="letsencrypt-dns01"
+LE_EMAIL="lawrence.gab.phillips@gmail.com"
+
+GC() { gcloud --project="$PROJECT" --account="$ACCOUNT" "$@"; }
+log() { printf '\n[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+exists() { GC "$@" >/dev/null 2>&1; }
+
+TXN_STARTED=0
+cleanup_txn() { [[ "$TXN_STARTED" == "1" ]] && GC dns record-sets transaction abort --zone="$DNS_ZONE_NAME" >/dev/null 2>&1 || true; }
+trap cleanup_txn EXIT
+
+upsert_a_record() {
+  local name="$1"
+  local ip="$2"
+  local current
+  current="$(GC dns record-sets list --zone="$DNS_ZONE_NAME" \
+    --name="${name}." --type=A \
+    --format='value(rrdatas[0])' 2>/dev/null || echo "")"
+  if [[ "$current" == "$ip" ]]; then
+    echo "  $name -> $ip already correct"
+    return
+  fi
+  GC dns record-sets transaction start --zone="$DNS_ZONE_NAME" >/dev/null
+  TXN_STARTED=1
+  if [[ -n "$current" ]]; then
+    echo "  $name: replacing $current -> $ip"
+    GC dns record-sets transaction remove --zone="$DNS_ZONE_NAME" \
+      --name="${name}." --type=A --ttl=300 "$current" >/dev/null
+  else
+    echo "  $name: creating -> $ip"
+  fi
+  GC dns record-sets transaction add --zone="$DNS_ZONE_NAME" \
+    --name="${name}." --type=A --ttl=300 "$ip" >/dev/null
+  GC dns record-sets transaction execute --zone="$DNS_ZONE_NAME" >/dev/null
+  TXN_STARTED=0
+}
+
+log "GSA for cert-manager Cloud DNS access: $DNS_GSA"
+if exists iam service-accounts describe "$DNS_GSA"; then
+  echo "  already exists — skipping create"
+else
+  GC iam service-accounts create "$DNS_GSA_NAME" \
+    --display-name="cert-manager DNS-01 solver" \
+    --description="Used by cert-manager to solve ACME DNS-01 challenges in Cloud DNS"
+fi
+
+log "Granting roles/dns.admin to $DNS_GSA"
+GC projects add-iam-policy-binding "$PROJECT" \
+  --member="serviceAccount:$DNS_GSA" \
+  --role="roles/dns.admin" \
+  --condition=None \
+  --quiet >/dev/null
+
+log "Binding KSA cert-manager/cert-manager to $DNS_GSA via Workload Identity"
+GC iam service-accounts add-iam-policy-binding "$DNS_GSA" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT}.svc.id.goog[${CERT_MANAGER_NS}/cert-manager]" \
+  --quiet >/dev/null
+
+log "Installing cert-manager ($CERT_MANAGER_VERSION) via helm"
+helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
+helm repo update jetstack >/dev/null
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace "$CERT_MANAGER_NS" \
+  --create-namespace \
+  --version "$CERT_MANAGER_VERSION" \
+  --set crds.enabled=true \
+  --set startupapicheck.enabled=false \
+  --set "global.leaderElection.namespace=$CERT_MANAGER_NS" \
+  --set "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account=$DNS_GSA" \
+  --wait
+
+log "Rolling cert-manager deployments to pick up Workload Identity annotation"
+kubectl -n "$CERT_MANAGER_NS" rollout restart deployment cert-manager
+kubectl -n "$CERT_MANAGER_NS" rollout status  deployment cert-manager --timeout=180s
+
+log "Applying ClusterIssuer, Gateway, and Certificate manifests"
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${CLUSTER_ISSUER_NAME}
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ${LE_EMAIL}
+    privateKeySecretRef:
+      name: ${CLUSTER_ISSUER_NAME}-account-key
+    solvers:
+      - dns01:
+          cloudDNS:
+            project: ${PROJECT}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${CERT_NAME}
+  namespace: ${CERT_MANAGER_NS}
+spec:
+  secretName: ${CERT_SECRET_NAME}
+  issuerRef:
+    name: ${CLUSTER_ISSUER_NAME}
+    kind: ClusterIssuer
+  commonName: ${APEX_DOMAIN}
+  dnsNames:
+    - ${APEX_DOMAIN}
+    - ${API_HOST}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${GATEWAY_NAME}
+  namespace: ${CERT_MANAGER_NS}
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: ${CERT_SECRET_NAME}
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
+
+log "Waiting for Gateway to be programmed (GKE provisions the LB and assigns an IP)"
+for i in {1..40}; do
+  GATEWAY_IP="$(kubectl -n "$CERT_MANAGER_NS" get gateway "$GATEWAY_NAME" \
+    -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "")"
+  if [[ -n "$GATEWAY_IP" ]]; then
+    echo "  Gateway IP: $GATEWAY_IP"
+    break
+  fi
+  sleep 15
+done
+if [[ -z "${GATEWAY_IP:-}" ]]; then
+  echo "  Gateway did not acquire an IP within 10 minutes. Check:"
+  echo "    kubectl -n $CERT_MANAGER_NS describe gateway $GATEWAY_NAME"
+  exit 1
+fi
+
+log "Cloud DNS A records: $APEX_DOMAIN and $API_HOST -> $GATEWAY_IP"
+upsert_a_record "$APEX_DOMAIN" "$GATEWAY_IP"
+upsert_a_record "$API_HOST" "$GATEWAY_IP"
+
+log "Done."
+echo
+echo "Gateway: $GATEWAY_NAME (IP: $GATEWAY_IP, class: gke-l7-global-external-managed)"
+echo "DNS:     $APEX_DOMAIN and $API_HOST point at $GATEWAY_IP"
+echo
+echo "The certificate will issue once the registrar is pointed at the Cloud DNS"
+echo "nameservers and DNS-01 challenges can be resolved."
+echo
+echo "Check progress with:"
+echo "  kubectl -n ${CERT_MANAGER_NS} get certificate,challenge"
+echo "  kubectl -n ${CERT_MANAGER_NS} get gateway ${GATEWAY_NAME}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CHART_DIR="$REPO_ROOT/deploy/chart"
-SECRETS_FILE="$CHART_DIR/secrets.yaml"
+SECRETS_FILE="$CHART_DIR/secrets.enc.yaml"
 NAMESPACE="rumil"
 RELEASE="rumil"
-API_REPO="us-central1-docker.pkg.dev/varuna-400921/delphos/rumil-api"
-FRONTEND_REPO="us-central1-docker.pkg.dev/varuna-400921/delphos/rumil-frontend"
+API_REPO="us-central1-docker.pkg.dev/project-fe559f0f-d011-4af4-bf0/rumil/rumil-api"
+FRONTEND_REPO="us-central1-docker.pkg.dev/project-fe559f0f-d011-4af4-bf0/rumil/rumil-frontend"
 
 usage() {
     echo "Usage: $0 [--api] [--frontend] [--all] [--tag TAG]"
@@ -63,7 +63,7 @@ fi
 if $deploy_frontend; then
     echo "==> Building frontend (pnpm build)..."
     cd "$REPO_ROOT/frontend"
-    NEXT_PUBLIC_API_URL="" pnpm build
+    NEXT_PUBLIC_API_URL="https://api.rumil.ink" pnpm build
 
     echo "==> Building frontend image (linux/amd64)..."
     docker build --platform linux/amd64 \
@@ -77,8 +77,9 @@ if $deploy_frontend; then
 fi
 
 echo "==> Deploying with Helm (release=$RELEASE, namespace=$NAMESPACE, tag=$tag)..."
-helm upgrade "$RELEASE" "$CHART_DIR" \
+helm secrets upgrade --install "$RELEASE" "$CHART_DIR" \
     -n "$NAMESPACE" \
+    --create-namespace \
     --set "releaseId=$tag" \
     -f "$SECRETS_FILE"
 


### PR DESCRIPTION
## Summary

Migrates the rumil deployment off the old varuna-400921 cluster onto a fresh GCP project (`project-fe559f0f-d011-4af4-bf0`) in a brand-new GKE Autopilot cluster called `differential` in us-central1. The full new-side stand-up is reproducible from two idempotent scripts plus the existing helm chart.

**Scope note:** this PR only brings the new cluster up and points DNS at it. The old varuna-400921 cluster and its resources are still running, untouched.

**What ships:**
- Cluster + VPC + NAT + node SA + Artifact Registry + Cloud DNS zone via `deploy/infra/create-cluster.sh`.
- cert-manager + Workload Identity → Cloud DNS + Let's Encrypt DNS-01 ClusterIssuer + shared Gateway (`gke-l7-global-external-managed`) via `deploy/infra/install-platform.sh`.
- Chart updates: new image repo paths, HTTPRoutes enabled with real hostnames, `HealthCheckPolicy` resources pointing the LB at `/healthz`, HTTP→HTTPS redirect via a 301 filter, node-selector/toleration cruft for the old cluster dropped.
- Secrets now SOPS-encrypted against a KMS key in the new project (`projects/.../keyRings/sops/cryptoKeys/sops-key`); `deploy.sh` uses `helm-secrets` to decrypt at deploy time.

**Autopilot gotchas baked in:**
- cert-manager leader election moved out of `kube-system` (Warden blocks writes there, which silently stalls CA injection → x509 errors everywhere).
- GKE Gateway controller silently ignores the `networking.gke.io/addresses` annotation and auto-allocates its own reserved global IP. The install script now reads the IP after the Gateway is Programmed and sets Cloud DNS A records to match.
- Default LB health check probes `/`, which neither service returns 2xx on; `HealthCheckPolicy` resources point probes at `/healthz`.

**Live at:**
- https://rumil.ink (frontend, 401 basic-auth gate via `AUTH_PASSWORD` as before)
- https://api.rumil.ink/healthz (200)
- http://* → 301 → https

## Test plan

- [x] `deploy/infra/create-cluster.sh` provisions cluster from scratch (verified end-to-end)
- [x] `deploy/infra/install-platform.sh` installs cert-manager, issues cert, programs Gateway
- [x] `scripts/deploy.sh --all` builds, pushes to new AR, deploys chart
- [x] `https://api.rumil.ink/healthz` returns 200
- [x] `https://rumil.ink` returns 401 (gate working)
- [x] `http://{rumil.ink,api.rumil.ink}` → 301 to HTTPS
- [x] `sops decrypt deploy/chart/secrets.enc.yaml` round-trips to original values
- [x] `helm secrets template` decrypts on the fly and renders correct k8s Secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)