### PR TITLE
Wrap useSearchParams pages in Suspense

### DIFF
--- a/frontend/src/app/sign-in/page.tsx
+++ b/frontend/src/app/sign-in/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Fraunces, JetBrains_Mono } from "next/font/google";
 
@@ -23,7 +23,7 @@ const mono = JetBrains_Mono({
   display: "swap",
 });
 
-export default function SignInPage() {
+function SignInForm() {
   const [status, setStatus] = useState<"idle" | "pending">("idle");
   const [error, setError] = useState<string | null>(null);
   const searchParams = useSearchParams();
@@ -72,5 +72,13 @@ export default function SignInPage() {
         </div>
       </InviteShell>
     </div>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense fallback={null}>
+      <SignInForm />
+    </Suspense>
   );
 }

--- a/frontend/src/app/welcome/page.tsx
+++ b/frontend/src/app/welcome/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Fraunces, JetBrains_Mono } from "next/font/google";
 
@@ -22,7 +22,7 @@ const mono = JetBrains_Mono({
   display: "swap",
 });
 
-export default function WelcomePage() {
+function WelcomeForm() {
   const [password, setPassword] = useState("");
   const [status, setStatus] = useState<"idle" | "pending" | "wrong" | "ok">(
     "idle",
@@ -133,5 +133,13 @@ export default function WelcomePage() {
         </form>
       </InviteShell>
     </div>
+  );
+}
+
+export default function WelcomePage() {
+  return (
+    <Suspense fallback={null}>
+      <WelcomeForm />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary

The prod build for #366 failed at the static prerender step:

```
useSearchParams() should be wrapped in a suspense boundary at page "/sign-in".
Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
Error occurred prerendering page "/sign-in".
```

`useSearchParams()` can't be evaluated during static prerender because the URL isn't known at build time, so Next.js requires a Suspense ancestor to render a fallback during prerender and hydrate the real value on the client. Both `/sign-in` and `/welcome` were calling it at the top level of their page components.

## Fix

Each page is split into:
- An inner `*Form` component that uses `useSearchParams()` and renders the interactive UI.
- The default-exported page component, which now just renders `<Suspense fallback={null}>` around the form.

`null` is fine for the fallback because all the visible chrome (wordmark, label, title, paper backdrop) comes from `InviteShell`, which doesn't depend on searchParams and renders unconditionally. After hydration, the form takes over and reads the `?next=...` query param exactly as before.

## Test plan

- [x] `pnpm build` succeeds — both `/sign-in` and `/welcome` now show as static (`○`) in the route output, alongside the existing routes.
- [x] `npx tsc --noEmit` clean.
- [x] Verified locally: `/sign-in` and `/welcome` still render with the correct copy and form behaviour, and the `?next=` param is picked up after hydration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)