### PR TITLE
refactor(views): migrate hard-coded judgement reads to View abstraction

### DIFF
--- a/src/rumil/calls/assess.py
+++ b/src/rumil/calls/assess.py
@@ -23,7 +23,7 @@ class AssessCall(CallRunner):
     def _make_context_builder(self) -> ContextBuilder:
         return EmbeddingContext(
             self.call_type,
-            require_judgement_for_questions=True,
+            require_take_for_questions=True,
         )
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -55,7 +55,7 @@ class CreateViewContext(ContextBuilder):
             query,
             infra.db,
             scope_question_id=infra.question_id,
-            require_judgement_for_questions=True,
+            require_take_for_questions=True,
         )
         working_page_ids = result.page_ids
         preloaded_ids = list(infra.call.context_page_ids or [])
@@ -125,10 +125,10 @@ class EmbeddingContext(ContextBuilder):
         self,
         call_type: CallType,
         *,
-        require_judgement_for_questions: bool = False,
+        require_take_for_questions: bool = False,
     ) -> None:
         self._call_type = call_type
-        self._require_judgement_for_questions = require_judgement_for_questions
+        self._require_take_for_questions = require_take_for_questions
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
         question = await infra.db.get_page(infra.question_id)
@@ -138,7 +138,7 @@ class EmbeddingContext(ContextBuilder):
             infra.db,
             scope_question_id=infra.question_id,
             scope_linked_detail=PageDetail.ABSTRACT,
-            require_judgement_for_questions=self._require_judgement_for_questions,
+            require_take_for_questions=self._require_take_for_questions,
         )
         working_page_ids = result.page_ids
         preloaded_ids = infra.call.context_page_ids or []
@@ -949,7 +949,7 @@ class BigAssessContext(ContextBuilder):
             scope_question_id=infra.question_id,
             scope_detail=PageDetail.CONTENT,
             scope_linked_detail=PageDetail.ABSTRACT,
-            require_judgement_for_questions=True,
+            require_take_for_questions=True,
             full_page_char_budget=settings.big_assess_full_page_char_budget,
             abstract_page_char_budget=settings.big_assess_abstract_page_char_budget,
             summary_page_char_budget=settings.big_assess_summary_page_char_budget,

--- a/src/rumil/calls/find_considerations.py
+++ b/src/rumil/calls/find_considerations.py
@@ -60,7 +60,7 @@ class FindConsiderationsCall(CallRunner):
         return 0
 
     def _make_context_builder(self) -> ContextBuilder:
-        return EmbeddingContext(self.call_type, require_judgement_for_questions=True)
+        return EmbeddingContext(self.call_type, require_take_for_questions=True)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:
         return MultiRoundLoop(

--- a/src/rumil/calls/summarize.py
+++ b/src/rumil/calls/summarize.py
@@ -25,6 +25,7 @@ from rumil.settings import get_settings
 from rumil.tracing.page_load_tracking import page_track_scope
 from rumil.tracing.trace_events import ContextBuiltEvent, ErrorEvent, PageRef
 from rumil.tracing.tracer import CallTrace, set_trace
+from rumil.views import get_active_view
 
 log = logging.getLogger(__name__)
 
@@ -34,9 +35,9 @@ TASK = (
     "Produce a summary of this question subtree with three components:\n\n"
     "CONTENT (~1000 words, shorter is fine if the material doesn't require it): "
     "A structured synthesis covering: the question, the current state of evidence "
-    "(key considerations for and against, with their epistemic weight), any judgements "
-    "rendered and their confidence levels, what the child questions contribute and their "
-    "current state, and what remains uncertain or unresolved.\n\n"
+    "(key considerations for and against, with their epistemic weight), the current take "
+    "on the question and its confidence level, what the child questions contribute and "
+    "their current state, and what remains uncertain or unresolved.\n\n"
     "HEADLINE (~30 words): Fully self-contained. State the question, the current "
     "best answer or stance, and the main caveat. Must make sense with zero prior context.\n\n"
     "ABSTRACT (~200 words): Fully self-contained. Include the core conclusion, "
@@ -105,20 +106,27 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
         )
     )
 
+    view = get_active_view()
     considerations = await db.get_considerations_for_question(question_id)
-    judgements = await db.get_judgements_for_question(question_id)
+    headline = await view.headline_page(question_id, db)
     children = await db.get_child_questions(question_id)
+    child_headlines = await view.headline_pages_many([c.id for c in children], db)
     page_refs.extend(ref(p) for p, _ in considerations)
-    page_refs.extend(ref(j) for j in judgements)
+    if headline is not None:
+        page_refs.append(ref(headline))
     page_refs.extend(ref(c) for c in children)
+    for ch in children:
+        ch_headline = child_headlines.get(ch.id)
+        if ch_headline is not None:
+            page_refs.append(ref(ch_headline))
 
     if considerations:
         index_lines = ["Index of direct pages:"]
         for page, link in considerations:
             direction = f" [{link.direction.value}]" if link.direction else ""
             index_lines.append(f"- [consideration{direction}] {page.headline}")
-        for j in judgements:
-            index_lines.append(f"- [judgement R{j.robustness}] {j.headline}")
+        if headline is not None:
+            index_lines.append(f"- [take R{headline.robustness}] {headline.headline}")
         for child in children:
             index_lines.append(f"- [child question] {child.headline}")
         parts.append(_section("Index", "\n".join(index_lines)))
@@ -138,31 +146,22 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
             cons_parts.append(f"**Consideration{direction}:**\n\n{formatted}")
         parts.append(_section("Direct Considerations (full)", "\n\n---\n\n".join(cons_parts)))
 
-    if judgements:
-        most_recent = max(judgements, key=lambda j: j.created_at)
-        formatted_j = await format_page(
-            most_recent,
-            PageDetail.CONTENT,
-            linked_detail=None,
-            db=db,
-            track=True,
-            track_tags=summary_tag,
-        )
-        parts.append(_section("Most Recent Judgement (full)", formatted_j))
-        older = [j for j in judgements if j.id != most_recent.id]
-        if older:
-            older_lines = [
-                await format_page(j, PageDetail.HEADLINE, track=True, track_tags=summary_tag)
-                for j in older
-            ]
-            parts.append(
-                _section(
-                    "Earlier Judgements (summaries)",
-                    "\n".join(f"- {line}" for line in older_lines),
-                )
-            )
+    if headline is not None:
+        formatted_take = await view.render_for_executive_summary(question_id, db)
+        if formatted_take:
+            parts.append(_section("Current Take (full)", formatted_take))
 
     if children:
+        grandchildren_by_parent: dict[str, list[Page]] = {}
+        all_grandchildren: list[Page] = []
+        for child in children:
+            gcs = await db.get_child_questions(child.id)
+            grandchildren_by_parent[child.id] = gcs
+            all_grandchildren.extend(gcs)
+        grandchild_headlines = await view.headline_pages_many(
+            [gc.id for gc in all_grandchildren], db
+        )
+
         child_parts = []
         for child in children:
             child_section_parts: list[str] = [f"**Child question:** {child.headline}"]
@@ -182,19 +181,17 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
             else:
                 child_section_parts.append("_(No summary available yet)_")
 
-            child_judgements = await db.get_judgements_for_question(child.id)
-            if child_judgements:
-                page_refs.extend(ref(j) for j in child_judgements)
-                most_recent_j = max(child_judgements, key=lambda j: j.created_at)
-                formatted_cj = await format_page(
-                    most_recent_j,
+            child_headline = child_headlines.get(child.id)
+            if child_headline is not None:
+                formatted_ch = await format_page(
+                    child_headline,
                     PageDetail.ABSTRACT,
                     linked_detail=None,
                     db=db,
                     track=True,
                     track_tags=summary_tag,
                 )
-                child_section_parts.append(f"**Judgement (medium):**\n{formatted_cj}")
+                child_section_parts.append(f"**Take (medium):**\n{formatted_ch}")
 
             child_considerations = await db.get_considerations_for_question(child.id)
             if child_considerations:
@@ -206,7 +203,7 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
                 ]
                 child_section_parts.append("**Considerations (short):**\n" + "\n".join(con_lines))
 
-            grandchildren = await db.get_child_questions(child.id)
+            grandchildren = grandchildren_by_parent.get(child.id, [])
             if grandchildren:
                 page_refs.extend(ref(gc) for gc in grandchildren)
                 gc_lines = []
@@ -214,9 +211,9 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
                     gc_summary = await db.get_latest_summary_for_question(gc.id)
                     if gc_summary:
                         page_refs.append(ref(gc_summary))
-                    gc_judgements = await db.get_judgements_for_question(gc.id)
-                    if gc_judgements:
-                        page_refs.extend(ref(j) for j in gc_judgements)
+                    gc_headline = grandchild_headlines.get(gc.id)
+                    if gc_headline is not None:
+                        page_refs.append(ref(gc_headline))
                     gc_hl = await format_page(
                         gc, PageDetail.HEADLINE, track=True, track_tags=summary_tag
                     )
@@ -232,20 +229,20 @@ async def _build_summary_context(question_id: str, db: DB) -> tuple[str, list[Pa
                         if gc_summary
                         else None
                     )
-                    gc_short_j = (
+                    gc_short_take = (
                         await format_page(
-                            max(gc_judgements, key=lambda j: j.created_at),
+                            gc_headline,
                             PageDetail.HEADLINE,
                             track=True,
                             track_tags=summary_tag,
                         )
-                        if gc_judgements
+                        if gc_headline is not None
                         else None
                     )
                     gc_lines.append(
                         f"  - {gc_hl}"
                         + (f"\n    Summary: {gc_medium}" if gc_medium else "")
-                        + (f"\n    Judgement: {gc_short_j}" if gc_short_j else "")
+                        + (f"\n    Take: {gc_short_take}" if gc_short_take else "")
                     )
                 child_section_parts.append("**Grandchild questions:**\n" + "\n".join(gc_lines))
 
@@ -343,7 +340,7 @@ async def summarize_question(
                 robustness=2,
                 robustness_reasoning=(
                     "Auto-generated subtree summary — robustness could be "
-                    "strengthened by cross-checking the cited judgements and "
+                    "strengthened by cross-checking the cited takes and "
                     "resolving any conflicting subtree conclusions."
                 ),
                 provenance_model=get_settings().model,

--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -304,7 +304,7 @@ class UpdateViewContext(ContextBuilder):
             query,
             infra.db,
             scope_question_id=infra.question_id,
-            require_judgement_for_questions=True,
+            require_take_for_questions=True,
             full_page_similarity_floor=0.6,
             abstract_page_similarity_floor=0.5,
             summary_page_similarity_floor=0.4,

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -17,6 +17,7 @@ from rumil.models import Page, PageDetail, PageLink, PageType
 from rumil.settings import get_settings
 from rumil.tracing.page_load_tracking import get_page_track_tags
 from rumil.tracing.tracer import get_trace
+from rumil.views import get_active_view
 
 log = logging.getLogger(__name__)
 
@@ -53,8 +54,8 @@ async def render_page_and_immediate_children(
     """Render a page and its direct child questions (one level deep).
 
     For question pages: renders the root with its considerations and
-    judgements, then each direct child question with their considerations
-    and judgements. Non-question root pages are rendered standalone.
+    current take, then each direct child question with their considerations
+    and current take. Non-question root pages are rendered standalone.
 
     Pages whose IDs appear in *content_page_ids* are rendered at CONTENT
     detail regardless of the *detail* parameter.
@@ -79,10 +80,8 @@ async def render_page_and_immediate_children(
 
     children = await db.get_child_questions(root_id)
     all_question_ids = [root_id] + [c.id for c in children]
-    considerations_by_q, judgements_by_q = (
-        await db.get_considerations_for_questions(all_question_ids),
-        await db.get_judgements_for_questions(all_question_ids),
-    )
+    considerations_by_q = await db.get_considerations_for_questions(all_question_ids)
+    headline_by_q = await get_active_view().headline_pages_many(all_question_ids, db)
 
     parts: list[str] = []
     visited: set[str] = set()
@@ -129,24 +128,22 @@ async def render_page_and_immediate_children(
             con_items.sort(key=lambda x: x[0], reverse=True)
             parts.append("\n".join(line for _, line in con_items))
 
-        all_judgements = judgements_by_q.get(question.id, [])
-        judgements = [max(all_judgements, key=lambda j: j.created_at)] if all_judgements else []
-        if judgements:
+        headline = headline_by_q.get(question.id)
+        if headline is not None:
+            visited.add(headline.id)
             parts.append("")
-            parts.append(f"{indent}**Judgements:**")
-            for j in judgements:
-                visited.add(j.id)
-                parts.append(
-                    f"{indent}- "
-                    + await format_page(
-                        j,
-                        linked_detail or PageDetail.HEADLINE,
-                        linked_detail=None,
-                        db=db,
-                        track=True,
-                        track_tags={"source": "prioritization"},
-                    )
+            parts.append(f"{indent}**Current take:**")
+            parts.append(
+                f"{indent}- "
+                + await format_page(
+                    headline,
+                    linked_detail or PageDetail.HEADLINE,
+                    linked_detail=None,
+                    db=db,
+                    track=True,
+                    track_tags={"source": "prioritization"},
                 )
+            )
 
     await _render_question(root, 0)
 
@@ -247,9 +244,9 @@ async def format_page(
     - ABSTRACT: header block + abstract text.
     - CONTENT: header block + full content.
 
-    *linked_detail* controls how considerations, judgements, and sub-question
-    judgements are rendered for question pages. Set to None to omit them
-    entirely.
+    *linked_detail* controls how considerations, the current take on the
+    question, and the current take on sub-questions are rendered for
+    question pages. Set to None to omit them entirely.
 
     When *include_superseding* is True (the default) and the page is
     superseded, the output includes the superseded page annotated as such,
@@ -260,9 +257,9 @@ async def format_page(
     are merged with any explicit *track_tags* (explicit wins on conflict).
     Supersession replacement renders are not tracked separately (they
     represent the same logical page). Linked-item renders (considerations,
-    judgements, child-question judgements for QUESTION pages) DO track
+    current take, child-question takes for QUESTION pages) DO track
     when *track* is True, using source tags ``linked_consideration`` /
-    ``linked_judgement`` / ``linked_child_judgement`` — this is how
+    ``linked_take`` / ``linked_child_take`` — this is how
     scope-question linked items become visible in ``page_format_events``.
     """
     if track:
@@ -385,58 +382,54 @@ async def format_page(
                 + "\n".join(line for _, _, line in con_items)
             )
 
-        j_items: list[tuple[datetime, str]] = []
-        judgements = await db.get_judgements_for_question(page.id)
-        for j in judgements:
-            if j.id in _exclude:
-                continue
+        view = get_active_view()
+        headline = await view.headline_page(page.id, db)
+        if headline is not None and headline.id not in _exclude:
             rendered = await format_page(
-                j,
+                headline,
                 linked_detail,
                 db=db,
                 linked_detail=None,
                 highlight_run_id=highlight_run_id,
                 track=track,
-                track_tags={"source": "linked_judgement"},
+                track_tags={"source": "linked_take"},
             )
-            j_items.append((j.created_at, "- " + rendered))
-        if j_items:
-            j_items.sort(key=lambda x: x[0])
             sections.append(
-                "#### Judgements on this question\n\n"
-                "_Standing answers the workspace has recorded for this question._\n\n"
-                + "\n".join(line for _, line in j_items)
+                "#### Current take on this question\n\n"
+                "_The standing answer the workspace has recorded for this question._\n\n"
+                + "- "
+                + rendered
             )
 
         children = await db.get_child_questions(page.id)
-        child_judgements = await db.get_judgements_for_questions(
-            [child.id for child in children if child.id not in _exclude]
+        child_headlines = await view.headline_pages_many(
+            [child.id for child in children if child.id not in _exclude],
+            db,
         )
         child_blocks: list[str] = []
         for child in children:
             if child.id in _exclude:
                 continue
-            child_js = [j for j in child_judgements.get(child.id, []) if j.id not in _exclude]
-            if not child_js:
+            child_headline = child_headlines.get(child.id)
+            if child_headline is None or child_headline.id in _exclude:
                 continue
-            sub_lines = [f"- On sub-question `{child.id[:8]}` — {child.headline}:"]
-            for j in sorted(child_js, key=lambda x: x.created_at):
-                rendered = await format_page(
-                    j,
-                    linked_detail,
-                    db=db,
-                    linked_detail=None,
-                    highlight_run_id=highlight_run_id,
-                    track=track,
-                    track_tags={"source": "linked_child_judgement"},
-                )
-                sub_lines.append(f"  - {rendered}")
-            child_blocks.append("\n".join(sub_lines))
+            rendered = await format_page(
+                child_headline,
+                linked_detail,
+                db=db,
+                linked_detail=None,
+                highlight_run_id=highlight_run_id,
+                track=track,
+                track_tags={"source": "linked_child_take"},
+            )
+            child_blocks.append(
+                f"- On sub-question `{child.id[:8]}` — {child.headline}:\n  - {rendered}"
+            )
         if child_blocks:
             sections.append(
-                "#### Judgements on sub-questions\n\n"
+                "#### Current take on sub-questions\n\n"
                 "_Answers recorded on questions nested under this one "
-                "(not judgements of this question itself)._\n\n" + "\n".join(child_blocks)
+                "(not the take on this question itself)._\n\n" + "\n".join(child_blocks)
             )
 
         if sections:
@@ -527,7 +520,6 @@ async def render_child_investigation_results(
     - NEW Summary/Judgement: full content
     - Old Summary/Judgement: abstract only
     """
-    from rumil.views import get_active_view
 
     children = await db.get_child_questions(parent_question_id)
     if not children:
@@ -881,7 +873,7 @@ async def build_embedding_based_context(
     full_page_similarity_floor: float | None = None,
     abstract_page_similarity_floor: float | None = None,
     summary_page_similarity_floor: float | None = None,
-    require_judgement_for_questions: bool = False,
+    require_take_for_questions: bool = False,
     exclude_page_ids: set[str] | None = None,
     input_type: str = "query",
 ) -> EmbeddingBasedContextResult:
@@ -959,13 +951,11 @@ async def build_embedding_based_context(
             scope_page_ids = [scope_question_id]
             ranked = [(p, s) for p, s in ranked if p.id != scope_question_id]
 
-    if require_judgement_for_questions:
+    if require_take_for_questions:
         question_ids = [p.id for p, _ in ranked if p.page_type == PageType.QUESTION]
-        judgements_by_qid = await db.get_judgements_for_questions(question_ids)
-        has_judgement = {qid for qid, js in judgements_by_qid.items() if js}
-        ranked = [
-            (p, s) for p, s in ranked if p.page_type != PageType.QUESTION or p.id in has_judgement
-        ]
+        headline_by_qid = await get_active_view().headline_pages_many(question_ids, db)
+        has_take = {qid for qid, headline in headline_by_qid.items() if headline is not None}
+        ranked = [(p, s) for p, s in ranked if p.page_type != PageType.QUESTION or p.id in has_take]
 
     distillation_budget = distillation_page_char_budget
     full_budget = full_page_char_budget

--- a/src/rumil/prompts/ab-eval-dimension.md
+++ b/src/rumil/prompts/ab-eval-dimension.md
@@ -58,4 +58,4 @@ You must continue to explore until your sense of the differences between the two
 
 ## Seed context
 
-Seed contexts for both arms are provided below, in the user message. Each seed shows the scope question, current judgement, and the 1-hop subgraph at headline level for that arm. The seeds are intentionally compact — use the tools above to drill into anything that looks interesting or suspicious.
+Seed contexts for both arms are provided below, in the user message. Each seed shows the scope question, the current take on it (a View or a Judgement, depending on the workspace's configuration), and the 1-hop subgraph at headline level for that arm. The seeds are intentionally compact — use the tools above to drill into anything that looks interesting or suspicious.

--- a/src/rumil/prompts/preamble.md
+++ b/src/rumil/prompts/preamble.md
@@ -41,7 +41,7 @@ The workspace contains Claims, Questions, Judgements, Sources, Wiki, View, and V
 
 **Claim** pages are positive assertions — something the workspace is asserting *is* the case about the world. A claim has to be **specific enough that a credence score (how likely is this to be true) can be meaningfully assigned to it**: it names its subject, makes a falsifiable statement, and doesn't dissolve under questions like "in what context?" or "compared to what?". If the best you can say is a vague gesture, it is not yet a claim — turn it into a question, a judgement, or a View item rather than forcing it into a claim shape.
 
-**Judgement** pages are the workspace's current best take on a question. They carry a *robustness* score (how solid is this view) but no credence — a judgement is already the considered answer, so "how likely is this to be true" is the wrong frame.
+**Judgement** pages are one way the workspace records its current best take on a question (the other is **View** pages — see below). They carry a *robustness* score (how solid is this view) but no credence — a judgement is already the considered answer, so "how likely is this to be true" is the wrong frame. Whether a question's overall take lives as a Judgement or a View depends on how the workspace is configured; both play the same role.
 
 **Source** pages are ingested documents — they are created by the system, not by other research instances.
 

--- a/src/rumil/prompts/run-eval-consistency.md
+++ b/src/rumil/prompts/run-eval-consistency.md
@@ -10,7 +10,7 @@ You are looking at a research workspace where a run has added new pages and link
 
 Assess the following dimensions:
 
-1. **Top-level judgement coherence**: Does the top-level judgement ultimately rely on information that is contradictory, without handling the contradictions correctly? Trace the reasoning chain from the final judgement back through its supporting claims and sub-judgements.
+1. **Top-level take coherence**: Does the workspace's top-level take on the scope question (a View page or a Judgement, depending on configuration) ultimately rely on information that is contradictory, without handling the contradictions correctly? Trace the reasoning chain from that final take back through its supporting claims, View items, and sub-question takes.
 
 2. **Unresolved contradictions**: Does the analysis contain contradictions that go unmentioned? Are there claims that point in opposite directions without any acknowledgment of the tension?
 
@@ -23,7 +23,7 @@ Assess the following dimensions:
 ## How to work
 
 1. Use `explore_subgraph` to navigate the workspace graph, starting from the root question. Use `load_page` to read the full content of individual pages
-2. Identify the top-level judgement and trace its reasoning chain
+2. Identify the workspace's top-level take on the scope question (the View page, if the variant is sectioned; otherwise the latest Judgement) and trace its reasoning chain
 3. Look for claims marked `[ADDED BY THIS RUN]` that point in different directions
 4. Check whether contradictions are acknowledged and handled
 5. Pay special attention to cases where contradictory evidence supports the same conclusion

--- a/src/rumil/prompts/run-eval-research-progress.md
+++ b/src/rumil/prompts/run-eval-research-progress.md
@@ -14,7 +14,7 @@ Assess the following dimensions:
 
 2. **Key information uncovered**: Did the run surface crucial pieces of information -- data points, precedents, mechanisms, or dynamics -- that were not present in the workspace before and that materially affect the analysis?
 
-3. **Substantial updates**: To what extent did the run produce findings that should substantially update our view on the question? Were there claims or judgements with high credence and robustness that moved the needle?
+3. **Substantial updates**: To what extent did the run produce findings that should substantially update our view on the question? Were there claims, judgements, or View items with high credence and robustness that moved the needle?
 
 4. **Depth vs breadth**: Were the depth and breadth of investigation appropriate? Did the run go deep where it mattered, or spread itself thin? Conversely, did it tunnel too narrowly into one subtopic while neglecting important angles? Is the allocation of depth proportional to the importance of each subtopic?
 
@@ -23,7 +23,7 @@ Assess the following dimensions:
 ## How to work
 
 1. Use `explore_subgraph` to navigate the workspace graph, starting from the root question. Use `load_page` to read the full content of individual pages
-2. Examine the claims, judgements, and subquestions marked `[ADDED BY THIS RUN]`
+2. Examine the claims, judgements, View items, and subquestions marked `[ADDED BY THIS RUN]`
 3. Assess whether each major output represents genuine progress or is relatively obvious
 4. Look for moments where the analysis took a non-obvious turn that paid off
 5. Consider the overall trajectory: did the run make the workspace significantly more knowledgeable?

--- a/src/rumil/prompts/run-eval-research-redundancy.md
+++ b/src/rumil/prompts/run-eval-research-redundancy.md
@@ -30,7 +30,7 @@ Assess two distinct forms of redundancy:
 
 1. Use `search_workspace` with the headlines or abstracts of suspect subquestions to find semantically similar pages elsewhere in the workspace -- this is your main tool for finding both literal near-duplicates and overlapping investigations across different subtrees.
 2. Use `explore_subgraph` to navigate the graph and map out which subtrees the run created. Use `load_page` to read the full content of individual pages.
-3. When you find two questions that look similar, read their content (and their judgements / claims, if any) to decide whether they are genuinely asking the same thing or merely adjacent.
+3. When you find two questions that look similar, read their content (and their views / judgements / claims, if any) to decide whether they are genuinely asking the same thing or merely adjacent.
 4. Be specific -- cite page IDs for each pair or cluster you flag as redundant, and explain the overlap.
 
 You must continue to explore until your assessment of this dimension has converged.

--- a/src/rumil/run_eval/seed.py
+++ b/src/rumil/run_eval/seed.py
@@ -44,7 +44,7 @@ async def build_eval_seed_context(
 
     view = get_active_view()
     headline = await view.headline_page(resolved, db)
-    take_text = await view.render_for_prioritization(resolved, db)
+    take_text = await view.render_for_executive_summary(resolved, db)
     exclude_ids: set[str] | None = None
     if take_text:
         parts.append("## Current take")

--- a/src/rumil/run_eval/seed.py
+++ b/src/rumil/run_eval/seed.py
@@ -1,16 +1,18 @@
 """Seed context for run-eval agents.
 
-The seed is deliberately compact: the scope question and its current
-judgement(s) rendered at full content, plus a headline-only view of the
-1-hop subgraph with overflow indicators for everything further out. The
-agent is expected to drill into anything interesting via
-``explore_subgraph`` / ``load_page`` — handing it every neighbor up-front
-tends to produce wide-but-shallow reads rather than targeted digs.
+The seed is deliberately compact: the scope question and its current take
+(View page or Judgement, depending on the workspace's view variant)
+rendered at full content, plus a headline-only view of the 1-hop subgraph
+with overflow indicators for everything further out. The agent is
+expected to drill into anything interesting via ``explore_subgraph`` /
+``load_page`` — handing it every neighbor up-front tends to produce
+wide-but-shallow reads rather than targeted digs.
 """
 
 from rumil.context import format_page
 from rumil.database import DB
 from rumil.models import PageDetail
+from rumil.views import get_active_view
 from rumil.workspace_exploration.explore import render_subgraph
 
 
@@ -40,23 +42,17 @@ async def build_eval_seed_context(
     )
     parts.append("")
 
-    judgements = await db.get_judgements_for_question(resolved)
-    judgement_ids: set[str] = set()
-    if judgements:
-        parts.append("## Current judgement")
+    view = get_active_view()
+    headline = await view.headline_page(resolved, db)
+    take_text = await view.render_for_prioritization(resolved, db)
+    exclude_ids: set[str] | None = None
+    if take_text:
+        parts.append("## Current take")
         parts.append("")
-        for judgement in judgements:
-            judgement_ids.add(judgement.id)
-            parts.append(
-                await format_page(
-                    judgement,
-                    PageDetail.CONTENT,
-                    linked_detail=None,
-                    db=db,
-                    highlight_run_id=highlight_run_id,
-                )
-            )
-            parts.append("")
+        parts.append(take_text)
+        parts.append("")
+    if headline is not None:
+        exclude_ids = {headline.id}
 
     parts.append("## Local subgraph (1-hop, headlines only)")
     parts.append("")
@@ -64,7 +60,7 @@ async def build_eval_seed_context(
         resolved,
         db,
         max_depth=1,
-        exclude_ids=judgement_ids or None,
+        exclude_ids=exclude_ids,
         highlight_run_id=highlight_run_id,
     )
     parts.append(subgraph_text)

--- a/src/rumil/views/base.py
+++ b/src/rumil/views/base.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from datetime import datetime
 
 from rumil.database import DB
+from rumil.models import Page
 from rumil.tracing.broadcast import Broadcaster
 
 
@@ -20,6 +21,41 @@ class View(ABC):
     @abstractmethod
     async def exists(self, question_id: str, db: DB) -> bool:
         """True if this variant already has a refreshable summary for *question_id*."""
+
+    @abstractmethod
+    async def headline_page(self, question_id: str, db: DB) -> Page | None:
+        """The single canonical page representing the overall take on *question_id*.
+
+        For ``JudgementView`` this is the latest active judgement; for
+        ``SectionedView`` this is the active VIEW page. Callers needing the
+        page id (e.g. to exclude from a subgraph render) or its robustness
+        should use this rather than reaching for variant-specific accessors.
+        Returns None when no take has been recorded yet.
+        """
+
+    @abstractmethod
+    async def headline_pages_many(
+        self,
+        question_ids: Sequence[str],
+        db: DB,
+    ) -> dict[str, Page | None]:
+        """Batch counterpart to :meth:`headline_page` for traversal hot loops.
+
+        Returns ``{question_id: headline_page_or_None}`` for every input id,
+        issuing a bounded number of queries regardless of input size.
+        """
+
+    @abstractmethod
+    async def render_for_executive_summary(
+        self,
+        question_id: str,
+        db: DB,
+    ) -> str | None:
+        """Full-detail render of the overall take, for executive-summary contexts.
+
+        Used by ``calls/summarize.py`` for the headline question. Returns
+        None when no take has been recorded yet.
+        """
 
     @abstractmethod
     async def refresh(

--- a/src/rumil/views/judgement.py
+++ b/src/rumil/views/judgement.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 from rumil.context import format_page
 from rumil.database import DB
-from rumil.models import PageDetail
+from rumil.models import Page, PageDetail
 from rumil.orchestrators.common import assess_question
 from rumil.tracing.broadcast import Broadcaster
 from rumil.views.base import View
@@ -25,6 +25,35 @@ class JudgementView(View):
     async def exists(self, question_id: str, db: DB) -> bool:
         judgements = await db.get_judgements_for_question(question_id)
         return bool(judgements)
+
+    async def headline_page(self, question_id: str, db: DB) -> Page | None:
+        return await self._latest_judgement(question_id, db)
+
+    async def headline_pages_many(
+        self,
+        question_ids: Sequence[str],
+        db: DB,
+    ) -> dict[str, Page | None]:
+        by_question = await db.get_judgements_for_questions(question_ids)
+        return {
+            qid: max(judgements, key=lambda j: j.created_at) if judgements else None
+            for qid, judgements in by_question.items()
+        }
+
+    async def render_for_executive_summary(
+        self,
+        question_id: str,
+        db: DB,
+    ) -> str | None:
+        latest = await self._latest_judgement(question_id, db)
+        if latest is None:
+            return None
+        return await format_page(
+            latest,
+            PageDetail.CONTENT,
+            linked_detail=None,
+            db=db,
+        )
 
     async def refresh(
         self,

--- a/src/rumil/views/sectioned.py
+++ b/src/rumil/views/sectioned.py
@@ -13,7 +13,7 @@ from rumil.calls.create_view import CreateViewCall
 from rumil.calls.update_view import UpdateViewCall
 from rumil.context import format_page, render_view
 from rumil.database import DB
-from rumil.models import CallType, PageDetail
+from rumil.models import CallType, Page, PageDetail
 from rumil.tracing.broadcast import Broadcaster
 from rumil.views.base import View
 
@@ -25,6 +25,28 @@ class SectionedView(View):
 
     async def exists(self, question_id: str, db: DB) -> bool:
         return await db.get_view_for_question(question_id) is not None
+
+    async def headline_page(self, question_id: str, db: DB) -> Page | None:
+        return await db.get_view_for_question(question_id)
+
+    async def headline_pages_many(
+        self,
+        question_ids: Sequence[str],
+        db: DB,
+    ) -> dict[str, Page | None]:
+        return await db.get_views_for_questions(question_ids)
+
+    async def render_for_executive_summary(
+        self,
+        question_id: str,
+        db: DB,
+    ) -> str | None:
+        view = await db.get_view_for_question(question_id)
+        if view is None:
+            return None
+        items = await db.get_view_items(view.id, min_importance=2)
+        text = await render_view(view, items, min_importance=2)
+        return text if text.strip() else None
 
     async def refresh(
         self,

--- a/src/rumil/workspace_exploration/explore.py
+++ b/src/rumil/workspace_exploration/explore.py
@@ -26,6 +26,7 @@ from rumil.models import LinkType, Page, PageDetail, PageType
 from rumil.settings import get_settings
 from rumil.tracing.trace_events import RenderQuestionSubgraphEvent
 from rumil.tracing.tracer import CallTrace
+from rumil.views import get_active_view
 
 log = logging.getLogger(__name__)
 
@@ -220,12 +221,11 @@ async def _render_subgraph_impl(
         frontier = [cid for cid in next_ids if cid in pages_by_id]
 
     question_ids = [pid for pid, p in pages_by_id.items() if p.page_type == PageType.QUESTION]
-    judgements_by_question = await db.get_judgements_for_questions(question_ids)
+    headline_by_question = await get_active_view().headline_pages_many(question_ids, db)
     robustness_by_question: dict[str, int | None] = {}
     for qid in question_ids:
-        judgements = judgements_by_question.get(qid, [])
-        robs = [j.robustness for j in judgements if j.robustness is not None]
-        robustness_by_question[qid] = max(robs) if robs else None
+        headline = headline_by_question.get(qid)
+        robustness_by_question[qid] = headline.robustness if headline is not None else None
 
     lines: list[str] = []
     await _emit(

--- a/tests/test_embedding_context.py
+++ b/tests/test_embedding_context.py
@@ -8,6 +8,7 @@ from rumil.context import (
     format_page,
 )
 from rumil.models import Page, PageDetail, PageLayer, PageType, Workspace
+from rumil.settings import override_settings
 
 
 def _make_page(headline: str, content: str, page_type: PageType = PageType.CLAIM) -> Page:
@@ -186,11 +187,11 @@ def mock_embeddings_mixed(mocker):
     )
 
 
-async def test_require_judgement_filters_unjudged_questions(
+async def test_require_take_filters_questions_without_take(
     mock_embeddings_mixed,
     mocker,
 ):
-    """Questions without judgements are excluded when require_judgement_for_questions is set."""
+    """Questions without a take are excluded when require_take_for_questions is set."""
     db = mocker.AsyncMock()
 
     async def fake_get_judgements_many(qids):
@@ -198,32 +199,34 @@ async def test_require_judgement_filters_unjudged_questions(
 
     db.get_judgements_for_questions = mocker.AsyncMock(side_effect=fake_get_judgements_many)
 
-    result = await build_embedding_based_context(
-        "test query",
-        db,
-        require_judgement_for_questions=True,
-        full_page_char_budget=10_000,
-    )
+    with override_settings(view_variant="judgement"):
+        result = await build_embedding_based_context(
+            "test query",
+            db,
+            require_take_for_questions=True,
+            full_page_char_budget=10_000,
+        )
 
     assert QUESTION_WITH_JUDGEMENT.id in result.page_ids
     assert QUESTION_WITHOUT_JUDGEMENT.id not in result.page_ids
     assert CLAIM_PAGE.id in result.page_ids
 
 
-async def test_require_judgement_false_keeps_all_questions(
+async def test_require_take_false_keeps_all_questions(
     mock_embeddings_mixed,
     mocker,
 ):
-    """Without the flag, all questions appear regardless of judgement status."""
+    """Without the flag, all questions appear regardless of take status."""
     db = mocker.AsyncMock()
-    db.get_judgements_for_question = mocker.AsyncMock(return_value=[])
+    db.get_judgements_for_questions = mocker.AsyncMock(return_value={})
 
-    result = await build_embedding_based_context(
-        "test query",
-        db,
-        require_judgement_for_questions=False,
-        full_page_char_budget=10_000,
-    )
+    with override_settings(view_variant="judgement"):
+        result = await build_embedding_based_context(
+            "test query",
+            db,
+            require_take_for_questions=False,
+            full_page_char_budget=10_000,
+        )
 
     assert QUESTION_WITH_JUDGEMENT.id in result.page_ids
     assert QUESTION_WITHOUT_JUDGEMENT.id in result.page_ids

--- a/tests/test_eval_seed.py
+++ b/tests/test_eval_seed.py
@@ -82,7 +82,7 @@ async def test_seed_includes_current_take_full_content_judgement_variant(tmp_db)
         seed = await build_eval_seed_context(scope.id, tmp_db)
 
     assert "## Current take" in seed
-    assert "The answer" in seed
+    assert "Full content for The answer" in seed
 
 
 @pytest.mark.asyncio

--- a/tests/test_eval_seed.py
+++ b/tests/test_eval_seed.py
@@ -11,6 +11,7 @@ from rumil.models import (
     Workspace,
 )
 from rumil.run_eval.seed import build_eval_seed_context
+from rumil.settings import override_settings
 
 
 def _question(headline: str) -> Page:
@@ -30,6 +31,19 @@ def _judgement(headline: str) -> Page:
         workspace=Workspace.RESEARCH,
         content=f"Full content for {headline}",
         headline=headline,
+        robustness=3,
+    )
+
+
+def _view(headline: str) -> Page:
+    return Page(
+        page_type=PageType.VIEW,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        content=f"Full content for {headline}",
+        headline=headline,
+        sections=["broader_context", "confident_views"],
+        robustness=3,
     )
 
 
@@ -57,27 +71,44 @@ async def test_seed_renders_scope_full_content(tmp_db):
 
 
 @pytest.mark.asyncio
-async def test_seed_includes_current_judgement_full_content(tmp_db):
+async def test_seed_includes_current_take_full_content_judgement_variant(tmp_db):
     scope = _question("Root scope")
     judgement = _judgement("The answer")
     await tmp_db.save_page(scope)
     await tmp_db.save_page(judgement)
     await _link(tmp_db, judgement, scope, LinkType.ANSWERS)
 
-    seed = await build_eval_seed_context(scope.id, tmp_db)
+    with override_settings(view_variant="judgement"):
+        seed = await build_eval_seed_context(scope.id, tmp_db)
 
-    assert "## Current judgement" in seed
-    assert "Full content for The answer" in seed
+    assert "## Current take" in seed
+    assert "The answer" in seed
 
 
 @pytest.mark.asyncio
-async def test_seed_omits_judgement_section_when_none(tmp_db):
+async def test_seed_includes_current_take_full_content_sectioned_variant(tmp_db):
+    scope = _question("Root scope")
+    view = _view("View on root scope")
+    await tmp_db.save_page(scope)
+    await tmp_db.save_page(view)
+    await _link(tmp_db, view, scope, LinkType.VIEW_OF)
+
+    with override_settings(view_variant="sectioned"):
+        seed = await build_eval_seed_context(scope.id, tmp_db)
+
+    assert "## Current take" in seed
+    assert "View on root scope" in seed
+    assert "Full content for View on root scope" in seed
+
+
+@pytest.mark.asyncio
+async def test_seed_omits_take_section_when_no_take_recorded(tmp_db):
     scope = _question("Root scope")
     await tmp_db.save_page(scope)
 
     seed = await build_eval_seed_context(scope.id, tmp_db)
 
-    assert "## Current judgement" not in seed
+    assert "## Current take" not in seed
 
 
 @pytest.mark.asyncio
@@ -117,19 +148,35 @@ async def test_seed_shows_overflow_marker_beyond_one_hop(tmp_db):
 
 
 @pytest.mark.asyncio
-async def test_seed_excludes_judgement_from_subgraph(tmp_db):
+async def test_seed_excludes_judgement_headline_from_subgraph(tmp_db):
     scope = _question("Root scope")
     judgement = _judgement("The answer")
     await tmp_db.save_page(scope)
     await tmp_db.save_page(judgement)
     await _link(tmp_db, judgement, scope, LinkType.ANSWERS)
 
-    seed = await build_eval_seed_context(scope.id, tmp_db)
+    with override_settings(view_variant="judgement"):
+        seed = await build_eval_seed_context(scope.id, tmp_db)
 
-    # Full content in the judgement section, not duplicated as a headline
+    # Full content in the take section, not duplicated as a headline
     # entry in the 1-hop subgraph.
     subgraph_section = seed.split("## Local subgraph", 1)[1]
     assert judgement.id[:8] not in subgraph_section
+
+
+@pytest.mark.asyncio
+async def test_seed_excludes_view_headline_from_subgraph(tmp_db):
+    scope = _question("Root scope")
+    view = _view("View on root scope")
+    await tmp_db.save_page(scope)
+    await tmp_db.save_page(view)
+    await _link(tmp_db, view, scope, LinkType.VIEW_OF)
+
+    with override_settings(view_variant="sectioned"):
+        seed = await build_eval_seed_context(scope.id, tmp_db)
+
+    subgraph_section = seed.split("## Local subgraph", 1)[1]
+    assert view.id[:8] not in subgraph_section
 
 
 @pytest.mark.asyncio

--- a/tests/test_explore_subgraph.py
+++ b/tests/test_explore_subgraph.py
@@ -1,0 +1,122 @@
+"""Tests for subgraph rendering — verifying that the 'Answered at robustness'
+annotation flows through the active View variant rather than judgements only.
+"""
+
+import pytest
+
+from rumil.models import LinkType, Page, PageLayer, PageLink, PageType, Workspace
+from rumil.settings import override_settings
+from rumil.workspace_exploration.explore import render_subgraph
+
+
+def _question(headline: str) -> Page:
+    return Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Body: {headline}",
+        headline=headline,
+    )
+
+
+def _judgement(headline: str, robustness: int) -> Page:
+    return Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Body: {headline}",
+        headline=headline,
+        robustness=robustness,
+    )
+
+
+def _view(headline: str, robustness: int) -> Page:
+    return Page(
+        page_type=PageType.VIEW,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        content=f"Body: {headline}",
+        headline=headline,
+        sections=["confident_views"],
+        robustness=robustness,
+    )
+
+
+@pytest.mark.asyncio
+async def test_subgraph_marks_question_with_view_as_answered_under_sectioned_variant(tmp_db):
+    """A question with a View (and no judgement) should show 'Answered at robustness ...'."""
+    parent = _question("Parent Q")
+    child = _question("Child Q")
+    view = _view("View on child", robustness=4)
+    await tmp_db.save_page(parent)
+    await tmp_db.save_page(child)
+    await tmp_db.save_page(view)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=parent.id,
+            to_page_id=child.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=view.id,
+            to_page_id=child.id,
+            link_type=LinkType.VIEW_OF,
+        )
+    )
+
+    with override_settings(view_variant="sectioned"):
+        result = await render_subgraph(parent.id, tmp_db, max_depth=1)
+
+    assert "Answered at robustness 4/5" in result
+
+
+@pytest.mark.asyncio
+async def test_subgraph_marks_question_with_judgement_as_answered_under_judgement_variant(
+    tmp_db,
+):
+    parent = _question("Parent Q")
+    child = _question("Child Q")
+    judgement = _judgement("Judgement on child", robustness=3)
+    await tmp_db.save_page(parent)
+    await tmp_db.save_page(child)
+    await tmp_db.save_page(judgement)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=parent.id,
+            to_page_id=child.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=judgement.id,
+            to_page_id=child.id,
+            link_type=LinkType.ANSWERS,
+        )
+    )
+
+    with override_settings(view_variant="judgement"):
+        result = await render_subgraph(parent.id, tmp_db, max_depth=1)
+
+    assert "Answered at robustness 3/5" in result
+
+
+@pytest.mark.asyncio
+async def test_subgraph_marks_unanswered_question(tmp_db):
+    parent = _question("Parent Q")
+    child = _question("Child Q")
+    await tmp_db.save_page(parent)
+    await tmp_db.save_page(child)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=parent.id,
+            to_page_id=child.id,
+            link_type=LinkType.CHILD_QUESTION,
+        )
+    )
+
+    result = await render_subgraph(parent.id, tmp_db, max_depth=1)
+
+    assert "Unanswered" in result

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from rumil.models import Page, PageLayer, PageType, Workspace
+from rumil.models import LinkType, Page, PageLayer, PageLink, PageType, Workspace
 from rumil.settings import override_settings
 from rumil.views import VIEW_VARIANTS, get_active_view
 from rumil.views.judgement import JudgementView
@@ -107,3 +107,135 @@ async def test_judgement_view_refresh_calls_assess_with_summarise_false(
     assert result == "judgement-call-id"
     assess_mock.assert_called_once()
     assert assess_mock.call_args.kwargs["summarise"] is False
+
+
+async def _save_judgement(db, question: Page, headline: str, robustness: int = 3) -> Page:
+    judgement = Page(
+        page_type=PageType.JUDGEMENT,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Body for {headline}",
+        headline=headline,
+        robustness=robustness,
+    )
+    await db.save_page(judgement)
+    await db.save_link(
+        PageLink(
+            from_page_id=judgement.id,
+            to_page_id=question.id,
+            link_type=LinkType.ANSWERS,
+        )
+    )
+    return judgement
+
+
+async def _save_view(db, question: Page, headline: str, robustness: int = 4) -> Page:
+    view = Page(
+        page_type=PageType.VIEW,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        content=f"Body for {headline}",
+        headline=headline,
+        sections=["broader_context", "confident_views"],
+        robustness=robustness,
+    )
+    await db.save_page(view)
+    await db.save_link(
+        PageLink(
+            from_page_id=view.id,
+            to_page_id=question.id,
+            link_type=LinkType.VIEW_OF,
+        )
+    )
+    return view
+
+
+async def test_judgement_view_headline_page_returns_latest_judgement(tmp_db, question_page):
+    await _save_judgement(tmp_db, question_page, "Older take", robustness=2)
+    latest = await _save_judgement(tmp_db, question_page, "Newer take", robustness=4)
+
+    headline = await JudgementView().headline_page(question_page.id, tmp_db)
+
+    assert headline is not None
+    assert headline.id == latest.id
+
+
+async def test_judgement_view_headline_page_returns_none_when_absent(tmp_db, question_page):
+    headline = await JudgementView().headline_page(question_page.id, tmp_db)
+    assert headline is None
+
+
+async def test_sectioned_view_headline_page_returns_view(tmp_db, question_page):
+    view = await _save_view(tmp_db, question_page, "View on Q")
+
+    headline = await SectionedView().headline_page(question_page.id, tmp_db)
+
+    assert headline is not None
+    assert headline.id == view.id
+
+
+async def test_sectioned_view_headline_page_returns_none_when_absent(tmp_db, question_page):
+    headline = await SectionedView().headline_page(question_page.id, tmp_db)
+    assert headline is None
+
+
+async def test_judgement_view_headline_pages_many_batches(
+    tmp_db, question_page, child_question_page
+):
+    judgement = await _save_judgement(tmp_db, child_question_page, "Child take")
+
+    result = await JudgementView().headline_pages_many(
+        [question_page.id, child_question_page.id], tmp_db
+    )
+
+    assert result[question_page.id] is None
+    child_headline = result[child_question_page.id]
+    assert child_headline is not None
+    assert child_headline.id == judgement.id
+
+
+async def test_sectioned_view_headline_pages_many_batches(
+    tmp_db, question_page, child_question_page
+):
+    view = await _save_view(tmp_db, child_question_page, "View on child")
+
+    result = await SectionedView().headline_pages_many(
+        [question_page.id, child_question_page.id], tmp_db
+    )
+
+    assert result[question_page.id] is None
+    child_headline = result[child_question_page.id]
+    assert child_headline is not None
+    assert child_headline.id == view.id
+
+
+async def test_judgement_view_render_for_executive_summary(tmp_db, question_page):
+    await _save_judgement(tmp_db, question_page, "The take", robustness=4)
+
+    rendered = await JudgementView().render_for_executive_summary(question_page.id, tmp_db)
+
+    assert rendered is not None
+    assert "The take" in rendered
+
+
+async def test_judgement_view_render_for_executive_summary_returns_none_when_absent(
+    tmp_db, question_page
+):
+    rendered = await JudgementView().render_for_executive_summary(question_page.id, tmp_db)
+    assert rendered is None
+
+
+async def test_sectioned_view_render_for_executive_summary(tmp_db, question_page):
+    await _save_view(tmp_db, question_page, "View headline")
+
+    rendered = await SectionedView().render_for_executive_summary(question_page.id, tmp_db)
+
+    assert rendered is not None
+    assert "View headline" in rendered
+
+
+async def test_sectioned_view_render_for_executive_summary_returns_none_when_absent(
+    tmp_db, question_page
+):
+    rendered = await SectionedView().render_for_executive_summary(question_page.id, tmp_db)
+    assert rendered is None


### PR DESCRIPTION
## Summary

- Several read paths (eval seed, `explore_subgraph` annotations, question rendering in `context.py`, `summarize.py`) treated `PageType.JUDGEMENT` as the canonical "overall take" on a question. Under the sectioned View variant this silently missed the take, since Views (not Judgements) carry it there.
- Extends the `View` ABC with `headline_page`, `headline_pages_many`, and `render_for_executive_summary`, implemented on both `JudgementView` and `SectionedView`. Every read path now resolves the canonical take through the active variant.
- Renames the embedding-context filter from `require_judgement_for_questions` to `require_take_for_questions` and switches its implementation to the View abstraction. Eval prompts now refer to "current take" rather than "current judgement".

Out of scope (per agreed plan): orchestrator scoring (already View-aware via `render_for_parent_scoring`), `moves/base.py` strength rules and `LinkType.ANSWERS` semantics (judgement-specific by current design), and the frontend `--type-judgement` styling.

## Test plan

- [ ] Bring up this worktree's local Supabase stack (the per-offset `wm_*` containers — currently down for offset 15)
- [ ] `uv run pytest tests/test_views.py tests/test_eval_seed.py tests/test_explore_subgraph.py tests/test_embedding_context.py`
- [ ] Spot-check a smoke run under `view_variant=sectioned` and one under `view_variant=judgement`; confirm the eval seed contains `## Current take` with the right artefact in each
- [ ] Run a single ab-eval pair against the sectioned smoke run; confirm the seed prompt fed to each agent shows the View body and the View page is excluded from the 1-hop subgraph render

🤖 Generated with [Claude Code](https://claude.com/claude-code)