### PR TITLE
feat(self-improve): add --improvement-instructions flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ uv run python main.py --self-improve QUESTION_ID
 # Investigate and self-improve in one command (analyses the just-finished run)
 uv run python main.py "Your question here" --budget 20 --self-improve
 
+# Steer the self-improvement analysis with free-text instructions
+uv run python main.py --self-improve QUESTION_ID \
+    --improvement-instructions "concentrate on prioritization quality"
+
 # Evaluate the judgement quality for a question
 uv run python main.py --evaluate QUESTION_ID
 

--- a/main.py
+++ b/main.py
@@ -571,7 +571,12 @@ async def cmd_summary(
     return summary_text
 
 
-async def cmd_self_improve(question_id: str, db: DB) -> None:
+async def cmd_self_improve(
+    question_id: str,
+    db: DB,
+    *,
+    instructions: str | None = None,
+) -> None:
     question = await db.get_page(question_id)
     if not question:
         resolved = await db.resolve_page_id(question_id)
@@ -588,8 +593,10 @@ async def cmd_self_improve(question_id: str, db: DB) -> None:
     log.info(
         "(Uses one or more LLM calls with read-only tools, does not count against research budget)"
     )
+    if instructions and instructions.strip():
+        print(f"Steering instructions: {instructions.strip()[:200]}\n")
 
-    text = await run_self_improvement(question.id, db)
+    text = await run_self_improvement(question.id, db, instructions=instructions)
     if not text.strip():
         log.info("No analysis produced.")
         return
@@ -1136,6 +1143,19 @@ async def async_main():
         ),
     )
     parser.add_argument(
+        "--improvement-instructions",
+        dest="improvement_instructions",
+        metavar="TEXT",
+        default=None,
+        help=(
+            "Optional free-text steer for --self-improve. The string is "
+            "interpolated into the self-improvement prompt so the agent "
+            "focuses its analysis on what you care about (e.g. "
+            "'concentrate on prioritization quality and ignore prompt "
+            "wording'). Has no effect without --self-improve."
+        ),
+    )
+    parser.add_argument(
         "--max-depth",
         type=int,
         default=4,
@@ -1629,7 +1649,11 @@ async def async_main():
             budget_per_memo=args.budget_per_memo,
         )
     elif args.self_improve_id and args.self_improve_id != "__auto__":
-        await cmd_self_improve(args.self_improve_id, db)
+        await cmd_self_improve(
+            args.self_improve_id,
+            db,
+            instructions=args.improvement_instructions,
+        )
     elif args.continue_id:
         await cmd_continue(
             args.continue_id,
@@ -1676,7 +1700,11 @@ async def async_main():
             )
             log.info("Obsidian vault exported to: %s", out)
         if do_self_improve:
-            await cmd_self_improve(question_id, db)
+            await cmd_self_improve(
+                question_id,
+                db,
+                instructions=args.improvement_instructions,
+            )
     else:
         parser.print_help()
 

--- a/src/rumil/cli_client.py
+++ b/src/rumil/cli_client.py
@@ -76,6 +76,7 @@ def _request_from_args(args: argparse.Namespace) -> OrchestratorRunRequest:
         no_trace=bool(getattr(args, "no_trace", False)),
         auto_summary=getattr(args, "summary_id", None) == "__auto__",
         auto_self_improve=getattr(args, "self_improve_id", None) == "__auto__",
+        improvement_instructions=getattr(args, "improvement_instructions", None),
         available_moves=getattr(args, "available_moves", None),
         available_calls=getattr(args, "available_calls", None),
         view_variant=getattr(args, "view_variant", None),

--- a/src/rumil/k8s/submit.py
+++ b/src/rumil/k8s/submit.py
@@ -169,6 +169,8 @@ def _build_container_command(spec: OrchestratorRunRequest, *, run_id: str) -> Se
         args.append("--summary")
     if spec.auto_self_improve:
         args.append("--self-improve")
+    if spec.improvement_instructions and spec.auto_self_improve:
+        args += ["--improvement-instructions", spec.improvement_instructions]
     if spec.available_moves:
         args += ["--available-moves", spec.available_moves]
     if spec.available_calls:

--- a/src/rumil/k8s/types.py
+++ b/src/rumil/k8s/types.py
@@ -53,6 +53,9 @@ class OrchestratorRunRequest(BaseModel):
     # are non-orchestrator modes and aren't supported remotely.
     auto_summary: bool = False
     auto_self_improve: bool = False
+    # Optional steering string for --self-improve. Only meaningful when
+    # auto_self_improve is True; ignored otherwise.
+    improvement_instructions: str | None = None
 
     available_moves: str | None = None
     available_calls: str | None = None

--- a/src/rumil/self_improve.py
+++ b/src/rumil/self_improve.py
@@ -562,8 +562,18 @@ async def _run_agent(
     return final_text
 
 
-async def run_self_improvement(question_id: str, db: DB) -> str:
-    """Run a self-improvement analysis for a question. Returns markdown text."""
+async def run_self_improvement(
+    question_id: str,
+    db: DB,
+    *,
+    instructions: str | None = None,
+) -> str:
+    """Run a self-improvement analysis for a question. Returns markdown text.
+
+    `instructions` is an optional free-text steer from the user — when set,
+    it's interpolated into the user message so the agent focuses its
+    analysis on what the user cares about.
+    """
     resolved = await db.resolve_page_id(question_id)
     if not resolved:
         raise ValueError(f"Question '{question_id}' not found")
@@ -584,9 +594,21 @@ async def run_self_improvement(question_id: str, db: DB) -> str:
 
     tools = _build_tools(resolved, subtree, calls, db)
     system_prompt = _load_prompt("self_improve.md")
+    instructions_block = ""
+    trimmed = (instructions or "").strip()
+    if trimmed:
+        instructions_block = (
+            "## Steering from the user\n\n"
+            "The user has asked you to focus this analysis on the following. "
+            "Treat it as a strong steer on what to dig into and what kinds of "
+            "improvements to surface — but stay honest: if a focus area turns "
+            "up nothing real, say so rather than padding.\n\n"
+            f"{trimmed}\n\n"
+        )
     user_message = (
         f"The investigation to analyse is rooted at question "
         f"[{resolved[:8]}]: {question.headline}\n\n"
+        f"{instructions_block}"
         "Start by calling get_investigation_overview. Then drill in "
         "wherever the shape suggests something worth a closer look. "
         "When you're ready, write the full self-improvement analysis "

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -107,6 +107,20 @@ def test_request_from_args_forwards_auto_self_improve():
     assert spec.auto_summary is False
 
 
+def test_request_from_args_forwards_improvement_instructions():
+    args = _args_namespace(
+        self_improve_id="__auto__",
+        improvement_instructions="focus on prioritization quality",
+    )
+    spec = _request_from_args(args)
+    assert spec.improvement_instructions == "focus on prioritization quality"
+
+
+def test_request_from_args_no_improvement_instructions_by_default():
+    spec = _request_from_args(_args_namespace())
+    assert spec.improvement_instructions is None
+
+
 def test_request_from_args_ignores_summary_with_real_id():
     """`--summary <QID>` is the standalone (non-orchestrator) mode and is
     rejected before it reaches the request builder; defensively, a real ID

--- a/tests/test_k8s_submit.py
+++ b/tests/test_k8s_submit.py
@@ -94,6 +94,32 @@ def test_container_command_forwards_auto_self_improve_as_bare_flag():
     assert idx == len(cmd) - 1 or cmd[idx + 1].startswith("--")
 
 
+def test_container_command_forwards_improvement_instructions():
+    cmd = list(
+        _build_container_command(
+            _spec(
+                auto_self_improve=True,
+                improvement_instructions="focus on prioritization",
+            ),
+            run_id=_RUN_ID,
+        )
+    )
+    assert "--improvement-instructions" in cmd
+    idx = cmd.index("--improvement-instructions")
+    assert cmd[idx + 1] == "focus on prioritization"
+
+
+def test_container_command_omits_improvement_instructions_without_self_improve():
+    """The flag is meaningless without --self-improve, so don't forward it."""
+    cmd = list(
+        _build_container_command(
+            _spec(improvement_instructions="focus on prioritization"),
+            run_id=_RUN_ID,
+        )
+    )
+    assert "--improvement-instructions" not in cmd
+
+
 def test_container_command_omits_auto_flags_by_default():
     cmd = _build_container_command(_spec(), run_id=_RUN_ID)
     assert "--summary" not in cmd

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -548,6 +548,52 @@ async def test_run_self_improvement_rejects_non_question_page(tmp_db):
         await run_self_improvement(claim.id, tmp_db)
 
 
+async def test_run_self_improvement_omits_steering_block_when_no_instructions(
+    monkeypatch, tmp_db, question_page
+):
+    captured: dict[str, str] = {}
+
+    async def fake_run_agent(system_prompt, user_message, tools):
+        captured["user_message"] = user_message
+        return ""
+
+    monkeypatch.setattr(si, "_run_agent", fake_run_agent)
+    await run_self_improvement(question_page.id, tmp_db)
+    assert "Steering from the user" not in captured["user_message"]
+
+
+async def test_run_self_improvement_interpolates_instructions(monkeypatch, tmp_db, question_page):
+    captured: dict[str, str] = {}
+
+    async def fake_run_agent(system_prompt, user_message, tools):
+        captured["user_message"] = user_message
+        return ""
+
+    monkeypatch.setattr(si, "_run_agent", fake_run_agent)
+    await run_self_improvement(
+        question_page.id,
+        tmp_db,
+        instructions="focus on prioritization quality",
+    )
+    msg = captured["user_message"]
+    assert "Steering from the user" in msg
+    assert "focus on prioritization quality" in msg
+
+
+async def test_run_self_improvement_treats_blank_instructions_as_none(
+    monkeypatch, tmp_db, question_page
+):
+    captured: dict[str, str] = {}
+
+    async def fake_run_agent(system_prompt, user_message, tools):
+        captured["user_message"] = user_message
+        return ""
+
+    monkeypatch.setattr(si, "_run_agent", fake_run_agent)
+    await run_self_improvement(question_page.id, tmp_db, instructions="   \n  ")
+    assert "Steering from the user" not in captured["user_message"]
+
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 


### PR DESCRIPTION
## Summary

- New `--improvement-instructions TEXT` CLI flag that steers `--self-improve` toward what the user wants the analysis to focus on (e.g. "concentrate on prioritization quality and ignore prompt wording"). When set, the string is interpolated into the user message under a "Steering from the user" block; without it, the prompt is unchanged.
- Threaded through both standalone (`--self-improve QID`) and auto (`<question> --self-improve`) paths in main.py, and forwarded through the k8s remote-run path (`OrchestratorRunRequest.improvement_instructions`, `cli_client`, `k8s/submit`). The flag is only emitted to the in-pod CLI when `--self-improve` is also active, since it's meaningless otherwise.
- README updated with a usage example.

## Test plan

- [x] `uv run pytest tests/test_self_improve.py tests/test_k8s_submit.py tests/test_cli_client.py` — 126 passed
- [x] `uv run python main.py --help` shows `--improvement-instructions TEXT` in the help output
- [ ] Live smoke: `uv run python main.py --self-improve QID --improvement-instructions "focus on prioritization quality"` against an existing question