### PR TITLE
fix(frontend): bypass Supabase client in serverFetch when AUTH_ENABLED=0

### DIFF
--- a/frontend/src/lib/api-base.ts
+++ b/frontend/src/lib/api-base.ts
@@ -2,10 +2,15 @@ import { createClient } from "@/lib/supabase/server";
 
 export const API_BASE = process.env.API_BASE_URL || "http://localhost:8000";
 
+const AUTH_DISABLED =
+  process.env.AUTH_ENABLED === "0" || process.env.AUTH_ENABLED === "false";
+
 export async function serverFetch(
   url: string,
   init?: RequestInit,
 ): Promise<Response> {
+  if (AUTH_DISABLED) return fetch(url, init);
+
   const supabase = await createClient();
   const {
     data: { session },


### PR DESCRIPTION
## Summary
- `serverFetch` runs on every server-rendered page and always constructed a Supabase server client to attach a JWT, so `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` were de-facto required even with the local `AUTH_ENABLED=0` escape hatch.
- Mirror the short-circuit already used in `middleware.ts` and `current-user.ts` so those env vars are truly only needed when exercising the real auth flow — matching what `frontend/.env.template` already documents.

## Test plan
- [x] Unset `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY`, set `AUTH_ENABLED=0` on both backend and frontend, run the app and confirm SSR pages (`/`, `/traces/[runId]`, `/ab-evals`) load without Supabase env errors.
- [ ] With `AUTH_ENABLED` unset/`1` and the Supabase vars filled in, confirm the real auth flow still attaches the JWT to `/api/*` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)