### PR TITLE
feat(jobs): support --continue on remote k8s orchestrator runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,10 @@ fire-and-forget from the laptop's perspective.
 
 Constraints:
 
-- `--executor prod` is only supported for orchestrator runs (a question with
-  `--budget`). For `--list`, `--summary`, `--continue`, etc., use
-  `--db prod` (or `--db prod --executor local`).
+- `--executor prod` is only supported for orchestrator runs — either a
+  question with `--budget`, or `--continue QUESTION_ID --budget`. For
+  `--list`, `--summary`, etc., use `--db prod` (or `--db prod --executor
+  local`).
 - `--db local --executor prod` is rejected — the cluster cannot reach a
   local Supabase.
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -4379,9 +4379,28 @@
       "OrchestratorRunRequest": {
         "properties": {
           "question": {
-            "type": "string",
-            "minLength": 1,
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Question"
+          },
+          "continue_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Continue Id"
           },
           "budget": {
             "type": "integer",
@@ -4498,12 +4517,11 @@
         },
         "type": "object",
         "required": [
-          "question",
           "budget",
           "workspace"
         ],
         "title": "OrchestratorRunRequest",
-        "description": "Inputs for a remote orchestrator run.\n\nMirrors the subset of `main.py` flags that are forwarded into the\nin-pod CLI invocation. Flags that only make sense on the laptop\n(--db, --executor, --staged, --env-file, --run-id-file, --cli-user-id)\nare intentionally absent \u2014 the in-pod run is always `--db prod\n--executor local`."
+        "description": "Inputs for a remote orchestrator run.\n\nMirrors the subset of `main.py` flags that are forwarded into the\nin-pod CLI invocation. Flags that only make sense on the laptop\n(--db, --executor, --staged, --env-file, --run-id-file, --cli-user-id)\nare intentionally absent \u2014 the in-pod run is always `--db prod\n--executor local`.\n\nExactly one of `question` (start a new investigation) or\n`continue_id` (resume an existing question by ID) must be set."
       },
       "OrchestratorRunResponse": {
         "properties": {

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1236,12 +1236,19 @@ export type MovesExecutedEventOut = {
  * (--db, --executor, --staged, --env-file, --run-id-file, --cli-user-id)
  * are intentionally absent — the in-pod run is always `--db prod
  * --executor local`.
+ *
+ * Exactly one of `question` (start a new investigation) or
+ * `continue_id` (resume an existing question by ID) must be set.
  */
 export type OrchestratorRunRequest = {
     /**
      * Question
      */
-    question: string;
+    question?: string | null;
+    /**
+     * Continue Id
+     */
+    continue_id?: string | null;
     /**
      * Budget
      */

--- a/main.py
+++ b/main.py
@@ -132,7 +132,6 @@ _NON_ORCHESTRATOR_FLAGS: tuple[str, ...] = (
     "report_id",
     "scan_memos_id",
     "draft_memos_path",
-    "continue_id",
     "batch_file",
     "run_eval_id",
     "ab_eval_ids",
@@ -1491,10 +1490,11 @@ async def async_main():
         get_settings().force_twophase_recurse = True
 
     if executor_choice == "prod":
-        if not args.question or _is_non_orchestrator_mode(args):
+        if (not args.question and not args.continue_id) or _is_non_orchestrator_mode(args):
             parser.error(
-                "--executor prod is only supported for orchestrator runs (a question with "
-                "--budget). For other modes, omit --executor or use --executor local."
+                "--executor prod is only supported for orchestrator runs (a question or "
+                "--continue, with --budget). For other modes, omit --executor or use "
+                "--executor local."
             )
         args.budget = _default_budget(args.budget)
         sys.exit(submit_remote_orchestrator_run(args))

--- a/src/rumil/api/jobs.py
+++ b/src/rumil/api/jobs.py
@@ -15,6 +15,7 @@ of a valid Supabase JWT (FE-issued or CLI-minted) can submit and view.
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Sequence
 from typing import cast
 
@@ -23,6 +24,7 @@ from kubernetes import client
 from kubernetes.client.exceptions import ApiException
 
 from rumil.api.auth import AuthUser, get_current_user
+from rumil.database import DB
 from rumil.k8s import OrchestratorRunRequest, OrchestratorRunResponse
 from rumil.k8s.submit import (
     JOB_ANNOTATION_QUESTION,
@@ -56,12 +58,15 @@ def _build_trace_url(run_id: str) -> str:
     response_model=OrchestratorRunResponse,
     status_code=201,
 )
-def create_orchestrator_run(
+async def create_orchestrator_run(
     body: OrchestratorRunRequest,
     user: AuthUser = Depends(get_current_user),
 ) -> OrchestratorRunResponse:
+    annotation = await _resolve_question_annotation(body)
     try:
-        job_name, run_id = submit_orchestrator_job(body, owner_user_id=user.user_id)
+        job_name, run_id = submit_orchestrator_job(
+            body, owner_user_id=user.user_id, question_annotation=annotation
+        )
     except Exception as exc:
         log.exception("orchestrator job submission failed")
         raise HTTPException(status_code=500, detail="failed to submit orchestrator job") from exc
@@ -71,6 +76,23 @@ def create_orchestrator_run(
         logs_url=build_logs_url(job_name),
         trace_url=_build_trace_url(run_id),
     )
+
+
+async def _resolve_question_annotation(body: OrchestratorRunRequest) -> str | None:
+    """For continue runs, look up the question's headline so /jobs shows it
+    instead of just the bare ID. Returns None for new-question runs (the
+    submitter falls back to the user-typed question text)."""
+    if not body.continue_id:
+        return None
+    db = await DB.create(run_id=str(uuid.uuid4()), prod=get_settings().is_prod_db)
+    try:
+        page = await db.get_page(body.continue_id)
+    except Exception:
+        log.warning("failed to resolve continue_id headline for /jobs label", exc_info=True)
+        return None
+    finally:
+        await db.close()
+    return page.headline if page and page.headline else None
 
 
 @router.get("", response_model=list[JobListItem])

--- a/src/rumil/cli_client.py
+++ b/src/rumil/cli_client.py
@@ -56,6 +56,7 @@ def mint_cli_jwt(*, user_id: str, secret: str, ttl_s: int = _DEFAULT_JWT_TTL_S) 
 
 def _request_from_args(args: argparse.Namespace) -> OrchestratorRunRequest:
     question = args.question
+    continue_id = getattr(args, "continue_id", None)
     if isinstance(question, str) and question.endswith(".json") and Path(question).exists():
         # Structured-question file inputs aren't supported remotely yet — too
         # much new surface for v1. Users can always copy the headline text.
@@ -64,7 +65,8 @@ def _request_from_args(args: argparse.Namespace) -> OrchestratorRunRequest:
             "pass the question as a plain string."
         )
     return OrchestratorRunRequest(
-        question=question,
+        question=question or None,
+        continue_id=continue_id or None,
         budget=args.budget,
         workspace=args.workspace_name,
         smoke_test=bool(getattr(args, "smoke_test", False)),

--- a/src/rumil/k8s/submit.py
+++ b/src/rumil/k8s/submit.py
@@ -136,10 +136,14 @@ def _job_name(spec: OrchestratorRunRequest) -> str:
 
 def _build_container_command(spec: OrchestratorRunRequest, *, run_id: str) -> Sequence[str]:
     """Translate the request into the in-pod CLI invocation."""
-    args: list[str] = [
-        "python",
-        "main.py",
-        spec.question,
+    args: list[str] = ["python", "main.py"]
+    if spec.continue_id:
+        args += ["--continue", spec.continue_id]
+    else:
+        # Validated by OrchestratorRunRequest: exactly one of question/continue_id is set.
+        assert spec.question is not None
+        args.append(spec.question)
+    args += [
         "--budget",
         str(spec.budget),
         "--workspace",
@@ -178,6 +182,20 @@ def _build_container_command(spec: OrchestratorRunRequest, *, run_id: str) -> Se
     return args
 
 
+def _question_annotation(spec: OrchestratorRunRequest) -> str:
+    """Display string stored on the Job for the /jobs UI.
+
+    For new investigations, the user-typed question is the natural label.
+    For continue runs, we don't have the headline here (would require a DB
+    lookup), so a callable annotation overrider can supply a richer string;
+    by default we show the continue_id so the row is at least clickable.
+    """
+    if spec.question:
+        return spec.question
+    assert spec.continue_id is not None
+    return f"(continue) {spec.continue_id}"
+
+
 def _build_job(
     spec: OrchestratorRunRequest,
     *,
@@ -187,6 +205,7 @@ def _build_job(
     image: str,
     env: Sequence[client.V1EnvVar],
     env_from: Sequence[client.V1EnvFromSource],
+    question_annotation: str | None = None,
 ) -> dict[str, Any]:
     manifest = _load_manifest()
     manifest.setdefault("metadata", {})
@@ -204,7 +223,8 @@ def _build_job(
 
     annotations = dict(metadata.get("annotations") or {})
     annotations[JOB_ANNOTATION_WORKSPACE_NAME] = spec.workspace
-    annotations[JOB_ANNOTATION_QUESTION] = spec.question[:QUESTION_ANNOTATION_MAX_CHARS]
+    annotation_label = question_annotation or _question_annotation(spec)
+    annotations[JOB_ANNOTATION_QUESTION] = annotation_label[:QUESTION_ANNOTATION_MAX_CHARS]
     metadata["annotations"] = annotations
 
     spec_block: dict[str, Any] = manifest["spec"]
@@ -231,12 +251,21 @@ def _env_from_to_dict(e: client.V1EnvFromSource) -> dict[str, Any]:
     return cast(dict[str, Any], client.ApiClient().sanitize_for_serialization(e))
 
 
-def submit_orchestrator_job(spec: OrchestratorRunRequest, *, owner_user_id: str) -> tuple[str, str]:
+def submit_orchestrator_job(
+    spec: OrchestratorRunRequest,
+    *,
+    owner_user_id: str,
+    question_annotation: str | None = None,
+) -> tuple[str, str]:
     """Create the Job and return (job_name, run_id). Raises on k8s API errors.
 
     The run_id is generated here and threaded into both the Job's
     `rumil.ink/run-id` label and the in-pod CLI's `--run-id` flag, so
     callers know the trace URL the moment the Job is submitted.
+
+    `question_annotation` overrides the human-readable label stamped on
+    the Job for the /jobs UI. Useful for `continue_id` runs, where the
+    caller can resolve the question's headline before submission.
     """
     batch, apps = _kube_clients()
     image, env, env_from = _read_api_runtime(apps)
@@ -252,6 +281,7 @@ def submit_orchestrator_job(spec: OrchestratorRunRequest, *, owner_user_id: str)
         image=image,
         env=env,
         env_from=env_from,
+        question_annotation=question_annotation,
     )
     batch.create_namespaced_job(namespace=NAMESPACE, body=body)
     log.info(

--- a/src/rumil/k8s/types.py
+++ b/src/rumil/k8s/types.py
@@ -7,9 +7,9 @@ without dragging server-side modules.
 """
 
 from datetime import datetime
-from typing import Literal
+from typing import Literal, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 JobStatus = Literal["pending", "running", "failed", "completed"]
 
@@ -27,9 +27,13 @@ class OrchestratorRunRequest(BaseModel):
     (--db, --executor, --staged, --env-file, --run-id-file, --cli-user-id)
     are intentionally absent — the in-pod run is always `--db prod
     --executor local`.
+
+    Exactly one of `question` (start a new investigation) or
+    `continue_id` (resume an existing question by ID) must be set.
     """
 
-    question: str = Field(min_length=1)
+    question: str | None = Field(default=None, min_length=1)
+    continue_id: str | None = Field(default=None, min_length=1)
     budget: int = Field(ge=1)
     workspace: str = Field(min_length=1)
 
@@ -56,6 +60,12 @@ class OrchestratorRunRequest(BaseModel):
     # rumil-api Deployment so a caller cannot point the Job at an arbitrary
     # registry. Used by scripts/remote_run.sh.
     container_tag: str | None = Field(default=None, pattern=_CONTAINER_TAG_PATTERN)
+
+    @model_validator(mode="after")
+    def _exactly_one_of_question_or_continue_id(self) -> Self:
+        if bool(self.question) == bool(self.continue_id):
+            raise ValueError("exactly one of `question` or `continue_id` must be set")
+        return self
 
 
 class OrchestratorRunResponse(BaseModel):

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -42,6 +42,7 @@ def test_mint_cli_jwt_rejects_missing_secret():
 def _args_namespace(**overrides) -> argparse.Namespace:
     base: dict = {
         "question": "is the sky blue?",
+        "continue_id": None,
         "budget": 1,
         "workspace_name": "ws",
         "smoke_test": False,
@@ -59,6 +60,16 @@ def _args_namespace(**overrides) -> argparse.Namespace:
     }
     base.update(overrides)
     return argparse.Namespace(**base)
+
+
+def test_request_from_args_forwards_continue_id():
+    """`--continue X --prod` must reach the API with continue_id set and no
+    question, so the in-pod CLI runs `--continue X` instead of treating
+    the ID as a positional question."""
+    args = _args_namespace(question=None, continue_id="qid-abcdef")
+    spec = _request_from_args(args)
+    assert spec.continue_id == "qid-abcdef"
+    assert spec.question is None
 
 
 def test_request_from_args_maps_field_names():

--- a/tests/test_jobs_router.py
+++ b/tests/test_jobs_router.py
@@ -83,6 +83,63 @@ async def test_post_orchestrator_run_returns_empty_logs_url_when_no_project(
 
 
 @pytest.mark.asyncio
+async def test_post_orchestrator_run_forwards_continue_id_with_resolved_headline(
+    mocker, auth_overridden_client
+):
+    """`--continue` runs reach the submitter with continue_id set, and the
+    API resolves the question's headline to use as the /jobs annotation."""
+    fake_submit = mocker.patch(
+        "rumil.api.jobs.submit_orchestrator_job",
+        return_value=("rumil-orch-ws-cont", _FAKE_RUN_ID),
+    )
+    mocker.patch("rumil.api.jobs.build_logs_url", return_value="")
+    fake_db = mocker.MagicMock()
+
+    async def fake_get_page(_):
+        page = mocker.MagicMock()
+        page.headline = "Why is the sky blue?"
+        return page
+
+    fake_db.get_page = fake_get_page
+
+    async def fake_close():
+        return None
+
+    fake_db.close = fake_close
+
+    async def fake_create(**_):
+        return fake_db
+
+    mocker.patch("rumil.api.jobs.DB.create", side_effect=fake_create)
+
+    body = {"continue_id": "qid-abcdef", "budget": 4, "workspace": "ws"}
+    resp = await auth_overridden_client.post("/api/jobs/orchestrator-runs", json=body)
+    assert resp.status_code == 201
+
+    fake_submit.assert_called_once()
+    _, kwargs = fake_submit.call_args
+    assert kwargs["question_annotation"] == "Why is the sky blue?"
+    spec_arg = fake_submit.call_args.args[0]
+    assert spec_arg.continue_id == "qid-abcdef"
+    assert spec_arg.question is None
+
+
+@pytest.mark.asyncio
+async def test_post_orchestrator_run_rejects_missing_question_and_continue_id(
+    mocker, auth_overridden_client
+):
+    """Pydantic validator: exactly one of question/continue_id must be set."""
+    mocker.patch(
+        "rumil.api.jobs.submit_orchestrator_job",
+        return_value=("should-not-be-called", _FAKE_RUN_ID),
+    )
+    resp = await auth_overridden_client.post(
+        "/api/jobs/orchestrator-runs", json={"budget": 1, "workspace": "ws"}
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_post_orchestrator_run_validates_request_body(mocker, auth_overridden_client):
     mocker.patch(
         "rumil.api.jobs.submit_orchestrator_job",

--- a/tests/test_k8s_submit.py
+++ b/tests/test_k8s_submit.py
@@ -265,6 +265,65 @@ def test_request_validation_rejects_zero_budget():
         OrchestratorRunRequest(question="q", budget=0, workspace="ws")
 
 
+def test_request_validation_rejects_neither_question_nor_continue_id():
+    with pytest.raises(ValidationError, match="exactly one of"):
+        OrchestratorRunRequest(budget=1, workspace="ws")
+
+
+def test_request_validation_rejects_both_question_and_continue_id():
+    with pytest.raises(ValidationError, match="exactly one of"):
+        OrchestratorRunRequest(question="q", continue_id="qid", budget=1, workspace="ws")
+
+
+def test_request_accepts_continue_id_alone():
+    spec = OrchestratorRunRequest(continue_id="qid", budget=1, workspace="ws")
+    assert spec.continue_id == "qid"
+    assert spec.question is None
+
+
+def test_container_command_uses_continue_flag_when_continuing():
+    spec = OrchestratorRunRequest(continue_id="qid-xyz", budget=3, workspace="ws")
+    cmd = list(_build_container_command(spec, run_id=_RUN_ID))
+    assert cmd[:2] == ["python", "main.py"]
+    assert "--continue" in cmd and cmd[cmd.index("--continue") + 1] == "qid-xyz"
+    # The positional question slot must be empty so argparse doesn't think
+    # the run_id (or any later flag) is a new question.
+    assert "qid-xyz" not in cmd[: cmd.index("--continue")]
+
+
+def test_build_job_default_annotation_for_continue_run():
+    spec = OrchestratorRunRequest(continue_id="qid-abcdef", budget=1, workspace="ws")
+    body = _build_job(
+        spec,
+        name="x",
+        owner_user_id="",
+        run_id=_RUN_ID,
+        image="img",
+        env=[],
+        env_from=[],
+    )
+    annotation = body["metadata"]["annotations"][JOB_ANNOTATION_QUESTION]
+    assert "qid-abcdef" in annotation
+    assert "continue" in annotation.lower()
+
+
+def test_build_job_uses_question_annotation_override():
+    """Caller can supply a resolved headline (e.g. from a DB lookup) to
+    override the default `(continue) <id>` placeholder."""
+    spec = OrchestratorRunRequest(continue_id="qid", budget=1, workspace="ws")
+    body = _build_job(
+        spec,
+        name="x",
+        owner_user_id="",
+        run_id=_RUN_ID,
+        image="img",
+        env=[],
+        env_from=[],
+        question_annotation="Why is the sky blue?",
+    )
+    assert body["metadata"]["annotations"][JOB_ANNOTATION_QUESTION] == "Why is the sky blue?"
+
+
 @pytest.mark.parametrize(
     "image,expected",
     [

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -131,7 +131,6 @@ def test_orchestrator_question_is_not_a_non_orchestrator_mode():
         ("add_question", "q"),
         ("summary_id", "s"),
         ("report_id", "r"),
-        ("continue_id", "c"),
         ("batch_file", "b.jsonl"),
         ("run_eval_id", "e"),
         ("ab_eval_ids", ["a", "b"]),
@@ -142,6 +141,21 @@ def test_orchestrator_question_is_not_a_non_orchestrator_mode():
 def test_each_non_orchestrator_flag_is_detected(flag, value):
     args = _make_namespace(**{flag: value})
     assert main_module._is_non_orchestrator_mode(args) is True
+
+
+def test_continue_id_is_orchestrator_mode():
+    """`--continue X --budget N` runs the orchestrator on an existing question
+    — it must NOT be classified as non-orchestrator, otherwise `--prod` would
+    silently downgrade to local."""
+    args = _make_namespace(continue_id="some-qid", budget=4)
+    assert main_module._is_non_orchestrator_mode(args) is False
+
+
+def test_prod_with_continue_resolves_to_prod_prod():
+    """Regression: `--continue X --prod` must hit the remote k8s path, not
+    silently fall back to a local run against prod Supabase."""
+    args = _make_namespace(prod_db=True, continue_id="some-qid", budget=4)
+    assert _resolve(args) == ("prod", "prod")
 
 
 def test_ingest_files_alone_is_non_orchestrator():


### PR DESCRIPTION
## Summary

- `--continue X --prod` previously silently fell back to a local run against prod Supabase, because `continue_id` was misclassified as a non-orchestrator mode (`main.py:_NON_ORCHESTRATOR_FLAGS`). With the silent downgrade gone, the request also has to be valid on the API/k8s side — so this PR wires `continue_id` through end-to-end.
- `OrchestratorRunRequest` now requires exactly one of `question` or `continue_id`. The in-pod CLI invocation becomes `python main.py --continue <id> ...` instead of a positional question.
- The API endpoint resolves the question's headline via `DB.get_page` for continue runs so `/jobs` shows real text instead of the bare ID; falls back to `(continue) <id>` if the lookup fails.

## Test plan

- [x] `uv run pytest tests/test_k8s_submit.py tests/test_cli_client.py tests/test_main_dispatch.py tests/test_jobs_router.py` — 123 passed (7 new tests).
- [x] `npx tsc --noEmit` in frontend — no new errors (pre-existing supabase/ssr errors unrelated).
- [ ] After deploy: `uv run python main.py --continue <qid> --prod --budget N --workspace ...` should print a job name + Cloud Logging URL (instead of a 422 from the old API schema or a silent local run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)