### PR TITLE
k8s: forward per-request env overrides into orchestrator Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,38 @@ you're running against a different project.
 You can also pass `--container-tag TAG` to `main.py` directly if you've
 already built and pushed the image yourself.
 
+#### Forwarding local config into the cloud Job
+
+When you submit a run with `--executor prod` (or `--prod`), the CLI
+auto-forwards a curated subset of your locally-loaded `Settings` into
+the Job's container env. Any forwardable field whose value differs
+from its class default is sent in the request's `extra_env` and shadows
+the value the Job would otherwise inherit from the deployed `rumil-api`.
+
+This means experiment knobs you set locally — via `.env`,
+`.env.overrides`, or your shell — Just Work remotely:
+
+```bash
+# Run a remote orchestrator with an overridden model
+RUMIL_MODEL_OVERRIDE=claude-sonnet-4-6 \
+  uv run python main.py "is the sky blue?" --budget 2 --smoke-test \
+  --workspace cloud-config-scratch --prod
+```
+
+The forwarded set covers the per-run tuning surface (every
+`_capture_field`-marked Settings field) plus `RUMIL_MODEL_OVERRIDE`,
+`RUMIL_SMOKE_TEST`, `RUMIL_TEST_MODE`, and `FORCE_TWOPHASE_RECURSE`.
+
+Credentials, DB URLs, GCP identifiers, frontend/API URLs, and Langfuse
+keys are intentionally *not* forwarded — the Job inherits those from
+the deployed Pod's secrets and env, and a stray local override would
+point a cloud run at the wrong resources.
+
+The launcher endpoint (`POST /api/jobs/orchestrator-runs`) accepts an
+`extra_env` field for any Settings name; the curated CLI subset is just
+how `main.py` chooses what to send. Other clients (curl, scripts) can
+override anything they want.
+
 ### Testing individual calls
 
 `scripts/run_call.py` runs a single call type (find-considerations, assess, prioritize) against the local database, useful for development and debugging without the full orchestrator loop.

--- a/src/rumil/cli_client.py
+++ b/src/rumil/cli_client.py
@@ -82,6 +82,7 @@ def _request_from_args(args: argparse.Namespace) -> OrchestratorRunRequest:
         ingest_num_claims=getattr(args, "ingest_num_claims", None),
         run_name=getattr(args, "run_name", None),
         container_tag=getattr(args, "container_tag", None),
+        extra_env=get_settings().cli_forwardable_overrides(),
     )
 
 

--- a/src/rumil/k8s/submit.py
+++ b/src/rumil/k8s/submit.py
@@ -233,7 +233,9 @@ def _build_job(
     container = containers[0]
     container["image"] = image
     container["command"] = _build_container_command(spec, run_id=run_id)
-    container["env"] = [_env_var_to_dict(e) for e in env]
+    overrides = dict(spec.extra_env)
+    inherited = [_env_var_to_dict(e) for e in env if e.name not in overrides]
+    container["env"] = inherited + [{"name": k, "value": v} for k, v in overrides.items()]
     container["envFrom"] = [_env_from_to_dict(e) for e in env_from]
     return manifest
 

--- a/src/rumil/k8s/types.py
+++ b/src/rumil/k8s/types.py
@@ -6,10 +6,13 @@ submitter (`rumil.k8s.submit`). Kept FastAPI-free so the CLI can import them
 without dragging server-side modules.
 """
 
+import re
 from datetime import datetime
 from typing import Literal, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from rumil.settings import Settings
 
 JobStatus = Literal["pending", "running", "failed", "completed"]
 
@@ -17,6 +20,8 @@ JobStatus = Literal["pending", "running", "failed", "completed"]
 # bounded for safety. Validates the user-supplied container_tag so we never
 # splice an attacker-controlled value into a Job's image string.
 _CONTAINER_TAG_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$"
+
+_ENV_VAR_NAME = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
 
 class OrchestratorRunRequest(BaseModel):
@@ -61,11 +66,42 @@ class OrchestratorRunRequest(BaseModel):
     # registry. Used by scripts/remote_run.sh.
     container_tag: str | None = Field(default=None, pattern=_CONTAINER_TAG_PATTERN)
 
+    # Per-request env-var overrides. Keys must be uppercase env-var names
+    # corresponding to a known Settings field; values land verbatim in the
+    # spawned Job's container env, shadowing the values inherited from the
+    # rumil-api Deployment. This is the trust boundary for cloud-job config
+    # — the API accepts any Settings field name and trusts authenticated
+    # callers not to abuse it. The CLI restricts itself to a curated subset
+    # via `Settings.cli_forwardable_overrides()`; other clients are free to
+    # send anything.
+    extra_env: dict[str, str] = Field(default_factory=dict)
+
     @model_validator(mode="after")
     def _exactly_one_of_question_or_continue_id(self) -> Self:
         if bool(self.question) == bool(self.continue_id):
             raise ValueError("exactly one of `question` or `continue_id` must be set")
         return self
+
+    @field_validator("extra_env")
+    @classmethod
+    def _validate_extra_env(cls, v: dict[str, str]) -> dict[str, str]:
+        if not v:
+            return v
+        known = Settings.all_env_keys()
+        for key, value in v.items():
+            if not _ENV_VAR_NAME.match(key):
+                raise ValueError(
+                    f"extra_env key {key!r} must match {_ENV_VAR_NAME.pattern} "
+                    "(uppercase env-var name)"
+                )
+            if key not in known:
+                raise ValueError(f"extra_env key {key!r} is not a known Settings field")
+            if not value:
+                raise ValueError(
+                    f"extra_env value for {key!r} must be non-empty; "
+                    "omit the key to fall back to the inherited default"
+                )
+        return v
 
 
 class OrchestratorRunResponse(BaseModel):

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -48,6 +48,24 @@ def _capture_field(**kwargs: Any) -> Any:
     return Field(json_schema_extra=_CAPTURE, **kwargs)
 
 
+# Settings field names the CLI auto-forwards into the cloud Job's env when
+# their local value differs from the class default. Curated rather than
+# blanket: a developer's local `.env` setting (say) SUPABASE_PROD_URL or
+# ANTHROPIC_API_KEY would otherwise redirect the cloud Job at their laptop's
+# resources or burn local quota. The cloud Job already inherits those from
+# the rumil-api Deployment. The set covers experiment knobs the user actually
+# wants to vary per run: every `_capture_field`-marked field plus a small
+# handful of mode/override booleans/strings.
+_CLI_FORWARDABLE_EXTRAS: frozenset[str] = frozenset(
+    {
+        "rumil_model_override",
+        "rumil_smoke_test",
+        "rumil_test_mode",
+        "force_twophase_recurse",
+    }
+)
+
+
 class Settings(BaseSettings):
     # ".env" is the shared (often symlinked) project env; ".env.overrides"
     # layers on top — typically written by the workmux post_create hook for
@@ -259,6 +277,55 @@ class Settings(BaseSettings):
         result["model"] = self.model
         result["git_commit"] = _get_git_commit()
         return result
+
+    @classmethod
+    def all_env_keys(cls) -> frozenset[str]:
+        """Uppercased view of every Settings field name.
+
+        Used by the cloud-job launcher to validate caller-supplied
+        `extra_env` keys: anything not in this set is a typo or an
+        unrelated env var, and we 422 it at submission time rather than
+        let it silently fall on the floor (Settings is configured
+        extra="ignore", so unknown env vars don't surface anywhere).
+        """
+        return frozenset(name.upper() for name in cls.model_fields)
+
+    @classmethod
+    def _cli_forwardable_fields(cls) -> frozenset[str]:
+        """Snake_case Settings field names the CLI may auto-forward.
+
+        Every `_capture_field`-marked field (the existing per-run tuning
+        surface) plus a small set of mode/override knobs. Credentials,
+        DB URLs, GCP identifiers, etc. are intentionally excluded — the
+        cloud Job inherits those from the rumil-api Deployment and a
+        local override would point it at the wrong resources.
+        """
+        capture_marked = {
+            name
+            for name, field_info in cls.model_fields.items()
+            if isinstance(field_info.json_schema_extra, dict)
+            and field_info.json_schema_extra.get("capture")
+        }
+        return frozenset(capture_marked | _CLI_FORWARDABLE_EXTRAS)
+
+    def cli_forwardable_overrides(self) -> dict[str, str]:
+        """Forwardable Settings fields whose value differs from the default.
+
+        Returned as a dict of `{ENV_VAR_NAME: stringified_value}` ready
+        to drop into the cloud-job request's `extra_env`. Bools become
+        "true"/"false" so they round-trip through pydantic-settings'
+        env parsing; `None`-valued fields are omitted.
+        """
+        out: dict[str, str] = {}
+        for name in self._cli_forwardable_fields():
+            field_info = type(self).model_fields[name]
+            current = getattr(self, name)
+            if current is None or current == field_info.default:
+                continue
+            out[name.upper()] = (
+                "true" if current is True else "false" if current is False else str(current)
+            )
+        return out
 
 
 _settings_var: contextvars.ContextVar[Settings | None] = contextvars.ContextVar(

--- a/tests/test_jobs_router.py
+++ b/tests/test_jobs_router.py
@@ -153,6 +153,88 @@ async def test_post_orchestrator_run_validates_request_body(mocker, auth_overrid
 
 
 @pytest.mark.asyncio
+async def test_post_orchestrator_run_rejects_unknown_extra_env_key(mocker, auth_overridden_client):
+    """Settings.all_env_keys() is the API trust boundary — unknown keys
+    are rejected at submission time so typos don't silently fall on
+    the floor (Settings is configured extra='ignore')."""
+    mocker.patch(
+        "rumil.api.jobs.submit_orchestrator_job",
+        return_value=("should-not-be-called", _FAKE_RUN_ID),
+    )
+    resp = await auth_overridden_client.post(
+        "/api/jobs/orchestrator-runs",
+        json={
+            "question": "q",
+            "budget": 1,
+            "workspace": "ws",
+            "extra_env": {"NOT_A_REAL_SETTING": "x"},
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_post_orchestrator_run_rejects_lowercase_extra_env_key(
+    mocker, auth_overridden_client
+):
+    mocker.patch(
+        "rumil.api.jobs.submit_orchestrator_job",
+        return_value=("should-not-be-called", _FAKE_RUN_ID),
+    )
+    resp = await auth_overridden_client.post(
+        "/api/jobs/orchestrator-runs",
+        json={
+            "question": "q",
+            "budget": 1,
+            "workspace": "ws",
+            "extra_env": {"available_moves": "extra"},
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_post_orchestrator_run_rejects_empty_extra_env_value(mocker, auth_overridden_client):
+    mocker.patch(
+        "rumil.api.jobs.submit_orchestrator_job",
+        return_value=("should-not-be-called", _FAKE_RUN_ID),
+    )
+    resp = await auth_overridden_client.post(
+        "/api/jobs/orchestrator-runs",
+        json={
+            "question": "q",
+            "budget": 1,
+            "workspace": "ws",
+            "extra_env": {"AVAILABLE_MOVES": ""},
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_post_orchestrator_run_forwards_extra_env_to_submitter(
+    mocker, auth_overridden_client
+):
+    fake_submit = mocker.patch(
+        "rumil.api.jobs.submit_orchestrator_job",
+        return_value=("rumil-orch-ws-extra", _FAKE_RUN_ID),
+    )
+    mocker.patch("rumil.api.jobs.build_logs_url", return_value="")
+    resp = await auth_overridden_client.post(
+        "/api/jobs/orchestrator-runs",
+        json={
+            "question": "q",
+            "budget": 1,
+            "workspace": "ws",
+            "extra_env": {"RUMIL_MODEL_OVERRIDE": "claude-sonnet-4-6"},
+        },
+    )
+    assert resp.status_code == 201
+    spec_arg = fake_submit.call_args.args[0]
+    assert spec_arg.extra_env == {"RUMIL_MODEL_OVERRIDE": "claude-sonnet-4-6"}
+
+
+@pytest.mark.asyncio
 async def test_post_orchestrator_run_returns_500_when_submitter_fails(
     mocker, auth_overridden_client
 ):

--- a/tests/test_jobs_router.py
+++ b/tests/test_jobs_router.py
@@ -20,6 +20,7 @@ from rumil.k8s.submit import (
     JOB_LABEL_RUN_KIND_VALUE,
     JOB_LABEL_WORKSPACE,
 )
+from rumil.settings import override_settings
 
 
 @pytest.fixture
@@ -252,12 +253,17 @@ async def test_post_orchestrator_run_returns_500_when_submitter_fails(
 @pytest.mark.asyncio
 async def test_post_orchestrator_run_unauthorized_without_token():
     """No dependency override -> JWT path runs, returns 401 without bearer."""
+    # Pin auth_enabled=True regardless of the developer's local .env (the
+    # shared dev .env sets AUTH_ENABLED=0 for frictionless local API access,
+    # which would otherwise short-circuit the auth dependency to 200/201
+    # here).
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as anon:
-        resp = await anon.post(
-            "/api/jobs/orchestrator-runs",
-            json={"question": "q", "budget": 1, "workspace": "ws"},
-        )
+    with override_settings(auth_enabled=True):
+        async with AsyncClient(transport=transport, base_url="http://test") as anon:
+            resp = await anon.post(
+                "/api/jobs/orchestrator-runs",
+                json={"question": "q", "budget": 1, "workspace": "ws"},
+            )
     assert resp.status_code == 401
 
 
@@ -411,6 +417,7 @@ async def test_get_jobs_lists_with_label_selector(mocker, auth_overridden_client
 @pytest.mark.asyncio
 async def test_get_jobs_unauthorized_without_token():
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as anon:
-        resp = await anon.get("/api/jobs")
+    with override_settings(auth_enabled=True):
+        async with AsyncClient(transport=transport, base_url="http://test") as anon:
+            resp = await anon.get("/api/jobs")
     assert resp.status_code == 401

--- a/tests/test_k8s_submit.py
+++ b/tests/test_k8s_submit.py
@@ -390,6 +390,85 @@ def test_request_accepts_normal_container_tags(good_tag):
     assert spec.container_tag == good_tag
 
 
+def test_build_job_appends_extra_env_entries():
+    spec = _spec(extra_env={"AVAILABLE_MOVES": "extra"})
+    body = _build_job(
+        spec,
+        name="x",
+        owner_user_id="",
+        run_id=_RUN_ID,
+        image="img",
+        env=[client.V1EnvVar(name="USE_PROD_DB", value="1")],
+        env_from=[],
+    )
+    container = body["spec"]["template"]["spec"]["containers"][0]
+    names = [e["name"] for e in container["env"]]
+    assert "AVAILABLE_MOVES" in names
+    by_name = {e["name"]: e["value"] for e in container["env"]}
+    assert by_name["AVAILABLE_MOVES"] == "extra"
+
+
+def test_build_job_drops_inherited_entries_shadowed_by_extra_env():
+    """If extra_env names a key already in inherited env, the inherited
+    one is dropped — never two entries with the same name."""
+    spec = _spec(extra_env={"USE_PROD_DB": "0"})
+    body = _build_job(
+        spec,
+        name="x",
+        owner_user_id="",
+        run_id=_RUN_ID,
+        image="img",
+        env=[
+            client.V1EnvVar(name="USE_PROD_DB", value="1"),
+            client.V1EnvVar(name="OTHER", value="keep"),
+        ],
+        env_from=[],
+    )
+    container = body["spec"]["template"]["spec"]["containers"][0]
+    names = [e["name"] for e in container["env"]]
+    assert names.count("USE_PROD_DB") == 1
+    by_name = {e["name"]: e["value"] for e in container["env"]}
+    assert by_name["USE_PROD_DB"] == "0"  # the override won
+    assert by_name["OTHER"] == "keep"  # unrelated inherited entry preserved
+
+
+def test_build_job_extra_env_appends_after_inherited():
+    """Inherited env first, overrides last — order reflects intent for
+    anyone reading the manifest later."""
+    spec = _spec(extra_env={"AVAILABLE_MOVES": "extra"})
+    body = _build_job(
+        spec,
+        name="x",
+        owner_user_id="",
+        run_id=_RUN_ID,
+        image="img",
+        env=[
+            client.V1EnvVar(name="USE_PROD_DB", value="1"),
+            client.V1EnvVar(name="OTHER", value="keep"),
+        ],
+        env_from=[],
+    )
+    names = [e["name"] for e in body["spec"]["template"]["spec"]["containers"][0]["env"]]
+    assert names == ["USE_PROD_DB", "OTHER", "AVAILABLE_MOVES"]
+
+
+def test_build_job_no_extra_env_preserves_inherited_order():
+    body = _build_job(
+        _spec(),
+        name="x",
+        owner_user_id="",
+        run_id=_RUN_ID,
+        image="img",
+        env=[
+            client.V1EnvVar(name="A", value="1"),
+            client.V1EnvVar(name="B", value="2"),
+        ],
+        env_from=[],
+    )
+    names = [e["name"] for e in body["spec"]["template"]["spec"]["containers"][0]["env"]]
+    assert names == ["A", "B"]
+
+
 def test_build_logs_url_returns_empty_when_project_unset():
     with override_settings(gcp_project_id=""):
         assert build_logs_url("rumil-orch-ws-aaaa") == ""

--- a/tests/test_settings_forwardable.py
+++ b/tests/test_settings_forwardable.py
@@ -1,0 +1,155 @@
+"""Tests for Settings.all_env_keys() and Settings.cli_forwardable_overrides()."""
+
+from __future__ import annotations
+
+from pydantic_core import PydanticUndefined
+
+from rumil.settings import Settings
+
+
+def _defaults_for_fields(field_names: frozenset[str]) -> dict[str, object]:
+    """Materialise each field's class default into a kwargs dict, skipping fields without a fixed default."""
+    out: dict[str, object] = {}
+    for name in field_names:
+        default = Settings.model_fields[name].default
+        if default is PydanticUndefined:
+            continue
+        out[name] = default
+    return out
+
+
+def _settings_at_defaults(**overrides: object) -> Settings:
+    """Build a Settings instance pinned to forwardable-field defaults plus any explicit overrides.
+
+    Pinning blocks values from the local `.env` / shell environment from
+    leaking into the test — passing kwargs takes precedence over both.
+    """
+    base = _defaults_for_fields(Settings._cli_forwardable_fields())
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_all_env_keys_uppercases_every_field():
+    keys = Settings.all_env_keys()
+    assert "ANTHROPIC_API_KEY" in keys
+    assert "AVAILABLE_MOVES" in keys
+    assert "RUMIL_MODEL_OVERRIDE" in keys
+    assert "USE_PROD_DB" in keys
+
+
+def test_all_env_keys_size_matches_model_fields():
+    assert len(Settings.all_env_keys()) == len(Settings.model_fields)
+
+
+def test_all_env_keys_rejects_lowercase():
+    """No lowercase keys leak through — defends the API validator's
+    'must match ^[A-Z][A-Z0-9_]*$' check from drift."""
+    keys = Settings.all_env_keys()
+    assert all(k == k.upper() for k in keys)
+
+
+def test_cli_forwardable_overrides_empty_at_defaults():
+    settings = _settings_at_defaults()
+    assert settings.cli_forwardable_overrides() == {}
+
+
+def test_cli_forwardable_overrides_includes_capture_marked_overrides():
+    settings = _settings_at_defaults(available_moves="experimental")
+    out = settings.cli_forwardable_overrides()
+    assert out["AVAILABLE_MOVES"] == "experimental"
+
+
+def test_cli_forwardable_overrides_includes_extra_set_overrides():
+    """rumil_model_override / rumil_smoke_test etc. aren't capture-marked
+    but are explicitly forwardable."""
+    settings = _settings_at_defaults(rumil_model_override="claude-sonnet-4-6", rumil_smoke_test="1")
+    out = settings.cli_forwardable_overrides()
+    assert out["RUMIL_MODEL_OVERRIDE"] == "claude-sonnet-4-6"
+    assert out["RUMIL_SMOKE_TEST"] == "1"
+
+
+def test_cli_forwardable_overrides_stringifies_bool_as_lowercase():
+    """pydantic-settings parses 'true'/'false' on Job startup."""
+    settings = _settings_at_defaults(force_twophase_recurse=True)
+    out = settings.cli_forwardable_overrides()
+    assert out["FORCE_TWOPHASE_RECURSE"] == "true"
+
+
+def test_cli_forwardable_overrides_stringifies_int():
+    settings = _settings_at_defaults(ingest_num_claims=8)
+    out = settings.cli_forwardable_overrides()
+    assert out["INGEST_NUM_CLAIMS"] == "8"
+
+
+def test_cli_forwardable_overrides_stringifies_float():
+    settings = _settings_at_defaults(global_prio_budget_fraction=0.5)
+    out = settings.cli_forwardable_overrides()
+    assert out["GLOBAL_PRIO_BUDGET_FRACTION"] == "0.5"
+
+
+def test_cli_forwardable_overrides_excludes_credentials_even_when_set():
+    """Defends the curated CLI subset: a developer with a local .env
+    pointing at prod must not have those values silently pushed into
+    the cloud Job."""
+    settings = _settings_at_defaults(
+        anthropic_api_key="sk-secret",
+        supabase_prod_url="https://laptop.supabase.local",
+        supabase_prod_key="laptop-secret",
+        gcp_project_id="laptop-project",
+        frontend_url="http://laptop.local",
+    )
+    out = settings.cli_forwardable_overrides()
+    assert "ANTHROPIC_API_KEY" not in out
+    assert "SUPABASE_PROD_URL" not in out
+    assert "SUPABASE_PROD_KEY" not in out
+    assert "GCP_PROJECT_ID" not in out
+    assert "FRONTEND_URL" not in out
+
+
+def test_cli_forwardable_overrides_omits_field_set_back_to_default():
+    """A field re-set to its default value is indistinguishable from
+    the unset case — both should be omitted (otherwise we'd shadow
+    the cloud's deployed value with a duplicate of the same value,
+    inflating the env list)."""
+    default = Settings.model_fields["available_moves"].default
+    settings = _settings_at_defaults(available_moves=default)
+    assert "AVAILABLE_MOVES" not in settings.cli_forwardable_overrides()
+
+
+def test_cli_forwardable_fields_includes_capture_marked():
+    fields = Settings._cli_forwardable_fields()
+    assert "available_moves" in fields
+    assert "view_variant" in fields
+    assert "ingest_num_claims" in fields
+
+
+def test_cli_forwardable_fields_includes_explicit_extras():
+    fields = Settings._cli_forwardable_fields()
+    assert "rumil_model_override" in fields
+    assert "rumil_smoke_test" in fields
+    assert "rumil_test_mode" in fields
+    assert "force_twophase_recurse" in fields
+
+
+def test_cli_forwardable_fields_excludes_credentials_and_infra():
+    fields = Settings._cli_forwardable_fields()
+    for excluded in (
+        "anthropic_api_key",
+        "supabase_prod_url",
+        "supabase_prod_key",
+        "supabase_jwt_secret",
+        "gcp_project_id",
+        "gcp_cluster_name",
+        "frontend_url",
+        "rumil_api_url",
+        "default_cli_user_id",
+        "auth_enabled",
+        "langfuse_public_key",
+        "langfuse_secret_key",
+        "voyage_ai_api_key",
+        "jina_api_key",
+        "use_prod_db",
+        "tracing_enabled",
+        "db_max_concurrent_queries",
+    ):
+        assert excluded not in fields, f"{excluded} should not be CLI-forwardable"


### PR DESCRIPTION
## Summary

- Add an `extra_env: dict[str, str]` field on `OrchestratorRunRequest` so callers can override Settings values per cloud-job run; the API merges these into the Job's container env (deduping inherited entries with the same key).
- The CLI auto-populates `extra_env` from a curated subset of locally-loaded `Settings` (every `_capture_field`-marked field plus `RUMIL_MODEL_OVERRIDE`/`RUMIL_SMOKE_TEST`/`RUMIL_TEST_MODE`/`FORCE_TWOPHASE_RECURSE`), so e.g. `RUMIL_MODEL_OVERRIDE=claude-sonnet-4-6 main.py … --prod` Just Works. Credentials, DB URLs, GCP IDs, frontend/API URLs, and Langfuse keys are intentionally excluded.
- API-side validator rejects unknown keys, lowercase keys, and empty values at submission time so typos 422 instead of being silently dropped by `Settings(extra='ignore')`.

## Test plan

- [x] `uv run pytest tests/test_settings_forwardable.py tests/test_k8s_submit.py tests/test_jobs_router.py` — 89 passed locally (two pre-existing unauth-test failures on this branch's baseline are unrelated and being looked at separately).
- [ ] Once deployed: `RUMIL_MODEL_OVERRIDE=claude-sonnet-4-6 uv run python main.py "Is the sky blue?" --executor prod --workspace cloud-config-scratch --budget 2 --smoke-test`, then `kubectl -n rumil get pod -l job-name=<job_name> -o jsonpath='{.items[0].spec.containers[0].env}' | jq` to confirm `RUMIL_MODEL_OVERRIDE` lands on the pod and the trace's `capture_config()` shows `model = claude-sonnet-4-6`.
- [ ] Negative path: curl `extra_env: {"NOT_A_REAL_SETTING": "x"}` against the deployed API — expect 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)