### PR TITLE
Deploy to prod from CI on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   backend-lint-type:
@@ -70,3 +70,74 @@ jobs:
         run: pnpm lint
       - name: TypeScript
         run: npx tsc --noEmit
+
+  deploy:
+    name: deploy to prod
+    needs: [backend-lint-type, backend-tests, frontend-lint-type]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/1082891349463/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: rumil-ci@project-fe559f0f-d011-4af4-bf0.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Run prod migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          supabase link --project-ref aesjaehibxrzearctiqp
+          supabase db push
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: differential
+          location: us-central1
+
+      - name: Install sops
+        run: |
+          curl -fsSL https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64 \
+            -o /tmp/sops
+          sudo install -m 0755 /tmp/sops /usr/local/bin/sops
+
+      - name: Install helm-secrets plugin
+        run: helm plugin install https://github.com/jkroepke/helm-secrets
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Build, push, and deploy
+        run: ./scripts/deploy.sh --all --tag "${GITHUB_SHA::7}"


### PR DESCRIPTION
## Summary
- Adds a `deploy` job to `ci.yml` that runs after the existing lint/type/test jobs on a push to `main`.
- Gated by a `production` GitHub Environment with required reviewer — every deploy needs an explicit approval click in the Actions UI before it proceeds.
- Runs `supabase db push` against prod **before** building/pushing images or running `helm upgrade`, so a failed migration aborts the deploy with no app changes.

## How it works
- **GCP auth:** Workload Identity Federation. The `rumil-ci` service account can push to Artifact Registry, deploy to GKE, and decrypt the SOPS key. The OIDC provider attribute-condition locks impersonation to `chaosGuppy/rumil` so no other repo can assume it.
- **Environment policy:** `production` env has this repo's owner as required reviewer and is restricted to the `main` branch.
- **Concurrency:** workflow-level no longer cancels in-progress runs on `main` (so a second merge won't kill a live deploy). Job-level `deploy-prod` concurrency serializes deploys if two merges stack up.

## Required repo secrets (already added)
- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_DB_PASSWORD`

(GCP credentials come through WIF — no secret needed.)

## Test plan
- [ ] Merge this PR to main.
- [ ] Confirm CI runs and the `deploy` job appears with a pending approval in the Actions tab.
- [ ] Click approve; confirm migrations succeed, images build and push to Artifact Registry, and `helm upgrade` rolls out cleanly.
- [ ] Verify `api.rumil.ink` and `rumil.ink` respond healthy after rollout.
- [ ] (Optional) Try rejecting a deploy from the Actions UI on a later merge to confirm the abort path works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)