### PR TITLE
add FreeformView: four-section prose View variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ uv run python main.py "Your question" --available-moves default --budget 10
 uv run python main.py "Your question" --available-calls multi-subquestion --budget 20
 
 # Select a view variant (the ever-evolving best summary of a question)
-# 'sectioned' = importance-scored items (default), 'judgement' = flat NL judgement page
+# 'sectioned' = importance-scored items (default), 'judgement' = flat NL judgement page,
+# 'freeform' = four long-form prose sections (framing, deductions, research direction, returns curve)
 uv run python main.py "Your question" --view-variant judgement --budget 10
 
 # Tune how many considerations each ingest call extracts (default: 4)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3586,6 +3586,8 @@
           "create_view",
           "global_prioritization",
           "update_view",
+          "create_freeform_view",
+          "update_freeform_view",
           "generate_spec",
           "generate_artefact",
           "critique_artefact",
@@ -6292,6 +6294,17 @@
             "type": "boolean",
             "title": "Auto Self Improve",
             "default": false
+          },
+          "improvement_instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Improvement Instructions"
           },
           "available_moves": {
             "anyOf": [

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -397,7 +397,7 @@ export type CallSummary = {
 /**
  * CallType
  */
-export type CallType = 'find_considerations' | 'assess' | 'prioritization' | 'ingest' | 'reframe' | 'maintain' | 'summarize' | 'scout_subquestions' | 'scout_estimates' | 'scout_hypotheses' | 'scout_analogies' | 'scout_paradigm_cases' | 'scout_factchecks' | 'scout_web_questions' | 'scout_deep_questions' | 'scout_c_how_true' | 'scout_c_how_false' | 'scout_c_cruxes' | 'scout_c_relevant_evidence' | 'scout_c_stress_test_cases' | 'scout_c_robustify' | 'scout_c_strengthen' | 'web_research' | 'evaluate' | 'grounding_feedback' | 'feedback_update' | 'link_subquestions' | 'ab_eval' | 'ab_eval_comparison' | 'ab_eval_summary' | 'run_eval' | 'create_view' | 'global_prioritization' | 'update_view' | 'generate_spec' | 'generate_artefact' | 'critique_artefact' | 'critique_artefact_request_only' | 'refine_spec' | 'red_team' | 'claude_code_direct' | 'versus_judge';
+export type CallType = 'find_considerations' | 'assess' | 'prioritization' | 'ingest' | 'reframe' | 'maintain' | 'summarize' | 'scout_subquestions' | 'scout_estimates' | 'scout_hypotheses' | 'scout_analogies' | 'scout_paradigm_cases' | 'scout_factchecks' | 'scout_web_questions' | 'scout_deep_questions' | 'scout_c_how_true' | 'scout_c_how_false' | 'scout_c_cruxes' | 'scout_c_relevant_evidence' | 'scout_c_stress_test_cases' | 'scout_c_robustify' | 'scout_c_strengthen' | 'web_research' | 'evaluate' | 'grounding_feedback' | 'feedback_update' | 'link_subquestions' | 'ab_eval' | 'ab_eval_comparison' | 'ab_eval_summary' | 'run_eval' | 'create_view' | 'global_prioritization' | 'update_view' | 'create_freeform_view' | 'update_freeform_view' | 'generate_spec' | 'generate_artefact' | 'critique_artefact' | 'critique_artefact_request_only' | 'refine_spec' | 'red_team' | 'claude_code_direct' | 'versus_judge';
 
 /**
  * CallTypeFruitScoreItem
@@ -2058,6 +2058,10 @@ export type OrchestratorRunRequest = {
      * Auto Self Improve
      */
     auto_self_improve?: boolean;
+    /**
+     * Improvement Instructions
+     */
+    improvement_instructions?: string | null;
     /**
      * Available Moves
      */

--- a/frontend/src/app/pages/[pageId]/page.tsx
+++ b/frontend/src/app/pages/[pageId]/page.tsx
@@ -186,10 +186,12 @@ function titleCase(sec: string): string {
 function ViewItemsSection({
   linksFrom,
   sections,
+  viewKind,
   stagedRunId,
 }: {
   linksFrom: LinkedPageOut[];
   sections: string[];
+  viewKind?: string;
   stagedRunId?: string;
 }) {
   const viewItems = linksFrom.filter(
@@ -211,6 +213,41 @@ function ViewItemsSection({
   const orderedSections = sections.length > 0
     ? sections.filter((s) => bySection.has(s))
     : Array.from(bySection.keys());
+
+  if (viewKind === "freeform") {
+    return (
+      <div className="freeform-view">
+        {orderedSections.map((sec, idx) => {
+          const items = bySection.get(sec) ?? [];
+          return (
+            <article key={sec} className="freeform-section">
+              <header className="freeform-section-header">
+                <span className="freeform-section-counter">
+                  {String(idx + 1).padStart(2, "0")}
+                </span>
+                <h3 className="freeform-section-heading">{titleCase(sec)}</h3>
+              </header>
+              <div className="freeform-section-body">
+                {items.map((lp) => (
+                  <div key={lp.page.id} className="freeform-section-prose">
+                    <Markdown remarkPlugins={[remarkGfm]}>
+                      {lp.page.content || ""}
+                    </Markdown>
+                    <Link
+                      href={withStagedRun(`/pages/${lp.page.id}`, stagedRunId)}
+                      className="freeform-section-permalink"
+                    >
+                      {lp.page.id.slice(0, 8)}
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <div className="view-items-section">
@@ -534,6 +571,11 @@ export default async function PageDetailPage({
           <ViewItemsSection
             linksFrom={links_from}
             sections={page.sections ?? []}
+            viewKind={
+              typeof page.extra?.view_kind === "string"
+                ? (page.extra.view_kind as string)
+                : undefined
+            }
             stagedRunId={stagedRunId}
           />
         )}
@@ -1353,5 +1395,98 @@ const styles = `
   .view-item-headline {
     font-size: 0.85rem;
     line-height: 1.35;
+  }
+
+  .freeform-view {
+    margin-top: 2.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+    max-width: 42rem;
+  }
+  .freeform-section {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.85rem;
+    border-top: 1px solid var(--color-border);
+    padding-top: 1.4rem;
+  }
+  .freeform-section:first-child {
+    border-top: none;
+    padding-top: 0;
+  }
+  .freeform-section-header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.7rem;
+  }
+  .freeform-section-counter {
+    font-family: var(--font-geist-mono), ui-monospace, monospace;
+    font-size: 0.7rem;
+    color: var(--type-view);
+    letter-spacing: 0.05em;
+    font-feature-settings: "tnum";
+  }
+  .freeform-section-heading {
+    font-family: var(--font-geist-mono), ui-monospace, monospace;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-muted);
+    margin: 0;
+  }
+  .freeform-section-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+    border-left: 2px solid var(--type-view-border);
+    padding-left: 1.1rem;
+  }
+  .freeform-section-prose {
+    font-family: ui-serif, Georgia, "Times New Roman", serif;
+    font-size: 1rem;
+    line-height: 1.65;
+    color: var(--color-foreground, inherit);
+  }
+  .freeform-section-prose p {
+    margin: 0 0 0.9rem 0;
+  }
+  .freeform-section-prose p:last-child {
+    margin-bottom: 0;
+  }
+  .freeform-section-prose ul,
+  .freeform-section-prose ol {
+    margin: 0 0 0.9rem 0;
+    padding-left: 1.4rem;
+  }
+  .freeform-section-prose li {
+    margin: 0.2rem 0;
+  }
+  .freeform-section-prose blockquote {
+    margin: 0.9rem 0;
+    padding-left: 0.9rem;
+    border-left: 2px solid var(--color-border);
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .freeform-section-prose code {
+    font-family: var(--font-geist-mono), ui-monospace, monospace;
+    font-size: 0.92em;
+  }
+  .freeform-section-permalink {
+    display: inline-block;
+    margin-top: 0.6rem;
+    font-family: var(--font-geist-mono), ui-monospace, monospace;
+    font-size: 0.65rem;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--color-border);
+    padding-bottom: 1px;
+  }
+  .freeform-section-permalink:hover {
+    color: var(--type-view);
+    border-bottom-color: var(--type-view);
   }
 `;

--- a/main.py
+++ b/main.py
@@ -1330,7 +1330,8 @@ async def async_main():
         dest="view_variant",
         default=None,
         help="View variant (default: 'sectioned'). Options: 'sectioned' "
-        "(importance-scored items), 'judgement' (flat NL judgement).",
+        "(importance-scored items), 'judgement' (flat NL judgement), "
+        "'freeform' (four long-form prose sections).",
     )
     parser.add_argument(
         "--ingest-num-claims",

--- a/src/rumil/available_moves.py
+++ b/src/rumil/available_moves.py
@@ -156,6 +156,8 @@ PRESETS: dict[str, AvailableMoves] = {
             MoveType.LOAD_PAGE,
             MoveType.UPDATE_EPISTEMIC,
         ],
+        CallType.CREATE_FREEFORM_VIEW: [],
+        CallType.UPDATE_FREEFORM_VIEW: [],
         CallType.GENERATE_SPEC: [
             MoveType.ADD_SPEC_ITEM,
         ],
@@ -318,6 +320,8 @@ PRESETS: dict[str, AvailableMoves] = {
             MoveType.LOAD_PAGE,
             MoveType.UPDATE_EPISTEMIC,
         ],
+        CallType.CREATE_FREEFORM_VIEW: [],
+        CallType.UPDATE_FREEFORM_VIEW: [],
         CallType.GENERATE_SPEC: [
             MoveType.ADD_SPEC_ITEM,
         ],

--- a/src/rumil/calls/__init__.py
+++ b/src/rumil/calls/__init__.py
@@ -6,6 +6,7 @@ from rumil.calls.create_view import CreateViewCall
 from rumil.calls.critique_artefact import CritiqueArtefactCall
 from rumil.calls.critique_artefact_request_only import RequestOnlyCritiqueArtefactCall
 from rumil.calls.find_considerations import FindConsiderationsCall
+from rumil.calls.freeform_view import CreateFreeformViewCall, UpdateFreeformViewCall
 from rumil.calls.generate_artefact import GenerateArtefactCall
 from rumil.calls.generate_spec import GenerateSpecCall
 from rumil.calls.ingest import IngestCall
@@ -36,6 +37,7 @@ __all__ = [
     "AssessCall",
     "BigAssessCall",
     "CallRunner",
+    "CreateFreeformViewCall",
     "CreateViewCall",
     "CritiqueArtefactCall",
     "FindConsiderationsCall",
@@ -61,6 +63,7 @@ __all__ = [
     "ScoutParadigmCasesCall",
     "ScoutSubquestionsCall",
     "ScoutWebQuestionsCall",
+    "UpdateFreeformViewCall",
     "UpdateViewCall",
     "WebResearchCall",
 ]

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -118,6 +118,60 @@ class CreateViewContext(ContextBuilder):
         )
 
 
+class FreeformViewContext(ContextBuilder):
+    """Context for FreeformView creation/update: question, considerations,
+    judgements, child-question takes via embedding-based context. Existing-view
+    section content is fed per-section by the workspace updater on update calls,
+    so this builder does not inline it."""
+
+    async def build_context(self, infra: CallInfra) -> ContextResult:
+        question = await infra.db.get_page(infra.question_id)
+        query = question.headline if question else infra.question_id
+
+        result = await build_embedding_based_context(
+            query,
+            infra.db,
+            scope_question_id=infra.question_id,
+            require_take_for_questions=True,
+        )
+        working_page_ids = result.page_ids
+        preloaded_ids = list(infra.call.context_page_ids or [])
+
+        context_text = result.context_text
+        if preloaded_ids:
+            pages_by_id = await infra.db.get_pages_by_ids(preloaded_ids)
+            parts_pre: list[str] = []
+            for pid in preloaded_ids:
+                page = pages_by_id.get(pid)
+                if page:
+                    parts_pre += [
+                        "",
+                        "---",
+                        "",
+                        f"## Pre-loaded Page: `{pid[:8]}`",
+                        "",
+                        await format_page(
+                            page,
+                            PageDetail.CONTENT,
+                            db=infra.db,
+                            track=True,
+                            track_tags={"source": "preloaded"},
+                        ),
+                    ]
+            context_text += "\n".join(parts_pre)
+
+        return ContextResult(
+            context_text=context_text,
+            working_page_ids=working_page_ids,
+            preloaded_ids=preloaded_ids,
+            full_page_ids=result.full_page_ids,
+            abstract_page_ids=result.abstract_page_ids,
+            summary_page_ids=result.summary_page_ids,
+            distillation_page_ids=result.distillation_page_ids,
+            budget_usage=result.budget_usage,
+        )
+
+
 class RedTeamContext(ContextBuilder):
     """Context for red-teaming: loads the View, judgements, subquestion map,
     and high-confidence claims to enable structural challenge of the overall picture."""

--- a/src/rumil/calls/freeform_view.py
+++ b/src/rumil/calls/freeform_view.py
@@ -145,7 +145,7 @@ class _CreateFreeformViewUpdater(WorkspaceUpdater):
             raise ValueError(
                 f"CreateFreeformViewCall on question {question_id[:8]} but a view "
                 f"already exists ({existing_view.id[:8]}). Use UpdateFreeformViewCall "
-                f"or FreeformView.refresh()."
+                "or FreeformView.refresh()."
             )
 
         question = await db.get_page(question_id)
@@ -218,7 +218,7 @@ class _UpdateFreeformViewUpdater(WorkspaceUpdater):
         existing_view = await db.get_view_for_question(question_id)
         if existing_view is None:
             raise RuntimeError(
-                f"UpdateFreeformViewCall requires an existing View for question "
+                "UpdateFreeformViewCall requires an existing View for question "
                 f"{question_id[:8]}, but none was found."
             )
 

--- a/src/rumil/calls/freeform_view.py
+++ b/src/rumil/calls/freeform_view.py
@@ -1,0 +1,334 @@
+"""Create / update FreeformView calls.
+
+A FreeformView is a four-section prose summary of a question, written one
+section at a time in a shared, cached conversation at maximum reasoning effort.
+Reuses the existing VIEW / VIEW_ITEM page machinery: one VIEW page with
+``sections=FREEFORM_VIEW_SECTIONS`` and ``extra={"view_kind": "freeform"}``,
+plus four VIEW_ITEM pages (one per section) linked via VIEW_ITEM with
+``section`` and ``position=0``.
+"""
+
+import logging
+import uuid
+from collections.abc import Mapping
+
+from rumil.calls.closing_reviewers import StandardClosingReview
+from rumil.calls.context_builders import FreeformViewContext
+from rumil.calls.stages import (
+    CallInfra,
+    CallRunner,
+    ClosingReviewer,
+    ContextBuilder,
+    ContextResult,
+    UpdateResult,
+    WorkspaceUpdater,
+)
+from rumil.constants import FREEFORM_VIEW_SECTION_BRIEFS, FREEFORM_VIEW_SECTIONS
+from rumil.database import DB
+from rumil.llm import (
+    LLMExchangeMetadata,
+    build_system_prompt,
+    text_call,
+)
+from rumil.models import (
+    Call,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.settings import get_settings
+from rumil.tracing.trace_events import ViewCreatedEvent
+
+log = logging.getLogger(__name__)
+
+VIEW_KIND_FREEFORM = "freeform"
+
+
+async def _run_section_sequence(
+    infra: CallInfra,
+    context: ContextResult,
+    *,
+    view_id: str,
+    prior_sections: Mapping[str, str] | None = None,
+) -> UpdateResult:
+    """Run one max-effort LLM call per FreeformView section, sharing message
+    history with prompt caching across calls. Persists each section as a
+    VIEW_ITEM page linked to ``view_id``. Returns the accumulated UpdateResult.
+    """
+    system_prompt = build_system_prompt("freeform_view")
+    messages: list[dict] = []
+    created_page_ids: list[str] = []
+
+    for i, section_name in enumerate(FREEFORM_VIEW_SECTIONS):
+        parts: list[str] = []
+        if i == 0:
+            parts.append(context.context_text)
+        parts.append(FREEFORM_VIEW_SECTION_BRIEFS[section_name])
+        if prior_sections and section_name in prior_sections:
+            parts.append(
+                "Here is the previous version of this section. Write a fresh, "
+                "standalone replacement that incorporates new findings; do not "
+                "reference, echo, or compare against this prior version.\n\n"
+                "<prior_version>\n" + prior_sections[section_name] + "\n</prior_version>"
+            )
+        user_msg = "\n\n".join(parts)
+        messages.append({"role": "user", "content": user_msg})
+
+        meta = LLMExchangeMetadata(
+            call_id=infra.call.id,
+            phase=f"freeform_section_{section_name}",
+        )
+        response_text = await text_call(
+            system_prompt,
+            messages=messages,
+            cache=True,
+            effort="max",
+            metadata=meta,
+            db=infra.db,
+        )
+        messages.append({"role": "assistant", "content": response_text})
+
+        item = Page(
+            page_type=PageType.VIEW_ITEM,
+            layer=PageLayer.WIKI,
+            workspace=Workspace.RESEARCH,
+            headline=section_name,
+            content=response_text,
+            provenance_call_type=infra.call.call_type.value,
+            provenance_call_id=infra.call.id,
+            provenance_model=get_settings().model,
+        )
+        await infra.db.save_page(item)
+        await infra.db.save_link(
+            PageLink(
+                from_page_id=view_id,
+                to_page_id=item.id,
+                link_type=LinkType.VIEW_ITEM,
+                section=section_name,
+                position=0,
+            )
+        )
+        created_page_ids.append(item.id)
+        log.info(
+            "FreeformView section %s -> page %s (%d chars)",
+            section_name,
+            item.id[:8],
+            len(response_text),
+        )
+
+    return UpdateResult(
+        created_page_ids=created_page_ids,
+        moves=[],
+        all_loaded_ids=[],
+        messages=messages,
+    )
+
+
+class _CreateFreeformViewUpdater(WorkspaceUpdater):
+    """Materializes a fresh FreeformView page, then runs the four-section
+    LLM sequence. Rejects creation if a view already exists for the question
+    — callers go through ``FreeformView.refresh()`` for updates."""
+
+    def __init__(self, view_id: str, call_type: CallType) -> None:
+        self._view_id = view_id
+        self._call_type = call_type
+
+    async def materialize(self, infra: CallInfra) -> None:
+        db = infra.db
+        question_id = infra.question_id
+        existing_view = await db.get_view_for_question(question_id)
+        if existing_view:
+            raise ValueError(
+                f"CreateFreeformViewCall on question {question_id[:8]} but a view "
+                f"already exists ({existing_view.id[:8]}). Use UpdateFreeformViewCall "
+                f"or FreeformView.refresh()."
+            )
+
+        question = await db.get_page(question_id)
+        q_headline = question.headline if question else question_id[:8]
+
+        view = Page(
+            id=self._view_id,
+            page_type=PageType.VIEW,
+            layer=PageLayer.WIKI,
+            workspace=Workspace.RESEARCH,
+            content="",
+            headline=f"View: {q_headline}",
+            sections=list(FREEFORM_VIEW_SECTIONS),
+            extra={"view_kind": VIEW_KIND_FREEFORM},
+            provenance_call_type=self._call_type.value,
+            provenance_call_id=infra.call.id,
+            provenance_model=get_settings().model,
+        )
+        await db.save_page(view)
+        await db.save_link(
+            PageLink(
+                from_page_id=view.id,
+                to_page_id=question_id,
+                link_type=LinkType.VIEW_OF,
+            )
+        )
+        await infra.trace.record_strict(
+            ViewCreatedEvent(
+                view_id=view.id,
+                view_headline=view.headline,
+                question_id=question_id,
+                superseded_view_id=None,
+            )
+        )
+
+    async def update_workspace(
+        self,
+        infra: CallInfra,
+        context: ContextResult,
+    ) -> UpdateResult:
+        await self.materialize(infra)
+        return await _run_section_sequence(
+            infra,
+            context,
+            view_id=self._view_id,
+            prior_sections=None,
+        )
+
+
+class _UpdateFreeformViewUpdater(WorkspaceUpdater):
+    """Mints a new FreeformView page (superseding the old one), reads the
+    prior section content, and runs the four-section LLM sequence with the
+    prior version of each section fed into its user message.
+
+    Unlike ``UpdateViewWorkspaceUpdater``, we do not copy old VIEW_ITEM links
+    onto the new view: a freeform update always rewrites all four sections,
+    so four fresh items are created on the new view and the old items remain
+    on the superseded view for audit.
+    """
+
+    def __init__(self, view_id: str, call_type: CallType) -> None:
+        self._view_id = view_id
+        self._call_type = call_type
+
+    async def materialize(self, infra: CallInfra) -> tuple[str, dict[str, str]]:
+        """Create a new VIEW page, supersede the old, and return
+        ``(old_view_id, prior_sections_by_name)``."""
+        db = infra.db
+        question_id = infra.question_id
+        existing_view = await db.get_view_for_question(question_id)
+        if existing_view is None:
+            raise RuntimeError(
+                f"UpdateFreeformViewCall requires an existing View for question "
+                f"{question_id[:8]}, but none was found."
+            )
+
+        question = await db.get_page(question_id)
+        q_headline = question.headline if question else question_id[:8]
+
+        new_view = Page(
+            id=self._view_id,
+            page_type=PageType.VIEW,
+            layer=PageLayer.WIKI,
+            workspace=Workspace.RESEARCH,
+            content="",
+            headline=f"View: {q_headline}",
+            sections=list(FREEFORM_VIEW_SECTIONS),
+            extra={"view_kind": VIEW_KIND_FREEFORM},
+            provenance_call_type=self._call_type.value,
+            provenance_call_id=infra.call.id,
+            provenance_model=get_settings().model,
+        )
+        await db.save_page(new_view)
+        await db.save_link(
+            PageLink(
+                from_page_id=new_view.id,
+                to_page_id=question_id,
+                link_type=LinkType.VIEW_OF,
+            )
+        )
+        await db.supersede_page(existing_view.id, new_view.id)
+
+        prior_items = await db.get_view_items(existing_view.id)
+        prior_sections: dict[str, str] = {}
+        for page, link in prior_items:
+            if link.section and page.content:
+                prior_sections[link.section] = page.content
+
+        await infra.trace.record_strict(
+            ViewCreatedEvent(
+                view_id=new_view.id,
+                view_headline=new_view.headline,
+                question_id=question_id,
+                superseded_view_id=existing_view.id,
+            )
+        )
+        log.info(
+            "FreeformView update: new view %s supersedes %s; %d prior sections recovered",
+            new_view.id[:8],
+            existing_view.id[:8],
+            len(prior_sections),
+        )
+        return existing_view.id, prior_sections
+
+    async def update_workspace(
+        self,
+        infra: CallInfra,
+        context: ContextResult,
+    ) -> UpdateResult:
+        _, prior_sections = await self.materialize(infra)
+        return await _run_section_sequence(
+            infra,
+            context,
+            view_id=self._view_id,
+            prior_sections=prior_sections,
+        )
+
+
+class CreateFreeformViewCall(CallRunner):
+    """Create a FreeformView for a question."""
+
+    context_builder_cls = FreeformViewContext
+    workspace_updater_cls = _CreateFreeformViewUpdater  # type: ignore[assignment]
+    closing_reviewer_cls = StandardClosingReview  # type: ignore[assignment]
+    call_type = CallType.CREATE_FREEFORM_VIEW
+
+    def __init__(self, question_id: str, call: Call, db: DB, **kwargs) -> None:
+        self._view_id: str = str(uuid.uuid4())
+        super().__init__(question_id, call, db, **kwargs)
+
+    def _make_context_builder(self) -> ContextBuilder:
+        return FreeformViewContext()
+
+    def _make_workspace_updater(self) -> WorkspaceUpdater:
+        return _CreateFreeformViewUpdater(view_id=self._view_id, call_type=self.call_type)
+
+    def _make_closing_reviewer(self) -> ClosingReviewer:
+        return StandardClosingReview(self.call_type)
+
+    def task_description(self) -> str:
+        return f"Create a FreeformView for question `{self.infra.question_id}`."
+
+
+class UpdateFreeformViewCall(CallRunner):
+    """Update an existing FreeformView for a question by superseding it."""
+
+    context_builder_cls = FreeformViewContext
+    workspace_updater_cls = _UpdateFreeformViewUpdater  # type: ignore[assignment]
+    closing_reviewer_cls = StandardClosingReview  # type: ignore[assignment]
+    call_type = CallType.UPDATE_FREEFORM_VIEW
+
+    def __init__(self, question_id: str, call: Call, db: DB, **kwargs) -> None:
+        self._view_id: str = str(uuid.uuid4())
+        super().__init__(question_id, call, db, **kwargs)
+
+    def _make_context_builder(self) -> ContextBuilder:
+        return FreeformViewContext()
+
+    def _make_workspace_updater(self) -> WorkspaceUpdater:
+        return _UpdateFreeformViewUpdater(view_id=self._view_id, call_type=self.call_type)
+
+    def _make_closing_reviewer(self) -> ClosingReviewer:
+        return StandardClosingReview(self.call_type)
+
+    def task_description(self) -> str:
+        return f"Update the FreeformView for question `{self.infra.question_id}`."

--- a/src/rumil/constants.py
+++ b/src/rumil/constants.py
@@ -31,6 +31,52 @@ DEFAULT_VIEW_SECTIONS: list[str] = [
     "other",
 ]
 
+FREEFORM_VIEW_SECTIONS: list[str] = [
+    "framing_and_interpretation",
+    "assertions_and_deductions",
+    "research_direction",
+    "returns_to_further_research",
+]
+
+FREEFORM_VIEW_SECTION_BRIEFS: dict[str, str] = {
+    "framing_and_interpretation": (
+        "Write the **framing_and_interpretation** section.\n\n"
+        "What is this question really about? At a very high level, what is "
+        "important to consider when investigating it? Are there frames that "
+        "might seem important superficially but, on deeper reflection, should "
+        "be deprioritised? Are there ambiguities in the question, and if so, "
+        "what are the most helpful resolutions?"
+    ),
+    "assertions_and_deductions": (
+        "Write the **assertions_and_deductions** section.\n\n"
+        "What can we state about the answer to this question, and at what "
+        "confidence level? Reasoning carefully and deeply from the available "
+        "(likely uncertain) evidence, claims, and crystallised knowledge, "
+        "what can we derive? Use language that carefully and faithfully "
+        "conveys uncertainty, and show how that uncertainty propagates "
+        "through your reasoning. Do not introduce meaningless probabilities "
+        "over high-level, undefined propositions; only reason in terms of "
+        "probabilities when the proposition is precise enough that the "
+        "assignment is genuinely meaningful. Otherwise, prefer language like "
+        '"confident", "uncertain", "would expect to update upon further '
+        'research".'
+    ),
+    "research_direction": (
+        "Write the **research_direction** section.\n\n"
+        "What cruxes and key unknowns would, if investigated, most improve "
+        "our answer to the question?"
+    ),
+    "returns_to_further_research": (
+        "Write the **returns_to_further_research** section.\n\n"
+        "How much reducible uncertainty remains in the question? How far "
+        'are we from a "perfect" (i.e. maximally-uncertainty-reduced) '
+        "answer? And what does the curve of returns to further research "
+        "look like? Is it flat for a long time but spikes at high enough "
+        "effort? Does it saturate quickly? Linear for a long time before "
+        "saturating? Or something else?"
+    ),
+}
+
 
 def compute_round_budget(total: int, used: int) -> int:
     """Decide how much budget to allocate to a single prioritization round.

--- a/src/rumil/context.py
+++ b/src/rumil/context.py
@@ -504,6 +504,42 @@ async def render_view(
     return "\n".join(parts)
 
 
+async def render_freeform_view(
+    view: Page,
+    items_with_links: Sequence[tuple[Page, PageLink]],
+) -> str:
+    """Render a FreeformView page as concatenated section prose.
+
+    Sections are rendered in the order specified by ``view.sections``;
+    unknown sections fall after them in arbitrary order. Items without
+    section metadata are skipped.
+    """
+    parts: list[str] = [f"## View: {view.headline}", ""]
+
+    sections_order = view.sections or []
+    section_index = {s: i for i, s in enumerate(sections_order)}
+
+    by_section: dict[str, tuple[Page, PageLink]] = {}
+    for page, link in items_with_links:
+        if link.section:
+            by_section[link.section] = (page, link)
+
+    ordered_sections = sorted(
+        by_section.keys(),
+        key=lambda s: section_index.get(s, 999),
+    )
+    for sec in ordered_sections:
+        label = sec.replace("_", " ").title()
+        page, _link = by_section[sec]
+        parts.append(f"### {label}")
+        parts.append("")
+        if page.content:
+            parts.append(page.content.strip())
+            parts.append("")
+
+    return "\n".join(parts)
+
+
 async def render_child_investigation_results(
     db: DB,
     parent_question_id: str,

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -544,6 +544,7 @@ async def call_anthropic_api(
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     cache: bool = False,
+    effort: str | None = None,
 ) -> APIResponse:
     """Make a single Anthropic API call with retry logic.
 
@@ -563,8 +564,13 @@ async def call_anthropic_api(
         kwargs["temperature"] = DEFAULT_TEMPERATURE
     if (thinking := _thinking_config(model)) is not None:
         kwargs["thinking"] = thinking
-    if (effort := _effort_level(model)) is not None:
-        kwargs["output_config"] = {"effort": effort}
+    base_effort = _effort_level(model)
+    # Caller can override only when the model actually supports `effort`;
+    # for Haiku/older Sonnet `_effort_level` returns None and the param is
+    # not accepted by the API.
+    effective_effort = effort if (effort is not None and base_effort is not None) else base_effort
+    if effective_effort is not None:
+        kwargs["output_config"] = {"effort": effective_effort}
     if tools:
         kwargs["tools"] = tools
 
@@ -925,6 +931,8 @@ async def text_call(
     metadata: LLMExchangeMetadata | None = None,
     db: DB | None = None,
     model: str | None = None,
+    cache: bool = False,
+    effort: str | None = None,
 ) -> str:
     """Make a plain text LLM call. Returns the raw text response.
 
@@ -932,7 +940,11 @@ async def text_call(
     Pass `metadata` and `db` together to persist the exchange and record a
     trace event against the call identified by `metadata.call_id`. Pass `model`
     to override the default model — names starting with ``gemini-`` route to
-    Vertex AI, everything else routes to Anthropic.
+    Vertex AI, everything else routes to Anthropic. Pass `cache=True` to place
+    a prompt-cache breakpoint on the last message (Anthropic only — the Google
+    branch ignores it). Pass `effort` (e.g. ``"max"``) to override the default
+    effort level derived from the model; ignored for models that do not support
+    the effort parameter.
     """
     settings = get_settings()
     effective_model = model or settings.model
@@ -961,6 +973,8 @@ async def text_call(
         msg_list,
         metadata=metadata,
         db=db,
+        cache=cache,
+        effort=effort,
     )
     for block in api_resp.message.content:
         if isinstance(block, TextBlock):

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -86,6 +86,8 @@ class CallType(str, Enum):
     CREATE_VIEW = "create_view"
     GLOBAL_PRIORITIZATION = "global_prioritization"
     UPDATE_VIEW = "update_view"
+    CREATE_FREEFORM_VIEW = "create_freeform_view"
+    UPDATE_FREEFORM_VIEW = "update_freeform_view"
     GENERATE_SPEC = "generate_spec"
     GENERATE_ARTEFACT = "generate_artefact"
     CRITIQUE_ARTEFACT = "critique_artefact"

--- a/src/rumil/prompts/freeform_view.md
+++ b/src/rumil/prompts/freeform_view.md
@@ -8,7 +8,7 @@ This is one of the most crucial steps in our research process, so give thorough,
 
 In order, you will write:
 
-1. **Framing and interpertation** — What is this question _really_ about? Which high-level considerations, factors, dynamics, and frames truly matter, which superficially-attractive ones should be deprioritised? What ambiguities are inherent in the question, if any, and what is the space of useful resolutions of these?
+1. **Framing and interpretation** — What is this question _really_ about? Which high-level considerations, factors, dynamics, and frames truly matter, which superficially-attractive ones should be deprioritised? What ambiguities are inherent in the question, if any, and what is the space of useful resolutions of these?
 2. **Assertions and deductions** — What can we say about the answer, and at what confidence? Using careful reasoning, propagating uncertainty throughout, what incisive deductions can we make?
 3. **Research direction** — What cruxes and key unknowns would, if investigated, most improve the answer?
 4. **Returns to further research** — How much reducible uncertainty remains? What does the curve of returns to further research look like?

--- a/src/rumil/prompts/freeform_view.md
+++ b/src/rumil/prompts/freeform_view.md
@@ -1,0 +1,27 @@
+## The task
+
+Across this conversation you will write the four sections one at a time. The earlier sections of _this_ conversation are visible to you when writing later ones, so you may build on what you have already established — but each finished section must read as a **standalone piece**. Do not write phrases like "as discussed above", "see the previous section", or "building on the prior section". Imagine each section being read in isolation.
+
+This is one of the most crucial steps in our research process, so give thorough, high-effort responses here.
+
+## The four sections
+
+In order, you will write:
+
+1. **Framing and interpertation** — What is this question _really_ about? Which high-level considerations, factors, dynamics, and frames truly matter, which superficially-attractive ones should be deprioritised? What ambiguities are inherent in the question, if any, and what is the space of useful resolutions of these?
+2. **Assertions and deductions** — What can we say about the answer, and at what confidence? Using careful reasoning, propagating uncertainty throughout, what incisive deductions can we make?
+3. **Research direction** — What cruxes and key unknowns would, if investigated, most improve the answer?
+4. **Returns to further research** — How much reducible uncertainty remains? What does the curve of returns to further research look like?
+
+The user will give you the brief for the current section in each turn.
+
+## Style and epistemics
+
+- **Prefer natural-language hedges.** "Confident", "uncertain", "would expect to update upon further research", "mostly because", "two competing considerations" are usually the right register.
+- **Do not introduce probabilities over high-level, undefined propositions.** A number like p(X) only carries meaning when X is precise enough that the assignment is genuinely well-defined. When the underlying object is fuzzy, hedge in words instead.
+- **Show your reasoning.** Where uncertainty matters, walk the reader through it: which considerations push which way, which assumptions are doing work, and what would change the picture.
+- **Prose, not bullets.** Sections should read as continuous, deliberate writing — paragraphs that develop an argument. Lists and headings are fine when genuinely useful, but the default is prose.
+
+## When given a prior version
+
+For an _update_ of an existing FreeformView, the user message for a section will include a `<prior_version>` block with the previous content of that section. Your job is to write a fresh, standalone replacement that incorporates new findings from the conversation context. **Do not** echo, annotate, or compare against the prior version — the reader of your output will not see it. Write as if from scratch, but informed by what you have learned.

--- a/src/rumil/views/freeform.py
+++ b/src/rumil/views/freeform.py
@@ -1,0 +1,201 @@
+"""`FreeformView`: View stored as a VIEW page with four long-form prose sections.
+
+Each section is a separate VIEW_ITEM page linked via VIEW_ITEM with a
+``section`` name; the VIEW page carries ``extra={"view_kind": "freeform"}``
+so callers can distinguish from sectioned views.
+"""
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime
+
+from rumil.budget import _consume_budget
+from rumil.calls.freeform_view import (
+    CreateFreeformViewCall,
+    UpdateFreeformViewCall,
+)
+from rumil.context import format_page, render_freeform_view
+from rumil.database import DB
+from rumil.models import CallType, Page, PageDetail
+from rumil.tracing.broadcast import Broadcaster
+from rumil.views.base import View
+
+log = logging.getLogger(__name__)
+
+
+class FreeformView(View):
+    """View as a four-section, long-form-prose VIEW page."""
+
+    async def exists(self, question_id: str, db: DB) -> bool:
+        return await db.get_view_for_question(question_id) is not None
+
+    async def headline_page(self, question_id: str, db: DB) -> Page | None:
+        return await db.get_view_for_question(question_id)
+
+    async def headline_pages_many(
+        self,
+        question_ids: Sequence[str],
+        db: DB,
+    ) -> dict[str, Page | None]:
+        return await db.get_views_for_questions(question_ids)
+
+    async def render_for_executive_summary(
+        self,
+        question_id: str,
+        db: DB,
+    ) -> str | None:
+        view = await db.get_view_for_question(question_id)
+        if view is None:
+            return None
+        items = await db.get_view_items(view.id)
+        text = await render_freeform_view(view, items)
+        return text if text.strip() else None
+
+    async def refresh(
+        self,
+        question_id: str,
+        db: DB,
+        *,
+        parent_call_id: str | None = None,
+        context_page_ids: Sequence[str] | None = None,
+        broadcaster: Broadcaster | None = None,
+        force: bool = False,
+        call_id: str | None = None,
+        sequence_id: str | None = None,
+        sequence_position: int | None = None,
+        pool_question_id: str | None = None,
+    ) -> str | None:
+        if await self.exists(question_id, db):
+            return await update_freeform_view_for_question(
+                question_id,
+                db,
+                parent_call_id=parent_call_id,
+                context_page_ids=context_page_ids,
+                broadcaster=broadcaster,
+                force=force,
+                call_id=call_id,
+                sequence_id=sequence_id,
+                sequence_position=sequence_position,
+                pool_question_id=pool_question_id,
+            )
+        return await create_freeform_view_for_question(
+            question_id,
+            db,
+            parent_call_id=parent_call_id,
+            context_page_ids=context_page_ids,
+            broadcaster=broadcaster,
+            force=force,
+            call_id=call_id,
+            sequence_id=sequence_id,
+            sequence_position=sequence_position,
+            pool_question_id=pool_question_id,
+        )
+
+    async def render_for_prioritization(self, question_id: str, db: DB) -> str | None:
+        return await self.render_for_executive_summary(question_id, db)
+
+    async def render_for_parent_scoring(self, question_id: str, db: DB) -> str | None:
+        return await self.render_for_executive_summary(question_id, db)
+
+    async def render_for_child_investigation_results(
+        self,
+        question_id: str,
+        db: DB,
+        *,
+        last_view_created_at: datetime | None,
+    ) -> tuple[bool, str, list[str]] | None:
+        view = await db.get_view_for_question(question_id)
+        if view is None:
+            return None
+
+        is_new = last_view_created_at is None or view.created_at > last_view_created_at
+        page_ids: list[str] = [view.id]
+        lines = [f"**Status:** FreeformView available{' [NEW]' if is_new else ''}"]
+
+        items = await db.get_view_items(view.id)
+        if items:
+            text = await render_freeform_view(view, items)
+            if text.strip():
+                lines.append("")
+                lines.append(text)
+            for page, _link in items:
+                page_ids.append(page.id)
+        elif view.content:
+            detail = PageDetail.CONTENT if is_new else PageDetail.ABSTRACT
+            lines.append("")
+            lines.append(
+                await format_page(
+                    view,
+                    detail,
+                    linked_detail=None,
+                    db=db,
+                    track=True,
+                    track_tags={"source": "child_investigation"},
+                )
+            )
+
+        return is_new, "\n".join(lines), page_ids
+
+
+async def create_freeform_view_for_question(
+    question_id: str,
+    db: DB,
+    *,
+    parent_call_id: str | None = None,
+    context_page_ids: Sequence[str] | None = None,
+    broadcaster: Broadcaster | None = None,
+    force: bool = False,
+    call_id: str | None = None,
+    sequence_id: str | None = None,
+    sequence_position: int | None = None,
+    pool_question_id: str | None = None,
+) -> str | None:
+    """Run a CreateFreeformView call. Returns call ID, or None if no budget."""
+    log.info("create_freeform_view_for_question: question=%s", question_id[:8])
+    if not await _consume_budget(db, force=force, pool_question_id=pool_question_id):
+        return None
+
+    call = await db.create_call(
+        CallType.CREATE_FREEFORM_VIEW,
+        scope_page_id=question_id,
+        parent_call_id=parent_call_id,
+        context_page_ids=context_page_ids,
+        call_id=call_id,
+        sequence_id=sequence_id,
+        sequence_position=sequence_position,
+    )
+    instance = CreateFreeformViewCall(question_id, call, db, broadcaster=broadcaster)
+    await instance.run()
+    return call.id
+
+
+async def update_freeform_view_for_question(
+    question_id: str,
+    db: DB,
+    *,
+    parent_call_id: str | None = None,
+    context_page_ids: Sequence[str] | None = None,
+    broadcaster: Broadcaster | None = None,
+    force: bool = False,
+    call_id: str | None = None,
+    sequence_id: str | None = None,
+    sequence_position: int | None = None,
+    pool_question_id: str | None = None,
+) -> str | None:
+    """Run an UpdateFreeformView call. Returns call ID, or None if no budget."""
+    log.info("update_freeform_view_for_question: question=%s", question_id[:8])
+    if not await _consume_budget(db, force=force, pool_question_id=pool_question_id):
+        return None
+
+    call = await db.create_call(
+        CallType.UPDATE_FREEFORM_VIEW,
+        scope_page_id=question_id,
+        parent_call_id=parent_call_id,
+        context_page_ids=context_page_ids,
+        call_id=call_id,
+        sequence_id=sequence_id,
+        sequence_position=sequence_position,
+    )
+    instance = UpdateFreeformViewCall(question_id, call, db, broadcaster=broadcaster)
+    await instance.run()
+    return call.id

--- a/src/rumil/views/registry.py
+++ b/src/rumil/views/registry.py
@@ -13,7 +13,7 @@ themselves depend on pieces of `rumil.orchestrators`).
 from rumil.settings import get_settings
 from rumil.views.base import View
 
-VIEW_VARIANTS: tuple[str, ...] = ("sectioned", "judgement")
+VIEW_VARIANTS: tuple[str, ...] = ("sectioned", "judgement", "freeform")
 
 
 def get_active_view() -> View:
@@ -27,4 +27,8 @@ def get_active_view() -> View:
         from rumil.views.judgement import JudgementView
 
         return JudgementView()
+    if variant == "freeform":
+        from rumil.views.freeform import FreeformView
+
+        return FreeformView()
     raise ValueError(f"Unknown view_variant: {variant!r}. Valid values: {list(VIEW_VARIANTS)}")

--- a/tests/test_freeform_view.py
+++ b/tests/test_freeform_view.py
@@ -1,0 +1,386 @@
+"""Tests for FreeformView (CreateFreeformView / UpdateFreeformView)."""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from rumil.calls.freeform_view import (
+    VIEW_KIND_FREEFORM,
+    _CreateFreeformViewUpdater,
+    _run_section_sequence,
+    _UpdateFreeformViewUpdater,
+)
+from rumil.calls.stages import CallInfra, ContextResult
+from rumil.constants import FREEFORM_VIEW_SECTIONS
+from rumil.context import render_freeform_view
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+from rumil.moves.base import MoveState
+from rumil.tracing.tracer import CallTrace
+from rumil.views.freeform import FreeformView
+
+
+def _question(headline: str = "Test question") -> Page:
+    return Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=headline,
+        headline=headline,
+    )
+
+
+async def _make_infra(tmp_db, q: Page, call_type: CallType) -> CallInfra:
+    call = Call(
+        call_type=call_type,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=q.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+    return CallInfra(
+        question_id=q.id,
+        call=call,
+        db=tmp_db,
+        trace=CallTrace(call.id, tmp_db),
+        state=MoveState(call, tmp_db),
+    )
+
+
+@pytest_asyncio.fixture
+async def question(tmp_db):
+    q = _question()
+    await tmp_db.save_page(q)
+    return q
+
+
+async def test_create_materialize_creates_view_with_freeform_sections(tmp_db, question):
+    """_CreateFreeformViewUpdater.materialize creates a VIEW page with the
+    four freeform sections, view_kind=freeform metadata, and a VIEW_OF link."""
+    view_id = str(uuid.uuid4())
+    updater = _CreateFreeformViewUpdater(view_id, CallType.CREATE_FREEFORM_VIEW)
+    infra = await _make_infra(tmp_db, question, CallType.CREATE_FREEFORM_VIEW)
+
+    await updater.materialize(infra)
+
+    view = await tmp_db.get_page(view_id)
+    assert view is not None
+    assert view.page_type == PageType.VIEW
+    assert view.sections == list(FREEFORM_VIEW_SECTIONS)
+    assert view.extra.get("view_kind") == VIEW_KIND_FREEFORM
+
+    found_view = await tmp_db.get_view_for_question(question.id)
+    assert found_view is not None
+    assert found_view.id == view_id
+
+
+async def test_create_materialize_refuses_when_view_exists(tmp_db, question):
+    """Creating a freeform view should refuse if any view already exists."""
+    existing = Page(
+        page_type=PageType.VIEW,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        headline="View: Test question",
+        content="",
+        sections=list(FREEFORM_VIEW_SECTIONS),
+    )
+    await tmp_db.save_page(existing)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=existing.id,
+            to_page_id=question.id,
+            link_type=LinkType.VIEW_OF,
+        )
+    )
+
+    updater = _CreateFreeformViewUpdater(str(uuid.uuid4()), CallType.CREATE_FREEFORM_VIEW)
+    infra = await _make_infra(tmp_db, question, CallType.CREATE_FREEFORM_VIEW)
+    with pytest.raises(ValueError, match="already exists"):
+        await updater.materialize(infra)
+
+
+async def test_update_materialize_supersedes_old_view_and_returns_prior_sections(tmp_db, question):
+    """_UpdateFreeformViewUpdater.materialize should mint a fresh VIEW,
+    supersede the old one, and return prior section content keyed by section name."""
+    old_view = Page(
+        id=str(uuid.uuid4()),
+        page_type=PageType.VIEW,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        content="",
+        headline="View: Test question",
+        sections=list(FREEFORM_VIEW_SECTIONS),
+        extra={"view_kind": VIEW_KIND_FREEFORM},
+    )
+    await tmp_db.save_page(old_view)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=old_view.id,
+            to_page_id=question.id,
+            link_type=LinkType.VIEW_OF,
+        )
+    )
+
+    section_contents = {
+        "framing_and_interpretation": "Old framing prose.",
+        "assertions_and_deductions": "Old deductions prose.",
+        "research_direction": "Old research-direction prose.",
+        "returns_to_further_research": "Old returns-curve prose.",
+    }
+    for sec, content in section_contents.items():
+        item = Page(
+            page_type=PageType.VIEW_ITEM,
+            layer=PageLayer.WIKI,
+            workspace=Workspace.RESEARCH,
+            headline=sec,
+            content=content,
+        )
+        await tmp_db.save_page(item)
+        await tmp_db.save_link(
+            PageLink(
+                from_page_id=old_view.id,
+                to_page_id=item.id,
+                link_type=LinkType.VIEW_ITEM,
+                section=sec,
+                position=0,
+            )
+        )
+
+    new_view_id = str(uuid.uuid4())
+    updater = _UpdateFreeformViewUpdater(new_view_id, CallType.UPDATE_FREEFORM_VIEW)
+    infra = await _make_infra(tmp_db, question, CallType.UPDATE_FREEFORM_VIEW)
+    old_id, prior_sections = await updater.materialize(infra)
+
+    assert old_id == old_view.id
+    assert prior_sections == section_contents
+
+    # New view exists and is the active view for the question.
+    found_view = await tmp_db.get_view_for_question(question.id)
+    assert found_view is not None
+    assert found_view.id == new_view_id
+    assert found_view.extra.get("view_kind") == VIEW_KIND_FREEFORM
+
+    # Old view is superseded.
+    refreshed_old = await tmp_db.get_page(old_view.id)
+    assert refreshed_old is not None
+    assert refreshed_old.is_superseded
+
+
+async def test_update_materialize_raises_without_existing_view(tmp_db, question):
+    """Updating a freeform view should refuse when none exists."""
+    updater = _UpdateFreeformViewUpdater(str(uuid.uuid4()), CallType.UPDATE_FREEFORM_VIEW)
+    infra = await _make_infra(tmp_db, question, CallType.UPDATE_FREEFORM_VIEW)
+    with pytest.raises(RuntimeError, match="requires an existing View"):
+        await updater.materialize(infra)
+
+
+async def test_run_section_sequence_creates_one_item_per_section(tmp_db, question, mocker):
+    """_run_section_sequence should issue one LLM call per section,
+    create one VIEW_ITEM per section with the right section metadata,
+    and grow the messages list across calls."""
+    calls_seen: list[dict] = []
+
+    async def fake_text_call(system_prompt, **kwargs):
+        msgs = kwargs.get("messages") or []
+        calls_seen.append({"messages": list(msgs), "cache": kwargs.get("cache")})
+        section = FREEFORM_VIEW_SECTIONS[len(calls_seen) - 1]
+        return f"Prose for {section}."
+
+    mocker.patch("rumil.calls.freeform_view.text_call", side_effect=fake_text_call)
+
+    # Materialize the view first so VIEW_ITEM links have a valid parent.
+    view_id = str(uuid.uuid4())
+    create_updater = _CreateFreeformViewUpdater(view_id, CallType.CREATE_FREEFORM_VIEW)
+    infra = await _make_infra(tmp_db, question, CallType.CREATE_FREEFORM_VIEW)
+    await create_updater.materialize(infra)
+
+    context = ContextResult(context_text="<context>", working_page_ids=[])
+    result = await _run_section_sequence(infra, context, view_id=view_id, prior_sections=None)
+
+    assert len(calls_seen) == len(FREEFORM_VIEW_SECTIONS)
+    # Every call should request caching.
+    assert all(c["cache"] is True for c in calls_seen)
+    # Message history grows across calls (call N has 2*(N-1) prior messages).
+    for i, c in enumerate(calls_seen):
+        assert len(c["messages"]) == 2 * i + 1
+
+    assert len(result.created_page_ids) == len(FREEFORM_VIEW_SECTIONS)
+    items = await tmp_db.get_view_items(view_id)
+    by_section = {link.section: page for page, link in items}
+    for sec in FREEFORM_VIEW_SECTIONS:
+        assert sec in by_section
+        assert by_section[sec].content == f"Prose for {sec}."
+
+
+async def test_run_section_sequence_includes_prior_version_when_updating(tmp_db, question, mocker):
+    """When prior_sections is provided, each section's user message should
+    contain the matching prior_version block."""
+    seen_user_messages: list[str] = []
+
+    async def fake_text_call(system_prompt, **kwargs):
+        msgs = kwargs.get("messages") or []
+        # Last user message is the most recent one we're about to respond to.
+        last_user = next(
+            (m for m in reversed(msgs) if m.get("role") == "user"),
+            None,
+        )
+        seen_user_messages.append(last_user["content"] if last_user else "")
+        section = FREEFORM_VIEW_SECTIONS[len(seen_user_messages) - 1]
+        return f"Updated {section}."
+
+    mocker.patch("rumil.calls.freeform_view.text_call", side_effect=fake_text_call)
+
+    view_id = str(uuid.uuid4())
+    create_updater = _CreateFreeformViewUpdater(view_id, CallType.CREATE_FREEFORM_VIEW)
+    infra = await _make_infra(tmp_db, question, CallType.CREATE_FREEFORM_VIEW)
+    await create_updater.materialize(infra)
+
+    prior = {sec: f"PRIOR-{sec}-CONTENT" for sec in FREEFORM_VIEW_SECTIONS}
+    context = ContextResult(context_text="<context>", working_page_ids=[])
+    await _run_section_sequence(infra, context, view_id=view_id, prior_sections=prior)
+
+    assert len(seen_user_messages) == len(FREEFORM_VIEW_SECTIONS)
+    for sec, msg in zip(FREEFORM_VIEW_SECTIONS, seen_user_messages):
+        assert "<prior_version>" in msg
+        assert f"PRIOR-{sec}-CONTENT" in msg
+
+
+async def test_freeform_view_refresh_routes_to_create_when_no_view(tmp_db, question, mocker):
+    """FreeformView.refresh dispatches CreateFreeformView when no view exists."""
+    create_mock = mocker.patch(
+        "rumil.views.freeform.create_freeform_view_for_question",
+        return_value="created-call-id",
+    )
+    update_mock = mocker.patch(
+        "rumil.views.freeform.update_freeform_view_for_question",
+        return_value="updated-call-id",
+    )
+
+    view = FreeformView()
+    result = await view.refresh(question.id, tmp_db)
+    assert result == "created-call-id"
+    assert create_mock.called
+    assert not update_mock.called
+
+
+async def test_freeform_view_refresh_routes_to_update_when_view_exists(tmp_db, question, mocker):
+    """FreeformView.refresh dispatches UpdateFreeformView when a view exists."""
+    existing = Page(
+        page_type=PageType.VIEW,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        headline="View: Test question",
+        content="",
+        sections=list(FREEFORM_VIEW_SECTIONS),
+    )
+    await tmp_db.save_page(existing)
+    await tmp_db.save_link(
+        PageLink(
+            from_page_id=existing.id,
+            to_page_id=question.id,
+            link_type=LinkType.VIEW_OF,
+        )
+    )
+
+    create_mock = mocker.patch(
+        "rumil.views.freeform.create_freeform_view_for_question",
+        return_value="created-call-id",
+    )
+    update_mock = mocker.patch(
+        "rumil.views.freeform.update_freeform_view_for_question",
+        return_value="updated-call-id",
+    )
+
+    view = FreeformView()
+    result = await view.refresh(question.id, tmp_db)
+    assert result == "updated-call-id"
+    assert update_mock.called
+    assert not create_mock.called
+
+
+async def test_render_freeform_view_renders_sections_in_canonical_order():
+    """render_freeform_view orders sections by view.sections, ignoring
+    importance and rendering full content per section."""
+    view = Page(
+        page_type=PageType.VIEW,
+        layer=PageLayer.WIKI,
+        workspace=Workspace.RESEARCH,
+        headline="View: Q",
+        content="",
+        sections=list(FREEFORM_VIEW_SECTIONS),
+    )
+    items: list[tuple[Page, PageLink]] = []
+    # Insert items in REVERSE order to verify sorting by sections list.
+    for sec in reversed(FREEFORM_VIEW_SECTIONS):
+        item = Page(
+            page_type=PageType.VIEW_ITEM,
+            layer=PageLayer.WIKI,
+            workspace=Workspace.RESEARCH,
+            headline=sec,
+            content=f"Body of {sec}.",
+        )
+        link = PageLink(
+            from_page_id=view.id,
+            to_page_id=item.id,
+            link_type=LinkType.VIEW_ITEM,
+            section=sec,
+            position=0,
+        )
+        items.append((item, link))
+
+    text = await render_freeform_view(view, items)
+
+    # Each section header appears in canonical order.
+    last_idx = -1
+    for sec in FREEFORM_VIEW_SECTIONS:
+        label = sec.replace("_", " ").title()
+        idx = text.index(f"### {label}")
+        assert idx > last_idx, f"section {sec} out of order"
+        last_idx = idx
+        assert f"Body of {sec}." in text
+
+
+async def test_freeform_view_render_for_executive_summary_returns_none_without_view(
+    tmp_db, question
+):
+    """render_for_executive_summary returns None when no view exists."""
+    view = FreeformView()
+    assert await view.render_for_executive_summary(question.id, tmp_db) is None
+
+
+@pytest.mark.integration
+async def test_freeform_view_create_end_to_end(tmp_db):
+    """Real-LLM end-to-end: a CreateFreeformView call produces 1 view + 4 sections."""
+    from rumil.views.freeform import create_freeform_view_for_question
+
+    q = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="Will indoor agriculture be economically viable for staple crops by 2040?",
+        headline="Will indoor agriculture be economically viable for staple crops by 2040?",
+    )
+    await tmp_db.save_page(q)
+
+    call_id = await create_freeform_view_for_question(q.id, tmp_db, force=True)
+    assert call_id is not None
+
+    view = await tmp_db.get_view_for_question(q.id)
+    assert view is not None
+    assert view.extra.get("view_kind") == VIEW_KIND_FREEFORM
+
+    items = await tmp_db.get_view_items(view.id)
+    sections_seen = {link.section for _, link in items}
+    assert sections_seen == set(FREEFORM_VIEW_SECTIONS)
+    for page, _ in items:
+        assert page.content.strip(), "each section should have non-empty prose"

--- a/tests/test_freeform_view.py
+++ b/tests/test_freeform_view.py
@@ -27,7 +27,7 @@ from rumil.models import (
 )
 from rumil.moves.base import MoveState
 from rumil.tracing.tracer import CallTrace
-from rumil.views.freeform import FreeformView
+from rumil.views.freeform import FreeformView, create_freeform_view_for_question
 
 
 def _question(headline: str = "Test question") -> Page:
@@ -361,8 +361,6 @@ async def test_freeform_view_render_for_executive_summary_returns_none_without_v
 @pytest.mark.integration
 async def test_freeform_view_create_end_to_end(tmp_db):
     """Real-LLM end-to-end: a CreateFreeformView call produces 1 view + 4 sections."""
-    from rumil.views.freeform import create_freeform_view_for_question
-
     q = Page(
         page_type=PageType.QUESTION,
         layer=PageLayer.SQUIDGY,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -28,7 +28,7 @@ def test_get_active_view_rejects_unknown_variant():
 
 
 def test_view_variants_exposes_known_names():
-    assert set(VIEW_VARIANTS) == {"sectioned", "judgement"}
+    assert set(VIEW_VARIANTS) == {"sectioned", "judgement", "freeform"}
 
 
 async def test_sectioned_view_exists_reflects_db_state(tmp_db, question_page, mocker):


### PR DESCRIPTION
## Summary

- New `FreeformView` View variant producing long-form prose summaries instead of atomic importance-scored items. Four fixed sections (`framing_and_interpretation`, `assertions_and_deductions`, `research_direction`, `returns_to_further_research`) are written by separate LLM calls sharing a cached conversation at `effort=max`.
- Updates feed only the prior version of the section being rewritten and request a fresh standalone replacement — they do not echo or annotate the old version.
- Reuses existing `VIEW` / `VIEW_ITEM` machinery: one `VIEW` page tagged `extra={"view_kind": "freeform"}` plus four `VIEW_ITEM` pages keyed by `section`. Selectable via `--view-variant freeform`.
- Frontend `ViewItemsSection` detects `view.extra.view_kind === "freeform"` and renders sections as numbered prose articles (serif body, mono labels, left rule) instead of the atomic-item chip layout.
- `text_call` and `call_anthropic_api` get optional `cache` and `effort` parameters — additive, default off, ignored on models that don't support `effort`.

## Test plan
- [x] `uv run pytest tests/test_freeform_view.py` — 10 unit tests pass (1 integration test gated behind `--integration`)
- [x] `uv run pyright` clean
- [x] `npx tsc --noEmit` (frontend) clean
- [x] Smoke test: `uv run python main.py "..." --workspace freeform-scratch --view-variant freeform --budget 8 --smoke-test` produces 1 `VIEW` + 4 `VIEW_ITEM` section pages with `view_kind=freeform`
- [x] Update flow: a follow-up `--continue` run dispatches `UPDATE_FREEFORM_VIEW`, supersedes the old view, recovers all 4 prior sections, and feeds each into its respective LLM turn (verified `<prior_version>` block in trace)
- [x] Supersession chain in DB verified end-to-end (3 view generations, each correctly superseded by the next)
- [ ] Production smoke (Opus 4.7, `effort=max`) — recommend running once before merge to eyeball real prose quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)