### PR TITLE
feat(update_view): add propose_new phase to surface gap-filling items

### DIFF
--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -122,10 +122,6 @@ class ProposedItem(BaseModel):
 
 class DeepReviewBatchResponse(BaseModel):
     item_reviews: list[ItemReview] = Field(description="One review per item in the batch")
-    proposed_items: list[ProposedItem] = Field(
-        default_factory=list,
-        description="New items to add to the View (zero or more)",
-    )
 
 
 class DemotionChoice(BaseModel):
@@ -446,10 +442,9 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
         messages, flagged_ids = await self._phase_triage(infra, system_prompt, sections, messages)
 
         if flagged_ids:
-            messages, phase2b_created = await self._phase_deep_review(
+            messages = await self._phase_deep_review(
                 infra, system_prompt, sections, messages, flagged_ids
             )
-            created_page_ids.extend(phase2b_created)
 
         messages, propose_created = await self._phase_propose_new(
             infra, system_prompt, sections, messages
@@ -664,7 +659,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
         sections: dict[str, str],
         messages: list[dict],
         flagged_ids: Sequence[str],
-    ) -> tuple[list[dict], list[str]]:
+    ) -> list[dict]:
         items = await infra.db.get_view_items(self._view_id)
         flagged_set = set(flagged_ids)
         flagged = [(page, link) for page, link in items if page.id in flagged_set]
@@ -674,7 +669,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                 PhaseSkippedEvent(phase="deep_review", reason="No flagged items found")
             )
             self._phase_lines.append("deep_review: skipped (no flagged items)")
-            return messages, []
+            return messages
 
         link_by_target = {page.id: link for page, link in items}
         page_by_id = {page.id: page for page, link in items}
@@ -693,7 +688,6 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
         related_considerations = [claim for claim, _ in parent_considerations]
 
         batch_sizes = _split_into_batches(len(flagged), DEEP_REVIEW_BATCH_SIZE)
-        created_page_ids: list[str] = []
         adjust_count = 0
         supersede_count = 0
         offset = 0
@@ -720,7 +714,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                 f"({batch_size} items for deep review)\n\n"
                 + "\n\n---\n\n".join(item_blocks)
                 + "\n\nReview all items in this batch. "
-                "You may also propose new items if you notice gaps."
+                "(A separate Propose New Items phase follows — do not propose net-new items here.)"
             )
 
             if batch_idx == 0:
@@ -770,25 +764,18 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                     if review.action == "supersede" and resolved in link_by_target:
                         del link_by_target[resolved]
 
-                for proposal in result.parsed.proposed_items:
-                    new_id = await self._create_proposed_item(infra, proposal)
-                    if new_id:
-                        created_page_ids.append(new_id)
-
         await infra.trace.record(
             UpdateViewPhaseCompletedEvent(
                 phase="deep_review",
                 items_processed=len(flagged),
                 items_modified=adjust_count + supersede_count,
-                items_created=len(created_page_ids),
             )
         )
         self._phase_lines.append(
             f"deep_review: reviewed {len(flagged)} item(s), "
-            f"superseded {supersede_count}, adjusted {adjust_count}, "
-            f"proposed {len(created_page_ids)} new item(s)"
+            f"superseded {supersede_count}, adjusted {adjust_count}"
         )
-        return messages, created_page_ids
+        return messages
 
     async def _phase_propose_new(
         self,

--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -451,6 +451,11 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             )
             created_page_ids.extend(phase2b_created)
 
+        messages, propose_created = await self._phase_propose_new(
+            infra, system_prompt, sections, messages
+        )
+        created_page_ids.extend(propose_created)
+
         messages = await self._phase_enforce_caps(infra, system_prompt, sections, messages)
 
         messages = await self._phase_prune(infra, system_prompt, sections, messages)
@@ -783,6 +788,85 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
             f"superseded {supersede_count}, adjusted {adjust_count}, "
             f"proposed {len(created_page_ids)} new item(s)"
         )
+        return messages, created_page_ids
+
+    async def _phase_propose_new(
+        self,
+        infra: CallInfra,
+        system_prompt: str,
+        sections: dict[str, str],
+        messages: list[dict],
+    ) -> tuple[list[dict], list[str]]:
+        items = await infra.db.get_view_items(self._view_id)
+
+        items_by_section: dict[str, list[tuple[Page, PageLink]]] = {}
+        for page, link in items:
+            items_by_section.setdefault(link.section or "other", []).append((page, link))
+
+        section_blocks: list[str] = []
+        for sec in DEFAULT_VIEW_SECTIONS:
+            bucket = items_by_section.get(sec, [])
+            header = f"### {sec} ({len(bucket)} item(s))"
+            if not bucket:
+                section_blocks.append(f"{header}\n(none)")
+                continue
+            bucket.sort(key=lambda pl: -(pl[1].importance or 0))
+            lines = [_render_item_compact(p, l) for p, l in bucket]
+            section_blocks.append(header + "\n" + "\n".join(lines))
+
+        state_text = "## Current View Items\n\n" + "\n\n".join(section_blocks)
+
+        user_content = (
+            sections.get("propose_new", "")
+            + "\n\n"
+            + state_text
+            + "\n\nPropose new items now. Return an empty list if the View "
+            "already captures the important picture."
+        )
+
+        propose_response_model = pydantic.create_model(
+            "ProposeNewBatch",
+            proposed_items=(
+                list[ProposedItem],
+                Field(
+                    default_factory=list,
+                    description="New items to add to the View (zero or more)",
+                ),
+            ),
+        )
+
+        messages.append({"role": "user", "content": user_content})
+
+        result = await structured_call(
+            system_prompt,
+            messages=list(messages),
+            response_model=propose_response_model,
+            cache=True,
+            metadata=LLMExchangeMetadata(
+                call_id=infra.call.id,
+                phase="propose_new",
+            ),
+            db=infra.db,
+        )
+
+        messages.append({"role": "assistant", "content": result.response_text or ""})
+
+        created_page_ids: list[str] = []
+        if result.parsed:
+            parsed_dict = result.parsed.model_dump()
+            proposals = [ProposedItem(**raw) for raw in parsed_dict.get("proposed_items", [])]
+            for proposal in proposals:
+                new_id = await self._create_proposed_item(infra, proposal)
+                if new_id:
+                    created_page_ids.append(new_id)
+
+        await infra.trace.record(
+            UpdateViewPhaseCompletedEvent(
+                phase="propose_new",
+                items_created=len(created_page_ids),
+            )
+        )
+        self._phase_lines.append(f"propose_new: created {len(created_page_ids)} new item(s)")
         return messages, created_page_ids
 
     async def _phase_enforce_caps(

--- a/src/rumil/prompts/update_view.md
+++ b/src/rumil/prompts/update_view.md
@@ -60,7 +60,7 @@ When superseding, write the replacement item as you would a fresh View item: a c
 
 Each item is rendered with its **Cited evidence** (pages the item already depends on) and, when applicable, a **Related considerations on the parent question (not cited by this item)** block. The latter lists considerations of the scope question that the item does not already cite — these are the most likely source of overlooked contradictions or complications. Before choosing an action, scan this list and ask whether any of these considerations should change, complicate, or replace the item under review.
 
-You may also **propose entirely new items** if you notice gaps — evidence or conclusions that the View should capture but currently doesn't. New items should include full scores (robustness, robustness_reasoning, importance, section) and follow the same format as existing items.
+This phase only acts on the items shown. **Do not propose net-new items here** — a dedicated *Propose New Items* phase follows that handles gap-filling separately.
 
 <!-- PHASE:propose_new — DO NOT RENAME THIS MARKER -->
 

--- a/src/rumil/prompts/update_view.md
+++ b/src/rumil/prompts/update_view.md
@@ -5,16 +5,17 @@ You are incrementally updating an existing **View page** for a question. Unlike 
 The View consists of **atomic items** organized into **sections**, each with epistemic scores. Your job across multiple phases is to bring the View up to date with the current evidence.
 
 <!-- PHASE:context — DO NOT RENAME THIS MARKER -->
+
 ## Shared Context
 
 A View is a curated, structured summary of the workspace's current best understanding on a research question. Each View item is a short, self-contained observation with:
 
-* **Robustness (1-5)**: How well-investigated (1=wild guess, 3=considered view, 5=thoroughly tested)
-* **Importance (1-5)**: How core to the View (5=essential, 1=marginal)
+- **Robustness (1-5)**: How well-investigated (1=wild guess, 3=considered view, 5=thoroughly tested)
+- **Importance (1-5)**: How core to the View (5=essential, 1=marginal)
 
 View items do **not** carry a credence score — credence applies only to claim pages. If a View item's underlying assertion is sharp and falsifiable enough to deserve a credence score, a separate claim page should exist (or be created) and the View item should cite it.
 
-**Sections:** broader\_context, confident\_views, live\_hypotheses, key\_evidence, assessments, key\_uncertainties, other.
+**Sections:** broader_context, confident_views, live_hypotheses, key_evidence, assessments, key_uncertainties, other.
 
 You will be asked to review View items in batches across several phases. Apply your judgement carefully — small, well-justified changes are better than sweeping revisions.
 
@@ -23,34 +24,37 @@ The context may include a **Child Investigation Results** section showing the la
 The context may also include a **Recent findings from claim investigations** section. Claim investigations drill into specific considerations of this question and often produce counter-evidence or reframings that live at the claim level and have not yet been reflected in the View. Treat these findings the same way as child-investigation results: they should directly pressure existing View items or motivate new ones. If a finding here materially contradicts a View item, supersede or adjust that item rather than leaving both standing.
 
 <!-- PHASE:score_unscored — DO NOT RENAME THIS MARKER -->
+
 ## Phase: Score Unscored Proposals
 
 These items were proposed by other calls but have not yet been scored. For each item, assign:
 
-* **importance** (1-5): How core is this item to the View?
-* **section**: Which section best fits this item's role?
-* **robustness** (optional): Override if the current score looks wrong. If you set this, you must also provide **robustness_reasoning** — per the preamble rubric, explain where the uncertainty sits and how reducible it is.
+- **importance** (1-5): How core is this item to the View?
+- **section**: Which section best fits this item's role?
+- **robustness** (optional): Override if the current score looks wrong. If you set this, you must also provide **robustness_reasoning** — per the preamble rubric, explain where the uncertainty sits and how reducible it is.
 
 Do not enforce importance caps at this stage — just score each item on its merits.
 
 <!-- PHASE:triage — DO NOT RENAME THIS MARKER -->
+
 ## Phase: Triage
 
 You are doing a shallow review of existing View items. For each item, decide:
 
-* **ok**: The item looks fine — scores are reasonable, content is accurate, section is appropriate. No changes needed.
-* **review**: Something about this item warrants a closer look — the scores may be off, the content may be outdated or inaccurate, it may be in the wrong section, or it may need to be replaced with a better formulation.
+- **ok**: The item looks fine — scores are reasonable, content is accurate, section is appropriate. No changes needed.
+- **review**: Something about this item warrants a closer look — the scores may be off, the content may be outdated or inaccurate, it may be in the wrong section, or it may need to be replaced with a better formulation.
 
 Err on the side of flagging items for review. It is better to review an item that turns out to be fine than to miss one that needs updating. But do not flag everything — focus on items where you see a specific reason for concern.
 
 <!-- PHASE:deep_review — DO NOT RENAME THIS MARKER -->
+
 ## Phase: Deep Review
 
 For each item in this batch, choose one action:
 
-* **keep**: The item is fine as-is after closer inspection. No changes.
-* **adjust**: The item's scores or section assignment need updating. Provide the new values and brief reasoning. If you change the robustness score, you must also provide `new_robustness_reasoning` explaining where the uncertainty stems from and how reducible it is.
-* **supersede**: The item should be replaced with a new version. Provide a new headline, content, robustness, robustness_reasoning, importance, and section. The old item will be superseded and the new one linked to the View.
+- **keep**: The item is fine as-is after closer inspection. No changes.
+- **adjust**: The item's scores or section assignment need updating. Provide the new values and brief reasoning. If you change the robustness score, you must also provide `new_robustness_reasoning` explaining where the uncertainty stems from and how reducible it is.
+- **supersede**: The item should be replaced with a new version. Provide a new headline, content, robustness, robustness_reasoning, importance, and section. The old item will be superseded and the new one linked to the View.
 
 When superseding, write the replacement item as you would a fresh View item: a clear headline, content with an epistemic gloss explaining the robustness score, and careful scoring. Provide `robustness_reasoning` per the preamble rubric — where the uncertainty sits and how reducible it is.
 
@@ -58,7 +62,32 @@ Each item is rendered with its **Cited evidence** (pages the item already depend
 
 You may also **propose entirely new items** if you notice gaps — evidence or conclusions that the View should capture but currently doesn't. New items should include full scores (robustness, robustness_reasoning, importance, section) and follow the same format as existing items.
 
+<!-- PHASE:propose_new — DO NOT RENAME THIS MARKER -->
+
+## Phase: Propose New Items
+
+You have now reviewed the existing items. In this phase you decide whether anything important is **missing** from the View — observations the View should capture but currently doesn't.
+
+The most likely sources of gaps are:
+
+- Findings in the **Child Investigation Results** section (especially items marked **[NEW]**) whose synthesis is not reflected in any current View item — for example, a child View whose top-line answer or load-bearing crux contradicts or simply isn't present in any parent-View item.
+- Findings in the **Recent findings from claim investigations** section that change the picture (new mechanisms, sign flips, magnitude updates, missing channels) and aren't yet captured.
+- Considerations on the parent question that point at structurally important content (a missing channel under the question's framing, a key empirical anchor, a load-bearing uncertainty) which no existing item addresses.
+
+Each proposal must be a **net-new** item, not a restatement of an existing one. Before proposing an item, check the current View state shown below: if a current item already covers the observation, do not propose a duplicate — flag it for `review` in a future call instead, or trust that earlier triage already handled it.
+
+Apply the same standards as when creating a View from scratch:
+
+- **Atomic and self-contained.** One observation per item — newspaper headline plus one sentence of supporting reasoning.
+- **Section.** Place the item where it does the most orienting work.
+- **Importance.** Reserve I=5 for items the executive summary should lead with; I=4 for important context; I=3 for useful background; I=2 for noted-but-not-load-bearing. The next phase enforces caps, so honest scoring matters.
+- **Robustness + reasoning.** Score how well-investigated the underlying position is and explain where the residual uncertainty sits.
+- **Cite sources.** Reference page IDs (e.g. `[abc12345]`) for any specific claims, child views, or evidence the item rests on. Items without grounding don't earn a place.
+
+Be selective. Curation beats completeness — an empty proposal list is the right answer when the View already captures the important picture. But when there's a genuine gap, propose the item: views that fail to absorb new findings stop being useful summaries.
+
 <!-- PHASE:enforce_caps — DO NOT RENAME THIS MARKER -->
+
 ## Phase: Importance Cap Enforcement
 
 The View has importance caps that limit how many items can exist at each importance level. The items shown below are at a level that currently exceeds its cap.
@@ -68,11 +97,12 @@ Choose which items to **demote** (lower their importance score). For each item y
 Keep the items that are most central to understanding the question. Demote items that are useful context but not as critical.
 
 <!-- PHASE:prune — DO NOT RENAME THIS MARKER -->
+
 ## Phase: Prune Low-Value Items
 
 These are importance-1 and importance-2 items. Decide for each:
 
-* **keep**: The item still belongs in the View, even at low importance.
-* **remove**: The item adds little value and should be dropped from the View. This could be because it is redundant with higher-importance items, no longer relevant, or too marginal to justify inclusion.
+- **keep**: The item still belongs in the View, even at low importance.
+- **remove**: The item adds little value and should be dropped from the View. This could be because it is redundant with higher-importance items, no longer relevant, or too marginal to justify inclusion.
 
 Be willing to remove items that are not pulling their weight. A tighter View is more useful than a comprehensive one. But do not remove items that provide genuinely useful context or that track uncertainties worth monitoring.

--- a/tests/test_update_view.py
+++ b/tests/test_update_view.py
@@ -908,6 +908,128 @@ async def test_phase_enforce_caps_skips_within_limits(
     assert len(result_messages) == len(messages)
 
 
+async def test_phase_propose_new_creates_items_from_proposals(
+    tmp_db,
+    view_setup,
+    call_infra,
+    monkeypatch,
+):
+    """propose_new should turn each LLM proposal into a linked VIEW_ITEM."""
+    from rumil.calls import update_view as uv
+    from rumil.llm import StructuredCallResult
+
+    _, v, _ = view_setup
+    updater = UpdateViewWorkspaceUpdater(v.id, CallType.UPDATE_VIEW)
+
+    proposals = [
+        ProposedItem(
+            headline="Bottom-line magnitude",
+            content="Central estimate -1.5% to -2% [abc12345].",
+            robustness=3,
+            robustness_reasoning="Synthesizes multiple R3+ claims",
+            importance=5,
+            section="confident_views",
+            reasoning="No existing item names the magnitude",
+        ),
+        ProposedItem(
+            headline="Sign-uncertainty compression",
+            content="Sign uncertainty compresses directed EV by 2-5x [def45678].",
+            robustness=4,
+            robustness_reasoning="Mechanism is structural, not empirical",
+            importance=5,
+            section="confident_views",
+            reasoning="Methodologically load-bearing",
+        ),
+    ]
+
+    from pydantic import BaseModel
+
+    class _Parsed(BaseModel):
+        proposed_items: list[dict]
+
+    parsed = _Parsed(proposed_items=[p.model_dump() for p in proposals])
+
+    async def fake_structured_call(*args, **kwargs):
+        return StructuredCallResult(parsed=parsed, response_text="{}")
+
+    monkeypatch.setattr(uv, "structured_call", fake_structured_call)
+
+    messages = [
+        {"role": "user", "content": "context"},
+        {"role": "assistant", "content": "Understood."},
+    ]
+    n_before = len(messages)
+
+    result_messages, created_ids = await updater._phase_propose_new(
+        call_infra,
+        "system",
+        {"propose_new": "Propose new items."},
+        messages,
+    )
+
+    assert len(created_ids) == 2
+    assert len(result_messages) == n_before + 2
+
+    items_after = await tmp_db.get_view_items(v.id)
+    new_pages_by_id = {p.id: (p, l) for p, l in items_after if p.id in created_ids}
+    assert len(new_pages_by_id) == 2
+
+    for new_id in created_ids:
+        page, link = new_pages_by_id[new_id]
+        assert page.page_type == PageType.VIEW_ITEM
+        assert link.link_type == LinkType.VIEW_ITEM
+        assert link.section == "confident_views"
+        assert link.importance == 5
+
+    assert any("propose_new" in line and "created 2" in line for line in updater._phase_lines)
+
+
+async def test_phase_propose_new_no_proposals_records_phase_completed(
+    tmp_db,
+    view_setup,
+    call_infra,
+    monkeypatch,
+):
+    """propose_new should still record the phase event when the LLM proposes nothing."""
+    from rumil.calls import update_view as uv
+    from rumil.llm import StructuredCallResult
+
+    _, v, _items = view_setup
+    updater = UpdateViewWorkspaceUpdater(v.id, CallType.UPDATE_VIEW)
+
+    from pydantic import BaseModel
+
+    class _Parsed(BaseModel):
+        proposed_items: list[dict]
+
+    parsed = _Parsed(proposed_items=[])
+
+    async def fake_structured_call(*args, **kwargs):
+        return StructuredCallResult(parsed=parsed, response_text="{}")
+
+    monkeypatch.setattr(uv, "structured_call", fake_structured_call)
+
+    items_before = await tmp_db.get_view_items(v.id)
+    messages = [
+        {"role": "user", "content": "context"},
+        {"role": "assistant", "content": "Understood."},
+    ]
+    n_before = len(messages)
+
+    result_messages, created_ids = await updater._phase_propose_new(
+        call_infra,
+        "system",
+        {"propose_new": "Propose new items."},
+        messages,
+    )
+
+    assert created_ids == []
+    items_after = await tmp_db.get_view_items(v.id)
+    assert {p.id for p, _ in items_after} == {p.id for p, _ in items_before}
+    assert any("propose_new" in line and "created 0" in line for line in updater._phase_lines)
+    assert len(result_messages) == n_before + 2
+
+
 def test_is_explicit_duplicate_detects_marker():
     page_dup = _view_item("Dup", content="[Duplicate of abc123, created in error.]")
     page_normal = _view_item("Normal", content="Some normal observation.")

--- a/tests/test_update_view.py
+++ b/tests/test_update_view.py
@@ -1130,7 +1130,8 @@ def test_view_closing_review_prefers_phase_summary_over_moves():
         phase_summary=(
             "score_unscored: scored 3 item(s), modified 3\n"
             "triage: reviewed 5 item(s), flagged 2 for deep review\n"
-            "deep_review: reviewed 2 item(s), superseded 1, adjusted 1, proposed 1 new item(s)"
+            "deep_review: reviewed 2 item(s), superseded 1, adjusted 1\n"
+            "propose_new: created 1 new item(s)"
         )
     )
     rendered = reviewer._review_context(creation)


### PR DESCRIPTION
## Summary

- `update_view` previously had no path to add net-new items unless triage flagged an existing item for review. On a sparse or stale view, an entire orchestrator run's findings could land in subquestion views without ever propagating up to the parent view.
- Adds a `propose_new` phase between `deep_review` and `enforce_caps` that asks the LLM to scan the working context (`[NEW]` child investigations, recent claim-investigation findings, parent considerations) for observations the View should capture but doesn't, and propose them as fresh items.
- Reuses the existing `ProposedItem` schema and `_create_proposed_item` helper, so cap enforcement and pruning still run afterward on the expanded set.

## Repro / motivation

Run `4c09f137-9144-445e-a232-7aa08fc62c1c` (proj-us-democracy-ii, prod) ran 101 calls and produced 138 claims plus ~16 richly-populated subquestion views, but its three top-level `update_view` calls each reported `View created. 0 items.` — the final top-Q view stayed at 1 carried-over item the whole run. The structural cause was that `triage` flagged the only existing item as `ok`, so `deep_review` never ran, and there was no other phase that could add anything.

After this change, a staged re-run of `update_view` against that same view created **7 new items** spanning all the previously empty sections (bottom-line magnitude, AI-channel sign-uncertainty compression, authoritarianism × TAI tail risk, Trump-2 paradigm, channel decomposition, presidential-leverage uncertainty, Dem-counterfactual non-neutrality), all properly cited and within importance caps.

## Test plan

- [x] `uv run pytest tests/test_update_view.py` — 44 pass (42 existing + 2 new)
- [x] `uv run pyright` — clean
- [x] End-to-end staged run on prod top-Q (`f35b98c6`) — `propose_new` phase fired, 7 items created, no other phases regressed
- [x] Trace verifies pipeline ordering: `triage → propose_new → enforce_caps`, with caps still respected post-creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)