### PR TITLE
Add Langfuse Cloud integration for LLM observability

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,11 @@ SUPABASE_PROD_KEY=
 VOYAGE_AI_API_KEY=
 # Jina — used by web_research calls for scraping
 JINA_API_KEY=
+# Langfuse — LLM observability. Create your own dev project at https://us.cloud.langfuse.com
+# (each developer should use their own project; differential-prod is reserved for the deployed API)
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
 
 # --- Optional: dev / networking ---
 # Override if the frontend runs on a non-default port

--- a/deploy/chart/secrets.enc.yaml
+++ b/deploy/chart/secrets.enc.yaml
@@ -7,6 +7,8 @@ secrets:
         ANTHROPIC_API_KEY: ENC[AES256_GCM,data:YKJ/M6tL02x5f+DNH5ZsUTo8Gh7zCAzH0++UQ50Sp/HCSORyWQZBf/UbOGRW6oy6En3pSYsdeSUISn192Y1FtwrmT+jazqU94llWixBccGLPEeYLsPEGrw/GDfbyTlQcu/S1zT+BMvIal4ON,iv:rEsuzY92zDsi3tcOCfkYdhplb5k2RYMp31Q2fjKq6GE=,tag:xCgBR7dAxqwF3AqksJjT2Q==,type:str]
         VOYAGE_AI_API_KEY: ENC[AES256_GCM,data:BJ2ZgsYD2pAAXFMmRMEQsxS6L54d0hMtSxi5sCzWugIqdDZn/KdI1o0mzUaayA==,iv:4BFc4oWLOnseftARAPB/vd1Pj00aTec/vy/roHXXUmg=,tag:6WcZYM+AzqdtQ8DvAPsurg==,type:str]
         JINA_API_KEY: ENC[AES256_GCM,data:ypDGnljHYmHfpIW6PRW38xBlaKTFPryzl2In/mabjQYgV8v0cbHG/ODnjJQFWaF7qFtAAw3LVG5d+da9VgXgUSk=,iv:skfPatD2Sx5yhOe/HCgQ96KBoaQl/QnICn35fbhf0ek=,tag:BexlftTQAvb7PYl60EcAzQ==,type:str]
+        LANGFUSE_PUBLIC_KEY: ENC[AES256_GCM,data:Ox4sTdoxWiT1RH4rAJfh7sBTAQRuLUlX1wti8e8z4jjaRsOvOvXGpDgt,iv:hdT9IljxLTnMYscmBHLPhcrsJENeXWTUz1NZ6bxgBRU=,tag:dHZualBrMl1GAl9Jt7L1CA==,type:str]
+        LANGFUSE_SECRET_KEY: ENC[AES256_GCM,data:KQFGdMNW2fh6bfq15S06WhBBs80nueIX70vY0O734wZ28kO0ZauJRGu9,iv:ZtkEU0lKqQ7fKumN7YNMPlQM/nDakKez5qva4aGlQkk=,tag:bX0UiYyBxoyYt4YjI1t7Vw==,type:str]
     frontend:
         AUTH_PASSWORD: ENC[AES256_GCM,data:CMGTHHZmMFwS3LtZRUCZ3g==,iv:KxNRcglV2ZRhyUB8f/Ad9Hp+pKjC4Q6jLuSUrCBWVnI=,tag:A/NRcHOeSFKc+pTeD9DTOQ==,type:str]
 sops:
@@ -14,7 +16,7 @@ sops:
         - resource_id: projects/project-fe559f0f-d011-4af4-bf0/locations/global/keyRings/sops/cryptoKeys/sops-key
           created_at: "2026-04-24T17:00:18Z"
           enc: CiQAjT8VB/HCvkKXfDS3lbNLy1UlNdt2LyiyEPjz16f9k3K2rsgSSQDATLUF7bREVUk1jnQayf/uHIzouj3cZrZalQj8GWCkTyoKbVRqGsnsTd4GYxaQU41R4HDoAOHhGKadZkzgYf8C8t3IQ1enFTs=
-    lastmodified: "2026-04-24T17:00:18Z"
-    mac: ENC[AES256_GCM,data:V9bkxuWeQhJCSY/8OZv7xUcHumOyVolQe8bz/srf5ML7JHsbocxHxjohshf8UR4gz3Zwm4QnASiD6hQ6BMv/JDMzJYee0Fk607Xz64zW2gtvQxE/tFR+T79RDEXop6xIhd0SGuDcQXZcJT7d+MeV+VREFpfIZLjwk1ZuNAgxLmg=,iv:zZMtYu+qBPSijH1qXmo+qGxrT+eaUo4HZGS4ot5Isbc=,tag:vRnGUOSK6jRCHbmj+J+xVw==,type:str]
+    lastmodified: "2026-04-24T19:07:36Z"
+    mac: ENC[AES256_GCM,data:sjNgVlHHbKzz0OFs2un+BciTQqjivN6YKlddS/AxRpd/IpkJXi23P1lLMZjE+PHboDTRHh3/8IfoF7Fv4kuWVRxzw4mUIhLWAwfzcP5ax3+WqLxlJIaxBdBwHhMlYI5+pA1jiZVPv54ft4OBkLVilfHuvNJX4dCmSyvKryfi50I=,iv:q068F0kye0dD4lTtxHTXoDG0Yrhu7vmPWXVK0wv3LZ0=,tag:5THFtuxxJNhJJlDxnvLtvA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/deploy/chart/secrets.yaml.template
+++ b/deploy/chart/secrets.yaml.template
@@ -1,6 +1,6 @@
 # Template for secrets.enc.yaml
 # Fill in values and encrypt with:
-#   sops encrypt --gcp-kms projects/varuna-400921/locations/global/keyRings/sops/cryptoKeys/sops-key \
+#   sops encrypt --gcp-kms projects/project-fe559f0f-d011-4af4-bf0/locations/global/keyRings/sops/cryptoKeys/sops-key \
 #     secrets.yaml.template > secrets.enc.yaml
 
 secrets:
@@ -10,5 +10,7 @@ secrets:
     VOYAGE_AI_API_KEY: ""
     JINA_API_KEY: ""
     RUMIL_AUTH_PASSWORD: ""
+    LANGFUSE_PUBLIC_KEY: ""  # from differential-prod project at https://us.cloud.langfuse.com
+    LANGFUSE_SECRET_KEY: ""  # paired with LANGFUSE_PUBLIC_KEY
   frontend:
     AUTH_PASSWORD: ""  # same value as RUMIL_AUTH_PASSWORD above

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -51,6 +51,7 @@ api:
   env:
     USE_PROD_DB: "1"
     SUPABASE_PROD_URL: https://aesjaehibxrzearctiqp.supabase.co
+    LANGFUSE_BASE_URL: https://us.cloud.langfuse.com
 
   httproute:
     enabled: true

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -247,6 +247,16 @@
             }
           },
           {
+            "name": "include_hidden",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Hidden"
+            }
+          },
+          {
             "name": "staged_run_id",
             "in": "query",
             "required": false,
@@ -539,6 +549,16 @@
             }
           },
           {
+            "name": "include_hidden",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Hidden"
+            }
+          },
+          {
             "name": "project_id",
             "in": "query",
             "required": false,
@@ -590,6 +610,16 @@
             "schema": {
               "type": "string",
               "title": "Page Id"
+            }
+          },
+          {
+            "name": "include_hidden",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Hidden"
             }
           },
           {
@@ -888,6 +918,16 @@
             "schema": {
               "$ref": "#/components/schemas/Workspace",
               "default": "research"
+            }
+          },
+          {
+            "name": "include_hidden",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Hidden"
             }
           }
         ],
@@ -2304,6 +2344,10 @@
           "create_view",
           "global_prioritization",
           "update_view",
+          "generate_spec",
+          "generate_artefact",
+          "critique_artefact",
+          "refine_spec",
           "claude_code_direct"
         ],
         "title": "CallType"
@@ -3160,6 +3204,17 @@
               }
             ],
             "title": "Tool Uses"
+          },
+          "langfuse_trace_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Langfuse Trace Url"
           }
         },
         "type": "object",
@@ -3177,7 +3232,8 @@
           "duration_ms",
           "cost_usd",
           "has_thinking",
-          "tool_uses"
+          "tool_uses",
+          "langfuse_trace_url"
         ],
         "title": "LLMExchangeEventOut"
       },
@@ -3470,7 +3526,11 @@
           "depends_on",
           "view_item",
           "view_of",
-          "meta_for"
+          "meta_for",
+          "spec_of",
+          "artefact_of",
+          "critique_of",
+          "generated_from"
         ],
         "title": "LinkType"
       },
@@ -3767,6 +3827,11 @@
             "type": "string",
             "title": "Run Id",
             "default": ""
+          },
+          "hidden": {
+            "type": "boolean",
+            "title": "Hidden",
+            "default": false
           }
         },
         "type": "object",
@@ -3795,7 +3860,8 @@
           "fruit_remaining",
           "sections",
           "meta_type",
-          "run_id"
+          "run_id",
+          "hidden"
         ],
         "title": "Page"
       },
@@ -4057,7 +4123,9 @@
           "summary",
           "view",
           "view_item",
-          "view_meta"
+          "view_meta",
+          "spec_item",
+          "artefact"
         ],
         "title": "PageType"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -379,7 +379,7 @@ export type CallSummary = {
 /**
  * CallType
  */
-export type CallType = 'find_considerations' | 'assess' | 'prioritization' | 'ingest' | 'reframe' | 'maintain' | 'summarize' | 'scout_subquestions' | 'scout_estimates' | 'scout_hypotheses' | 'scout_analogies' | 'scout_paradigm_cases' | 'scout_factchecks' | 'scout_web_questions' | 'scout_deep_questions' | 'scout_c_how_true' | 'scout_c_how_false' | 'scout_c_cruxes' | 'scout_c_relevant_evidence' | 'scout_c_stress_test_cases' | 'scout_c_robustify' | 'scout_c_strengthen' | 'web_research' | 'evaluate' | 'grounding_feedback' | 'feedback_update' | 'link_subquestions' | 'ab_eval' | 'ab_eval_comparison' | 'ab_eval_summary' | 'run_eval' | 'create_view' | 'global_prioritization' | 'update_view' | 'claude_code_direct';
+export type CallType = 'find_considerations' | 'assess' | 'prioritization' | 'ingest' | 'reframe' | 'maintain' | 'summarize' | 'scout_subquestions' | 'scout_estimates' | 'scout_hypotheses' | 'scout_analogies' | 'scout_paradigm_cases' | 'scout_factchecks' | 'scout_web_questions' | 'scout_deep_questions' | 'scout_c_how_true' | 'scout_c_how_false' | 'scout_c_cruxes' | 'scout_c_relevant_evidence' | 'scout_c_stress_test_cases' | 'scout_c_robustify' | 'scout_c_strengthen' | 'web_research' | 'evaluate' | 'grounding_feedback' | 'feedback_update' | 'link_subquestions' | 'ab_eval' | 'ab_eval_comparison' | 'ab_eval_summary' | 'run_eval' | 'create_view' | 'global_prioritization' | 'update_view' | 'generate_spec' | 'generate_artefact' | 'critique_artefact' | 'refine_spec' | 'claude_code_direct';
 
 /**
  * CallTypeFruitScoreItem
@@ -927,6 +927,10 @@ export type LlmExchangeEventOut = {
     tool_uses: Array<{
         [key: string]: unknown;
     }> | null;
+    /**
+     * Langfuse Trace Url
+     */
+    langfuse_trace_url: string | null;
 };
 
 /**
@@ -1063,7 +1067,7 @@ export type LinkSubquestionsCompleteEventOut = {
 /**
  * LinkType
  */
-export type LinkType = 'consideration' | 'child_question' | 'supersedes' | 'related' | 'answers' | 'variant' | 'summarizes' | 'cites' | 'depends_on' | 'view_item' | 'view_of' | 'meta_for';
+export type LinkType = 'consideration' | 'child_question' | 'supersedes' | 'related' | 'answers' | 'variant' | 'summarizes' | 'cites' | 'depends_on' | 'view_item' | 'view_of' | 'meta_for' | 'spec_of' | 'artefact_of' | 'critique_of' | 'generated_from';
 
 /**
  * LinkedPageOut
@@ -1245,6 +1249,10 @@ export type Page = {
      * Run Id
      */
     run_id: string;
+    /**
+     * Hidden
+     */
+    hidden: boolean;
 };
 
 /**
@@ -1395,7 +1403,7 @@ export type PageRef = {
 /**
  * PageType
  */
-export type PageType = 'source' | 'claim' | 'question' | 'judgement' | 'wiki' | 'summary' | 'view' | 'view_item' | 'view_meta';
+export type PageType = 'source' | 'claim' | 'question' | 'judgement' | 'wiki' | 'summary' | 'view' | 'view_item' | 'view_meta' | 'spec_item' | 'artefact';
 
 /**
  * PaginatedPagesOut
@@ -2432,6 +2440,10 @@ export type ListPagesApiProjectsProjectIdPagesGetData = {
          */
         limit?: number;
         /**
+         * Include Hidden
+         */
+        include_hidden?: boolean;
+        /**
          * Staged Run Id
          */
         staged_run_id?: string | null;
@@ -2619,6 +2631,10 @@ export type GetDependentsApiPagesPageIdDependentsGetData = {
     };
     query?: {
         /**
+         * Include Hidden
+         */
+        include_hidden?: boolean;
+        /**
          * Project Id
          */
         project_id?: string;
@@ -2655,6 +2671,10 @@ export type GetDependenciesApiPagesPageIdDependenciesGetData = {
         page_id: string;
     };
     query?: {
+        /**
+         * Include Hidden
+         */
+        include_hidden?: boolean;
         /**
          * Project Id
          */
@@ -2841,6 +2861,10 @@ export type ListRootQuestionsApiProjectsProjectIdQuestionsGetData = {
     };
     query?: {
         workspace?: Workspace;
+        /**
+         * Include Hidden
+         */
+        include_hidden?: boolean;
     };
     url: '/api/projects/{project_id}/questions';
 };

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -904,6 +904,18 @@ const EventSection = memo(function EventSection({ event }: { event: TraceEvent }
             {exchangeLoading && (
               <span className="trace-exchange-loading">loading...</span>
             )}
+            {event.langfuse_trace_url && (
+              <a
+                href={event.langfuse_trace_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="trace-langfuse-link"
+                title="View this LLM call in Langfuse"
+              >
+                Langfuse ↗
+              </a>
+            )}
           </span>
         )}
         <span className="trace-event-time" suppressHydrationWarning>{formatTime(event.ts)}</span>

--- a/main.py
+++ b/main.py
@@ -43,6 +43,20 @@ from rumil.run_eval.agents import EVAL_AGENTS, EvalAgentSpec
 from rumil.settings import Settings, _settings_var, get_settings
 from rumil.sources import create_source_page, run_ingest_calls
 from rumil.summary import generate_summary, save_summary
+from rumil.tracing import get_langfuse
+
+
+def _maybe_print_langfuse_session(db: DB, *, indent: str = "") -> None:
+    """Print the Langfuse session URL when Langfuse is configured.
+
+    Called alongside the in-house "Trace:" prints so users can jump straight
+    into Langfuse for LLM-call detail. No-op when Langfuse is disabled.
+    """
+    if get_langfuse() is None:
+        return
+    settings = get_settings()
+    lf_base = settings.langfuse_base_url.rstrip("/")
+    print(f"{indent}Langfuse: {lf_base}/sessions?sessionId={db.run_id}")
 
 
 @dataclasses.dataclass
@@ -177,7 +191,9 @@ async def cmd_ingest(
     frontend = get_settings().frontend_url.rstrip("/")
     print(f"\nExtracting considerations for: {question.headline[:80]}")
     print(f"Budget: {effective_budget} call{'s' if effective_budget != 1 else ''}")
-    print(f"Trace:  {frontend}/traces/{db.run_id}\n")
+    print(f"Trace:  {frontend}/traces/{db.run_id}")
+    _maybe_print_langfuse_session(db, indent=" ")
+    print()
     await db.init_budget(effective_budget)
     made = await run_ingest_calls(source_pages, for_question_id, db)
     total, used = await db.get_budget()
@@ -202,7 +218,9 @@ async def cmd_evaluate(question_id: str, db: DB, *, eval_type: str = "default") 
 
     frontend = get_settings().frontend_url.rstrip("/")
     print(f"\nEvaluating judgement for: {question.headline[:80]}")
-    print(f"Trace: {frontend}/traces/{db.run_id}\n")
+    print(f"Trace: {frontend}/traces/{db.run_id}")
+    _maybe_print_langfuse_session(db)
+    print()
 
     call = await run_evaluation(question.id, db, eval_type=eval_type)
     print(f"\nEvaluation complete (call {call.id}).\n")
@@ -272,7 +290,9 @@ async def cmd_ground(eval_call_id: str, db: DB, *, from_stage: int = 1) -> None:
     print(f"\nRunning grounding feedback for: {question.headline[:80]}")
     if from_stage > 1:
         print(f"Resuming from stage {from_stage}")
-    print(f"Trace: {frontend}/traces/{db.run_id}\n")
+    print(f"Trace: {frontend}/traces/{db.run_id}")
+    _maybe_print_langfuse_session(db)
+    print()
 
     result = await run_grounding_feedback(
         call.scope_page_id,
@@ -335,7 +355,9 @@ async def cmd_feedback_update(
 
     frontend = get_settings().frontend_url.rstrip("/")
     print(f"\nRunning feedback update for: {question.headline[:80]}")
-    print(f"Trace: {frontend}/traces/{db.run_id}\n")
+    print(f"Trace: {frontend}/traces/{db.run_id}")
+    _maybe_print_langfuse_session(db)
+    print()
 
     if investigation_budget is not None:
         get_settings().feedback_investigation_budget = investigation_budget
@@ -390,7 +412,9 @@ async def cmd_feedback_update_from_file(
     frontend = get_settings().frontend_url.rstrip("/")
     print(f"\nRunning feedback update for: {question.headline[:80]}")
     print(f"Source: {file_path}")
-    print(f"Trace: {frontend}/traces/{db.run_id}\n")
+    print(f"Trace: {frontend}/traces/{db.run_id}")
+    _maybe_print_langfuse_session(db)
+    print()
 
     if investigation_budget is not None:
         get_settings().feedback_investigation_budget = investigation_budget
@@ -559,6 +583,7 @@ async def cmd_new(
     print(f"Headline:     {q.headline}")
     print(f"Budget:       {budget} research calls")
     print(f"Trace:        {frontend}/traces/{db.run_id}")
+    _maybe_print_langfuse_session(db, indent="       ")
 
     if ingest_files:
         source_pages = []
@@ -747,6 +772,7 @@ async def cmd_continue(
     )
     print(f"Budget:       {additional_budget} research calls")
     print(f"Trace:        {frontend}/traces/{db.run_id}")
+    _maybe_print_langfuse_session(db, indent="       ")
 
     if chat_first:
         source_pages: list[Page] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "claude-agent-sdk>=0.1.0",
     "tenacity>=9.0.0",
     "google-genai>=1.72",
+    "langfuse>=4.5.1",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -57,6 +57,7 @@ from rumil.models import CallStage, CallType
 from rumil.orchestrators import create_root_question
 from rumil.orchestrators.robustify import RobustifyOrchestrator
 from rumil.settings import get_settings
+from rumil.tracing import get_langfuse
 
 _SCOUT_CALL_TYPES: dict[str, tuple[CallType, type[CallRunner]]] = {
     "scout-subquestions": (CallType.SCOUT_SUBQUESTIONS, ScoutSubquestionsCall),
@@ -252,7 +253,11 @@ async def run(args: argparse.Namespace) -> None:
         print("Provide a question text or --question-id.")
         return
 
-    print(f"Trace: {frontend}/traces/{db.run_id}\n")
+    print(f"Trace: {frontend}/traces/{db.run_id}")
+    if get_langfuse() is not None:
+        lf_base = settings.langfuse_base_url.rstrip("/")
+        print(f"Langfuse session: {lf_base}/sessions?sessionId={db.run_id}")
+    print()
     if adopted_run_id:
         await db.add_budget(args.budget)
     else:

--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -34,6 +34,7 @@ from rumil.models import (
 )
 from rumil.moves.base import MoveState
 from rumil.settings import get_settings
+from rumil.tracing import observe
 from rumil.tracing.trace_events import (
     ErrorEvent,
     MovesExecutedEvent,
@@ -149,6 +150,7 @@ def prepare_tools(tools: Sequence[Tool]) -> tuple[list[dict], dict]:
     return tool_defs, tool_fns
 
 
+@observe(name="single_call")
 async def run_single_call(
     system_prompt: str,
     user_message: str = "",
@@ -253,6 +255,7 @@ async def run_single_call(
     )
 
 
+@observe(name="agent_loop")
 async def run_agent_loop(
     system_prompt: str,
     user_message: str = "",
@@ -597,6 +600,7 @@ async def mark_call_completed(call: Call, db: DB, summary: str) -> None:
     await db.save_call(call)
 
 
+@observe(name="closing_review")
 async def run_closing_review(
     call: Call,
     main_output: str,

--- a/src/rumil/calls/stages.py
+++ b/src/rumil/calls/stages.py
@@ -13,6 +13,7 @@ from rumil.calls.common import mark_call_completed, resolve_page_refs
 from rumil.database import DB
 from rumil.models import Call, CallStage, CallStatus, CallType, Dispatch, Move, MoveType
 from rumil.moves.base import MoveState
+from rumil.tracing import get_langfuse, observe, phase_span, propagate_attributes
 from rumil.tracing.page_load_tracking import page_track_scope
 from rumil.tracing.trace_events import ContextBuiltEvent, ErrorEvent
 from rumil.tracing.tracer import CallTrace, reset_trace, set_trace
@@ -202,14 +203,34 @@ class CallRunner(ABC):
             )
         )
 
+    @observe(name="call.run")
     async def run(self) -> None:
         call_db = await self.infra.db.fork()
         self.infra.db = call_db
         self.infra.state.db = call_db
         self.infra.trace.db = call_db
         trace_token = set_trace(self.infra.trace)
+        lf = get_langfuse()
+        if lf is not None:
+            lf.update_current_span(
+                name=f"call.{self.infra.call.call_type.value}",
+                metadata={
+                    "call_id": self.infra.call.id,
+                    "call_type": self.infra.call.call_type.value,
+                    "question_id": self.infra.question_id,
+                    "parent_call_id": self.infra.call.parent_call_id,
+                },
+            )
         try:
-            await self._run_stages()
+            with propagate_attributes(
+                session_id=self.infra.db.run_id or None,
+                metadata={
+                    "call_type": self.infra.call.call_type.value,
+                    "call_id": self.infra.call.id,
+                },
+                tags=[f"call_type:{self.infra.call.call_type.value}"],
+            ):
+                await self._run_stages()
         finally:
             try:
                 await call_db.close()
@@ -229,7 +250,8 @@ class CallRunner(ABC):
                     call_params=self.infra.call.call_params,
                 )
 
-                self.context_result = await self.context_builder.build_context(self.infra)
+                with phase_span("build_context"):
+                    self.context_result = await self.context_builder.build_context(self.infra)
                 await self._record_context_built(self.context_result)
                 if self.up_to_stage == CallStage.BUILD_CONTEXT:
                     await mark_call_completed(
@@ -240,10 +262,11 @@ class CallRunner(ABC):
                     await self.infra.trace.flush_page_loads()
                     return
 
-                self.update_result = await self.workspace_updater.update_workspace(
-                    self.infra,
-                    self.context_result,
-                )
+                with phase_span("update_workspace"):
+                    self.update_result = await self.workspace_updater.update_workspace(
+                        self.infra,
+                        self.context_result,
+                    )
                 if self.up_to_stage == CallStage.UPDATE_WORKSPACE:
                     await mark_call_completed(
                         self.infra.call,
@@ -253,11 +276,12 @@ class CallRunner(ABC):
                     await self.infra.trace.flush_page_loads()
                     return
 
-                await self.closing_reviewer.closing_review(
-                    self.infra,
-                    self.context_result,
-                    self.update_result,
-                )
+                with phase_span("closing_review"):
+                    await self.closing_reviewer.closing_review(
+                        self.infra,
+                        self.context_result,
+                        self.update_result,
+                    )
                 await self.infra.trace.flush_page_loads()
             except Exception as e:
                 await self.infra.trace.flush_page_loads()

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -41,6 +41,11 @@ from tenacity import (
 
 from rumil.pricing import compute_cost
 from rumil.settings import get_settings
+from rumil.tracing import (
+    get_langfuse,
+    langfuse_trace_url_for_current_observation,
+    observe,
+)
 from rumil.tracing.trace_events import ErrorEvent, LLMExchangeEvent
 from rumil.tracing.tracer import get_trace
 
@@ -431,10 +436,86 @@ async def _save_exchange(
                 cache_read_input_tokens=cache_read_input_tokens or None,
                 duration_ms=duration_ms,
                 cost_usd=cost_usd or None,
+                langfuse_trace_url=langfuse_trace_url_for_current_observation(),
             )
         )
 
 
+def _extract_model_parameters(api_kwargs: dict) -> dict:
+    """Pull Anthropic-API params into the flat shape Langfuse renders in the UI.
+
+    Skips `system`/`messages` (they go into `input`). Flattens nested config
+    dicts (`thinking`, `output_config`) into individual keys since
+    update_current_generation's model_parameters slot is shallow.
+    """
+    params: dict = {}
+    for key in ("model", "max_tokens", "temperature"):
+        if key in api_kwargs:
+            params[key] = api_kwargs[key]
+    if (tools := api_kwargs.get("tools")) is not None:
+        params["tool_count"] = len(tools)
+    if (thinking := api_kwargs.get("thinking")) is not None:
+        for k, v in thinking.items():
+            params[f"thinking_{k}"] = v
+    if (output_config := api_kwargs.get("output_config")) is not None:
+        for k, v in output_config.items():
+            params[k] = v
+    if (tool_choice := api_kwargs.get("tool_choice")) is not None:
+        params["tool_choice"] = str(tool_choice)
+    return params
+
+
+def _enrich_langfuse_generation(
+    *,
+    model: str,
+    messages: Sequence[dict],
+    response: anthropic.types.Message,
+    elapsed_ms: int,
+    api_kwargs: dict | None = None,
+) -> None:
+    """Populate the active Langfuse generation span with model, IO, and usage.
+
+    No-op when Langfuse is disabled or no observation is active.
+    """
+    client = get_langfuse()
+    if client is None:
+        return
+    try:
+        usage = response.usage
+        cache_creation = getattr(usage, "cache_creation_input_tokens", 0) or 0
+        cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
+        cost_usd = compute_cost(
+            model=model,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            cache_creation_input_tokens=cache_creation,
+            cache_read_input_tokens=cache_read,
+        )
+        output_text = "".join(
+            block.text for block in response.content if isinstance(block, TextBlock)
+        )
+        client.update_current_generation(
+            model=model,
+            input=_serialize_messages(messages),
+            output=output_text or None,
+            model_parameters=_extract_model_parameters(api_kwargs or {}),
+            usage_details={
+                "input": usage.input_tokens,
+                "output": usage.output_tokens,
+                "cache_creation_input": cache_creation,
+                "cache_read_input": cache_read,
+            },
+            cost_details={"total": cost_usd} if cost_usd else None,
+            metadata={
+                "stop_reason": response.stop_reason,
+                "duration_ms": elapsed_ms,
+            },
+        )
+    except Exception as exc:
+        log.debug("Langfuse enrichment failed: %s", exc)
+
+
+@observe(as_type="generation", name="anthropic.messages.create")
 async def call_api(
     client: anthropic.AsyncAnthropic,
     model: str,
@@ -560,6 +641,13 @@ async def call_api(
                         phase=metadata.phase,
                     )
                 )
+    _enrich_langfuse_generation(
+        model=model,
+        messages=messages,
+        response=response,
+        elapsed_ms=elapsed_ms,
+        api_kwargs=kwargs,
+    )
     return APIResponse(message=response, duration_ms=elapsed_ms)
 
 
@@ -746,6 +834,7 @@ def _inject_into_last_user_message(
     return msgs
 
 
+@observe(as_type="generation", name="anthropic.messages.parse")
 async def _structured_call_parse(
     system_prompt: str,
     response_model: type[T] | None,
@@ -795,6 +884,13 @@ async def _structured_call_parse(
     for block in response.content:
         if isinstance(block, TextBlock):
             response_text += block.text
+    _enrich_langfuse_generation(
+        model=model,
+        messages=msg_list,
+        response=response,
+        elapsed_ms=elapsed_ms,
+        api_kwargs=parse_kwargs,
+    )
     if metadata and db:
         serialized: Sequence[dict] | None = None
         if metadata.user_message is None:

--- a/src/rumil/orchestrators/base.py
+++ b/src/rumil/orchestrators/base.py
@@ -25,6 +25,7 @@ from rumil.orchestrators.dispatch_handlers import (
     DispatchContext,
 )
 from rumil.settings import get_settings
+from rumil.tracing import observe, propagate_attributes
 from rumil.tracing.broadcast import Broadcaster
 from rumil.tracing.trace_events import DispatchExecutedEvent
 from rumil.tracing.tracer import get_trace
@@ -33,8 +34,46 @@ from rumil.views import get_active_view
 log = logging.getLogger(__name__)
 
 
+def _wrap_run_with_session(run, orch_name: str):
+    """Wrap an orchestrator's run() so its body runs inside a Langfuse session.
+
+    Sets session_id=db.run_id and tags the trace with the orchestrator name
+    so all child spans (CallRunner.run, agent loops, LLM calls) inherit it.
+    No-op when Langfuse is disabled — propagate_attributes is a cheap
+    contextvar manipulation either way.
+    """
+    import functools
+
+    @functools.wraps(run)
+    async def wrapper(self, *args, **kwargs):
+        with propagate_attributes(
+            session_id=self.db.run_id or None,
+            metadata={"orchestrator": orch_name},
+            tags=[f"orchestrator:{orch_name}"],
+        ):
+            return await run(self, *args, **kwargs)
+
+    return wrapper
+
+
 class BaseOrchestrator(ABC):
     summarise_before_assess: bool = True
+
+    def __init_subclass__(cls, **kwargs):
+        """Auto-trace every concrete subclass's run() with a Langfuse span.
+
+        Wraps run() in propagate_attributes so the entire orchestrator
+        invocation appears as one Langfuse trace tagged with session_id=run_id
+        and the orchestrator class name. Subclasses that don't override run()
+        inherit the abstract decl and skip this.
+        """
+        super().__init_subclass__(**kwargs)
+        run = cls.__dict__.get("run")
+        if run is None or getattr(run, "__isabstractmethod__", False):
+            return
+        cls.run = observe(name=f"orchestrator.{cls.__name__}")(
+            _wrap_run_with_session(run, cls.__name__)
+        )
 
     def __init__(self, db: DB, broadcaster: Broadcaster | None = None):
         self.db = db

--- a/src/rumil/orchestrators/base.py
+++ b/src/rumil/orchestrators/base.py
@@ -3,6 +3,7 @@ BaseOrchestrator: abstract base class for all orchestrators.
 """
 
 import asyncio
+import functools
 import logging
 import uuid
 from abc import ABC, abstractmethod
@@ -42,7 +43,6 @@ def _wrap_run_with_session(run, orch_name: str):
     No-op when Langfuse is disabled — propagate_attributes is a cheap
     contextvar manipulation either way.
     """
-    import functools
 
     @functools.wraps(run)
     async def wrapper(self, *args, **kwargs):

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -59,6 +59,9 @@ class Settings(BaseSettings):
     supabase_prod_key: str = ""
     voyage_ai_api_key: str = ""
     jina_api_key: str = ""
+    langfuse_public_key: str = ""
+    langfuse_secret_key: str = ""
+    langfuse_base_url: str = "https://us.cloud.langfuse.com"
     frontend_url: str = "http://127.0.0.1:3000"
     db_max_concurrent_queries: int = 20
 
@@ -172,6 +175,10 @@ class Settings(BaseSettings):
                 "Set it before running the workspace."
             )
         return self.anthropic_api_key
+
+    @property
+    def langfuse_enabled(self) -> bool:
+        return bool(self.langfuse_public_key and self.langfuse_secret_key)
 
     @classmethod
     def from_env_files(cls, *env_files: str | Path) -> "Settings":

--- a/src/rumil/tracing/__init__.py
+++ b/src/rumil/tracing/__init__.py
@@ -1,0 +1,33 @@
+"""rumil tracing — in-house CallTrace plus Langfuse Cloud integration.
+
+For LLM observability, opt any function into Langfuse tracing with one line:
+
+    from rumil.tracing import observe
+
+    @observe()
+    async def my_function(...): ...
+
+When Langfuse is configured (LANGFUSE_PUBLIC_KEY + LANGFUSE_SECRET_KEY in
+settings), this emits a span to the configured project. When unset, it's a
+no-op and your function runs unmodified.
+"""
+
+from langfuse import observe, propagate_attributes
+
+from rumil.tracing.langfuse_client import (
+    flush_langfuse,
+    get_langfuse,
+    langfuse_trace_url_for_current_observation,
+    langfuse_trace_url_for_trace_id,
+    phase_span,
+)
+
+__all__ = [
+    "flush_langfuse",
+    "get_langfuse",
+    "langfuse_trace_url_for_current_observation",
+    "langfuse_trace_url_for_trace_id",
+    "observe",
+    "phase_span",
+    "propagate_attributes",
+]

--- a/src/rumil/tracing/langfuse_client.py
+++ b/src/rumil/tracing/langfuse_client.py
@@ -24,9 +24,17 @@ from rumil.settings import get_settings
 def get_langfuse() -> Langfuse | None:
     """Return a configured Langfuse client, or None when disabled.
 
-    Reads from settings (not env directly) so worktree/A-B configs work. The
-    SDK reads its own LANGFUSE_PUBLIC_KEY/SECRET_KEY/HOST env vars at client
-    construction, so we set them here from settings before instantiating.
+    **Process-wide singleton.** The first caller's settings determine the
+    enabled/disabled verdict and the client config (project keys, host) for
+    the rest of the process. To switch keys mid-process — e.g. in tests
+    that exercise both states — call ``get_langfuse.cache_clear()`` after
+    swapping settings (the test suite does this via an autouse fixture).
+    Even if you do clear our cache, ``langfuse.get_client()`` itself caches
+    by public_key, so true mid-process key switching needs more care.
+
+    The SDK reads its own LANGFUSE_PUBLIC_KEY/SECRET_KEY/HOST env vars at
+    client construction; we copy from settings to those env vars here so
+    each worktree's distinct .env feeds through correctly at process start.
     """
     settings = get_settings()
     if not settings.langfuse_enabled:

--- a/src/rumil/tracing/langfuse_client.py
+++ b/src/rumil/tracing/langfuse_client.py
@@ -1,0 +1,94 @@
+"""Langfuse Cloud integration helpers.
+
+Single source of truth for talking to Langfuse from rumil. When
+LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are set, every @observe-decorated
+function emits spans to the configured project. When unset, the SDK initializes
+in disabled mode and decorators become no-ops (one auth-error log line per
+process — noise we silence below).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from collections.abc import Iterator
+from functools import lru_cache
+
+from langfuse import Langfuse, get_client
+
+from rumil.settings import get_settings
+
+
+@lru_cache(maxsize=1)
+def get_langfuse() -> Langfuse | None:
+    """Return a configured Langfuse client, or None when disabled.
+
+    Reads from settings (not env directly) so worktree/A-B configs work. The
+    SDK reads its own LANGFUSE_PUBLIC_KEY/SECRET_KEY/HOST env vars at client
+    construction, so we set them here from settings before instantiating.
+    """
+    settings = get_settings()
+    if not settings.langfuse_enabled:
+        # Silence the SDK's auth-error warning when we deliberately ran with
+        # no keys — the user opted out, they don't need to see the complaint.
+        logging.getLogger("langfuse").setLevel(logging.ERROR)
+        return None
+    os.environ["LANGFUSE_PUBLIC_KEY"] = settings.langfuse_public_key
+    os.environ["LANGFUSE_SECRET_KEY"] = settings.langfuse_secret_key
+    os.environ["LANGFUSE_HOST"] = settings.langfuse_base_url
+    return get_client()
+
+
+def langfuse_trace_url_for_current_observation() -> str | None:
+    """Compose a deep-link URL to the current Langfuse trace + observation.
+
+    Returns None when Langfuse is disabled or no observation is currently
+    active. The URL points at the current observation inside its trace, so
+    clicking it from a rumil LLM-exchange event lands on that exact LLM call
+    in the Langfuse UI.
+    """
+    client = get_langfuse()
+    if client is None:
+        return None
+    trace_id = client.get_current_trace_id()
+    if not trace_id:
+        return None
+    base = client.get_trace_url(trace_id=trace_id)
+    if not base:
+        return None
+    obs_id = client.get_current_observation_id()
+    if obs_id:
+        return f"{base}?observation={obs_id}"
+    return base
+
+
+def langfuse_trace_url_for_trace_id(trace_id: str) -> str | None:
+    """Compose a Langfuse trace URL from an explicit trace_id."""
+    client = get_langfuse()
+    if client is None:
+        return None
+    return client.get_trace_url(trace_id=trace_id)
+
+
+def flush_langfuse() -> None:
+    """Best-effort flush of pending Langfuse events. Safe to call when disabled."""
+    client = get_langfuse()
+    if client is None:
+        return
+    client.flush()
+
+
+@contextlib.contextmanager
+def phase_span(name: str) -> Iterator[None]:
+    """Open a Langfuse span for the duration of a workflow phase.
+
+    No-op when Langfuse is disabled. Use this to add named spans without
+    refactoring callers into their own decorated functions.
+    """
+    client = get_langfuse()
+    if client is None:
+        yield
+        return
+    with client.start_as_current_observation(name=name, as_type="span"):
+        yield

--- a/src/rumil/tracing/trace_events.py
+++ b/src/rumil/tracing/trace_events.py
@@ -88,6 +88,7 @@ class LLMExchangeEvent(BaseModel):
     cost_usd: float | None = None
     has_thinking: bool | None = None
     tool_uses: list[dict[str, Any]] | None = None
+    langfuse_trace_url: str | None = None
 
 
 class WarningEvent(BaseModel):

--- a/tests/test_langfuse_integration.py
+++ b/tests/test_langfuse_integration.py
@@ -7,7 +7,7 @@ to render its "Langfuse ↗" link.
 
 import pytest
 
-from rumil.settings import override_settings
+from rumil.settings import get_settings, override_settings
 from rumil.tracing import (
     flush_langfuse,
     get_langfuse,
@@ -34,12 +34,8 @@ def test_get_langfuse_returns_none_when_disabled():
 
 def test_langfuse_enabled_property():
     with override_settings(langfuse_public_key="", langfuse_secret_key=""):
-        from rumil.settings import get_settings
-
         assert get_settings().langfuse_enabled is False
     with override_settings(langfuse_public_key="pk-x", langfuse_secret_key="sk-y"):
-        from rumil.settings import get_settings
-
         assert get_settings().langfuse_enabled is True
 
 

--- a/tests/test_langfuse_integration.py
+++ b/tests/test_langfuse_integration.py
@@ -1,0 +1,114 @@
+"""Tests for the Langfuse Cloud integration helpers.
+
+Covers the disabled-by-default behaviour (the path most tests and CI run on)
+plus structural guarantees on the LLMExchangeEvent that the frontend relies on
+to render its "Langfuse ↗" link.
+"""
+
+import pytest
+
+from rumil.settings import override_settings
+from rumil.tracing import (
+    flush_langfuse,
+    get_langfuse,
+    langfuse_trace_url_for_current_observation,
+    observe,
+    phase_span,
+)
+from rumil.tracing.langfuse_client import get_langfuse as _raw_get_langfuse
+from rumil.tracing.trace_events import LLMExchangeEvent
+
+
+@pytest.fixture(autouse=True)
+def _clear_langfuse_singleton():
+    """Reset the lru_cache between tests so settings overrides take effect."""
+    _raw_get_langfuse.cache_clear()
+    yield
+    _raw_get_langfuse.cache_clear()
+
+
+def test_get_langfuse_returns_none_when_disabled():
+    with override_settings(langfuse_public_key="", langfuse_secret_key=""):
+        assert get_langfuse() is None
+
+
+def test_langfuse_enabled_property():
+    with override_settings(langfuse_public_key="", langfuse_secret_key=""):
+        from rumil.settings import get_settings
+
+        assert get_settings().langfuse_enabled is False
+    with override_settings(langfuse_public_key="pk-x", langfuse_secret_key="sk-y"):
+        from rumil.settings import get_settings
+
+        assert get_settings().langfuse_enabled is True
+
+
+def test_trace_url_helper_returns_none_when_disabled():
+    with override_settings(langfuse_public_key="", langfuse_secret_key=""):
+        assert langfuse_trace_url_for_current_observation() is None
+
+
+def test_phase_span_is_noop_when_disabled():
+    with (
+        override_settings(langfuse_public_key="", langfuse_secret_key=""),
+        phase_span("anything"),
+    ):
+        assert True
+
+
+def test_observe_decorator_passes_through_when_disabled():
+    with override_settings(langfuse_public_key="", langfuse_secret_key=""):
+
+        @observe()
+        def double(x):
+            return x * 2
+
+        assert double(21) == 42
+
+
+@pytest.mark.asyncio
+async def test_observe_decorator_works_on_async_when_disabled():
+    with override_settings(langfuse_public_key="", langfuse_secret_key=""):
+
+        @observe()
+        async def add_one(x):
+            return x + 1
+
+        assert await add_one(5) == 6
+
+
+def test_flush_is_safe_when_disabled():
+    with override_settings(langfuse_public_key="", langfuse_secret_key=""):
+        flush_langfuse()
+
+
+def test_llm_exchange_event_round_trips_without_langfuse_url():
+    """Existing JSONB rows have no langfuse_trace_url — must deserialize cleanly."""
+    payload = {
+        "event": "llm_exchange",
+        "exchange_id": "exch-123",
+        "phase": "inner_loop",
+        "round": 0,
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "duration_ms": 1234,
+        "cost_usd": 0.001,
+    }
+    evt = LLMExchangeEvent.model_validate(payload)
+    assert evt.langfuse_trace_url is None
+    assert evt.exchange_id == "exch-123"
+    re = LLMExchangeEvent.model_validate(evt.model_dump())
+    assert re.langfuse_trace_url is None
+
+
+def test_llm_exchange_event_carries_langfuse_url():
+    url = "https://us.cloud.langfuse.com/project/abc/traces/xyz?observation=obs-1"
+    evt = LLMExchangeEvent(
+        exchange_id="exch-456",
+        phase="closing_review",
+        langfuse_trace_url=url,
+    )
+    dumped = evt.model_dump()
+    assert dumped["langfuse_trace_url"] == url
+    re = LLMExchangeEvent.model_validate(dumped)
+    assert re.langfuse_trace_url == url

--- a/uv.lock
+++ b/uv.lock
@@ -183,6 +183,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -646,6 +655,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -827,6 +848,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -980,6 +1013,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/38/14121ead61e0e75f79c3a35e5148ac7c2fe754a55f76eab3eed573269524/langchain_text_splitters-1.1.1.tar.gz", hash = "sha256:34861abe7c07d9e49d4dc852d0129e26b32738b60a74486853ec9b6d6a8e01d2", size = 279352, upload-time = "2026-02-18T23:02:42.798Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/66/d9e0c3b83b0ad75ee746c51ba347cacecb8d656b96e1d513f3e334d1ccab/langchain_text_splitters-1.1.1-py3-none-any.whl", hash = "sha256:5ed0d7bf314ba925041e7d7d17cd8b10f688300d5415fb26c29442f061e329dc", size = 35734, upload-time = "2026-02-18T23:02:41.913Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/bd/9b12c9dd3ae1883619b20daa6d60f20a780ce2d25564d9b2168db27cbeb0/langfuse-4.5.1.tar.gz", hash = "sha256:fe8f9219f4101c0921934b0aeb1b45834f8e7d248e5f830b2c89c5b40aea6d83", size = 279735, upload-time = "2026-04-24T15:21:43.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/63/77bd7220dfd60885a272a851f780b3f83e0f653ee3a852347552c3e24a28/langfuse-4.5.1-py3-none-any.whl", hash = "sha256:5923cafe8289c9e3c53cb6992f4b46ec3132473b9f9eb65eb33ad28e2682db81", size = 479527, upload-time = "2026-04-24T15:21:45.568Z" },
 ]
 
 [[package]]
@@ -1300,6 +1352,88 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1561,6 +1695,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -2162,6 +2311,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "httpx" },
+    { name = "langfuse" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "supabase" },
@@ -2193,6 +2343,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "google-genai", specifier = ">=1.72" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "langfuse", specifier = ">=4.5.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pypdf", marker = "extra == 'pdf'", specifier = ">=6.7.5" },
@@ -2658,6 +2809,55 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
 name = "xxhash"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2842,6 +3042,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Wires every Anthropic API call into Langfuse as a typed `generation` with model parameters, usage, and cost.
- Workflow nesting (orchestrator → call → phase → agent loop → API) mirrors the function-call tree via `@observe` decorators.
- Adds `langfuse_trace_url` to `LLMExchangeEvent` so the in-house trace UI deep-links to the matching Langfuse observation.
- Disabled gracefully when keys are unset — each developer sets up their own Langfuse dev project; CI is unaffected.

## Architecture

Single source of truth in `src/rumil/tracing/langfuse_client.py`:

- `get_langfuse()` — lazy singleton, reads from `Settings`, returns `None` when disabled.
- `langfuse_trace_url_for_current_observation()` — composes a deep-link URL (`?observation=…`) from the active OTel context.
- `phase_span(name)` — context manager for named workflow spans without refactoring callers into separate functions.

Re-exported from `rumil.tracing`:

```python
from rumil.tracing import observe

@observe()
async def my_function(...): ...   # one-line opt-in
```

Span tree:

```
orchestrator.GlobalPrioOrchestrator        (auto-decorated via __init_subclass__)
└─ call.find_considerations                (CallRunner.run, propagates session_id=run_id)
   ├─ build_context                        (phase_span)
   ├─ update_workspace                     (phase_span)
   │  └─ agent_loop                        (run_agent_loop)
   │     ├─ anthropic.messages.create      (call_api → generation, model+params+usage+cost)
   │     └─ ...
   └─ closing_review                       (phase_span)
      └─ anthropic.messages.parse          (_structured_call_parse → generation)
```

Retries inside `call_api` collapse into one generation span — retry attempts are visible in metadata, not as confusing flat siblings.

## Infra

- Prod keys live in `deploy/chart/secrets.enc.yaml` (SOPS, GCP KMS).
- `LANGFUSE_BASE_URL` is in `deploy/chart/values.yaml` (not a secret).
- Local dev: each developer creates their own Langfuse project at https://us.cloud.langfuse.com and drops keys into `.env`. See `.env.template`.
- `differential-prod` is the production project name.

## Test plan

- [x] `uv run pytest` — 554 tests pass, 9 new in `tests/test_langfuse_integration.py`.
- [x] `uv run pyright` — clean.
- [x] `npx tsc --noEmit` (frontend) — clean after type regen.
- [x] Local smoke: `uv run python main.py "Is the sky blue?" --workspace lf-scratch --smoke-test --budget 2` — printed both Trace and Langfuse URLs; verified `langfuse_trace_url` populated on each LLM exchange in the local DB.
- [ ] Open the printed Langfuse session URL after first prod deploy, confirm trace tree mirrors the workflow and that the Parameters panel shows model/temperature/thinking_*/effort.

## Notes for reviewers

- Orchestrator decoration uses `BaseOrchestrator.__init_subclass__` so all 6 existing subclasses (and any future ones) get traced uniformly without touching their files.
- `_enrich_langfuse_generation` populates the typed `model_parameters` slot so Langfuse renders temperature/thinking/effort/tool_count in its UI.
- The "Langfuse ↗" link on each LLM-exchange row in the trace UI uses `event.langfuse_trace_url` (auto-generated from the new `LLMExchangeEvent` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)