### PR TITLE
Parallel run_call/run_prio + get_dispatches/execute_dispatches stages

### DIFF
--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -47,6 +47,8 @@ const CALL_TYPE_ACCENT: Record<string, string> = {
   find_considerations: "#5b8def",
   assess: "#a07cdf",
   prioritization: "#d4943a",
+  initial_prioritization: "#e8a64d",
+  main_phase_prioritization: "#b87320",
   recurse: "#e8853a",
   ingest: "#4dab6f",
   reframe: "#c46b6b",
@@ -66,6 +68,18 @@ const CALL_TYPE_ACCENT: Record<string, string> = {
   web_research: "#c4884d",
   evaluate: "#d46b9f",
 };
+
+function displayCallType(call: {
+  call_type: string;
+  call_params?: { [key: string]: unknown } | null;
+}): string {
+  if (call.call_type === "prioritization" && call.call_params) {
+    const phase = call.call_params.phase;
+    if (phase === "initial") return "initial_prioritization";
+    if (phase === "main_phase") return "main_phase_prioritization";
+  }
+  return call.call_type;
+}
 
 function compactTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -1632,7 +1646,8 @@ export const CallNode = memo(function CallNode({
     }
   }, [isHashTarget]);
   const duration = getDuration(call);
-  const accent = CALL_TYPE_ACCENT[call.call_type] || "#7a8a9e";
+  const callTypeLabel = displayCallType(call);
+  const accent = CALL_TYPE_ACCENT[callTypeLabel] || "#7a8a9e";
 
   const warningCount = useMemo(
     () =>
@@ -1691,7 +1706,7 @@ export const CallNode = memo(function CallNode({
           className="trace-call-header"
         >
           <span className="trace-call-type">
-            {call.call_type}
+            {callTypeLabel}
           </span>
           {node.scope_page_summary && (
             <span className="trace-call-scope">{node.scope_page_summary}</span>
@@ -1724,7 +1739,12 @@ export const CallNode = memo(function CallNode({
         <div className="trace-call-body">
           {call.call_params && Object.keys(call.call_params).length > 0 && (
             <div className="trace-call-params">
-              {Object.entries(call.call_params).map(([key, value]) => (
+              {Object.entries(call.call_params)
+                .filter(
+                  ([key]) =>
+                    !(call.call_type === "prioritization" && key === "phase"),
+                )
+                .map(([key, value]) => (
                 <span key={key} className="trace-call-param">
                   <span className="trace-call-param-label">
                     {key.replace(/_/g, " ")}

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -7,6 +7,13 @@ Usage:
     # Find considerations on an existing question by ID
     uv run python scripts/run_call.py find-considerations --question-id <UUID>
 
+    # Run the same call against several questions in parallel
+    uv run python scripts/run_call.py find-considerations --question-id <UUID1> <UUID2> <UUID3>
+
+    # Mix existing question ids with new question texts; everything runs in parallel
+    uv run python scripts/run_call.py find-considerations \\
+        "Why is water wet?" "Is the sky blue?" --question-id <UUID1> <UUID2>
+
     # Assess an existing question
     uv run python scripts/run_call.py assess --question-id <UUID>
 
@@ -30,12 +37,18 @@ If --question-id points at a question staged under another run, that run's run_i
 is adopted automatically so the call continues inside the staged lineage (budget
 is added to rather than clobbered; no new `runs` row is created). Passing
 --no-stage against a staged question is rejected.
+
+When multiple targets are passed (any mix of --question-id values and positional
+question texts), each gets its own run_id / DB / staging adoption logic and the
+calls execute concurrently via asyncio.gather.
 """
 
 import argparse
 import asyncio
 import logging
 import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
 
 from rumil.calls.call_registry import ASSESS_CALL_CLASSES
 from rumil.calls.find_considerations import FindConsiderationsCall
@@ -181,6 +194,126 @@ async def run_call(args: argparse.Namespace, db: DB, question_id: str) -> None:
         print(f"Unknown call type: {call_type}")
 
 
+@dataclass
+class _TaskPlan:
+    """Resolved per-target state, populated by ``_prepare_task`` before execution."""
+
+    db: DB
+    question_id: str
+    headline: str
+    run_id: str
+    adopted_run_id: str | None
+    is_new_question: bool
+    frontend_url: str
+    langfuse_url: str | None
+
+
+async def _prepare_task(
+    args: argparse.Namespace,
+    *,
+    question_id: str | None,
+    question_text: str | None,
+) -> _TaskPlan | None:
+    """Resolve staging/project/question/budget/run-row for one target.
+
+    Runs quietly (no logging.basicConfig yet) so the gathered plan list can be
+    printed as a clean header before the noisy execution phase begins.
+    """
+    settings = get_settings()
+    workspace = args.workspace
+    staged_flag = not args.no_stage
+
+    adopted_run_id: str | None = None
+    if question_id:
+        probe = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod, staged=False)
+        info = await probe.get_page_staging_info(question_id)
+        if info is None:
+            print(f"Question {question_id} not found.")
+            return None
+        is_staged, owning_run_id, _owning_project_id = info
+        if is_staged:
+            if not staged_flag:
+                print(
+                    f"Question {question_id[:8]} is staged under run {owning_run_id[:8]}; "
+                    "cannot run with --no-stage. Drop --no-stage to adopt the staged run."
+                )
+                return None
+            adopted_run_id = owning_run_id
+
+    run_id = adopted_run_id or str(uuid.uuid4())
+    db = await DB.create(run_id=run_id, prod=args.prod, staged=staged_flag)
+    project = await db.get_or_create_project(workspace)
+    db.project_id = project.id
+
+    is_new_question = False
+    if question_id:
+        page = await db.get_page(question_id)
+        if not page:
+            print(f"Question {question_id} not found.")
+            return None
+        if page.project_id and page.project_id != db.project_id:
+            db.project_id = page.project_id
+        resolved_text = page.headline
+        resolved_qid = question_id
+    else:
+        assert question_text is not None
+        resolved_text = question_text
+        resolved_qid = await create_root_question(resolved_text, db)
+        is_new_question = True
+
+    if adopted_run_id:
+        await db.add_budget(args.budget)
+    else:
+        await db.init_budget(args.budget)
+
+    name = args.name or resolved_text
+    config = settings.capture_config()
+    if not adopted_run_id:
+        await db.create_run(name=name, question_id=resolved_qid, config=config)
+
+    langfuse_url: str | None = None
+    if get_langfuse() is not None:
+        lf_base = settings.langfuse_base_url.rstrip("/")
+        langfuse_url = f"{lf_base}/sessions?sessionId={db.run_id}"
+
+    return _TaskPlan(
+        db=db,
+        question_id=resolved_qid,
+        headline=resolved_text,
+        run_id=db.run_id,
+        adopted_run_id=adopted_run_id,
+        is_new_question=is_new_question,
+        frontend_url=settings.frontend_url,
+        langfuse_url=langfuse_url,
+    )
+
+
+def _print_plan_header(plans: Sequence[_TaskPlan]) -> None:
+    if not plans:
+        return
+    print()
+    print(f"=== Targets ({len(plans)}) ===")
+    for p in plans:
+        if p.is_new_question:
+            kind = "NEW    "
+        elif p.adopted_run_id:
+            kind = "ADOPTED"
+        else:
+            kind = "EXIST  "
+        headline = p.headline if len(p.headline) <= 100 else p.headline[:97] + "..."
+        print(f"  [{kind}] q={p.question_id[:8]} run={p.run_id[:8]}  {headline}")
+        print(f"           Trace: {p.frontend_url}/traces/{p.run_id}")
+        if p.langfuse_url:
+            print(f"           Langfuse: {p.langfuse_url}")
+    print()
+
+
+async def _execute_task(args: argparse.Namespace, plan: _TaskPlan) -> None:
+    print(f"Running {args.call_type} on {plan.question_id[:8]}...")
+    await run_call(args, plan.db, plan.question_id)
+    print(f"Done with {plan.question_id[:8]}.")
+
+
 async def run(args: argparse.Namespace) -> None:
     settings = get_settings()
     if args.available_moves is not None:
@@ -192,6 +325,23 @@ async def run(args: argparse.Namespace) -> None:
     if args.force_twophase_recurse:
         settings.force_twophase_recurse = True
 
+    question_ids: list[str] = list(args.question_id) if args.question_id else []
+    question_texts: list[str] = list(args.question_text) if args.question_text else []
+
+    if not question_ids and not question_texts:
+        print("Provide at least one question text or --question-id.")
+        return
+
+    prep_tasks = [
+        _prepare_task(args, question_id=qid, question_text=None) for qid in question_ids
+    ] + [_prepare_task(args, question_id=None, question_text=qt) for qt in question_texts]
+    plan_results = await asyncio.gather(*prep_tasks)
+    plans: list[_TaskPlan] = [p for p in plan_results if p is not None]
+    if not plans:
+        return
+
+    _print_plan_header(plans)
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
@@ -199,76 +349,7 @@ async def run(args: argparse.Namespace) -> None:
     )
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
-    workspace = args.workspace
-    staged_flag = not args.no_stage
-
-    adopted_run_id: str | None = None
-    if args.question_id:
-        probe = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod, staged=False)
-        info = await probe.get_page_staging_info(args.question_id)
-        if info is None:
-            print(f"Question {args.question_id} not found.")
-            return
-        is_staged, owning_run_id, _owning_project_id = info
-        if is_staged:
-            if not staged_flag:
-                print(
-                    f"Question {args.question_id[:8]} is staged under run {owning_run_id[:8]}; "
-                    "cannot run with --no-stage. Drop --no-stage to adopt the staged run."
-                )
-                return
-            adopted_run_id = owning_run_id
-
-    run_id = adopted_run_id or str(uuid.uuid4())
-    db = await DB.create(run_id=run_id, prod=args.prod, staged=staged_flag)
-    project = await db.get_or_create_project(workspace)
-    db.project_id = project.id
-
-    frontend = settings.frontend_url
-
-    if args.question_id:
-        question_id = args.question_id
-        page = await db.get_page(question_id)
-        if not page:
-            print(f"Question {question_id} not found.")
-            return
-        if page.project_id and page.project_id != db.project_id:
-            db.project_id = page.project_id
-        question_text = page.headline
-        if adopted_run_id:
-            print(f"Adopted staged run {adopted_run_id[:8]} for question: {question_text}")
-        else:
-            print(f"Using existing question: {question_text}")
-    elif args.question_text:
-        question_text = args.question_text
-        question_id = await create_root_question(question_text, db)
-        print(f"Created question: {question_id[:8]}")
-    else:
-        print("Provide a question text or --question-id.")
-        return
-
-    print(f"Trace: {frontend}/traces/{db.run_id}")
-    if get_langfuse() is not None:
-        lf_base = settings.langfuse_base_url.rstrip("/")
-        print(f"Langfuse session: {lf_base}/sessions?sessionId={db.run_id}")
-    print()
-    if adopted_run_id:
-        await db.add_budget(args.budget)
-    else:
-        await db.init_budget(args.budget)
-
-    name = args.name or question_text
-    config = settings.capture_config()
-    if not adopted_run_id:
-        await db.create_run(
-            name=name,
-            question_id=question_id,
-            config=config,
-        )
-
-    print(f"Running {args.call_type} on {question_id[:8]}...")
-    await run_call(args, db, question_id)
-    print("\nDone.")
+    await asyncio.gather(*(_execute_task(args, p) for p in plans))
 
 
 def main() -> None:
@@ -289,11 +370,18 @@ def main() -> None:
     )
     parser.add_argument(
         "question_text",
-        nargs="?",
-        default=None,
-        help="Question text (creates a new question)",
+        nargs="*",
+        default=[],
+        help="One or more question texts. Each creates a new question; multiple "
+        "texts (and/or --question-id values) run in parallel.",
     )
-    parser.add_argument("--question-id", help="Existing question UUID")
+    parser.add_argument(
+        "--question-id",
+        nargs="+",
+        metavar="UUID",
+        help="One or more existing question UUIDs. Combined with positional "
+        "question texts, all targets run in parallel (each gets its own run_id).",
+    )
     parser.add_argument("--budget", type=int, default=5, help="Budget (default: 5)")
     parser.add_argument(
         "--max-rounds",

--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -288,11 +288,11 @@ async def _prepare_task(
     )
 
 
-def _print_plan_header(plans: Sequence[_TaskPlan]) -> None:
+def _print_plan_header(plans: Sequence[_TaskPlan], *, title: str = "Targets") -> None:
     if not plans:
         return
     print()
-    print(f"=== Targets ({len(plans)}) ===")
+    print(f"=== {title} ({len(plans)}) ===")
     for p in plans:
         if p.is_new_question:
             kind = "NEW    "
@@ -350,6 +350,7 @@ async def run(args: argparse.Namespace) -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     await asyncio.gather(*(_execute_task(args, p) for p in plans))
+    _print_plan_header(plans, title="Recap")
 
 
 def main() -> None:

--- a/scripts/run_prio.py
+++ b/scripts/run_prio.py
@@ -1,13 +1,36 @@
-"""Run TwoPhaseOrchestrator._get_next_batch on a question and print the result.
+"""Run a single prioritization round (get_dispatches + execute_dispatches).
 
 Usage:
+    # Run prio on an existing question by ID
     uv run python scripts/run_prio.py --question-id <UUID> --budget 10
 
-    # Use smoke-test settings
+    # Run on several questions in parallel
+    uv run python scripts/run_prio.py --question-id <UUID1> <UUID2> --budget 10
+
+    # Mix existing question ids with new question texts; everything runs in parallel
+    uv run python scripts/run_prio.py --question-id <UUID1> "A new question?" --budget 10
+
+    # Stop after prioritization — see the chosen dispatches without running them
+    uv run python scripts/run_prio.py --question-id <UUID> --budget 10 \\
+        --up-to-stage get_dispatches
+
+    # Use smoke-test settings (haiku model)
     uv run python scripts/run_prio.py --question-id <UUID> --budget 10 --smoke-test
 
     # Use a custom workspace
     uv run python scripts/run_prio.py --question-id <UUID> --budget 10 --workspace my-scratch
+
+A single round is run per target: prioritize once, then (unless ``--up-to-stage
+get_dispatches``) execute the chosen sequences and recursive children. For a
+full multi-round orchestration loop use ``main.py --continue`` instead.
+
+All runs are staged by default (use --no-stage to disable). Workspace defaults
+to 'default' but is auto-detected from --question-id when possible. If a
+provided question is staged under another run, that run's run_id is adopted
+(budget is added to rather than clobbered; no new ``runs`` row is created).
+
+When multiple targets are passed, each gets its own run_id / DB / staging
+adoption logic and the rounds execute concurrently via asyncio.gather.
 """
 
 import argparse
@@ -15,58 +38,22 @@ import asyncio
 import json
 import logging
 import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
 
 from rumil.database import DB
-from rumil.orchestrators import TwoPhaseOrchestrator
+from rumil.orchestrators import (
+    OrchestrationStage,
+    PrioritizationResult,
+    TwoPhaseOrchestrator,
+    create_root_question,
+)
 from rumil.settings import get_settings
+from rumil.tracing import get_langfuse
 
 
-async def run(args: argparse.Namespace) -> None:
-    settings = get_settings()
-    if args.smoke_test:
-        settings.rumil_smoke_test = "1"
-    if args.available_calls is not None:
-        settings.available_calls = args.available_calls
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
-        datefmt="%H:%M:%S",
-    )
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-
-    db = await DB.create(run_id=str(uuid.uuid4()))
-
-    page = await db.get_page(args.question_id)
-    if not page:
-        print(f"Question {args.question_id} not found.")
-        return
-
-    if page.project_id:
-        db.project_id = page.project_id
-    elif args.workspace:
-        project = await db.get_or_create_project(args.workspace)
-        db.project_id = project.id
-
-    frontend = settings.frontend_url
-    print(f"Trace: {frontend}/traces/{db.run_id}\n")
-
-    await db.init_budget(args.budget)
-    await db.create_run(
-        name=page.headline,
-        question_id=args.question_id,
-        config=settings.capture_config(),
-    )
-
-    orch = TwoPhaseOrchestrator(db)
-    await orch._setup()
-
-    try:
-        result = await orch._get_next_batch(args.question_id, args.budget)
-    finally:
-        await orch._teardown()
-
-    print("\n=== PrioritizationResult ===")
+def _print_result(question_id: str, result: PrioritizationResult) -> None:
+    print(f"\n=== PrioritizationResult for {question_id[:8]} ===")
     print(f"call_id: {result.call_id}")
     print(f"dispatch_sequences: {len(result.dispatch_sequences)}")
     for i, seq in enumerate(result.dispatch_sequences):
@@ -81,27 +68,269 @@ async def run(args: argparse.Namespace) -> None:
             print(f"  child question: {child_qid}")
 
 
+@dataclass
+class _TaskPlan:
+    """Resolved per-target state, populated by ``_prepare_task`` before execution."""
+
+    db: DB
+    question_id: str
+    headline: str
+    run_id: str
+    adopted_run_id: str | None
+    is_new_question: bool
+    frontend_url: str
+    langfuse_url: str | None
+
+
+async def _prepare_task(
+    args: argparse.Namespace,
+    *,
+    question_id: str | None,
+    question_text: str | None,
+) -> _TaskPlan | None:
+    """Resolve staging/project/question/budget/run-row for one target.
+
+    Runs quietly (no logging.basicConfig yet) so the gathered plan list can be
+    printed as a clean header before the noisy execution phase begins.
+    """
+    settings = get_settings()
+    workspace = args.workspace
+    staged_flag = not args.no_stage
+
+    adopted_run_id: str | None = None
+    if question_id:
+        probe = await DB.create(run_id=str(uuid.uuid4()), prod=args.prod, staged=False)
+        info = await probe.get_page_staging_info(question_id)
+        if info is None:
+            print(f"Question {question_id} not found.")
+            return None
+        is_staged, owning_run_id, _owning_project_id = info
+        if is_staged:
+            if not staged_flag:
+                print(
+                    f"Question {question_id[:8]} is staged under run {owning_run_id[:8]}; "
+                    "cannot run with --no-stage. Drop --no-stage to adopt the staged run."
+                )
+                return None
+            adopted_run_id = owning_run_id
+
+    run_id = adopted_run_id or str(uuid.uuid4())
+    db = await DB.create(run_id=run_id, prod=args.prod, staged=staged_flag)
+    project = await db.get_or_create_project(workspace)
+    db.project_id = project.id
+
+    is_new_question = False
+    if question_id:
+        page = await db.get_page(question_id)
+        if not page:
+            print(f"Question {question_id} not found.")
+            return None
+        if page.project_id and page.project_id != db.project_id:
+            db.project_id = page.project_id
+        resolved_text = page.headline
+        resolved_qid = question_id
+    else:
+        assert question_text is not None
+        resolved_text = question_text
+        resolved_qid = await create_root_question(resolved_text, db)
+        is_new_question = True
+
+    if adopted_run_id:
+        await db.add_budget(args.budget)
+    else:
+        await db.init_budget(args.budget)
+
+    name = args.name or resolved_text
+    config = settings.capture_config()
+    if not adopted_run_id:
+        await db.create_run(name=name, question_id=resolved_qid, config=config)
+
+    langfuse_url: str | None = None
+    if get_langfuse() is not None:
+        lf_base = settings.langfuse_base_url.rstrip("/")
+        langfuse_url = f"{lf_base}/sessions?sessionId={db.run_id}"
+
+    return _TaskPlan(
+        db=db,
+        question_id=resolved_qid,
+        headline=resolved_text,
+        run_id=db.run_id,
+        adopted_run_id=adopted_run_id,
+        is_new_question=is_new_question,
+        frontend_url=settings.frontend_url,
+        langfuse_url=langfuse_url,
+    )
+
+
+def _print_plan_header(plans: Sequence[_TaskPlan]) -> None:
+    if not plans:
+        return
+    print()
+    print(f"=== Targets ({len(plans)}) ===")
+    for p in plans:
+        if p.is_new_question:
+            kind = "NEW    "
+        elif p.adopted_run_id:
+            kind = "ADOPTED"
+        else:
+            kind = "EXIST  "
+        headline = p.headline if len(p.headline) <= 100 else p.headline[:97] + "..."
+        print(f"  [{kind}] q={p.question_id[:8]} run={p.run_id[:8]}  {headline}")
+        print(f"           Trace: {p.frontend_url}/traces/{p.run_id}")
+        if p.langfuse_url:
+            print(f"           Langfuse: {p.langfuse_url}")
+    print()
+
+
+async def _execute_task(args: argparse.Namespace, plan: _TaskPlan) -> None:
+    up_to_stage = OrchestrationStage(args.up_to_stage) if args.up_to_stage else None
+    orch = TwoPhaseOrchestrator(plan.db)
+    orch.run_initial_scouts_only = args.initial_scouts_only
+    await orch._setup()
+    try:
+        print(f"Prioritizing {plan.question_id[:8]} (budget={args.budget})...")
+        result = await orch.get_dispatches(
+            plan.question_id,
+            args.budget,
+            total_remaining=args.budget,
+        )
+        _print_result(plan.question_id, result)
+
+        if up_to_stage == OrchestrationStage.GET_DISPATCHES:
+            print(f"\nStopping after get_dispatches for {plan.question_id[:8]}.")
+            return
+
+        if not result.dispatch_sequences and not result.children:
+            print(f"\nNothing to execute for {plan.question_id[:8]}.")
+            return
+
+        if args.initial_scouts_only:
+            print(f"\nExecuting scout dispatches only for {plan.question_id[:8]}...")
+        else:
+            print(f"\nExecuting dispatches for {plan.question_id[:8]}...")
+        await orch.execute_dispatches(result, plan.question_id)
+        print(f"Done with {plan.question_id[:8]}.")
+    finally:
+        await orch._teardown()
+
+
+async def run(args: argparse.Namespace) -> None:
+    settings = get_settings()
+    if args.smoke_test:
+        settings.rumil_smoke_test = "1"
+    if args.available_calls is not None:
+        settings.available_calls = args.available_calls
+    if args.available_moves is not None:
+        settings.available_moves = args.available_moves
+    if args.force_twophase_recurse:
+        settings.force_twophase_recurse = True
+
+    question_ids: list[str] = list(args.question_id) if args.question_id else []
+    question_texts: list[str] = list(args.question_text) if args.question_text else []
+
+    if not question_ids and not question_texts:
+        print("Provide at least one question text or --question-id.")
+        return
+
+    prep_tasks = [
+        _prepare_task(args, question_id=qid, question_text=None) for qid in question_ids
+    ] + [_prepare_task(args, question_id=None, question_text=qt) for qt in question_texts]
+    plan_results = await asyncio.gather(*prep_tasks)
+    plans: list[_TaskPlan] = [p for p in plan_results if p is not None]
+    if not plans:
+        return
+
+    _print_plan_header(plans)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    await asyncio.gather(*(_execute_task(args, p) for p in plans))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Run TwoPhaseOrchestrator._get_next_batch and print the result.",
+        description="Run a single prioritization round (get_dispatches + execute_dispatches).",
     )
-    parser.add_argument("--question-id", required=True, help="Question UUID")
-    parser.add_argument("--budget", type=int, required=True, help="Budget for prioritization")
+    parser.add_argument(
+        "question_text",
+        nargs="*",
+        default=[],
+        help="One or more question texts. Each creates a new question; multiple "
+        "texts (and/or --question-id values) run in parallel.",
+    )
+    parser.add_argument(
+        "--question-id",
+        nargs="+",
+        metavar="UUID",
+        help="One or more existing question UUIDs. Combined with positional "
+        "question texts, all targets run in parallel (each gets its own run_id).",
+    )
+    parser.add_argument("--budget", type=int, required=True, help="Budget per question")
     parser.add_argument(
         "--smoke-test",
         action="store_true",
-        help="Use smoke-test settings",
+        help="Use smoke-test settings (haiku model, reduced rounds)",
+    )
+    parser.add_argument(
+        "--force-twophase-recurse",
+        action="store_true",
+        dest="force_twophase_recurse",
+        help="Force the two-phase orchestrator to dispatch two recurse calls",
+    )
+    parser.add_argument(
+        "--name",
+        default="",
+        help="Optional name for the run (defaults to question text)",
     )
     parser.add_argument(
         "--workspace",
+        default="default",
+        help="Project workspace name (default: 'default'). "
+        "Auto-detected from --question-id when possible.",
+    )
+    parser.add_argument(
+        "--available-moves",
+        dest="available_moves",
         default=None,
-        help="Project workspace name (inferred from question if omitted)",
+        help="Available-moves preset name (default: 'default').",
     )
     parser.add_argument(
         "--available-calls",
         dest="available_calls",
         default=None,
-        help="Available-calls preset name",
+        help="Available-calls preset name (default: 'default').",
+    )
+    parser.add_argument(
+        "--prod",
+        action="store_true",
+        help="Use the production database instead of local Supabase",
+    )
+    parser.add_argument(
+        "--no-stage",
+        action="store_true",
+        dest="no_stage",
+        help="Run without staging (default: runs are staged)",
+    )
+    parser.add_argument(
+        "--up-to-stage",
+        choices=[OrchestrationStage.GET_DISPATCHES.value],
+        default=None,
+        help="Stop after this stage. 'get_dispatches' produces the prioritization "
+        "plan and prints it without executing the chosen calls.",
+    )
+    parser.add_argument(
+        "--initial-scouts-only",
+        action="store_true",
+        dest="initial_scouts_only",
+        help="Execute only the scout dispatches (call_type starting with 'scout_') "
+        "from the prioritization plan; skip recursive children and other dispatch "
+        "types. Useful for assessing the quality of scout outputs (e.g. subquestion "
+        "generation) without firing off downstream work.",
     )
     args = parser.parse_args()
     asyncio.run(run(args))

--- a/scripts/run_prio.py
+++ b/scripts/run_prio.py
@@ -162,11 +162,11 @@ async def _prepare_task(
     )
 
 
-def _print_plan_header(plans: Sequence[_TaskPlan]) -> None:
+def _print_plan_header(plans: Sequence[_TaskPlan], *, title: str = "Targets") -> None:
     if not plans:
         return
     print()
-    print(f"=== Targets ({len(plans)}) ===")
+    print(f"=== {title} ({len(plans)}) ===")
     for p in plans:
         if p.is_new_question:
             kind = "NEW    "
@@ -250,6 +250,7 @@ async def run(args: argparse.Namespace) -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     await asyncio.gather(*(_execute_task(args, p) for p in plans))
+    _print_plan_header(plans, title="Recap")
 
 
 def main() -> None:

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -74,12 +74,19 @@ class QuestionBudgetPool:
     their assigned budget to the pool and draw from it together. The pool
     is the authoritative stop signal for prio loops; the run-level budget
     remains the authoritative ceiling.
+
+    ``registered=False`` indicates that no pool row exists — the caller
+    bypassed ``qbp_register`` (e.g. ``scripts/run_prio.py`` running
+    ``get_dispatches`` outside ``run()``). Bailout checks should treat
+    this as "no pool gate" rather than "drained to zero", to match
+    ``qbp_consume``'s sentinel behaviour for the same case.
     """
 
     question_id: str
     contributed: int
     consumed: int
     active_calls: int
+    registered: bool = True
 
     @property
     def remaining(self) -> int:
@@ -2006,6 +2013,7 @@ class DB:
                 contributed=0,
                 consumed=0,
                 active_calls=0,
+                registered=False,
             )
         r = rows[0]
         return QuestionBudgetPool(

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -1851,6 +1851,7 @@ class DB:
         call_id: str | None = None,
         sequence_id: str | None = None,
         sequence_position: int | None = None,
+        call_params: dict | None = None,
     ) -> Call:
         log.debug(
             "create_call: type=%s, scope=%s, parent=%s, budget=%s",
@@ -1869,6 +1870,7 @@ class DB:
             context_page_ids=list(context_page_ids) if context_page_ids else [],
             sequence_id=sequence_id,
             sequence_position=sequence_position,
+            call_params=call_params,
         )
         if call_id is not None:
             call.id = call_id

--- a/src/rumil/orchestrators/__init__.py
+++ b/src/rumil/orchestrators/__init__.py
@@ -4,7 +4,7 @@ Budget is tracked here; prioritization and review calls are free.
 """
 
 from rumil.database import DB
-from rumil.orchestrators.base import BaseOrchestrator
+from rumil.orchestrators.base import BaseOrchestrator, OrchestrationStage
 from rumil.orchestrators.claim_investigation import ClaimInvestigationOrchestrator
 from rumil.orchestrators.common import (
     PRIORITIZATION_MOVES,
@@ -55,6 +55,7 @@ __all__ = [
     "ExperimentalOrchestrator",
     "FruitResult",
     "GlobalPrioOrchestrator",
+    "OrchestrationStage",
     "Orchestrator",
     "PrioritizationResult",
     "SubquestionScore",

--- a/src/rumil/orchestrators/base.py
+++ b/src/rumil/orchestrators/base.py
@@ -8,6 +8,7 @@ import logging
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from enum import StrEnum
 
 from rumil.calls.stages import CallRunner
 from rumil.constants import SMOKE_TEST_MAX_ROUNDS, compute_round_budget
@@ -19,6 +20,7 @@ from rumil.models import (
     Dispatch,
 )
 from rumil.orchestrators.common import (
+    PrioritizationResult,
     _create_broadcaster,
 )
 from rumil.orchestrators.dispatch_handlers import (
@@ -28,9 +30,22 @@ from rumil.orchestrators.dispatch_handlers import (
 from rumil.settings import get_settings
 from rumil.tracing import observe, propagate_attributes
 from rumil.tracing.broadcast import Broadcaster
-from rumil.tracing.trace_events import DispatchExecutedEvent
-from rumil.tracing.tracer import get_trace
+from rumil.tracing.trace_events import DispatchExecutedEvent, ErrorEvent
+from rumil.tracing.tracer import CallTrace, get_trace
 from rumil.views import get_active_view
+
+
+class OrchestrationStage(StrEnum):
+    """Stages of a single orchestrator round.
+
+    Used by scripts to truncate the round at a specific boundary —
+    e.g. run only ``get_dispatches`` to inspect what would be dispatched
+    without actually executing it.
+    """
+
+    GET_DISPATCHES = "get_dispatches"
+    EXECUTE_DISPATCHES = "execute_dispatches"
+
 
 log = logging.getLogger(__name__)
 
@@ -84,6 +99,12 @@ class BaseOrchestrator(ABC):
         # budget consumption debits this question's pool. None for
         # orchestrators outside a per-question prio cycle.
         self.pool_question_id: str | None = None
+        # Test/dev knob: when True, ``execute_dispatches`` runs only the
+        # scout dispatches (call_type starting with ``scout_``) from the
+        # selected dispatches and skips recursive children. Lets callers
+        # like scripts/run_prio.py spend on scouts to inspect their
+        # outputs without firing off the rest of the planned work.
+        self.run_initial_scouts_only: bool = False
 
     async def _pacing_params(self) -> tuple[int, int]:
         """Return (total, used) for budget pacing.
@@ -340,6 +361,100 @@ class BaseOrchestrator(ABC):
 
         sequence_results = await asyncio.gather(*tasks)
         return any(sequence_results)
+
+    async def get_dispatches(
+        self,
+        root_question_id: str,
+        budget: int,
+        *,
+        parent_call_id: str | None = None,
+        total_remaining: int | None = None,
+        last_call: bool = False,
+    ) -> PrioritizationResult:
+        """Run the prioritization step and return the planned dispatches.
+
+        Round-based orchestrators (TwoPhase, ClaimInvestigation, Experimental)
+        implement this as their per-round prioritization. Calling this without
+        ``execute_dispatches`` lets callers inspect what would be dispatched
+        without actually running the calls. Orchestrators with a different
+        shape (e.g. GlobalPrioOrchestrator) leave the default which raises.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement the "
+            "get_dispatches / execute_dispatches stage model."
+        )
+
+    async def execute_dispatches(
+        self,
+        result: PrioritizationResult,
+        root_question_id: str,
+    ) -> list:
+        """Run sequences and recursive children from ``result`` concurrently.
+
+        Returns the gather result list (with exceptions preserved). Returns
+        an empty list when there is nothing to execute. Errors are logged
+        and recorded on the prioritization call's trace if ``result.call_id``
+        is set; the caller decides whether to break based on the returned
+        list (typically: stop when it is empty or all entries are exceptions).
+
+        When ``self.run_initial_scouts_only`` is True, ``result`` is filtered
+        to scout-only sequences (every dispatch's ``call_type`` starts with
+        ``scout_``) and recursive children are skipped — useful for
+        inspecting scout outputs without firing off downstream work.
+        """
+        if self.run_initial_scouts_only:
+            scout_sequences = [
+                seq
+                for seq in result.dispatch_sequences
+                if seq and all(d.call_type.value.startswith("scout_") for d in seq)
+            ]
+            skipped = len(result.dispatch_sequences) - len(scout_sequences)
+            if skipped or result.children:
+                log.info(
+                    "run_initial_scouts_only: kept %d scout sequence(s); "
+                    "dropped %d non-scout sequence(s) and %d recursive child(ren).",
+                    len(scout_sequences),
+                    skipped,
+                    len(result.children),
+                )
+            result = PrioritizationResult(
+                dispatch_sequences=scout_sequences,
+                call_id=result.call_id,
+                children=(),
+            )
+
+        tasks: list = []
+        if result.dispatch_sequences:
+            tasks.append(
+                self._run_sequences(
+                    result.dispatch_sequences,
+                    root_question_id,
+                    result.call_id,
+                )
+            )
+        for child, child_qid in result.children:
+            tasks.append(child.run(child_qid))
+
+        if not tasks:
+            return []
+
+        gather_results = await asyncio.gather(*tasks, return_exceptions=True)
+        for r in gather_results:
+            if isinstance(r, Exception):
+                log.error("Concurrent dispatch failed: %s", r, exc_info=r)
+                if result.call_id:
+                    trace = CallTrace(
+                        result.call_id,
+                        self.db,
+                        broadcaster=self.broadcaster,
+                    )
+                    await trace.record(
+                        ErrorEvent(
+                            message=(f"Concurrent dispatch failed: {type(r).__name__}: {r}"),
+                            phase="dispatch",
+                        )
+                    )
+        return gather_results
 
     @abstractmethod
     async def run(self, root_question_id: str) -> None: ...

--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -43,7 +43,6 @@ from rumil.tracing.trace_events import (
     DispatchesPlannedEvent,
     DispatchExecutedEvent,
     DispatchTraceItem,
-    ErrorEvent,
     PhaseSkippedEvent,
     ScoringCompletedEvent,
 )
@@ -153,7 +152,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                     round_budget = effective
                 else:
                     round_budget = await self._paced_budget(effective)
-                result = await self._get_next_batch(
+                result = await self.get_dispatches(
                     claim_id,
                     round_budget,
                     total_remaining=effective,
@@ -162,40 +161,9 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                 if not result.dispatch_sequences and not result.children:
                     break
 
-                tasks: list = []
-                if result.dispatch_sequences:
-                    tasks.append(
-                        self._run_sequences(
-                            result.dispatch_sequences,
-                            claim_id,
-                            result.call_id,
-                        )
-                    )
-                for child, child_id in result.children:
-                    tasks.append(child.run(child_id))
-
-                if not tasks:
+                results = await self.execute_dispatches(result, claim_id)
+                if not results:
                     break
-
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-                for r in results:
-                    if isinstance(r, Exception):
-                        log.error("Concurrent dispatch failed: %s", r, exc_info=r)
-                        if result.call_id:
-                            trace = CallTrace(
-                                result.call_id,
-                                self.db,
-                                broadcaster=self.broadcaster,
-                            )
-                            await trace.record(
-                                ErrorEvent(
-                                    message=(
-                                        f"Concurrent dispatch failed: {type(r).__name__}: {r}"
-                                    ),
-                                    phase="dispatch",
-                                )
-                            )
-
                 if not any(not isinstance(r, Exception) for r in results):
                     break
 
@@ -273,14 +241,16 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             "Phase 1 skipped — claim already has research.",
         )
 
-    async def _get_next_batch(
+    async def get_dispatches(
         self,
-        claim_id: str,
+        root_question_id: str,
         budget: int,
+        *,
         parent_call_id: str | None = None,
         total_remaining: int | None = None,
         last_call: bool = False,
     ) -> "PrioritizationResult":
+        claim_id = root_question_id
 
         if self._invocation == 0:
             self._invocation += 1
@@ -552,17 +522,21 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         # the LLM dispatching, peer cycles can only consume more from the pool.
         # Using a fresh snapshot ensures the budget line and the Coordination
         # context section agree on what's available.
+        # Skip the bailout when the pool was never registered (e.g. callers
+        # that invoke get_dispatches outside the run() loop, like
+        # scripts/run_prio.py): "no pool" must not look like "drained to zero".
         fresh_pool = await self.db.qbp_get(claim_id)
-        budget = min(budget, max(fresh_pool.remaining, 0))
-        # If the pool drained between top-of-loop and now (i.e. peer cycles
-        # consumed our slice), bail before calling the LLM with budget 0.
-        if budget <= 0:
-            await mark_call_completed(
-                p_call,
-                self.db,
-                "Pool drained by peer cycles before this round could plan.",
-            )
-            return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
+        if fresh_pool.registered:
+            budget = min(budget, max(fresh_pool.remaining, 0))
+            # If the pool drained between top-of-loop and now (i.e. peer cycles
+            # consumed our slice), bail before calling the LLM with budget 0.
+            if budget <= 0:
+                await mark_call_completed(
+                    p_call,
+                    self.db,
+                    "Pool drained by peer cycles before this round could plan.",
+                )
+                return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=claim_id,

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -43,7 +43,6 @@ from rumil.tracing.trace_events import (
     DispatchesPlannedEvent,
     DispatchExecutedEvent,
     DispatchTraceItem,
-    ErrorEvent,
     ExperimentalScoringCompletedEvent,
     ExperimentalSubquestionScoreItem,
     PhaseSkippedEvent,
@@ -159,7 +158,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                 set_experimental_scout_budget(effective)
 
                 round_budget = await self._paced_budget(effective)
-                result = await self._get_next_batch(
+                result = await self.get_dispatches(
                     root_question_id,
                     round_budget,
                     total_remaining=effective,
@@ -167,40 +166,9 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                 if not result.dispatch_sequences and not result.children:
                     break
 
-                tasks: list = []
-                if result.dispatch_sequences:
-                    tasks.append(
-                        self._run_sequences(
-                            result.dispatch_sequences,
-                            root_question_id,
-                            result.call_id,
-                        )
-                    )
-                for child, child_qid in result.children:
-                    tasks.append(child.run(child_qid))
-
-                if not tasks:
+                results = await self.execute_dispatches(result, root_question_id)
+                if not results:
                     break
-
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-                for r in results:
-                    if isinstance(r, Exception):
-                        log.error("Concurrent dispatch failed: %s", r, exc_info=r)
-                        if result.call_id:
-                            trace = CallTrace(
-                                result.call_id,
-                                self.db,
-                                broadcaster=self.broadcaster,
-                            )
-                            await trace.record(
-                                ErrorEvent(
-                                    message=(
-                                        f"Concurrent dispatch failed: {type(r).__name__}: {r}"
-                                    ),
-                                    phase="dispatch",
-                                )
-                            )
-
                 if not any(not isinstance(r, Exception) for r in results):
                     break
 
@@ -277,13 +245,17 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             f"Initial prioritization skipped — {reason}",
         )
 
-    async def _get_next_batch(
+    async def get_dispatches(
         self,
-        question_id: str,
+        root_question_id: str,
         budget: int,
+        *,
         parent_call_id: str | None = None,
         total_remaining: int | None = None,
+        last_call: bool = False,
     ) -> PrioritizationResult:
+        del last_call  # unused — experimental does not gate on last-call
+        question_id = root_question_id
         if self._invocation == 0:
             self._invocation += 1
             effective_remaining = total_remaining if total_remaining is not None else budget
@@ -612,17 +584,21 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         # the LLM dispatching, peer cycles can only consume more from the pool.
         # Using a fresh snapshot ensures the budget line and the Coordination
         # context section agree on what's available.
+        # Skip the bailout when the pool was never registered (e.g. callers
+        # that invoke get_dispatches outside the run() loop, like
+        # scripts/run_prio.py): "no pool" must not look like "drained to zero".
         fresh_pool = await self.db.qbp_get(question_id)
-        budget = min(budget, max(fresh_pool.remaining, 0))
-        # If the pool drained between top-of-loop and now (i.e. peer cycles
-        # consumed our slice), bail before calling the LLM with budget 0/-1.
-        if budget <= 1:
-            await mark_call_completed(
-                p_call,
-                self.db,
-                "Pool drained by peer cycles before this round could plan.",
-            )
-            return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
+        if fresh_pool.registered:
+            budget = min(budget, max(fresh_pool.remaining, 0))
+            # If the pool drained between top-of-loop and now (i.e. peer cycles
+            # consumed our slice), bail before calling the LLM with budget 0/-1.
+            if budget <= 1:
+                await mark_call_completed(
+                    p_call,
+                    self.db,
+                    "Pool drained by peer cycles before this round could plan.",
+                )
+                return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=question_id,

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -120,6 +120,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             parent_call_id=parent_call_id,
             budget_allocated=initial_prioritization_budget,
             workspace=Workspace.PRIORITIZATION,
+            call_params={"phase": "initial"},
         )
         self._call_id = p_call.id
         self._initial_call = p_call
@@ -413,6 +414,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                 workspace=Workspace.PRIORITIZATION,
                 sequence_id=self._sequence_id,
                 sequence_position=self._seq_position if self._sequence_id else None,
+                call_params={"phase": "initial"},
             )
             if self._sequence_id is not None:
                 self._seq_position += 1
@@ -538,6 +540,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
             workspace=Workspace.PRIORITIZATION,
             sequence_id=self._sequence_id,
             sequence_position=self._seq_position if self._sequence_id else None,
+            call_params={"phase": "main_phase"},
         )
         if self._sequence_id is not None:
             self._seq_position += 1

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -121,6 +121,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             parent_call_id=parent_call_id,
             budget_allocated=initial_prioritization_budget,
             workspace=Workspace.PRIORITIZATION,
+            call_params={"phase": "initial"},
         )
         self._call_id = p_call.id
         self._initial_call = p_call
@@ -369,6 +370,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 workspace=Workspace.PRIORITIZATION,
                 sequence_id=self._sequence_id,
                 sequence_position=self._seq_position if self._sequence_id else None,
+                call_params={"phase": "initial"},
             )
             if self._sequence_id is not None:
                 self._seq_position += 1
@@ -493,6 +495,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             workspace=Workspace.PRIORITIZATION,
             sequence_id=self._sequence_id,
             sequence_position=self._seq_position if self._sequence_id else None,
+            call_params={"phase": "main_phase"},
         )
         if self._sequence_id is not None:
             self._seq_position += 1

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -45,7 +45,6 @@ from rumil.tracing.trace_events import (
     DispatchesPlannedEvent,
     DispatchExecutedEvent,
     DispatchTraceItem,
-    ErrorEvent,
     PhaseSkippedEvent,
     ScoringCompletedEvent,
     SubquestionScoreItem,
@@ -162,7 +161,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                     round_budget = effective
                 else:
                     round_budget = await self._paced_budget(effective)
-                result = await self._get_next_batch(
+                result = await self.get_dispatches(
                     root_question_id,
                     round_budget,
                     total_remaining=effective,
@@ -171,40 +170,9 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 if not result.dispatch_sequences and not result.children:
                     break
 
-                tasks: list = []
-                if result.dispatch_sequences:
-                    tasks.append(
-                        self._run_sequences(
-                            result.dispatch_sequences,
-                            root_question_id,
-                            result.call_id,
-                        )
-                    )
-                for child, child_qid in result.children:
-                    tasks.append(child.run(child_qid))
-
-                if not tasks:
+                results = await self.execute_dispatches(result, root_question_id)
+                if not results:
                     break
-
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-                for r in results:
-                    if isinstance(r, Exception):
-                        log.error("Concurrent dispatch failed: %s", r, exc_info=r)
-                        if result.call_id:
-                            trace = CallTrace(
-                                result.call_id,
-                                self.db,
-                                broadcaster=self.broadcaster,
-                            )
-                            await trace.record(
-                                ErrorEvent(
-                                    message=(
-                                        f"Concurrent dispatch failed: {type(r).__name__}: {r}"
-                                    ),
-                                    phase="dispatch",
-                                )
-                            )
-
                 if not any(not isinstance(r, Exception) for r in results):
                     break
 
@@ -296,14 +264,16 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             "Initial prioritization skipped — question already has a judgement or view.",
         )
 
-    async def _get_next_batch(
+    async def get_dispatches(
         self,
-        question_id: str,
+        root_question_id: str,
         budget: int,
+        *,
         parent_call_id: str | None = None,
         total_remaining: int | None = None,
         last_call: bool = False,
     ) -> PrioritizationResult:
+        question_id = root_question_id
         if self._invocation == 0:
             self._invocation += 1
             if await self._needs_initial_prioritization(question_id):
@@ -613,18 +583,22 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         # the LLM dispatching, peer cycles can only consume more from the pool.
         # Using a fresh snapshot ensures the budget line and the Coordination
         # context section agree on what's available.
+        # Skip the bailout when the pool was never registered (e.g. callers
+        # that invoke get_dispatches outside the run() loop, like
+        # scripts/run_prio.py): "no pool" must not look like "drained to zero".
         fresh_pool = await self.db.qbp_get(question_id)
-        budget = min(budget, max(fresh_pool.remaining, 0))
-        # If the pool drained between top-of-loop and now (i.e. peer cycles
-        # consumed our slice), bail before calling the LLM with budget 0/-1.
-        # The outer loop will break on the empty result.
-        if budget <= 0:
-            await mark_call_completed(
-                p_call,
-                self.db,
-                "Pool drained by peer cycles before this round could plan.",
-            )
-            return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
+        if fresh_pool.registered:
+            budget = min(budget, max(fresh_pool.remaining, 0))
+            # If the pool drained between top-of-loop and now (i.e. peer cycles
+            # consumed our slice), bail before calling the LLM with budget 0/-1.
+            # The outer loop will break on the empty result.
+            if budget <= 0:
+                await mark_call_completed(
+                    p_call,
+                    self.db,
+                    "Pool drained by peer cycles before this round could plan.",
+                )
+                return PrioritizationResult(dispatch_sequences=[], call_id=p_call.id)
         context_text, short_id_map = await build_prioritization_context(
             self.db,
             scope_question_id=question_id,

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -62,21 +62,35 @@ class ScriptedOrchestrator(BaseOrchestrator):
         self._call_id = call_id
         self.get_calls_count = 0
 
+    async def get_dispatches(
+        self,
+        root_question_id,
+        budget,
+        *,
+        parent_call_id=None,
+        total_remaining=None,
+        last_call=False,
+    ):
+        if self._index >= len(self._batches):
+            return PrioritizationResult(dispatch_sequences=[], call_id=self._call_id)
+        batch = self._batches[self._index]
+        self._index += 1
+        self.get_calls_count += 1
+        if not batch:
+            return PrioritizationResult(dispatch_sequences=[], call_id=self._call_id)
+        return PrioritizationResult(dispatch_sequences=[batch], call_id=self._call_id)
+
     async def run(self, root_question_id):
         await self._setup()
         try:
-            for batch in self._batches:
+            while True:
                 remaining = await self.db.budget_remaining()
                 if remaining <= 0:
                     break
-                self.get_calls_count += 1
-                if not batch:
+                result = await self.get_dispatches(root_question_id, remaining)
+                if not result.dispatch_sequences and not result.children:
                     break
-                await self._run_sequences(
-                    [batch],
-                    root_question_id,
-                    self._call_id,
-                )
+                await self.execute_dispatches(result, root_question_id)
         finally:
             await self._teardown()
 
@@ -274,7 +288,7 @@ async def test_concurrent_dispatch_failure_recorded_in_trace(
     dispatches = [[_assess_dispatch(question_page.id)]]
     call_count = 0
 
-    async def fake_get_next_batch(question_id, budget, parent_call_id=None, **kwargs):
+    async def fake_get_dispatches(question_id, budget, **kwargs):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -284,7 +298,7 @@ async def test_concurrent_dispatch_failure_recorded_in_trace(
             )
         return PrioritizationResult(dispatch_sequences=[])
 
-    mocker.patch.object(orch, "_get_next_batch", side_effect=fake_get_next_batch)
+    mocker.patch.object(orch, "get_dispatches", side_effect=fake_get_dispatches)
     mocker.patch.object(
         DB,
         "resolve_page_id",


### PR DESCRIPTION
## Summary

- **`run_call.py` / `run_prio.py`**: take any mix of `--question-id <UUID>...` and positional question texts, fan out concurrently. Each target gets its own run_id / DB / staging adoption logic. Pre-flight resolves headlines + run IDs and prints a structured `=== Targets (N) ===` block before the noisy execution; same block is printed again as `=== Recap ===` afterwards so trace URLs are always one screenful away.
- **Orchestrator stage abstraction**: introduces `OrchestrationStage` enum and refactors `BaseOrchestrator` to expose two stages — `get_dispatches` (the prioritization step) and `execute_dispatches` (run sequences + recursive children with consistent error handling). `TwoPhaseOrchestrator`, `ClaimInvestigationOrchestrator`, and `ExperimentalOrchestrator` have their `_get_next_batch` renamed to `get_dispatches` and delegate the gather/error-handling block to `execute_dispatches`. `GlobalPrioOrchestrator` keeps its own loop shape (default `get_dispatches` raises `NotImplementedError`).
- **`run_prio.py --up-to-stage get_dispatches`**: stop after prioritization and pretty-print the chosen dispatches without executing them. Default behavior is one round of prio + execute (a single round, not the full multi-round loop).
- **`run_prio.py --initial-scouts-only`**: `BaseOrchestrator.run_initial_scouts_only` filters `execute_dispatches` to scout-only sequences (`call_type` starts with `scout_`) and skips recursive children. Useful for assessing scout output quality without firing off downstream work.
- **Pool-registration bug fix**: `_main_phase_prioritization` (and `_phase2`) used to bail out with `"Pool drained by peer cycles before this round could plan."` when called outside `run()` — `qbp_get` returned a zero-default for missing rows, so `pool.remaining=0` looked the same as a drained pool. `QuestionBudgetPool` now carries a `registered: bool` flag (False when no row exists), and the bailout is gated on it. Symmetric with `qbp_consume`'s existing "no pool ⇒ no gate" sentinel. This previously caused two prod runs (864c2d81-…, 09376c30-…) to spend ~$0.63 of scoring before bailing without ever calling the dispatch LLM.
- Brought in trace-event changes from `distinguish-prio-phases-in-trace` (initial vs main-phase prio rendered distinctly in the trace UI) plus dead-code cleanup that came with that branch.

## Test plan

- [x] `uv run pyright` — clean
- [x] `uv run ruff check` — clean
- [x] `uv run pytest tests/test_orchestrator_dispatch.py tests/test_two_phase_recurse.py tests/test_two_phase_trace_events.py tests/test_global_prio_loop.py tests/test_call_sequences.py` — 40 passed
- [x] Manual smoke: `run_call.py refresh-view --question-id <UUID> --prod --no-stage` against prod ran successfully and produced a sectioned-view page.
- [x] Confirm `run_prio.py` with multiple question ids prints the `=== Targets ===` block before logs and `=== Recap ===` after.
- [x] Confirm `--up-to-stage get_dispatches` produces the prioritization plan and stops without executing.
- [x] Confirm `--initial-scouts-only` runs only scout calls from the chosen dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)