### PR TITLE
Simplify remote-run setup with sops-backed env sync

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,12 +10,12 @@ SUPABASE_PROD_KEY=
 
 # --- Optional: required for `--executor prod` (run orchestrator as a k8s Job) ---
 # SUPABASE_JWT_SECRET: HS256 secret used to mint short-lived CLI tokens that
-# the API verifies via Depends(get_current_user). Same secret as in the
-# cluster's rumil-api-secrets. Required to submit remote jobs.
+# the API verifies via Depends(get_current_user). Must match the cluster's
+# rumil-api-secrets. Populated automatically by `scripts/sync-prod-env.sh`.
 # SUPABASE_JWT_SECRET=
-# RUMIL_API_URL: where the laptop CLI POSTs to launch a Job. Default is the
-# deployed prod API; override only for staging or self-hosted instances.
-# RUMIL_API_URL=https://api.rumil.ink
+# RUMIL_API_URL: where the laptop CLI POSTs to launch a Job. Override only
+# for staging or self-hosted instances.
+RUMIL_API_URL=https://api.rumil.ink
 # DEFAULT_CLI_USER_ID: optional override. By default the CLI authenticates
 # as the shared service-account user baked into Settings; set this to
 # attribute remote runs to a specific Supabase user instead.

--- a/README.md
+++ b/README.md
@@ -293,21 +293,27 @@ Constraints:
 - `--db local --executor prod` is rejected — the cluster cannot reach a
   local Supabase.
 
-One-time setup on your laptop, in `.env` or `.env.local`:
+One-time setup on your laptop:
 
 ```bash
-# Where the rumil API lives. Defaults to https://api.rumil.ink and only
-# needs to be set if you're targeting a different deployment.
-RUMIL_API_URL=https://api.rumil.ink
+./scripts/sync-prod-env.sh
+```
 
-# Supabase HS256 secret used to mint short-lived CLI tokens. Same value as
-# the cluster's rumil-api-secrets — get it from the prod env you already
-# have, or ask in #infra.
-SUPABASE_JWT_SECRET=...
+This decrypts `deploy/chart/secrets.enc.yaml` via SOPS and merges the
+prod-only values (`SUPABASE_JWT_SECRET`, `SUPABASE_PROD_KEY`,
+`SUPABASE_PROD_URL`, `RUMIL_API_URL`) into your `.env` in place. The
+decrypted secrets are streamed in memory only — no plaintext file is
+written to disk. Re-run any time the upstream secrets rotate.
 
-# Optional: override the shared CLI service-account user (default lives in
-# Settings). Set to your own Supabase user_id to attribute jobs to yourself.
-# DEFAULT_CLI_USER_ID=...
+Prerequisites are the SOPS onboarding steps in
+[deploy/README.md](deploy/README.md) (`brew install sops`,
+`gcloud auth application-default login`, KMS-key access).
+
+To attribute remote runs to your own Supabase user instead of the shared
+service account, also set in `.env`:
+
+```bash
+# DEFAULT_CLI_USER_ID=<your supabase user_id>
 ```
 
 Then:

--- a/scripts/sync-prod-env.sh
+++ b/scripts/sync-prod-env.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Decrypt prod secrets via SOPS and write the prod-only ones into .env.
+#
+# Run this once after onboarding to enable `--executor prod` / `--prod`
+# orchestrator runs. Re-run any time the upstream secrets rotate.
+#
+# Plaintext never touches disk: the decrypted output is piped from `sops`
+# straight into a python helper that merges the relevant keys into .env
+# in memory and writes the result atomically.
+#
+# Prerequisites: `brew install sops` and `gcloud auth application-default login`
+# with access to the rumil KMS key (see deploy/README.md).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SECRETS_FILE="$REPO_ROOT/deploy/chart/secrets.enc.yaml"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
+
+# Vars whose values must match prod (not per-developer credentials).
+PROD_SECRET_KEYS=(SUPABASE_JWT_SECRET SUPABASE_PROD_KEY)
+
+# Non-secret prod values written verbatim (KEY=VALUE pairs).
+PROD_PLAIN_VALUES=(
+    "SUPABASE_PROD_URL=https://aesjaehibxrzearctiqp.supabase.co"
+    "RUMIL_API_URL=https://api.rumil.ink"
+)
+
+if ! command -v sops >/dev/null 2>&1; then
+    echo "error: sops not installed. Install with: brew install sops" >&2
+    exit 1
+fi
+if [[ ! -f "$SECRETS_FILE" ]]; then
+    echo "error: $SECRETS_FILE not found" >&2
+    exit 1
+fi
+
+# Resolve symlinks so we update the real .env file (in some worktrees .env is
+# symlinked to a shared location).
+ENV_TARGET="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$ENV_FILE")"
+mkdir -p "$(dirname "$ENV_TARGET")"
+[[ -e "$ENV_TARGET" ]] || : > "$ENV_TARGET"
+chmod 600 "$ENV_TARGET" 2>/dev/null || true
+
+sops decrypt --output-type json "$SECRETS_FILE" | python3 - \
+    "$ENV_TARGET" \
+    "${#PROD_SECRET_KEYS[@]}" "${PROD_SECRET_KEYS[@]}" \
+    "${PROD_PLAIN_VALUES[@]}" <<'PY'
+import json
+import os
+import sys
+import tempfile
+
+env_path = sys.argv[1]
+n_secret_keys = int(sys.argv[2])
+secret_keys = sys.argv[3 : 3 + n_secret_keys]
+plain_pairs = sys.argv[3 + n_secret_keys :]
+
+decrypted = json.load(sys.stdin) or {}
+api = (decrypted.get("secrets") or {}).get("api") or {}
+missing = [k for k in secret_keys if not api.get(k)]
+if missing:
+    print(f"error: missing keys in decrypted secrets: {missing}", file=sys.stderr)
+    sys.exit(1)
+
+values: dict[str, str] = {k: str(api[k]) for k in secret_keys}
+for pair in plain_pairs:
+    name, _, val = pair.partition("=")
+    values[name] = val
+
+with open(env_path, encoding="utf-8") as fh:
+    lines = fh.readlines()
+
+written: set[str] = set()
+out: list[str] = []
+for line in lines:
+    stripped = line.lstrip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        out.append(line)
+        continue
+    name = stripped.split("=", 1)[0].strip()
+    if name in values:
+        out.append(f"{name}={values[name]}\n")
+        written.add(name)
+    else:
+        out.append(line)
+
+remaining = [k for k in values if k not in written]
+if remaining:
+    if out and not out[-1].endswith("\n"):
+        out.append("\n")
+    for k in remaining:
+        out.append(f"{k}={values[k]}\n")
+
+dir_ = os.path.dirname(os.path.abspath(env_path)) or "."
+fd, tmp = tempfile.mkstemp(prefix=".env.", dir=dir_)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.writelines(out)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, env_path)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except FileNotFoundError:
+        pass
+    raise
+
+print(f"wrote {len(values)} prod var(s) to {env_path}: {', '.join(values)}")
+PY

--- a/scripts/sync-prod-env.sh
+++ b/scripts/sync-prod-env.sh
@@ -41,10 +41,7 @@ mkdir -p "$(dirname "$ENV_TARGET")"
 [[ -e "$ENV_TARGET" ]] || : > "$ENV_TARGET"
 chmod 600 "$ENV_TARGET" 2>/dev/null || true
 
-sops decrypt --output-type json "$SECRETS_FILE" | python3 - \
-    "$ENV_TARGET" \
-    "${#PROD_SECRET_KEYS[@]}" "${PROD_SECRET_KEYS[@]}" \
-    "${PROD_PLAIN_VALUES[@]}" <<'PY'
+read -r -d '' MERGE_PY <<'PY' || true
 import json
 import os
 import sys
@@ -107,3 +104,8 @@ except Exception:
 
 print(f"wrote {len(values)} prod var(s) to {env_path}: {', '.join(values)}")
 PY
+
+sops decrypt --output-type json "$SECRETS_FILE" | python3 -c "$MERGE_PY" \
+    "$ENV_TARGET" \
+    "${#PROD_SECRET_KEYS[@]}" "${PROD_SECRET_KEYS[@]}" \
+    "${PROD_PLAIN_VALUES[@]}"


### PR DESCRIPTION
## Summary

- Adds `scripts/sync-prod-env.sh`: decrypts `deploy/chart/secrets.enc.yaml` with SOPS and merges the prod-only env vars (`SUPABASE_JWT_SECRET`, `SUPABASE_PROD_KEY`, plus the non-secret `SUPABASE_PROD_URL` and `RUMIL_API_URL`) into `.env` atomically. Plaintext is streamed in memory only — no decrypted file is written to disk.
- Updates `.env.template` to uncomment `RUMIL_API_URL=https://api.rumil.ink` and points the `SUPABASE_JWT_SECRET` comment at the new script instead of the dead "ask in #infra" line.
- Updates the README's "Run on Kubernetes" section to recommend `./scripts/sync-prod-env.sh` for one-time setup, with a pointer to the SOPS onboarding steps in `deploy/README.md`.

## Test plan

- [x] `./scripts/sync-prod-env.sh` decrypts via SOPS and writes the four prod vars into `.env`, overwriting any existing values for those keys and leaving everything else untouched.
- [x] Re-running the script is idempotent (no duplicate lines, values match).
- [x] After running, `uv run python main.py "is the sky blue" --budget 1 --smoke-test --workspace k8s-smoke --prod` submits a remote orchestrator run and prints a Cloud Logging URL.
- [ ] `.env` ends up with mode 0600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)