### PR TITLE
Bump rollout-status timeout to 300s

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -99,11 +99,11 @@ helm secrets upgrade --install "$RELEASE" "$CHART_DIR" \
 echo "==> Waiting for rollout..."
 if $deploy_api; then
     echo "  API:"
-    kubectl rollout status "deployment/${RELEASE}-api" -n "$NAMESPACE" --timeout=120s
+    kubectl rollout status "deployment/${RELEASE}-api" -n "$NAMESPACE" --timeout=300s
 fi
 if $deploy_frontend; then
     echo "  Frontend:"
-    kubectl rollout status "deployment/${RELEASE}-frontend" -n "$NAMESPACE" --timeout=120s
+    kubectl rollout status "deployment/${RELEASE}-frontend" -n "$NAMESPACE" --timeout=300s
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- The previous deploy ([run](https://github.com/chaosGuppy/rumil/actions/runs/24940234108/job/73032783377)) succeeded at the helm step but `kubectl rollout status --timeout=120s` gave up before the new pod went Ready.
- The API startup probe is configured for up to ~300s (`periodSeconds: 10` × `failureThreshold: 30`), so 120s was always going to be tight — and now that the API image bundles `versus` + `langfuse` + `opentelemetry`, cold-start import time pushes us over the edge.
- Match the rollout-status timeout to the probe budget.

## Test plan
- [ ] Next deploy on main succeeds end-to-end (no rollout-status timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)