### PR TITLE
Increase default max_api_retries from 10 to 60

### DIFF
--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -97,7 +97,7 @@ class Settings(BaseSettings):
     subquestion_linker_enabled: bool = _capture_field(default=True)
 
     max_db_retries: int = _capture_field(default=10)
-    max_api_retries: int = _capture_field(default=10)
+    max_api_retries: int = _capture_field(default=60)
     max_api_retries_429: int | None = _capture_field(default=None)
     max_api_retries_500: int | None = _capture_field(default=None)
     max_api_retries_529: int | None = _capture_field(default=None)


### PR DESCRIPTION
## Summary
- Bump default `max_api_retries` from 10 → 60 in `src/rumil/settings.py` to better absorb transient Anthropic API failures during long runs.

## Test plan
- [ ] Confirm settings default is picked up by `llm.get_max_retries()` on fresh runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)