### PR TITLE
Add SOPS onboarding docs + deploy toolchain to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -18,3 +18,9 @@ brew "supabase/tap/supabase"
 
 # Task runner for the repo's justfile
 brew "just"
+
+# Deployment toolchain — needed to read/edit deploy/chart/secrets.enc.yaml
+# and to run ./scripts/deploy.sh against the GKE cluster.
+brew "sops"
+brew "helm"
+cask "google-cloud-sdk"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,107 @@
+# Deploying rumil
+
+Production runs on GKE Autopilot in GCP project `project-fe559f0f-d011-4af4-bf0`,
+cluster `differential` in `us-central1`. The Helm chart lives in `deploy/chart/`;
+build + push + roll happens via `./scripts/deploy.sh`.
+
+## One-time onboarding
+
+You need this once per developer machine. Once it's done, `./scripts/deploy.sh`
+and `sops decrypt deploy/chart/secrets.enc.yaml` both Just Work.
+
+### 1. Get the tools
+
+```bash
+brew bundle   # installs sops, helm, google-cloud-sdk (and the rest of the toolchain)
+helm plugin install https://github.com/jkroepke/helm-secrets
+gcloud components install gke-gcloud-auth-plugin
+```
+
+### 2. Authenticate gcloud — both kinds
+
+```bash
+gcloud auth login                          # for the gcloud CLI itself
+gcloud auth application-default login      # for libraries (SOPS reads ADC, not gcloud)
+gcloud config set project project-fe559f0f-d011-4af4-bf0
+```
+
+The second command is the one people forget. SOPS uses Application Default
+Credentials, so without it you'll get a cryptic auth error even though
+`gcloud auth list` shows you're signed in.
+
+### 3. Get IAM access (ask an admin)
+
+You need two grants on the GCP project, both to your Google account. Ask an
+existing admin (currently Lawrence) to run:
+
+```bash
+# Project membership so you can see the project in your console
+gcloud projects add-iam-policy-binding project-fe559f0f-d011-4af4-bf0 \
+  --member="user:YOU@example.com" \
+  --role="roles/browser"
+
+# SOPS key access — encrypt + decrypt
+gcloud kms keys add-iam-policy-binding sops-key \
+  --keyring=sops --location=global \
+  --project=project-fe559f0f-d011-4af4-bf0 \
+  --member="user:YOU@example.com" \
+  --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
+```
+
+If you only need to deploy (not edit secrets), `roles/cloudkms.cryptoKeyDecrypter`
+is enough on the KMS key. `EncrypterDecrypter` covers both.
+
+### 4. Get cluster credentials (only if you'll run `./scripts/deploy.sh`)
+
+```bash
+gcloud container clusters get-credentials differential \
+  --region=us-central1 --project=project-fe559f0f-d011-4af4-bf0
+```
+
+This writes a kubeconfig context that points at the GKE cluster.
+
+### 5. Smoke test
+
+```bash
+sops decrypt deploy/chart/secrets.enc.yaml > /dev/null && echo "SOPS OK"
+kubectl get pods -n rumil                                   # if you set up cluster creds
+```
+
+## Editing secrets
+
+```bash
+# Add or update a single key without dumping the whole file to disk
+sops set deploy/chart/secrets.enc.yaml '["secrets"]["api"]["MY_NEW_KEY"]' '"my-value"'
+
+# Inspect the decrypted file
+sops decrypt deploy/chart/secrets.enc.yaml | less
+
+# Edit interactively (opens $EDITOR with the decrypted file, re-encrypts on save)
+sops edit deploy/chart/secrets.enc.yaml
+```
+
+When adding a new key, also add it to `deploy/chart/secrets.yaml.template` so
+future devs know it exists.
+
+## Deploying
+
+```bash
+./scripts/deploy.sh --all                       # builds API + frontend, pushes, rolls
+./scripts/deploy.sh --api                       # API only
+./scripts/deploy.sh --frontend                  # frontend only
+./scripts/deploy.sh --api --tag <some-tag>      # custom image tag
+```
+
+Defaults: image tag = current git short SHA, namespace = `rumil`, release = `rumil`.
+
+## Common gotchas
+
+- **`gcloud auth login` ≠ `gcloud auth application-default login`.** Both are
+  required. The first authenticates the CLI; the second writes the credentials
+  JSON that SOPS (and other GCP client libraries) actually read.
+- **Multiple Google accounts.** ADC stores one set of credentials at a time.
+  `gcloud auth application-default print-access-token` prints whoever is
+  currently active there. Re-run the login command to switch.
+- **New encrypted files** need a matching entry in `.sops.yaml`. Currently
+  only `deploy/chart/secrets(\.enc)?\.yaml` is covered. Anything outside that
+  glob won't be auto-encrypted by `sops` and the `creation_rules` machinery.


### PR DESCRIPTION
## Summary

- New `deploy/README.md` covers the one-time onboarding for a developer who needs to decrypt `deploy/chart/secrets.enc.yaml` or run `./scripts/deploy.sh`: tools, both flavours of `gcloud auth`, the KMS IAM grants admins need to run, GKE cluster credentials, smoke test, and common gotchas.
- `Brewfile` now installs `sops`, `helm`, and `google-cloud-sdk` so `brew bundle` on a fresh dev box gets the deploy toolchain alongside the existing dev tools.

## Context

Onboarding a new dev was tribal knowledge. With four new contributors getting access this week, time to write it down.

(IAM grants for the new contributors — scatha@, 117brian@, dave.l.griffith@, raymondadouglas@ — were applied directly to the project via gcloud and aren't part of this PR.)

## Test plan

- [x] `brew bundle --check` — Brewfile parses (the new entries follow existing syntax).
- [ ] Have one of the new devs follow the README from a clean machine and confirm `sops decrypt deploy/chart/secrets.enc.yaml` works at the smoke test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)