### PR TITLE
docs(auth): document local AUTH_ENABLED=0 escape hatch

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,10 @@ LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
 # Override if the frontend runs on a non-default port
 FRONTEND_URL=http://127.0.0.1:3000
 
+# Skip JWT verification on the API. Pair with AUTH_ENABLED=0 in
+# frontend/.env.local for the simplest local setup. Default is on.
+AUTH_ENABLED=0
+
 # --- Optional: feature variants (uncomment to override defaults) ---
 # PRIORITIZER_VARIANT=two_phase
 # AVAILABLE_MOVES=default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,13 @@ uv run pre-commit install
 
 If `pre-commit install` errors with `Cowardly refusing to install hooks with core.hooksPath set`, your repo has a local `core.hooksPath` override. Either unset it (`git config --unset-all core.hooksPath`) or run hooks manually via `just precommit-all` / `uv run pre-commit run --all-files`.
 
+## Auth in local dev
+
+The deployed app has two gates: an invite password (`/welcome`) and Google OAuth via Supabase (`/sign-in`). For local dev you almost always want to skip both — the example env files do this by default.
+
+- Set `AUTH_ENABLED=0` in **both** `.env` (backend) and `frontend/.env.local` (frontend). The example files ship with this set. The middleware then skips the invite cookie and the Supabase session check, and the API skips JWT verification. The two sides must agree — if only the frontend has it, every `/api/*` call 401s.
+- To exercise the real flow locally, unset `AUTH_ENABLED` (or set to `1`) and fill in `INVITE_PASSWORD`, `INVITE_SECRET`, and the `NEXT_PUBLIC_SUPABASE_*` vars in `frontend/.env.local`. Local Google OAuth isn't wired up in `supabase/config.toml`, so the `/sign-in` button won't actually complete a flow against `supabase start` — you'd need to point at a real Supabase project.
+
 ## Common tasks
 
 A [justfile](./justfile) wraps the commands below — `brew bundle` installs `just` (or `brew install just` on its own). Run `just --list` to see recipes. Direct commands work too.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,23 @@
+# Copy to .env.local. Defaults below give the simplest local setup:
+# auth disabled on both sides, no Supabase credentials required.
+
+# Backend API URL (the Next.js middleware proxies /api/* here).
+NEXT_PUBLIC_API_URL=http://localhost:8000
+API_BASE_URL=http://localhost:8000
+
+# Skip the invite-password gate AND the Supabase session check. The backend
+# must match (set AUTH_ENABLED=0 in your root .env) or /api calls will 401.
+AUTH_ENABLED=0
+
+# --- Only needed if you want to exercise the real auth flow (AUTH_ENABLED unset/1) ---
+
+# Password the /welcome page accepts.
+# INVITE_PASSWORD=
+
+# HMAC key for signing the invite cookie. Any 32+ char random string.
+# INVITE_SECRET=
+
+# Supabase project credentials. Locally these come from `supabase start`
+# output; for production use the deployed project's values.
+# NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+# NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- New devs had no documented path to a working local setup: `CONTRIBUTING.md` told them to `cp frontend/.env.local.example`, but that file didn't exist, and the `AUTH_ENABLED=0` bypass for the invite gate + Supabase session was buried in source comments.
- Adds `frontend/.env.local.example` (with `AUTH_ENABLED=0` as the default and commented `INVITE_*` / `NEXT_PUBLIC_SUPABASE_*` for the real-flow path), un-ignores it in `frontend/.gitignore`, mirrors the flag in `.env.template`, and adds an "Auth in local dev" section to `CONTRIBUTING.md` that explains the two gates, the flag, and the local Google OAuth gap.

## Test plan
- [ ] Fresh clone: `cp .env.template .env`, `cp frontend/.env.local.example frontend/.env.local`, fill `ANTHROPIC_API_KEY`, `supabase start`, `./scripts/dev-api.sh`, `cd frontend && pnpm dev` — should land on the app without hitting `/welcome` or `/sign-in`.
- [ ] Confirm `/api/*` calls succeed (no 401) with both sides set to `AUTH_ENABLED=0`.
- [ ] Sanity: unset `AUTH_ENABLED` on the frontend only and confirm `/api/*` 401s as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)