### PR TITLE
Context-built event overhaul and stageable view calls

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2536,6 +2536,64 @@
               }
             ],
             "title": "Budget"
+          },
+          "full_pages": {
+            "items": {
+              "$ref": "#/components/schemas/PageRef"
+            },
+            "type": "array",
+            "title": "Full Pages",
+            "default": []
+          },
+          "abstract_pages": {
+            "items": {
+              "$ref": "#/components/schemas/PageRef"
+            },
+            "type": "array",
+            "title": "Abstract Pages",
+            "default": []
+          },
+          "summary_pages": {
+            "items": {
+              "$ref": "#/components/schemas/PageRef"
+            },
+            "type": "array",
+            "title": "Summary Pages",
+            "default": []
+          },
+          "distillation_pages": {
+            "items": {
+              "$ref": "#/components/schemas/PageRef"
+            },
+            "type": "array",
+            "title": "Distillation Pages",
+            "default": []
+          },
+          "scope_linked_pages": {
+            "items": {
+              "$ref": "#/components/schemas/PageRef"
+            },
+            "type": "array",
+            "title": "Scope Linked Pages",
+            "default": []
+          },
+          "budget_usage": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Budget Usage",
+            "default": {}
+          },
+          "context_text": {
+            "type": "string",
+            "title": "Context Text",
+            "default": ""
+          },
+          "context_text_chars": {
+            "type": "integer",
+            "title": "Context Text Chars",
+            "default": 0
           }
         },
         "type": "object",
@@ -2546,7 +2604,15 @@
           "working_context_page_ids",
           "preloaded_page_ids",
           "source_page_id",
-          "budget"
+          "budget",
+          "full_pages",
+          "abstract_pages",
+          "summary_pages",
+          "distillation_pages",
+          "scope_linked_pages",
+          "budget_usage",
+          "context_text",
+          "context_text_chars"
         ],
         "title": "ContextBuiltEventOut"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -536,6 +536,40 @@ export type ContextBuiltEventOut = {
      * Budget
      */
     budget: number | null;
+    /**
+     * Full Pages
+     */
+    full_pages: Array<PageRef>;
+    /**
+     * Abstract Pages
+     */
+    abstract_pages: Array<PageRef>;
+    /**
+     * Summary Pages
+     */
+    summary_pages: Array<PageRef>;
+    /**
+     * Distillation Pages
+     */
+    distillation_pages: Array<PageRef>;
+    /**
+     * Scope Linked Pages
+     */
+    scope_linked_pages: Array<PageRef>;
+    /**
+     * Budget Usage
+     */
+    budget_usage: {
+        [key: string]: number;
+    };
+    /**
+     * Context Text
+     */
+    context_text: string;
+    /**
+     * Context Text Chars
+     */
+    context_text_chars: number;
 };
 
 /**

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -174,6 +174,181 @@ function PageList({ pages }: { pages: PageRef[] }) {
   );
 }
 
+type CtxTierKey = "full" | "distillation" | "abstract" | "summary";
+
+const CTX_TIER_ORDER: { key: CtxTierKey; label: string }[] = [
+  { key: "full", label: "full" },
+  { key: "distillation", label: "distillation" },
+  { key: "abstract", label: "abstract" },
+  { key: "summary", label: "summary" },
+];
+
+function ContextBuiltBody({
+  event,
+}: {
+  event: Extract<TraceEvent, { event: "context_built" }>;
+}) {
+  const working = event.working_context_page_ids ?? [];
+  const preloaded = event.preloaded_page_ids ?? [];
+  const scopeLinked = event.scope_linked_pages ?? [];
+  const budgetUsage = event.budget_usage ?? {};
+  const tierPages: Record<CtxTierKey, PageRef[]> = {
+    full: event.full_pages ?? [],
+    distillation: event.distillation_pages ?? [],
+    abstract: event.abstract_pages ?? [],
+    summary: event.summary_pages ?? [],
+  };
+  const populatedTiers = CTX_TIER_ORDER.filter(
+    (t) => tierPages[t.key].length > 0 || (budgetUsage[t.key] ?? 0) > 0,
+  );
+  const totalTierChars = CTX_TIER_ORDER.reduce(
+    (sum, t) => sum + (budgetUsage[t.key] ?? 0),
+    0,
+  );
+  const uniquePageIds = new Set<string>();
+  for (const t of populatedTiers) for (const p of tierPages[t.key]) uniquePageIds.add(p.id);
+  for (const p of scopeLinked) uniquePageIds.add(p.id);
+  for (const p of preloaded) uniquePageIds.add(p.id);
+  if (populatedTiers.length === 0) for (const p of working) uniquePageIds.add(p.id);
+  const totalPages = uniquePageIds.size;
+  const promptChars =
+    event.context_text_chars ?? (event.context_text?.length ?? 0);
+
+  return (
+    <div className="trace-event-body">
+      <div className="trace-ctx-totals">
+        <span className="trace-ctx-totals-pages">
+          {totalPages} page{totalPages === 1 ? "" : "s"}
+        </span>
+        {promptChars > 0 && (
+          <>
+            <span className="trace-ctx-totals-sep">·</span>
+            <span className="trace-ctx-totals-chars">
+              {promptChars.toLocaleString()} prompt ch
+            </span>
+          </>
+        )}
+        {totalTierChars > 0 && totalTierChars !== promptChars && (
+          <>
+            <span className="trace-ctx-totals-sep">·</span>
+            <span className="trace-ctx-totals-chars">
+              {totalTierChars.toLocaleString()} tiered ch
+            </span>
+          </>
+        )}
+      </div>
+
+      {totalTierChars > 0 && (
+        <div
+          className="trace-ctx-budget-bar"
+          title={`tiered budget: ${totalTierChars.toLocaleString()} chars`}
+        >
+          {populatedTiers.map((t) => {
+            const chars = budgetUsage[t.key] ?? 0;
+            if (chars <= 0) return null;
+            return (
+              <div
+                key={t.key}
+                className={`trace-ctx-budget-seg trace-ctx-budget-seg--${t.key}`}
+                style={{ flexGrow: chars }}
+                title={`${t.label}: ${chars.toLocaleString()} ch`}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {populatedTiers.map((t) => {
+        const pages = tierPages[t.key];
+        const chars = budgetUsage[t.key] ?? 0;
+        return (
+          <div key={t.key} className="trace-ctx-tier">
+            <span className="trace-ctx-tier-label">
+              <span
+                className={`trace-ctx-tier-swatch trace-ctx-tier-swatch--${t.key}`}
+              />
+              {t.label}
+              <span className="trace-ctx-tier-count">({pages.length})</span>
+            </span>
+            <PageList pages={pages} />
+            <span className="trace-ctx-tier-chars">
+              {chars > 0 ? `${chars.toLocaleString()} ch` : "—"}
+            </span>
+          </div>
+        );
+      })}
+
+      {populatedTiers.length === 0 && working.length > 0 && (
+        <div className="trace-ctx-tier trace-ctx-tier--flat">
+          <span className="trace-ctx-tier-label">
+            <span className="trace-ctx-tier-swatch trace-ctx-tier-swatch--flat" />
+            working context
+            <span className="trace-ctx-tier-count">({working.length})</span>
+          </span>
+          <PageList pages={working} />
+          <span className="trace-ctx-tier-chars">—</span>
+        </div>
+      )}
+
+      {scopeLinked.length > 0 && (
+        <div className="trace-ctx-tier trace-ctx-tier--scope-linked">
+          <span className="trace-ctx-tier-label">
+            <span className="trace-ctx-tier-swatch trace-ctx-tier-swatch--scope-linked" />
+            scope-linked
+            <span className="trace-ctx-tier-count">({scopeLinked.length})</span>
+          </span>
+          <PageList pages={scopeLinked} />
+          <span className="trace-ctx-tier-chars">—</span>
+        </div>
+      )}
+
+      {preloaded.length > 0 && (
+        <div className="trace-ctx-tier trace-ctx-tier--preloaded">
+          <span className="trace-ctx-tier-label">
+            <span className="trace-ctx-tier-swatch trace-ctx-tier-swatch--preloaded" />
+            preloaded
+            <span className="trace-ctx-tier-count">({preloaded.length})</span>
+          </span>
+          <PageList pages={preloaded} />
+          <span className="trace-ctx-tier-chars">—</span>
+        </div>
+      )}
+
+      {event.source_page_id && (
+        <div className="trace-kv">
+          <span className="trace-kv-key">source</span>
+          <Link
+            href={`/pages/${event.source_page_id}`}
+            className="trace-kv-value trace-ctx-source-link"
+          >
+            {event.source_page_id.slice(0, 8)}
+          </Link>
+        </div>
+      )}
+
+      {event.context_text && (
+        <details className="trace-ctx-prompt">
+          <summary className="trace-ctx-prompt-summary">
+            <span className="trace-ctx-prompt-caret" />
+            context text
+            <span className="trace-ctx-prompt-chars">
+              {promptChars.toLocaleString()} ch
+            </span>
+          </summary>
+          <pre className="trace-ctx-prompt-body">{event.context_text}</pre>
+        </details>
+      )}
+
+      {event.budget != null && (
+        <div className="trace-kv">
+          <span className="trace-kv-key">budget</span>
+          <span className="trace-kv-value">{event.budget}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function RoleBadge({ role }: { role: string }) {
   const cls = role === "direct" ? "trace-role-badge-direct" : "trace-role-badge-structural";
   return <span className={`trace-role-badge ${cls}`}>{role}</span>;
@@ -739,28 +914,7 @@ const EventSection = memo(function EventSection({ event }: { event: TraceEvent }
         <ExchangeDetail detail={exchangeDetail} />
       )}
 
-      {event.event === "context_built" && (
-        <div className="trace-event-body">
-          {(event.working_context_page_ids ?? []).length > 0 && (
-            <div className="trace-kv">
-              <span className="trace-kv-key">working context</span>
-              <PageList pages={event.working_context_page_ids ?? []} />
-            </div>
-          )}
-          {(event.preloaded_page_ids ?? []).length > 0 && (
-            <div className="trace-kv">
-              <span className="trace-kv-key">preloaded</span>
-              <PageList pages={event.preloaded_page_ids ?? []} />
-            </div>
-          )}
-          {event.budget != null && (
-            <div className="trace-kv">
-              <span className="trace-kv-key">budget</span>
-              <span className="trace-kv-value">{event.budget}</span>
-            </div>
-          )}
-        </div>
-      )}
+      {event.event === "context_built" && <ContextBuiltBody event={event} />}
 
       {event.event === "moves_executed" && (
         <div className="trace-event-body">

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -397,6 +397,203 @@
   font-style: italic;
 }
 
+/* Context built — tiered breakdown of what went into the prompt */
+
+.trace-ctx-totals {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+.trace-ctx-totals-pages {
+  color: #333;
+  font-weight: 500;
+}
+.trace-ctx-totals-sep {
+  color: #bbb;
+}
+.trace-ctx-totals-chars {
+  color: #888;
+}
+
+.trace-ctx-budget-bar {
+  display: flex;
+  width: 100%;
+  height: 4px;
+  background: #f1f1f1;
+  border-radius: 2px;
+  overflow: hidden;
+  margin: 0 0 14px;
+}
+.trace-ctx-budget-seg {
+  height: 100%;
+  transition: opacity 0.12s ease;
+}
+.trace-ctx-budget-seg + .trace-ctx-budget-seg {
+  border-left: 1px solid rgba(255, 255, 255, 0.9);
+}
+.trace-ctx-budget-seg:hover {
+  opacity: 0.7;
+}
+.trace-ctx-budget-seg--full         { background: #2a2a2a; }
+.trace-ctx-budget-seg--distillation { background: #555; }
+.trace-ctx-budget-seg--abstract     { background: #8a8a8a; }
+.trace-ctx-budget-seg--summary      { background: #bcbcbc; }
+
+.trace-ctx-tier {
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: baseline;
+  padding: 4px 0;
+  border-bottom: 1px dashed transparent;
+}
+.trace-ctx-tier + .trace-ctx-tier {
+  border-top: 1px dashed #efefef;
+}
+.trace-ctx-tier--preloaded,
+.trace-ctx-tier--flat {
+  margin-top: 2px;
+}
+
+.trace-ctx-tier-label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 500;
+}
+
+.trace-ctx-tier-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+}
+.trace-ctx-tier-swatch--full         { background: #2a2a2a; }
+.trace-ctx-tier-swatch--distillation { background: #555; }
+.trace-ctx-tier-swatch--abstract     { background: #8a8a8a; }
+.trace-ctx-tier-swatch--summary      { background: #bcbcbc; }
+.trace-ctx-tier-swatch--preloaded {
+  background: transparent;
+  border: 1px solid #888;
+  border-radius: 2px;
+}
+.trace-ctx-tier-swatch--scope-linked {
+  background: transparent;
+  border: 1px solid #6b9fd8;
+  border-radius: 50%;
+  position: relative;
+}
+.trace-ctx-tier-swatch--scope-linked::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  background: #6b9fd8;
+  border-radius: 50%;
+  opacity: 0.55;
+}
+.trace-ctx-tier-swatch--flat {
+  background: transparent;
+  border: 1px dashed #888;
+}
+
+.trace-ctx-tier-count {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+  font-weight: 400;
+  color: #999;
+  letter-spacing: 0;
+  text-transform: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.trace-ctx-tier-chars {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+  color: #a0a0a0;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.trace-ctx-source-link {
+  color: #4a6aa8;
+  text-decoration: none;
+}
+.trace-ctx-source-link:hover {
+  text-decoration: underline;
+}
+
+.trace-ctx-prompt {
+  margin-top: 12px;
+}
+.trace-ctx-prompt-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 11px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 500;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.trace-ctx-prompt-summary::-webkit-details-marker { display: none; }
+.trace-ctx-prompt-summary::marker { content: ""; }
+
+.trace-ctx-prompt-caret {
+  width: 0;
+  height: 0;
+  border-left: 4px solid #888;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+}
+.trace-ctx-prompt[open] .trace-ctx-prompt-caret {
+  transform: rotate(90deg);
+}
+
+.trace-ctx-prompt-chars {
+  margin-left: auto;
+  font-family: var(--font-geist-mono), monospace;
+  color: #a0a0a0;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+  font-weight: 400;
+}
+
+.trace-ctx-prompt-body {
+  margin: 6px 0 0;
+  padding: 12px 14px;
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11.5px;
+  line-height: 1.6;
+  color: #2a2a2a;
+  background: #fafafa;
+  border: 1px solid #ececec;
+  border-left: 2px solid #2a2a2a;
+  border-radius: 3px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 360px;
+  overflow-y: auto;
+  tab-size: 2;
+}
+
 /* Moves */
 
 .trace-move-row {
@@ -1270,6 +1467,46 @@
   }
 
   .trace-empty { color: #666; }
+
+  .trace-ctx-totals-pages { color: #ddd; }
+  .trace-ctx-totals-sep { color: #555; }
+  .trace-ctx-totals-chars { color: #888; }
+
+  .trace-ctx-budget-bar { background: #252525; }
+  .trace-ctx-budget-seg + .trace-ctx-budget-seg {
+    border-left-color: rgba(0, 0, 0, 0.65);
+  }
+  .trace-ctx-budget-seg--full         { background: #efefef; }
+  .trace-ctx-budget-seg--distillation { background: #b5b5b5; }
+  .trace-ctx-budget-seg--abstract     { background: #7c7c7c; }
+  .trace-ctx-budget-seg--summary      { background: #4a4a4a; }
+
+  .trace-ctx-tier + .trace-ctx-tier { border-top-color: #1f1f1f; }
+  .trace-ctx-tier-label { color: #9a9a9a; }
+  .trace-ctx-tier-count { color: #777; }
+  .trace-ctx-tier-chars { color: #777; }
+
+  .trace-ctx-tier-swatch { border-color: rgba(255, 255, 255, 0.08); }
+  .trace-ctx-tier-swatch--full         { background: #efefef; }
+  .trace-ctx-tier-swatch--distillation { background: #b5b5b5; }
+  .trace-ctx-tier-swatch--abstract     { background: #7c7c7c; }
+  .trace-ctx-tier-swatch--summary      { background: #4a4a4a; }
+  .trace-ctx-tier-swatch--preloaded { border-color: #777; }
+  .trace-ctx-tier-swatch--scope-linked { border-color: #4a6aa8; }
+  .trace-ctx-tier-swatch--scope-linked::after { background: #4a6aa8; }
+  .trace-ctx-tier-swatch--flat { border-color: #777; }
+
+  .trace-ctx-source-link { color: #7baaf7; }
+
+  .trace-ctx-prompt-summary { color: #9a9a9a; }
+  .trace-ctx-prompt-caret { border-left-color: #777; }
+  .trace-ctx-prompt-chars { color: #777; }
+  .trace-ctx-prompt-body {
+    color: #d4d4d4;
+    background: #141414;
+    border-color: #262626;
+    border-left-color: #efefef;
+  }
 
   .trace-move-create { color: #3dba6e; }
   .trace-move-link { color: #6b9fd8; }

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -25,6 +25,11 @@ Usage:
 
 All runs are staged by default (use --no-stage to disable). Workspace defaults to
 'default' but is auto-detected from --question-id when possible.
+
+If --question-id points at a question staged under another run, that run's run_id
+is adopted automatically so the call continues inside the staged lineage (budget
+is added to rather than clobbered; no new `runs` row is created). Passing
+--no-stage against a staged question is rejected.
 """
 
 import argparse
@@ -33,6 +38,7 @@ import logging
 import uuid
 
 from rumil.calls.call_registry import ASSESS_CALL_CLASSES
+from rumil.calls.create_view import CreateViewCall
 from rumil.calls.find_considerations import FindConsiderationsCall
 from rumil.calls.link_subquestions import LinkSubquestionsCall
 from rumil.calls.scout_analogies import ScoutAnalogiesCall
@@ -44,6 +50,7 @@ from rumil.calls.scout_paradigm_cases import ScoutParadigmCasesCall
 from rumil.calls.scout_subquestions import ScoutSubquestionsCall
 from rumil.calls.scout_web_questions import ScoutWebQuestionsCall
 from rumil.calls.stages import CallRunner
+from rumil.calls.update_view import UpdateViewCall
 from rumil.calls.web_research import WebResearchCall
 from rumil.database import DB
 from rumil.models import CallStage, CallType
@@ -137,6 +144,32 @@ async def run_call(args: argparse.Namespace, db: DB, question_id: str) -> None:
         )
         await linker.run()
 
+    elif call_type == "create-view":
+        call = await db.create_call(
+            CallType.CREATE_VIEW,
+            scope_page_id=question_id,
+        )
+        create_view = CreateViewCall(
+            question_id,
+            call,
+            db,
+            up_to_stage=up_to_stage,
+        )
+        await create_view.run()
+
+    elif call_type == "update-view":
+        call = await db.create_call(
+            CallType.UPDATE_VIEW,
+            scope_page_id=question_id,
+        )
+        update_view = UpdateViewCall(
+            question_id,
+            call,
+            db,
+            up_to_stage=up_to_stage,
+        )
+        await update_view.run()
+
     elif call_type == "robustify":
         if up_to_stage:
             print("--up-to-stage is not supported for robustify.")
@@ -172,8 +205,27 @@ async def run(args: argparse.Namespace) -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     workspace = args.workspace
-    staged = not args.no_stage
-    db = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod, staged=staged)
+    staged_flag = not args.no_stage
+
+    adopted_run_id: str | None = None
+    if args.question_id:
+        probe = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod, staged=False)
+        info = await probe.get_page_staging_info(args.question_id)
+        if info is None:
+            print(f"Question {args.question_id} not found.")
+            return
+        is_staged, owning_run_id, _owning_project_id = info
+        if is_staged:
+            if not staged_flag:
+                print(
+                    f"Question {args.question_id[:8]} is staged under run {owning_run_id[:8]}; "
+                    "cannot run with --no-stage. Drop --no-stage to adopt the staged run."
+                )
+                return
+            adopted_run_id = owning_run_id
+
+    run_id = adopted_run_id or str(uuid.uuid4())
+    db = await DB.create(run_id=run_id, prod=args.prod, staged=staged_flag)
     project = await db.get_or_create_project(workspace)
     db.project_id = project.id
 
@@ -188,7 +240,10 @@ async def run(args: argparse.Namespace) -> None:
         if page.project_id and page.project_id != db.project_id:
             db.project_id = page.project_id
         question_text = page.headline
-        print(f"Using existing question: {question_text}")
+        if adopted_run_id:
+            print(f"Adopted staged run {adopted_run_id[:8]} for question: {question_text}")
+        else:
+            print(f"Using existing question: {question_text}")
     elif args.question_text:
         question_text = args.question_text
         question_id = await create_root_question(question_text, db)
@@ -198,15 +253,19 @@ async def run(args: argparse.Namespace) -> None:
         return
 
     print(f"Trace: {frontend}/traces/{db.run_id}\n")
-    await db.init_budget(args.budget)
+    if adopted_run_id:
+        await db.add_budget(args.budget)
+    else:
+        await db.init_budget(args.budget)
 
     name = args.name or question_text
     config = settings.capture_config()
-    await db.create_run(
-        name=name,
-        question_id=question_id,
-        config=config,
-    )
+    if not adopted_run_id:
+        await db.create_run(
+            name=name,
+            question_id=question_id,
+            config=config,
+        )
 
     print(f"Running {args.call_type} on {question_id[:8]}...")
     await run_call(args, db, question_id)
@@ -223,6 +282,8 @@ def main() -> None:
             "robustify",
             "web-research",
             "link-subquestions",
+            "create-view",
+            "update-view",
             *_SCOUT_CALL_TYPES,
         ],
         help="Type of call to run",

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel, Field
 from rumil.calls.common import (
     ABSTRACT_INSTRUCTION,
     PageSummaryItem,
-    resolve_page_refs,
     save_page_abstracts,
 )
 from rumil.calls.stages import CallInfra, ContextBuilder, ContextResult
@@ -37,27 +36,10 @@ from rumil.models import (
     PageType,
 )
 from rumil.settings import get_settings
-from rumil.tracing.trace_events import ContextBuiltEvent
 
 log = logging.getLogger(__name__)
 
 _B2_SEMAPHORE = asyncio.Semaphore(15)
-
-
-async def _record_context_built(
-    infra: CallInfra,
-    working_page_ids: Sequence[str],
-    preloaded_ids: Sequence[str],
-    *,
-    source_page_id: str | None = None,
-) -> None:
-    await infra.trace.record(
-        ContextBuiltEvent(
-            working_context_page_ids=await resolve_page_refs(working_page_ids, infra.db),
-            preloaded_page_ids=await resolve_page_refs(preloaded_ids, infra.db),
-            source_page_id=source_page_id,
-        )
-    )
 
 
 class CreateViewContext(ContextBuilder):
@@ -123,11 +105,15 @@ class CreateViewContext(ContextBuilder):
                     ]
             context_text += "\n".join(parts_pre)
 
-        await _record_context_built(infra, working_page_ids, preloaded_ids)
         return ContextResult(
             context_text=context_text,
             working_page_ids=working_page_ids,
             preloaded_ids=preloaded_ids,
+            full_page_ids=result.full_page_ids,
+            abstract_page_ids=result.abstract_page_ids,
+            summary_page_ids=result.summary_page_ids,
+            distillation_page_ids=result.distillation_page_ids,
+            budget_usage=result.budget_usage,
         )
 
 
@@ -150,6 +136,7 @@ class EmbeddingContext(ContextBuilder):
             query,
             infra.db,
             scope_question_id=infra.question_id,
+            scope_linked_detail=PageDetail.ABSTRACT,
             require_judgement_for_questions=self._require_judgement_for_questions,
         )
         working_page_ids = result.page_ids
@@ -177,11 +164,15 @@ class EmbeddingContext(ContextBuilder):
                     ]
             context_text += "\n".join(parts)
 
-        await _record_context_built(infra, working_page_ids, preloaded_ids)
         return ContextResult(
             context_text=context_text,
             working_page_ids=working_page_ids,
             preloaded_ids=preloaded_ids,
+            full_page_ids=result.full_page_ids,
+            abstract_page_ids=result.abstract_page_ids,
+            summary_page_ids=result.summary_page_ids,
+            distillation_page_ids=result.distillation_page_ids,
+            budget_usage=result.budget_usage,
         )
 
 
@@ -256,6 +247,12 @@ class ScoutSiblingAwareContext(EmbeddingContext):
             context_text=prepended,
             working_page_ids=result.working_page_ids,
             preloaded_ids=result.preloaded_ids,
+            full_page_ids=result.full_page_ids,
+            abstract_page_ids=result.abstract_page_ids,
+            summary_page_ids=result.summary_page_ids,
+            distillation_page_ids=result.distillation_page_ids,
+            budget_usage=result.budget_usage,
+            source_page_id=result.source_page_id,
         )
 
 
@@ -276,12 +273,6 @@ class IngestEmbeddingContext(ContextBuilder):
             scope_question_id=infra.question_id,
         )
         working_page_ids = result.page_ids
-        await _record_context_built(
-            infra,
-            working_page_ids,
-            [],
-            source_page_id=self._source_page.id,
-        )
 
         formatted_source = await format_page(
             self._source_page,
@@ -297,6 +288,12 @@ class IngestEmbeddingContext(ContextBuilder):
         return ContextResult(
             context_text=result.context_text + source_section,
             working_page_ids=working_page_ids,
+            full_page_ids=result.full_page_ids,
+            abstract_page_ids=result.abstract_page_ids,
+            summary_page_ids=result.summary_page_ids,
+            distillation_page_ids=result.distillation_page_ids,
+            budget_usage=result.budget_usage,
+            source_page_id=self._source_page.id,
         )
 
 
@@ -334,19 +331,14 @@ class WebResearchEmbeddingContext(ContextBuilder):
             emb_result.budget_usage,
         )
 
-        await infra.trace.record(
-            ContextBuiltEvent(
-                working_context_page_ids=await resolve_page_refs(
-                    working_page_ids,
-                    infra.db,
-                ),
-                preloaded_page_ids=[],
-            )
-        )
-
         return ContextResult(
             context_text=context_text,
             working_page_ids=working_page_ids,
+            full_page_ids=emb_result.full_page_ids,
+            abstract_page_ids=emb_result.abstract_page_ids,
+            summary_page_ids=emb_result.summary_page_ids,
+            distillation_page_ids=emb_result.distillation_page_ids,
+            budget_usage=emb_result.budget_usage,
         )
 
 
@@ -1035,9 +1027,13 @@ class BigAssessContext(ContextBuilder):
             if parts:
                 context_text += "\n".join(parts)
 
-        await _record_context_built(infra, working_page_ids, all_extra)
         return ContextResult(
             context_text=context_text,
             working_page_ids=working_page_ids,
             preloaded_ids=all_extra,
+            full_page_ids=result.full_page_ids,
+            abstract_page_ids=result.abstract_page_ids,
+            summary_page_ids=result.summary_page_ids,
+            distillation_page_ids=result.distillation_page_ids,
+            budget_usage=result.budget_usage,
         )

--- a/src/rumil/calls/create_view.py
+++ b/src/rumil/calls/create_view.py
@@ -1,14 +1,19 @@
 """Create View call: synthesize P1 output into a structured View page."""
 
 import logging
+import uuid
+from collections.abc import Sequence
 
 from rumil.calls.closing_reviewers import ViewClosingReview
 from rumil.calls.context_builders import CreateViewContext
 from rumil.calls.page_creators import SimpleAgentLoop
 from rumil.calls.stages import (
+    CallInfra,
     CallRunner,
     ClosingReviewer,
     ContextBuilder,
+    ContextResult,
+    UpdateResult,
     WorkspaceUpdater,
 )
 from rumil.constants import DEFAULT_VIEW_SECTIONS
@@ -17,6 +22,7 @@ from rumil.models import (
     Call,
     CallType,
     LinkType,
+    MoveType,
     Page,
     PageLayer,
     PageLink,
@@ -29,55 +35,66 @@ from rumil.tracing.trace_events import ViewCreatedEvent
 log = logging.getLogger(__name__)
 
 
-class CreateViewCall(CallRunner):
-    """Create a View page for a question from available evidence."""
+class _CreateViewUpdater(WorkspaceUpdater):
+    """Workspace updater for CREATE_VIEW: materializes the view page, then
+    delegates to a standard ``SimpleAgentLoop`` for tool-driven item creation.
 
-    context_builder_cls = CreateViewContext
-    workspace_updater_cls = SimpleAgentLoop
-    closing_reviewer_cls = ViewClosingReview  # type: ignore[assignment]
-    call_type = CallType.CREATE_VIEW
+    Materialization runs at the top of ``update_workspace`` so
+    ``--up-to-stage build_context`` doesn't persist anything — the view page
+    is side-effect-free until the LLM stage actually starts.
+    """
 
-    def __init__(self, question_id: str, call: Call, db: DB, **kwargs) -> None:
-        self._view_id: str = ""
-        super().__init__(question_id, call, db, **kwargs)
+    def __init__(
+        self,
+        view_id: str,
+        call_type: CallType,
+        task_description: str,
+        available_moves: Sequence[MoveType] | None,
+    ) -> None:
+        self._view_id = view_id
+        self._call_type = call_type
+        self._inner = SimpleAgentLoop(
+            call_type,
+            task_description,
+            available_moves=available_moves,
+        )
 
-    async def _run_stages(self) -> None:
-        """Create the View page infrastructure, then rebuild stages that need the view_id."""
-        self._view_id = await self._create_view_page()
-        self.workspace_updater = self._make_workspace_updater()
-        self.closing_reviewer = self._make_closing_reviewer()
-        await super()._run_stages()
+    async def materialize(self, infra: CallInfra) -> str | None:
+        """Persist the View page + VIEW_OF link, superseding any prior view
+        for this question. Returns the superseded view id (or None).
+        Exposed for tests.
+        """
+        db = infra.db
+        question_id = infra.question_id
+        existing_view = await db.get_view_for_question(question_id)
 
-    async def _create_view_page(self) -> str:
-        """Create the View page and VIEW_OF link before the LLM starts."""
-        existing_view = await self.infra.db.get_view_for_question(self.infra.question_id)
-
-        question = await self.infra.db.get_page(self.infra.question_id)
-        q_headline = question.headline if question else self.infra.question_id[:8]
+        question = await db.get_page(question_id)
+        q_headline = question.headline if question else question_id[:8]
 
         view = Page(
+            id=self._view_id,
             page_type=PageType.VIEW,
             layer=PageLayer.WIKI,
             workspace=Workspace.RESEARCH,
             content="",
             headline=f"View: {q_headline}",
             sections=list(DEFAULT_VIEW_SECTIONS),
-            provenance_call_type=self.call_type.value,
-            provenance_call_id=self.infra.call.id,
+            provenance_call_type=self._call_type.value,
+            provenance_call_id=infra.call.id,
             provenance_model=get_settings().model,
         )
-        await self.infra.db.save_page(view)
+        await db.save_page(view)
 
-        await self.infra.db.save_link(
+        await db.save_link(
             PageLink(
                 from_page_id=view.id,
-                to_page_id=self.infra.question_id,
+                to_page_id=question_id,
                 link_type=LinkType.VIEW_OF,
             )
         )
 
         if existing_view:
-            await self.infra.db.supersede_page(existing_view.id, view.id)
+            await db.supersede_page(existing_view.id, view.id)
             log.info(
                 "Superseded old view %s with new view %s",
                 existing_view.id[:8],
@@ -87,25 +104,51 @@ class CreateViewCall(CallRunner):
         log.info(
             "Created view page %s for question %s",
             view.id[:8],
-            self.infra.question_id[:8],
+            question_id[:8],
         )
-        await self.infra.trace.record_strict(
+        await infra.trace.record_strict(
             ViewCreatedEvent(
                 view_id=view.id,
                 view_headline=view.headline,
-                question_id=self.infra.question_id,
+                question_id=question_id,
                 superseded_view_id=existing_view.id if existing_view else None,
             )
         )
-        return view.id
+        return existing_view.id if existing_view else None
+
+    async def update_workspace(
+        self,
+        infra: CallInfra,
+        context: ContextResult,
+    ) -> UpdateResult:
+        await self.materialize(infra)
+        return await self._inner.update_workspace(infra, context)
+
+
+class CreateViewCall(CallRunner):
+    """Create a View page for a question from available evidence."""
+
+    context_builder_cls = CreateViewContext
+    workspace_updater_cls = SimpleAgentLoop
+    closing_reviewer_cls = ViewClosingReview  # type: ignore[assignment]
+    call_type = CallType.CREATE_VIEW
+
+    def __init__(self, question_id: str, call: Call, db: DB, **kwargs) -> None:
+        # Mint the view UUID up front so factories (task_description, closing
+        # reviewer, updater) can bind to it without needing the view to exist
+        # in the DB yet. The actual save_page happens at update_workspace time
+        # so --up-to-stage build_context is side-effect-free.
+        self._view_id: str = str(uuid.uuid4())
+        super().__init__(question_id, call, db, **kwargs)
 
     def _make_context_builder(self) -> ContextBuilder:
         return CreateViewContext()
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:
-        return SimpleAgentLoop(
-            self.call_type,
-            self.task_description(),
+        return _CreateViewUpdater(
+            view_id=self._view_id,
+            call_type=self.call_type,
+            task_description=self.task_description(),
             available_moves=self._resolve_available_moves(),
         )
 

--- a/src/rumil/calls/link_subquestions.py
+++ b/src/rumil/calls/link_subquestions.py
@@ -29,7 +29,6 @@ from rumil.scope_subquestion_linker.tool import (
 from rumil.scope_subquestion_linker.validation import validate_proposals
 from rumil.settings import get_settings
 from rumil.tracing.trace_events import (
-    ContextBuiltEvent,
     LinkSubquestionsCompleteEvent,
     ProposedSubquestion,
     ReviewCompleteEvent,
@@ -87,8 +86,6 @@ class LinkerContextBuilder(ContextBuilder):
             "## Seed Subgraphs (most relevant top-level questions)\n\n"
             f"{seed_block or '(none)'}\n"
         )
-
-        await infra.trace.record(ContextBuiltEvent())
 
         return ContextResult(
             context_text=context_text,

--- a/src/rumil/calls/stages.py
+++ b/src/rumil/calls/stages.py
@@ -9,12 +9,12 @@ from dataclasses import dataclass, field
 from typing import ClassVar
 
 from rumil.available_moves import get_moves_for_call
-from rumil.calls.common import mark_call_completed
+from rumil.calls.common import mark_call_completed, resolve_page_refs
 from rumil.database import DB
 from rumil.models import Call, CallStage, CallStatus, CallType, Dispatch, Move, MoveType
 from rumil.moves.base import MoveState
 from rumil.tracing.page_load_tracking import page_track_scope
-from rumil.tracing.trace_events import ErrorEvent
+from rumil.tracing.trace_events import ContextBuiltEvent, ErrorEvent
 from rumil.tracing.tracer import CallTrace, reset_trace, set_trace
 
 log = logging.getLogger(__name__)
@@ -43,6 +43,19 @@ class ContextResult:
     working_page_ids: list[str]
     preloaded_ids: Sequence[str] = field(default_factory=list)
     messages: list[dict] = field(default_factory=list)
+    # Tiered breakdown of working_page_ids at the fidelity each page was
+    # rendered at. Builders that don't run tiered selection leave these
+    # empty; the event then falls back to showing working_page_ids as a
+    # single undifferentiated group.
+    full_page_ids: Sequence[str] = field(default_factory=list)
+    abstract_page_ids: Sequence[str] = field(default_factory=list)
+    summary_page_ids: Sequence[str] = field(default_factory=list)
+    distillation_page_ids: Sequence[str] = field(default_factory=list)
+    # Per-tier character usage as produced by build_embedding_based_context.
+    budget_usage: dict[str, int] = field(default_factory=dict)
+    # Set by ingest-style builders: the source page whose content is being
+    # folded into the prompt.
+    source_page_id: str | None = None
 
 
 @dataclass
@@ -157,6 +170,37 @@ class CallRunner(ABC):
     @abstractmethod
     def task_description(self) -> str: ...
 
+    async def _record_context_built(self, result: ContextResult) -> None:
+        """Emit the context_built trace event from the ContextResult.
+
+        Single authoritative emission point so every call type records the
+        event uniformly. Builders fill in tier fields on ContextResult when
+        they have them; absent tiers become empty lists in the event.
+
+        Scope-linked pages (considerations, judgements, sub-question
+        judgements rendered by ``format_page(scope_page, linked_detail=...)``)
+        aren't part of the context builder's returned ID lists — they're
+        recovered from the trace's page-load log by source-tag prefix so the
+        event can show what actually went into the prompt.
+        """
+        db = self.infra.db
+        scope_linked_ids = self.infra.trace.page_ids_by_source_prefix("linked_")
+        await self.infra.trace.record(
+            ContextBuiltEvent(
+                working_context_page_ids=await resolve_page_refs(result.working_page_ids, db),
+                preloaded_page_ids=await resolve_page_refs(result.preloaded_ids, db),
+                full_pages=await resolve_page_refs(result.full_page_ids, db),
+                abstract_pages=await resolve_page_refs(result.abstract_page_ids, db),
+                summary_pages=await resolve_page_refs(result.summary_page_ids, db),
+                distillation_pages=await resolve_page_refs(result.distillation_page_ids, db),
+                scope_linked_pages=await resolve_page_refs(scope_linked_ids, db),
+                budget_usage=dict(result.budget_usage),
+                context_text=result.context_text,
+                context_text_chars=len(result.context_text),
+                source_page_id=result.source_page_id,
+            )
+        )
+
     async def run(self) -> None:
         call_db = await self.infra.db.fork()
         self.infra.db = call_db
@@ -185,6 +229,7 @@ class CallRunner(ABC):
                 )
 
                 self.context_result = await self.context_builder.build_context(self.infra)
+                await self._record_context_built(self.context_result)
                 if self.up_to_stage == CallStage.BUILD_CONTEXT:
                     await mark_call_completed(
                         self.infra.call,

--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import uuid
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal
@@ -216,18 +217,29 @@ def _render_item_full(
 
 
 class UpdateViewContext(ContextBuilder):
-    """Context for View update: embedding-based with raised similarity floors."""
+    """Context for View update: embedding-based with raised similarity floors.
 
-    def __init__(self, view_id: str, old_view_id: str | None = None) -> None:
-        self._view_id = view_id
-        self._old_view_id = old_view_id
+    The new view page doesn't exist yet at build_context time (it's created
+    at update_workspace time so ``--up-to-stage build_context`` stays
+    side-effect-free). We read items from the *old* view — the pending copy
+    preserves each item's target page, importance, section, and position, so
+    the context is byte-identical to what the new view would expose.
+    """
+
+    def __init__(self) -> None:
+        pass
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
         question = await infra.db.get_page(infra.question_id)
         query = question.headline if question else infra.question_id
 
-        old_view = await infra.db.get_page(self._old_view_id) if self._old_view_id else None
-        last_view_created_at = old_view.created_at if old_view else None
+        old_view = await infra.db.get_view_for_question(infra.question_id)
+        if not old_view:
+            raise RuntimeError(
+                f"UpdateViewContext requires an existing View for question "
+                f"{infra.question_id[:8]}, but none was found."
+            )
+        last_view_created_at = old_view.created_at
 
         child_section, child_page_ids = await render_child_investigation_results(
             infra.db,
@@ -235,7 +247,7 @@ class UpdateViewContext(ContextBuilder):
             last_view_created_at,
         )
 
-        items = await infra.db.get_view_items(self._view_id)
+        items = await infra.db.get_view_items(old_view.id)
         item_ids = [page.id for page, _ in items]
         links_by_item = await infra.db.get_links_from_many(item_ids) if item_ids else {}
         cited_ids: set[str] = set()
@@ -270,17 +282,101 @@ class UpdateViewContext(ContextBuilder):
 
 
 class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
-    """Multi-phase workspace updater for incremental View updates."""
+    """Multi-phase workspace updater for incremental View updates.
+
+    Materializes the new view page + copies items from the old view at the
+    start of ``update_workspace``, then runs the multi-phase review. This
+    keeps view-creation inside the workspace_update stage rather than ahead
+    of build_context, so ``--up-to-stage build_context`` is a clean preview.
+    """
 
     def __init__(self, view_id: str, call_type: CallType) -> None:
         self._view_id = view_id
         self._call_type = call_type
+
+    async def materialize(self, infra: CallInfra) -> tuple[str, str]:
+        """Create the new view page, supersede the old one, and copy
+        VIEW_ITEM links across. Returns ``(old_view_id, new_view_id)``.
+
+        Exposed as a public method so tests can exercise the materialization
+        step directly without running the full LLM-driven updater.
+        """
+        db = infra.db
+        question_id = infra.question_id
+        existing_view = await db.get_view_for_question(question_id)
+        if not existing_view:
+            raise RuntimeError(
+                f"UpdateViewCall requires an existing View for question "
+                f"{question_id[:8]}, but none was found."
+            )
+
+        question = await db.get_page(question_id)
+        q_headline = question.headline if question else question_id[:8]
+
+        new_view = Page(
+            id=self._view_id,
+            page_type=PageType.VIEW,
+            layer=PageLayer.WIKI,
+            workspace=Workspace.RESEARCH,
+            content="",
+            headline=f"View: {q_headline}",
+            sections=list(DEFAULT_VIEW_SECTIONS),
+            provenance_call_type=self._call_type.value,
+            provenance_call_id=infra.call.id,
+            provenance_model=get_settings().model,
+        )
+        await db.save_page(new_view)
+
+        await db.save_link(
+            PageLink(
+                from_page_id=new_view.id,
+                to_page_id=question_id,
+                link_type=LinkType.VIEW_OF,
+            )
+        )
+
+        await db.supersede_page(existing_view.id, new_view.id)
+
+        old_links = await db.get_links_from(existing_view.id)
+        copied = 0
+        for link in old_links:
+            if link.link_type == LinkType.VIEW_ITEM:
+                await db.save_link(
+                    PageLink(
+                        from_page_id=new_view.id,
+                        to_page_id=link.to_page_id,
+                        link_type=LinkType.VIEW_ITEM,
+                        importance=link.importance,
+                        section=link.section,
+                        position=link.position,
+                    )
+                )
+                copied += 1
+
+        log.info(
+            "Created new view %s (superseding %s) with %d copied items",
+            new_view.id[:8],
+            existing_view.id[:8],
+            copied,
+        )
+
+        await infra.trace.record_strict(
+            ViewCreatedEvent(
+                view_id=new_view.id,
+                view_headline=new_view.headline,
+                question_id=question_id,
+                superseded_view_id=existing_view.id,
+            )
+        )
+        return existing_view.id, new_view.id
 
     async def update_workspace(
         self,
         infra: CallInfra,
         context: ContextResult,
     ) -> UpdateResult:
+        await self.materialize(infra)
+
         sections = _load_prompt_sections()
         system_prompt = _build_update_view_system_prompt(sections.get("context", ""))
 
@@ -999,87 +1095,15 @@ class UpdateViewCall(CallRunner):
     call_type = CallType.UPDATE_VIEW
 
     def __init__(self, question_id: str, call: Call, db: DB, **kwargs) -> None:
-        self._view_id: str = ""
-        self._old_view_id: str = ""
+        # Mint the new view UUID up front so factories can bind to it. The
+        # actual save_page + supersede + link-copy runs at update_workspace
+        # time (inside UpdateViewWorkspaceUpdater.materialize), so
+        # --up-to-stage build_context doesn't mutate the workspace.
+        self._view_id: str = str(uuid.uuid4())
         super().__init__(question_id, call, db, **kwargs)
 
-    async def _run_stages(self) -> None:
-        """Create new View page, copy items, then run phases."""
-        self._old_view_id, self._view_id = await self._create_new_view_and_copy_items()
-        self.context_builder = self._make_context_builder()
-        self.workspace_updater = self._make_workspace_updater()
-        self.closing_reviewer = self._make_closing_reviewer()
-        await super()._run_stages()
-
-    async def _create_new_view_and_copy_items(self) -> tuple[str, str]:
-        """Create a new View page, supersede the old one, copy all VIEW_ITEM links."""
-        existing_view = await self.infra.db.get_view_for_question(self.infra.question_id)
-        if not existing_view:
-            raise RuntimeError(
-                f"UpdateViewCall requires an existing View for question "
-                f"{self.infra.question_id[:8]}, but none was found."
-            )
-
-        question = await self.infra.db.get_page(self.infra.question_id)
-        q_headline = question.headline if question else self.infra.question_id[:8]
-
-        new_view = Page(
-            page_type=PageType.VIEW,
-            layer=PageLayer.WIKI,
-            workspace=Workspace.RESEARCH,
-            content="",
-            headline=f"View: {q_headline}",
-            sections=list(DEFAULT_VIEW_SECTIONS),
-            provenance_call_type=self.call_type.value,
-            provenance_call_id=self.infra.call.id,
-            provenance_model=get_settings().model,
-        )
-        await self.infra.db.save_page(new_view)
-
-        await self.infra.db.save_link(
-            PageLink(
-                from_page_id=new_view.id,
-                to_page_id=self.infra.question_id,
-                link_type=LinkType.VIEW_OF,
-            )
-        )
-
-        await self.infra.db.supersede_page(existing_view.id, new_view.id)
-
-        old_links = await self.infra.db.get_links_from(existing_view.id)
-        for link in old_links:
-            if link.link_type == LinkType.VIEW_ITEM:
-                await self.infra.db.save_link(
-                    PageLink(
-                        from_page_id=new_view.id,
-                        to_page_id=link.to_page_id,
-                        link_type=LinkType.VIEW_ITEM,
-                        importance=link.importance,
-                        section=link.section,
-                        position=link.position,
-                    )
-                )
-
-        log.info(
-            "Created new view %s (superseding %s) with %d copied items",
-            new_view.id[:8],
-            existing_view.id[:8],
-            sum(1 for l in old_links if l.link_type == LinkType.VIEW_ITEM),
-        )
-
-        await self.infra.trace.record_strict(
-            ViewCreatedEvent(
-                view_id=new_view.id,
-                view_headline=new_view.headline,
-                question_id=self.infra.question_id,
-                superseded_view_id=existing_view.id,
-            )
-        )
-
-        return existing_view.id, new_view.id
-
     def _make_context_builder(self) -> ContextBuilder:
-        return UpdateViewContext(self._view_id, old_view_id=self._old_view_id)
+        return UpdateViewContext()
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:
         return UpdateViewWorkspaceUpdater(self._view_id, self.call_type)

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -258,8 +258,12 @@ async def format_page(
     When *track* is True, the page load is recorded via the ambient
     ``CallTrace`` (if one exists).  Ambient tags from ``page_track_scope``
     are merged with any explicit *track_tags* (explicit wins on conflict).
-    Recursive calls (supersession, linked items) do NOT track — only the
-    caller's top-level invocation is recorded.
+    Supersession replacement renders are not tracked separately (they
+    represent the same logical page). Linked-item renders (considerations,
+    judgements, child-question judgements for QUESTION pages) DO track
+    when *track* is True, using source tags ``linked_consideration`` /
+    ``linked_judgement`` / ``linked_child_judgement`` — this is how
+    scope-question linked items become visible in ``page_format_events``.
     """
     if track:
         trace = get_trace()
@@ -366,6 +370,8 @@ async def format_page(
                 db=db,
                 linked_detail=None,
                 highlight_run_id=highlight_run_id,
+                track=track,
+                track_tags={"source": "linked_consideration"},
             )
             line = "- " + rendered + link_tag
             if link.reasoning:
@@ -390,6 +396,8 @@ async def format_page(
                 db=db,
                 linked_detail=None,
                 highlight_run_id=highlight_run_id,
+                track=track,
+                track_tags={"source": "linked_judgement"},
             )
             j_items.append((j.created_at, "- " + rendered))
         if j_items:
@@ -419,6 +427,8 @@ async def format_page(
                     db=db,
                     linked_detail=None,
                     highlight_run_id=highlight_run_id,
+                    track=track,
+                    track_tags={"source": "linked_child_judgement"},
                 )
                 sub_lines.append(f"  - {rendered}")
             child_blocks.append("\n".join(sub_lines))

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -611,6 +611,27 @@ class DB:
             return None
         return pages[0]
 
+    async def get_page_staging_info(self, page_id: str) -> tuple[bool, str, str] | None:
+        """Return (staged, run_id, project_id) for a page, bypassing the staged
+        visibility filter. Returns None if the page doesn't exist.
+
+        Callers use this to discover whether a page is staged under another run
+        before deciding which run_id/staged combination to open a DB with.
+        """
+        rows = _rows(
+            await self._execute(
+                self.client.table("pages").select("staged, run_id, project_id").eq("id", page_id)
+            )
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        return (
+            bool(row.get("staged")),
+            row.get("run_id") or "",
+            row.get("project_id") or "",
+        )
+
     async def get_pages_by_ids(self, page_ids: Sequence[str]) -> dict[str, Page]:
         """Bulk-fetch pages by ID. Returns {id: Page} for pages that exist."""
         if not page_ids:

--- a/src/rumil/tracing/trace_events.py
+++ b/src/rumil/tracing/trace_events.py
@@ -43,6 +43,25 @@ class ContextBuiltEvent(BaseModel):
     preloaded_page_ids: PageRefList = []
     source_page_id: str | None = None
     budget: int | None = None
+    # Tiered breakdown of which pages went into the prompt at which fidelity.
+    # Empty lists when the context builder doesn't run tiered selection —
+    # the legacy working_context_page_ids field still carries the flat list.
+    full_pages: PageRefList = []
+    abstract_pages: PageRefList = []
+    summary_pages: PageRefList = []
+    distillation_pages: PageRefList = []
+    # Pages pulled in via the scope question's linked items — considerations,
+    # judgements, and sub-question judgements rendered inline by
+    # format_page(scope_page, linked_detail=...). These aren't in the
+    # embedding tiers; they're a separate category captured via page-load
+    # tracking during build_context.
+    scope_linked_pages: PageRefList = []
+    # Characters spent per tier (keys: full, abstract, summary, distillation).
+    budget_usage: dict[str, int] = {}
+    # The rendered context section the builder produced, plus its char count
+    # pre-computed so the UI can show a length at a glance without measuring.
+    context_text: str = ""
+    context_text_chars: int = 0
 
 
 class MovesExecutedEvent(BaseModel):

--- a/src/rumil/tracing/tracer.py
+++ b/src/rumil/tracing/tracer.py
@@ -64,6 +64,29 @@ class CallTrace:
             }
         )
 
+    def page_ids_by_source_prefix(self, prefix: str) -> list[str]:
+        """Return unique page IDs whose tracked ``source`` tag starts with *prefix*.
+
+        Order follows first-load order. Useful at event-emit time to surface
+        pages that were rendered by ``format_page`` but aren't directly part
+        of the context-builder's returned ``page_ids`` list — most notably
+        the scope question's linked items (considerations, judgements,
+        sub-question judgements) which are emitted inline by
+        ``format_page(scope_page, linked_detail=...)``.
+        """
+        seen: set[str] = set()
+        result: list[str] = []
+        for load in self._page_loads:
+            src = (load.get("tags") or {}).get("source") or ""
+            if not src.startswith(prefix):
+                continue
+            pid = load["page_id"]
+            if pid in seen:
+                continue
+            seen.add(pid)
+            result.append(pid)
+        return result
+
     async def flush_page_loads(self) -> None:
         """Batch-insert accumulated page-load events into the DB."""
         if not self._page_loads:

--- a/tests/test_update_view.py
+++ b/tests/test_update_view.py
@@ -9,7 +9,6 @@ from rumil.calls.update_view import (
     ItemReview,
     ProposedItem,
     UnscoredItemScore,
-    UpdateViewCall,
     UpdateViewWorkspaceUpdater,
     _parse_prompt_sections,
     _render_item_compact,
@@ -204,22 +203,36 @@ def test_render_item_full_without_citations():
     assert "Cited evidence" not in rendered
 
 
-async def test_create_new_view_and_copy_items(tmp_db, view_setup):
-    """UpdateViewCall should create a new View, supersede the old one,
-    and copy all VIEW_ITEM links."""
-    q, old_view, items = view_setup
+async def _materialize(tmp_db, question_id: str) -> tuple[str, str]:
+    """Drive UpdateViewWorkspaceUpdater.materialize directly using a real
+    CallInfra. Returns (old_view_id, new_view_id).
+    """
+    import uuid as _uuid
 
     call = Call(
         call_type=CallType.UPDATE_VIEW,
         workspace=Workspace.RESEARCH,
-        scope_page_id=q.id,
+        scope_page_id=question_id,
         status=CallStatus.PENDING,
     )
     await tmp_db.save_call(call)
+    infra = CallInfra(
+        question_id=question_id,
+        call=call,
+        db=tmp_db,
+        trace=CallTrace(call.id, tmp_db),
+        state=MoveState(call, tmp_db),
+    )
+    updater = UpdateViewWorkspaceUpdater(str(_uuid.uuid4()), CallType.UPDATE_VIEW)
+    return await updater.materialize(infra)
 
-    runner = UpdateViewCall(q.id, call, tmp_db)
 
-    old_id, new_id = await runner._create_new_view_and_copy_items()
+async def test_materialize_creates_new_view_and_copies_items(tmp_db, view_setup):
+    """UpdateViewWorkspaceUpdater.materialize should create a new View,
+    supersede the old one, and copy all VIEW_ITEM links."""
+    q, old_view, items = view_setup
+
+    old_id, new_id = await _materialize(tmp_db, q.id)
 
     assert old_id == old_view.id
     assert new_id != old_view.id
@@ -247,7 +260,7 @@ async def test_create_new_view_and_copy_items(tmp_db, view_setup):
     assert found_view.id == new_id
 
 
-async def test_create_new_view_preserves_link_metadata(tmp_db):
+async def test_materialize_preserves_link_metadata(tmp_db):
     """Link metadata (importance, section, position) should survive the copy."""
     q = _question()
     v = _view()
@@ -272,16 +285,7 @@ async def test_create_new_view_preserves_link_metadata(tmp_db):
         )
     )
 
-    call = Call(
-        call_type=CallType.UPDATE_VIEW,
-        workspace=Workspace.RESEARCH,
-        scope_page_id=q.id,
-        status=CallStatus.PENDING,
-    )
-    await tmp_db.save_call(call)
-    runner = UpdateViewCall(q.id, call, tmp_db)
-
-    _, new_id = await runner._create_new_view_and_copy_items()
+    _, new_id = await _materialize(tmp_db, q.id)
     new_items = await tmp_db.get_view_items(new_id)
     assert len(new_items) == 1
     _, link = new_items[0]
@@ -290,8 +294,22 @@ async def test_create_new_view_preserves_link_metadata(tmp_db):
     assert link.position == 7
 
 
-async def test_create_new_view_raises_without_existing_view(tmp_db):
-    """UpdateViewCall should raise if there's no existing View to update."""
+async def test_materialize_raises_without_existing_view(tmp_db):
+    """UpdateViewWorkspaceUpdater.materialize should raise if there's no
+    existing View to update."""
+    q = _question()
+    await tmp_db.save_page(q)
+    with pytest.raises(RuntimeError, match="requires an existing View"):
+        await _materialize(tmp_db, q.id)
+
+
+async def test_build_context_uses_stageable_guard_without_view(tmp_db):
+    """UpdateViewContext should refuse to build context when no View exists —
+    build_context runs before materialize, so it has to fetch the old view
+    directly and enforce the same precondition.
+    """
+    from rumil.calls.update_view import UpdateViewContext
+
     q = _question()
     await tmp_db.save_page(q)
     call = Call(
@@ -301,9 +319,43 @@ async def test_create_new_view_raises_without_existing_view(tmp_db):
         status=CallStatus.PENDING,
     )
     await tmp_db.save_call(call)
-    runner = UpdateViewCall(q.id, call, tmp_db)
+    infra = CallInfra(
+        question_id=q.id,
+        call=call,
+        db=tmp_db,
+        trace=CallTrace(call.id, tmp_db),
+        state=MoveState(call, tmp_db),
+    )
+    builder = UpdateViewContext()
     with pytest.raises(RuntimeError, match="requires an existing View"):
-        await runner._create_new_view_and_copy_items()
+        await builder.build_context(infra)
+
+
+async def test_create_view_updater_mints_view_id_but_defers_persist(tmp_db):
+    """CreateViewCall mints the view UUID in __init__ but doesn't persist the
+    view until update_workspace runs; verify the Page isn't present after
+    construction.
+    """
+    from rumil.calls.create_view import CreateViewCall
+
+    q = _question()
+    await tmp_db.save_page(q)
+    call = Call(
+        call_type=CallType.CREATE_VIEW,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=q.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    runner = CreateViewCall(q.id, call, tmp_db)
+    assert runner._view_id, "CreateViewCall should mint a view_id in __init__"
+
+    # Construction alone must not create any View page.
+    page_before = await tmp_db.get_page(runner._view_id)
+    assert page_before is None
+    found_view = await tmp_db.get_view_for_question(q.id)
+    assert found_view is None
 
 
 async def test_apply_item_score_updates_link(tmp_db, view_setup, call_infra):


### PR DESCRIPTION
## Summary

Three threads of improvement, all visible in the trace UI, plus some quality-of-life polish on `run_call.py`.

### 1. The `context_built` event now describes what's actually in the prompt

Emission moved out of each individual `ContextBuilder` and into a single authoritative point in `CallRunner._record_context_built`, so every call type records it the same way at the same moment. The event shape is enriched with:

- A per-tier breakdown of embedding-selected pages — `full_pages`, `abstract_pages`, `summary_pages`, `distillation_pages` — each a `PageRefList`.
- `budget_usage`: per-tier char counts from `build_embedding_based_context`.
- `context_text` and `context_text_chars`: the composed context section itself so the trace UI can show the exact string the builder produced.
- `scope_linked_pages`: pages pulled in via the scope question's linked items (considerations, judgements, child-question judgements) rendered inline by `format_page(scope_page, linked_detail=…)`. Recovered from the trace's page-load log at event-emit time via a new `CallTrace.page_ids_by_source_prefix("linked_")` helper — so the event reflects renders that aren't part of the builder's returned `page_ids`.
- `source_page_id`: carried through on `ContextResult` for ingest calls.

The frontend gets a redesigned `ContextBuiltBody` component:

- Totals row with unique page count (de-duplicated across categories) and prompt char count.
- A stacked char-budget bar keyed by tier shade (darker = higher fidelity).
- Per-tier rows showing label + swatch + page chips + char usage.
- A `scope-linked` row with a distinct blue-ring swatch so it reads as an off-axis category rather than a shade on the fidelity scale.
- Preloaded row, source-page row (ingest), and a collapsible `<details>` prompt-text preview with monospace + left-accent rule, capped at ~360px with scroll.
- Light/dark mode both covered; stays within the existing editorial grayscale and Geist Mono conventions.

### 2. `page_format_events` now reflects scope-linked renders

`format_page` used to explicitly *not* track linked-item recursive calls — only the outermost invocation hit `record_page_load`. That meant the `PageLoadStats` table at the bottom of the trace viewer radically undercounted what was in the prompt.

Now `format_page` forwards `track=True` into the three linked-item recursive call sites with dedicated source tags:

- `linked_consideration`
- `linked_judgement`
- `linked_child_judgement`

Supersession-replacement recursion is still intentionally untracked (it's the same logical page). Callers that don't opt in (`track=False`) are unaffected.

**Bonus fix that fell out of investigating the above:** `EmbeddingContext` now passes `scope_linked_detail=PageDetail.ABSTRACT` into `build_embedding_based_context`, matching what `BigAssessContext` already does. Previously scope-linked items defaulted to `HEADLINE`, which for pages without abstracts rendered as metadata-only — visually "headline-like" but burning no abstract budget. Now the 20k abstract budget actually gets used.

### 3. `CreateViewCall` / `UpdateViewCall` are side-effect-free at `--up-to-stage build_context`

Both classes used to override `_run_stages` and persist the View page (+ `VIEW_OF` link + supersede + copy-VIEW_ITEM-links for update) *before* `super()._run_stages()` ran. That meant `--up-to-stage build_context` against either call type silently created view pages — not a real preview primitive.

Both now:

- Mint the new view UUID in `__init__` (so factories that need it — `task_description`, `ViewClosingReview`, the workspace updater — can bind to a stable id immediately).
- Drop the `_run_stages` override entirely.
- Defer the `save_page` / `VIEW_OF` link / supersede / copy-items / `ViewCreatedEvent` to the top of `update_workspace`, inside a public `materialize()` method on each call's updater (exposed so tests can drive the mutation directly without running the full LLM loop).

`UpdateViewContext` also loses its `view_id` / `old_view_id` constructor args — it now fetches the old view lazily via `get_view_for_question()` inside `build_context` and uses its id for the `get_view_items()` lookup. This is safe because the item-copy on the new view preserves each link's `to_page_id`, `importance`, `section`, and `position`, so reading items from the old view produces byte-identical context to what the new view would have shown.

Three existing tests in `tests/test_update_view.py` that targeted `runner._create_new_view_and_copy_items()` are rewritten to exercise `UpdateViewWorkspaceUpdater.materialize()` directly. Two new tests pin the new guarantees — `UpdateViewContext` refuses to build context without an existing view, and `CreateViewCall` mints a view_id in `__init__` without persisting anything.

### 4. `scripts/run_call.py` polish

- `create-view` and `update-view` added to the supported call types (both already existed as `CallRunner` subclasses — script just didn't wire them in).
- When `--question-id` targets a question that's staged under an existing run, the script now probes the page via a new `DB.get_page_staging_info()` (raw lookup that bypasses the staged-visibility filter), adopts that run's `run_id`, continues inside the staged lineage (uses `add_budget` rather than `init_budget`, skips `create_run`). Previously a fresh `run_id` would be minted that couldn't see the staged question, and `get_page` would return `None` with a confusing "not found" error.
- `--no-stage` against a staged question is rejected with a helpful error rather than silently failing visibility.

## Test plan

- [x] 495 non-integration unit tests pass (were 493 pre-change; +2 net for new view-call tests).
- [x] Pyright clean across all changed modules.
- [x] Frontend `tsc --noEmit` clean.
- [x] Live smoke: `create-view --up-to-stage build_context` in a fresh workspace leaves exactly the question page — no view, no `VIEW_OF` link.
- [x] Live smoke: full `create-view` on the same question materializes the view + 12 `VIEW_ITEM` pages; `get_view_for_question` resolves correctly.
- [x] Live smoke: `update-view --up-to-stage build_context` against that view keeps exactly one unsuperseded view row — no new view, no supersession, no copied links.
- [x] Verified the enriched `context_built` event carries the new fields end-to-end against a real prod trace; confirmed the tier breakdown and scope-linked page lists match `page_format_events` rows.
- [ ] UI review: load a post-change trace and verify the new `ContextBuiltBody` renders (totals, budget bar, tier rows, scope-linked row, prompt-text preview) in both light and dark mode.

## Files touched

**Backend (8 files):**
`src/rumil/calls/stages.py`, `src/rumil/calls/context_builders.py`, `src/rumil/calls/create_view.py`, `src/rumil/calls/update_view.py`, `src/rumil/calls/link_subquestions.py`, `src/rumil/context.py`, `src/rumil/database.py`, `src/rumil/tracing/tracer.py`, `src/rumil/tracing/trace_events.py`.

**Frontend (3 files):**
`frontend/src/app/traces/[runId]/call-node.tsx` (`ContextBuiltBody` component), `frontend/src/app/traces/[runId]/trace.css` (new tier styles + dark-mode), `frontend/src/api/types.gen.ts` (auto-regenerated).

**Scripts (1 file):** `scripts/run_call.py`.

**Tests (1 file):** `tests/test_update_view.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)