### PR TITLE
fix(auth): attach JWT to every frontend API call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ CLAUDE.local.md
 .workmux.yaml
 .workmux-offset
 scripts/workmux-offset.sh
+scripts/write-worktree-env.sh
 
 # macOS
 .DS_Store

--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -6,7 +6,7 @@ import type { PageDetailOut, LinkedPageOut, Page, RunSummaryOut } from "@/api";
 import LinksContainer from "./links-container";
 import StagedBanner from "@/components/staged-banner";
 
-import { API_BASE } from "@/lib/api-base";
+import { API_BASE, serverFetch } from "@/lib/api-base";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { isAdmin as getIsAdmin } from "@/lib/current-user";
 import { fetchProjectName } from "@/lib/fetch-project-name";
@@ -71,7 +71,7 @@ async function getPageDetail(
   pageId: string,
   stagedRunId?: string,
 ): Promise<PageDetailOut | null> {
-  const res = await fetch(
+  const res = await serverFetch(
     withStagedRun(`${API_BASE}/api/pages/${pageId}/detail`, stagedRunId),
     { cache: "no-store" },
   );
@@ -83,7 +83,7 @@ async function getPageHeadline(
   pageId: string,
   stagedRunId?: string,
 ): Promise<{ headline: string; page_type: string } | null> {
-  const res = await fetch(
+  const res = await serverFetch(
     withStagedRun(`${API_BASE}/api/pages/${pageId}/detail`, stagedRunId),
     { cache: "no-store" },
   );
@@ -124,7 +124,7 @@ async function buildCitationMap(
   if (missing.length > 0) {
     const results = await Promise.all(
       missing.map(async (shortId) => {
-        const res = await fetch(
+        const res = await serverFetch(
           withStagedRun(`${API_BASE}/api/pages/short/${shortId}`, stagedRunId),
           { cache: "no-store" },
         );
@@ -169,7 +169,7 @@ async function getPageRun(
   pageId: string,
   stagedRunId?: string,
 ): Promise<RunSummaryOut | null> {
-  const res = await fetch(
+  const res = await serverFetch(
     withStagedRun(`${API_BASE}/api/pages/${pageId}/run`, stagedRunId),
     { cache: "no-store" },
   );

--- a/frontend/src/app/pages/[pageId]/stats/page.tsx
+++ b/frontend/src/app/pages/[pageId]/stats/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import type { PageDetailOut, QuestionStatsOut, Project } from "@/api";
 
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
+import { clientFetch } from "@/lib/client-fetch";
 import StagedBanner from "@/components/staged-banner";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { StatsView } from "@/components/stats-view";
@@ -47,7 +48,7 @@ export default function QuestionStatsPage() {
     let cancelled = false;
     async function load() {
       try {
-        const detailRes = await fetch(
+        const detailRes = await clientFetch(
           withStagedRun(`${API_BASE}/api/pages/${pageId}/detail`, stagedRunId),
           { cache: "no-store" },
         );
@@ -69,7 +70,7 @@ export default function QuestionStatsPage() {
           return;
         }
 
-        const statsRes = await fetch(
+        const statsRes = await clientFetch(
           withStagedRun(`${API_BASE}/api/pages/${pageId}/stats`, stagedRunId),
           { cache: "no-store" },
         );
@@ -96,7 +97,7 @@ export default function QuestionStatsPage() {
 
   useEffect(() => {
     if (!projectId) return;
-    fetch(`${API_BASE}/api/projects/${projectId}`, { cache: "no-store" })
+    clientFetch(`${API_BASE}/api/projects/${projectId}`, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : null))
       .then((d: Project | null) => {
         if (d) setProjectName(d.name);

--- a/frontend/src/app/projects/[projectId]/page.tsx
+++ b/frontend/src/app/projects/[projectId]/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import type { Page, PageType, PaginatedPagesOut, Project, RunListItemOut } from "@/api";
 
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
+import { clientFetch } from "@/lib/client-fetch";
 import { useStagedRun } from "@/lib/staged-run-context";
 import { withStagedRun } from "@/lib/staged-run-href";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
@@ -114,7 +115,7 @@ export default function PagesIndexPage() {
   }, []);
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/projects/${projectId}`, { cache: "no-store" })
+    clientFetch(`${API_BASE}/api/projects/${projectId}`, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : null))
       .then((data: Project | null) => {
         if (data) setProjectName(data.name);
@@ -132,7 +133,7 @@ export default function PagesIndexPage() {
     params.set("limit", String(PAGE_SIZE));
     const qs = params.toString();
     const url = `${API_BASE}/api/projects/${projectId}/pages?${qs}`;
-    fetch(url, { cache: "no-store" })
+    clientFetch(url, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : { items: [], total_count: 0, offset: 0, limit: PAGE_SIZE }))
       .then((data: PaginatedPagesOut) => {
         setPages(data.items);
@@ -146,7 +147,7 @@ export default function PagesIndexPage() {
       setRuns([]);
       return;
     }
-    fetch(`${API_BASE}/api/projects/${projectId}/runs`, {
+    clientFetch(`${API_BASE}/api/projects/${projectId}/runs`, {
       cache: "no-store",
     })
       .then((res) => (res.ok ? res.json() : []))

--- a/frontend/src/app/projects/[projectId]/stats/page.tsx
+++ b/frontend/src/app/projects/[projectId]/stats/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import type { ProjectStatsOut, Project } from "@/api";
 
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
+import { clientFetch } from "@/lib/client-fetch";
 import StagedBanner from "@/components/staged-banner";
 import { WorkspaceIndicator } from "@/components/workspace-indicator";
 import { StatsView } from "@/components/stats-view";
@@ -26,7 +27,7 @@ export default function ProjectStatsPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/projects/${projectId}`, { cache: "no-store" })
+    clientFetch(`${API_BASE}/api/projects/${projectId}`, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : null))
       .then((d: Project | null) => {
         if (d) setProjectName(d.name);
@@ -36,7 +37,7 @@ export default function ProjectStatsPage() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    fetch(withStagedRun(`${API_BASE}/api/projects/${projectId}/stats`, stagedRunId), {
+    clientFetch(withStagedRun(`${API_BASE}/api/projects/${projectId}/stats`, stagedRunId), {
       cache: "no-store",
     })
       .then(async (res) => {

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -13,6 +13,7 @@ import type {
   PageRef,
 } from "@/api/types.gen";
 import { CLIENT_API_BASE as QUERY_API_BASE } from "@/api-config";
+import { clientFetch } from "@/lib/client-fetch";
 import { useStagedRun } from "@/lib/staged-run-context";
 import { withStagedRun } from "@/lib/staged-run-href";
 import { traceKeys } from "@/lib/queries";
@@ -27,7 +28,7 @@ export type TreeNode = {
 };
 
 async function fetchCallEvents(callId: string): Promise<TraceEvent[]> {
-  const res = await fetch(`${QUERY_API_BASE}/api/calls/${callId}/events`);
+  const res = await clientFetch(`${QUERY_API_BASE}/api/calls/${callId}/events`);
   if (!res.ok) throw new Error(`Failed to fetch events: ${res.status}`);
   return res.json();
 }
@@ -859,7 +860,7 @@ const EventSection = memo(function EventSection({ event }: { event: TraceEvent }
     }
     setExchangeLoading(true);
     try {
-      const res = await fetch(
+      const res = await clientFetch(
         `${API_BASE}/api/llm-exchanges/${event.exchange_id}`,
       );
       if (res.ok) {

--- a/frontend/src/app/traces/[runId]/page-load-stats.tsx
+++ b/frontend/src/app/traces/[runId]/page-load-stats.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { PageLoadStatsOut, PageLoadEventOut } from "@/api/types.gen";
 import { CLIENT_API_BASE } from "@/api-config";
+import { clientFetch } from "@/lib/client-fetch";
 
 const DETAIL_ORDER = ["content", "abstract", "headline"];
 
@@ -102,7 +103,7 @@ export function PageLoadStats({ runId }: { runId: string }) {
   const [activeTags, setActiveTags] = useState<string[]>(["call_type"]);
 
   useEffect(() => {
-    fetch(`${CLIENT_API_BASE}/api/runs/${runId}/page-load-stats`)
+    clientFetch(`${CLIENT_API_BASE}/api/runs/${runId}/page-load-stats`)
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then(setStats)
       .catch(() => setError(true));

--- a/frontend/src/lib/client-fetch.ts
+++ b/frontend/src/lib/client-fetch.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+
+export async function clientFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const supabase = createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const headers = new Headers(init?.headers);
+  if (session?.access_token) {
+    headers.set("Authorization", `Bearer ${session.access_token}`);
+  }
+  return fetch(url, { ...init, headers });
+}

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 import type { RunTraceTreeOut, RealtimeConfigOut } from "@/api/types.gen";
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
+import { clientFetch } from "@/lib/client-fetch";
 
 export const traceKeys = {
   all: ["traces"] as const,
@@ -13,14 +14,14 @@ export const realtimeKeys = {
 };
 
 async function fetchRunTraceTree(runId: string): Promise<RunTraceTreeOut> {
-  const res = await fetch(`${API_BASE}/api/runs/${runId}/trace-tree`);
+  const res = await clientFetch(`${API_BASE}/api/runs/${runId}/trace-tree`);
   if (!res.ok) throw new Error(`Failed to fetch trace tree: ${res.status}`);
   return res.json();
 }
 
 async function fetchRealtimeConfig(): Promise<RealtimeConfigOut | null> {
   try {
-    const res = await fetch(`${API_BASE}/api/realtime/config`);
+    const res = await clientFetch(`${API_BASE}/api/realtime/config`);
     if (!res.ok) return null;
     return res.json();
   } catch {

--- a/frontend/src/lib/use-current-user.ts
+++ b/frontend/src/lib/use-current-user.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { AuthUserOut } from "@/api";
 import { CLIENT_API_BASE as API_BASE } from "@/api-config";
+import { clientFetch } from "@/lib/client-fetch";
 
 const ANONYMOUS: AuthUserOut = { user_id: "", email: "", is_admin: false };
 
@@ -10,7 +11,7 @@ export function useCurrentUser(): AuthUserOut | null {
   const [user, setUser] = useState<AuthUserOut | null>(null);
   useEffect(() => {
     let cancelled = false;
-    fetch(`${API_BASE}/api/auth/me`, { cache: "no-store" })
+    clientFetch(`${API_BASE}/api/auth/me`, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : ANONYMOUS))
       .then((data: AuthUserOut) => {
         if (!cancelled) setUser(data);

--- a/scripts/dev-api.sh
+++ b/scripts/dev-api.sh
@@ -26,11 +26,5 @@ for env_file in "$PROJECT_ROOT/frontend/.env.overrides" "$PROJECT_ROOT/frontend/
     done
 done
 
-FRONTEND_PORT=$((PORT - 5000))
-if [[ -z "${RUMIL_ALLOWED_ORIGINS:-}" ]]; then
-    export RUMIL_ALLOWED_ORIGINS="http://localhost:${FRONTEND_PORT},http://127.0.0.1:${FRONTEND_PORT}"
-fi
-
 echo "Starting API server on port $PORT${SOURCE:+ (from $SOURCE)}"
-echo "Allowed CORS origins: $RUMIL_ALLOWED_ORIGINS"
 exec uv run uvicorn rumil.api.app:app --reload --port "$PORT"

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -62,21 +62,12 @@ app = FastAPI(
     ),
 )
 
-_ALLOWED_FRONTEND_ORIGINS = [
-    o.strip()
-    for o in os.environ.get(
-        "RUMIL_ALLOWED_ORIGINS",
-        "http://localhost:3000,http://127.0.0.1:3000,http://localhost:3012,http://localhost:3013",
-    ).split(",")
-    if o.strip()
-]
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=_ALLOWED_FRONTEND_ORIGINS,
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type"],
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(jobs_router)


### PR DESCRIPTION
## Summary

- The page-detail server component and several client components were calling the API with raw `fetch()`. Once the API was gated behind the auth dependency in #379, every one of those calls returned 401 in prod — the page-detail page rendered as "Page not found", project pages stayed empty, etc.
- Server components now go through `serverFetch` (which reads the session cookie and adds `Authorization: Bearer ...`). Client components go through a new symmetric `clientFetch` helper that pulls the access token from the browser-side Supabase client.
- CORS handling is simplified to `allow_origins=["*"]` + `allow_credentials=False`. Safe because the API authenticates via bearer tokens (no cookies, no `credentials: "include"` anywhere); this drops the per-worktree `RUMIL_ALLOWED_ORIGINS` derivation in `dev-api.sh`.
- Worktree port math is consolidated into `scripts/write-worktree-env.sh` — single source of truth that derives api/frontend/supabase ports from the offset and writes both `.env.overrides` files.

## Test plan

- [x] Reproduce the bug locally with `AUTH_ENABLED=1`: `/projects/<id>` shows 401s in DevTools, `/pages/<id>` renders 404
- [x] After fix: project page loads cleanly, page detail renders content, no 401s in Network tab
- [x] `npx tsc --noEmit` passes for `frontend/`
- [ ] Smoke test in deployed prod once merged

## Follow-up

Remove `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:56721` from the tracked `frontend/.env` in a separate change — it's a stale hardcode that no worktree actually uses, and overrides should be the only source for this var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)