### PR TITLE
Decouple cache from manual JSON parsing in structured_call

### DIFF
--- a/src/rumil/calls/closing_reviewers.py
+++ b/src/rumil/calls/closing_reviewers.py
@@ -259,6 +259,7 @@ async def _self_assessment(
         metadata=meta,
         db=infra.db,
         cache=True,
+        parse_manually=True,
     )
     review_data = review_result.parsed.model_dump() if review_result.parsed else {}
 

--- a/src/rumil/calls/link_subquestions.py
+++ b/src/rumil/calls/link_subquestions.py
@@ -236,6 +236,7 @@ class LinkerClosingReviewer(ClosingReviewer):
             metadata=meta,
             db=infra.db,
             cache=True,
+            parse_manually=True,
         )
 
         remaining = 0

--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -276,6 +276,7 @@ class MultiRoundLoop(WorkspaceUpdater):
             metadata=meta,
             db=infra.db,
             cache=True,
+            parse_manually=True,
         )
         if result.parsed:
             log.info(

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -4,7 +4,8 @@ LLM interface. Wraps the Anthropic API and handles exchange persistence.
 Exports:
   - call_api: API call with retries and optional exchange logging
   - text_call: plain text call
-  - structured_call: structured output via messages.parse
+  - structured_call: structured output via messages.parse, or via
+        messages.create with manual JSON parsing when parse_manually=True
 
 Data types: Tool, ToolCall, RoundRecord, AgentResult, APIResponse,
             LLMExchangeMetadata.

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -715,6 +715,7 @@ async def _structured_call_cached(
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     model: str | None = None,
+    cache: bool = True,
 ) -> StructuredCallResult[T]:
     """Structured output via create() + manual JSON parsing for cache reuse.
 
@@ -738,7 +739,7 @@ async def _structured_call_cached(
             tools=tools,
             metadata=metadata,
             db=db,
-            cache=True,
+            cache=cache,
         )
         response_text = ""
         for block in api_resp.message.content:
@@ -845,8 +846,15 @@ async def _structured_call_parse(
     model: str | None = None,
     max_tokens: int | None = None,
     disable_thinking: bool = False,
+    cache: bool = False,
 ) -> StructuredCallResult[T]:
-    """Structured output via messages.parse (no cache sharing with create)."""
+    """Structured output via messages.parse.
+
+    messages.parse adds ``output_config.format`` to the request, which puts
+    these calls in a different cache namespace than plain ``messages.create``
+    calls (agent loops, ``call_api`` directly). Use ``parse_manually=True``
+    in ``structured_call`` to share cache with create-mode calls.
+    """
     settings = get_settings()
     client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
     model = model or settings.model
@@ -856,7 +864,7 @@ async def _structured_call_parse(
         "model": model,
         "max_tokens": max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
         "system": system_prompt,
-        "messages": msg_list,
+        "messages": _add_cache_breakpoint(msg_list) if cache else msg_list,
     }
     if _supports_sampling_params(model):
         parse_kwargs["temperature"] = DEFAULT_TEMPERATURE
@@ -954,6 +962,7 @@ async def structured_call(
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     cache: bool = False,
+    parse_manually: bool = False,
     model: str | None = None,
     max_tokens: int | None = None,
     disable_thinking: bool = False,
@@ -972,6 +981,7 @@ async def structured_call(
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     cache: bool = False,
+    parse_manually: bool = False,
     model: str | None = None,
     max_tokens: int | None = None,
     disable_thinking: bool = False,
@@ -990,6 +1000,7 @@ async def structured_call(
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     cache: bool = False,
+    parse_manually: bool = False,
     model: str | None = None,
     max_tokens: int | None = None,
     disable_thinking: bool = False,
@@ -1007,15 +1018,27 @@ async def structured_call(
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     cache: bool = False,
+    parse_manually: bool = False,
     model: str | None = None,
     max_tokens: int | None = None,
     disable_thinking: bool = False,
 ) -> StructuredCallResult[T] | StructuredCallResult[BaseModel]:
     """Run an LLM call that returns structured output matching response_model.
 
-    When cache=True, uses messages.create with manual JSON parsing so the
-    request shares the same cache namespace as agent loop calls. Otherwise
-    uses messages.parse with output_format for guaranteed schema adherence.
+    Two orthogonal flags control behavior:
+
+    - ``cache``: when True, places a cache breakpoint on the last message
+      so the request can be cached/read by subsequent calls.
+    - ``parse_manually``: when True, uses ``messages.create`` with the
+      JSON schema injected into the user message and validates the
+      response with pydantic. This puts the call in the same cache
+      namespace as agent-loop ``messages.create`` calls. Set this when
+      the structured call is part of a sequence whose other calls use
+      ``messages.create`` (e.g. fruit checks / closing reviews that share
+      tools and conversation history with a preceding agent loop). When
+      False (default), uses ``messages.parse`` with ``output_format``
+      for native schema adherence — preferable for pure structured-call
+      sequences since the API enforces the schema.
 
     Pass `messages` for multi-turn conversations, or `user_message` for single-turn.
     Pass `tools` to share cache prefix with agent calls.
@@ -1028,7 +1051,7 @@ async def structured_call(
     config for tasks that don't benefit from reasoning. For mostly-mechanical
     text generation (like writing prose from a complete spec) thinking just
     eats the max_tokens budget without improving quality. Only takes effect
-    on the cache=False path.
+    on the parse path (``parse_manually=False``).
     """
     if bool(metadata) != bool(db):
         raise ValueError("metadata and db must be provided together")
@@ -1038,20 +1061,21 @@ async def structured_call(
     raw_msgs = messages if messages is not None else [{"role": "user", "content": user_message}]
     model_name = response_model.__name__ if response_model else "None"
     log.debug(
-        "structured_call: response_model=%s, cache=%s",
+        "structured_call: response_model=%s, cache=%s, parse_manually=%s",
         model_name,
         cache,
+        parse_manually,
     )
 
-    if cache and response_model is not None:
+    if parse_manually and response_model is not None:
         if max_tokens is not None:
             raise ValueError(
-                "max_tokens is not supported on the cached (cache=True) path yet; "
+                "max_tokens is not supported on the parse_manually=True path yet; "
                 "plumb it through call_api if you need it."
             )
         if disable_thinking:
             raise ValueError(
-                "disable_thinking is not supported on the cached (cache=True) path yet."
+                "disable_thinking is not supported on the parse_manually=True path yet."
             )
         return await _structured_call_cached(
             system_prompt,
@@ -1061,6 +1085,7 @@ async def structured_call(
             metadata=metadata,
             db=db,
             model=model,
+            cache=cache,
         )
     return await _structured_call_parse(
         system_prompt,
@@ -1073,4 +1098,5 @@ async def structured_call(
         model=model,
         max_tokens=max_tokens,
         disable_thinking=disable_thinking,
+        cache=cache,
     )

--- a/src/rumil/orchestrators/global_prio.py
+++ b/src/rumil/orchestrators/global_prio.py
@@ -979,6 +979,7 @@ class GlobalPrioOrchestrator(BaseOrchestrator):
             metadata=meta,
             db=self.db,
             cache=True,
+            parse_manually=True,
         )
 
         if result.response_text:


### PR DESCRIPTION
## Summary

- Add a `parse_manually` flag to `structured_call` so cache control and parse-path selection are independent. `cache=True` previously forced the manual-JSON path because `messages.parse` adds `output_config.format`, which puts those calls in a separate cache namespace from `messages.create`. That coupling meant pure structured-call sequences couldn't opt into `messages.parse`'s native schema enforcement without losing caching.
- Set `parse_manually=True` at the four sites where the structured_call shares a tool/conversation prefix with surrounding `messages.create` calls — `closing_reviewers._self_assessment`, `link_subquestions.LinkerClosingReviewer`, `page_creators.MultiRoundLoop._run_fruit_check`, `global_prio._decide_phase`.
- Plumb cache breakpoint support through `_structured_call_parse` so other `cache=True` sites (update_view phases, `common._score_items_batched`) keep hitting cache between consecutive parse-mode calls.

## Test plan

- [x] `uv run pytest` (988 passed, 1 pre-existing stats failure fixed by applying pending local migration `20260428141905_add_views_to_question_focus_counts.sql`)
- [x] Smoke run on the global_prio decide path — confirmed structured_call reads 10,674 cached tokens from the preceding agent loop's cache prefix
- [ ] Watch a real run for cache_read on the four `parse_manually=True` sites in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)