### PR TITLE
feat(admin): sync admins from GCP project IAM

### DIFF
--- a/scripts/grant_admin.py
+++ b/scripts/grant_admin.py
@@ -9,12 +9,15 @@ email and writes via the service-role-keyed DB client.
     uv run python scripts/grant_admin.py --email x@y.z --prod
     uv run python scripts/grant_admin.py --email x@y.z --revoke
     uv run python scripts/grant_admin.py --list --prod
+    uv run python scripts/grant_admin.py --sync-gcp --gcp-project my-proj --prod
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import json
+import subprocess
 import sys
 import uuid
 
@@ -41,6 +44,55 @@ async def _do_revoke(db: DB, email: str) -> int:
     return 0
 
 
+def _gcp_user_emails(project: str) -> list[str]:
+    """Return unique `user:` member emails from the GCP project IAM policy.
+
+    Service accounts (`serviceAccount:`), groups, and domains are excluded.
+    """
+    result = subprocess.run(
+        ["gcloud", "projects", "get-iam-policy", project, "--format=json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    policy = json.loads(result.stdout)
+    emails: set[str] = set()
+    for binding in policy.get("bindings", []):
+        for member in binding.get("members", []):
+            if member.startswith("user:"):
+                emails.add(member[len("user:") :].strip().lower())
+    return sorted(emails)
+
+
+async def _do_sync_gcp(db: DB, project: str, note: str | None, dry_run: bool) -> int:
+    emails = _gcp_user_emails(project)
+    if not emails:
+        print(f"No user: principals found in GCP project {project!r}", file=sys.stderr)
+        return 1
+    print(f"Found {len(emails)} non-service-account principal(s) in {project}:")
+    for e in emails:
+        print(f"  - {e}")
+    if dry_run:
+        print("(dry-run — no changes made)")
+        return 0
+    granted = 0
+    missing: list[str] = []
+    for email in emails:
+        user_id = await db.find_auth_user_id_by_email(email)
+        if not user_id:
+            missing.append(email)
+            continue
+        await db.grant_admin(user_id, note=note)
+        print(f"Granted admin to {email} ({user_id})")
+        granted += 1
+    print(f"\nGranted admin to {granted}/{len(emails)} user(s).")
+    if missing:
+        print(f"Skipped {len(missing)} (no matching Supabase auth user):", file=sys.stderr)
+        for email in missing:
+            print(f"  - {email}", file=sys.stderr)
+    return 0
+
+
 async def _do_list(db: DB) -> int:
     rows = await db.list_admin_users()
     if not rows:
@@ -58,17 +110,32 @@ async def _main() -> int:
     parser.add_argument("--email", help="user's email in Supabase Auth")
     parser.add_argument("--revoke", action="store_true", help="remove admin")
     parser.add_argument("--list", action="store_true", help="list current admins")
+    parser.add_argument(
+        "--sync-gcp",
+        action="store_true",
+        help="grant admin to all user: principals in --gcp-project's IAM policy",
+    )
+    parser.add_argument("--gcp-project", help="GCP project id to read IAM policy from")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="with --sync-gcp, list candidate users without granting",
+    )
     parser.add_argument("--note", help="optional note attached to the grant")
     parser.add_argument("--prod", action="store_true", help="target the prod database")
     args = parser.parse_args()
 
-    if not args.list and not args.email:
-        parser.error("either --email or --list is required")
+    if not args.list and not args.email and not args.sync_gcp:
+        parser.error("one of --email, --list, or --sync-gcp is required")
+    if args.sync_gcp and not args.gcp_project:
+        parser.error("--sync-gcp requires --gcp-project")
 
     db = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod)
     try:
         if args.list:
             return await _do_list(db)
+        if args.sync_gcp:
+            return await _do_sync_gcp(db, args.gcp_project, args.note, args.dry_run)
         if args.revoke:
             return await _do_revoke(db, args.email)
         return await _do_grant(db, args.email, args.note)


### PR DESCRIPTION
## Summary
- Add a `--sync-gcp` mode to `scripts/grant_admin.py` that reads a GCP project's IAM policy via `gcloud` and grants app admin to every `user:` principal, skipping service accounts (and groups/domains).
- Supports `--dry-run` to preview the candidate list without writing.
- Users without a matching Supabase auth row are skipped and reported on stderr (they need to log in once first).

Usage:
```
uv run python scripts/grant_admin.py --sync-gcp \
  --gcp-project project-fe559f0f-d011-4af4-bf0 --prod
```

## Test plan
- [x] `--dry-run` against the prod GCP project lists the 6 expected `user:` principals and zero service accounts
- [x] Real run grants admin to those 6 users and reports any missing-from-auth skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)