### PR TITLE
fix(auth): use x-forwarded-host for OAuth callback redirect

### DIFF
--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -1,20 +1,37 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+// Standalone Next.js builds bind to HOSTNAME=0.0.0.0:3000, so
+// `request.nextUrl.origin` resolves to the pod's internal address rather
+// than the public origin the browser came from. Behind a load balancer
+// (GKE Gateway) we need to read the original host from `x-forwarded-host`
+// before emitting the redirect, otherwise the browser ends up at
+// `https://0.0.0.0:3000/`. Locally the header is absent and we fall
+// back to `nextUrl.origin`.
+function publicOrigin(request: NextRequest): string {
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  if (forwardedHost) {
+    const proto = request.headers.get("x-forwarded-proto") ?? "https";
+    return `${proto}://${forwardedHost}`;
+  }
+  return request.nextUrl.origin;
+}
+
 export async function GET(request: NextRequest) {
   const url = request.nextUrl;
   const code = url.searchParams.get("code");
   const next = url.searchParams.get("next") ?? "/";
+  const origin = publicOrigin(request);
 
   if (code) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(new URL(next, url.origin));
+      return NextResponse.redirect(new URL(next, origin));
     }
   }
 
-  const fallback = new URL("/sign-in", url.origin);
+  const fallback = new URL("/sign-in", origin);
   fallback.searchParams.set("error", "oauth_failed");
   return NextResponse.redirect(fallback);
 }


### PR DESCRIPTION
## Summary

After Google sign-in on prod, the post-auth redirect lands on `https://0.0.0.0:3000/` instead of `https://rumil.ink/`.

## Cause

`Dockerfile.frontend` sets `HOSTNAME=0.0.0.0` and `PORT=3000` so the Next.js standalone server binds inside the pod. Inside `/auth/callback/route.ts` we were doing:

```ts
return NextResponse.redirect(new URL(next, request.nextUrl.origin));
```

`request.nextUrl.origin` in the standalone runtime resolves to the pod's bind address, not the public hostname. Behind GKE Gateway the browser-facing host is only available on the `x-forwarded-host` header.

(The Supabase Auth → callback hop is fine — that one uses the redirect URL the browser supplied to `signInWithOAuth`, which the dashboard's allowlist already covers. The bug is the second hop, our own redirect after `exchangeCodeForSession`.)

## Fix

Extract a `publicOrigin(request)` helper that prefers `x-forwarded-host` (with `x-forwarded-proto` for the scheme) and falls back to `request.nextUrl.origin` for local dev where no proxy is in front. This is the pattern the `@supabase/ssr` docs use in their callback example.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] Local dev: callback still redirects to `http://localhost:3012/` (no `x-forwarded-host`, falls back to `nextUrl.origin`).
- [ ] **Post-merge**: complete a Google sign-in on prod and confirm the final redirect goes to `https://rumil.ink/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)