### PR TITLE
Fix API Docker build: copy versus path source

### DIFF
--- a/deploy/Dockerfile.api
+++ b/deploy/Dockerfile.api
@@ -5,6 +5,8 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock README.md ./
 COPY src/rumil ./src/rumil
+COPY versus/pyproject.toml ./versus/
+COPY versus/src ./versus/src
 RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.13-slim


### PR DESCRIPTION
## Summary
- Deploy was failing on the API image build because `pyproject.toml` declares `versus = { path = "versus", editable = true }` but `deploy/Dockerfile.api` only copied `src/rumil`. `uv sync --frozen` then errored with `Distribution not found at: file:///app/versus`.
- Copy `versus/pyproject.toml` and `versus/src` into the build context before `uv sync`.

Failing run: https://github.com/chaosGuppy/rumil/actions/runs/24940234108/job/73032783377

## Test plan
- [ ] CI passes on this PR
- [ ] Deploy workflow on main succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)