### PR TITLE
Tighten langfuse link spacing and font in trace events

### DIFF
--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -769,6 +769,20 @@
   font-size: 12px;
 }
 
+.trace-langfuse-link {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 11px;
+  margin-left: 14px;
+  color: #999;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.trace-langfuse-link:hover {
+  color: #444;
+  text-decoration: underline;
+}
+
 .trace-info-text {
   color: #4a7a8a;
   font-size: 13px;
@@ -1537,6 +1551,8 @@
   .trace-cache-pct { color: #4dd88a; }
   .trace-token-count { color: #666; }
   .trace-duration { color: #666; }
+  .trace-langfuse-link { color: #666; }
+  .trace-langfuse-link:hover { color: #bbb; }
   .trace-info-text { color: #5ba8b8; }
   .trace-warning-text { color: #d4a017; }
   .trace-error-text { color: #e55; }


### PR DESCRIPTION
## Summary
- Add a dedicated `.trace-langfuse-link` rule so the link no longer inherits the surrounding 13px `.trace-exchange-info` size — it now renders at 11px monospace, matching the duration/token chips it sits next to.
- Add 14px of left margin so there's clear separation from the timing section instead of sitting flush.
- Add a hover treatment and a dark-mode override that match the rest of the muted exchange-info row.

## Test plan
- [x] Open any trace with `llm_exchange` events that have `langfuse_trace_url` populated and confirm the Langfuse link reads as a quiet, smaller chip with breathing room from the duration.
- [ ] Toggle dark mode and confirm the link color and hover state look right against the dark background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)