### PR TITLE
fix(web_research): record create_claim moves into MoveState

### DIFF
--- a/src/rumil/calls/page_creators.py
+++ b/src/rumil/calls/page_creators.py
@@ -28,6 +28,7 @@ from rumil.llm import (
 )
 from rumil.models import (
     CallType,
+    Move,
     MoveType,
 )
 from rumil.moves.create_claim import (
@@ -436,15 +437,25 @@ class WebResearchLoop(WorkspaceUpdater):
                     inp: dict,
                     _infra=infra,
                 ) -> str:
-                    known_before = set(self.source_page_ids.values())
-                    result = await execute_with_source_creation(
+                    result, validated = await execute_with_source_creation(
                         inp, _infra.call, _infra.db, self.source_page_ids
                     )
-                    for sid in self.source_page_ids.values():
-                        if sid not in known_before:
-                            _infra.state.created_page_ids.append(sid)
+                    move_page_ids: list[str] = []
                     if result.created_page_id:
                         _infra.state.created_page_ids.append(result.created_page_id)
+                        _infra.state.last_created_id = result.created_page_id
+                        _infra.state.context_page_ids.add(result.created_page_id)
+                        move_page_ids.append(result.created_page_id)
+                    if result.extra_created_ids:
+                        for sid in result.extra_created_ids:
+                            _infra.state.created_page_ids.append(sid)
+                        move_page_ids.extend(result.extra_created_ids)
+                    if validated is not None:
+                        _infra.state.moves.append(
+                            Move(move_type=MoveType.CREATE_CLAIM, payload=validated)
+                        )
+                        _infra.state.move_created_ids.append(move_page_ids)
+                        _infra.state.move_trace_extras.append(result.trace_extra)
                     return result.message
 
                 wrapped.append(

--- a/src/rumil/clean/grounding.py
+++ b/src/rumil/clean/grounding.py
@@ -115,7 +115,7 @@ def _make_create_claim_tool(call: Call, db: DB):
         _CreateClaimInput.model_json_schema(),
     )
     async def create_claim(args: dict) -> dict:
-        result = await execute_with_source_creation(args, call, db, source_cache)
+        result, _ = await execute_with_source_creation(args, call, db, source_cache)
         return {"content": [{"type": "text", "text": result.message}]}
 
     return create_claim

--- a/src/rumil/moves/create_claim.py
+++ b/src/rumil/moves/create_claim.py
@@ -247,13 +247,22 @@ async def execute_with_source_creation(
     call: Call,
     db: DB,
     source_cache: dict[str, str],
-) -> MoveResult:
+) -> tuple[MoveResult, CreateClaimPayload | None]:
     """Like ``execute()``, but resolves HTTP URLs in ``source_urls`` first.
 
     For each ``source_urls`` entry starting with ``http``, scrapes the URL
     and creates a SOURCE page.  Also rewrites ``[url]`` inline citations
     in content to ``[shortid]``.
+
+    Returns ``(result, payload)``. ``payload`` is the validated
+    ``CreateClaimPayload`` actually executed (with URLs resolved to source
+    page IDs) — callers like the WebResearchLoop wrapper need it to record
+    a faithful ``Move``. ``payload`` is ``None`` when an error short-circuits
+    before payload construction. ``result.extra_created_ids`` lists the
+    SOURCE pages newly created on this call (already-cached sources are
+    not included).
     """
+    known_sources_before = set(source_cache.values())
     source_urls = inp.get("source_urls", [])
     if source_urls:
         resolved: list[str] = []
@@ -269,14 +278,17 @@ async def execute_with_source_creation(
                 resolved.append(sid)
         if failed_urls:
             urls = ", ".join(failed_urls)
-            return MoveResult(
-                message=(
-                    f"ERROR: Could not fetch the following source(s): {urls}. "
-                    "Find a different, accessible source that supports "
-                    "the same information, or modify the claim so it "
-                    "does not rely on the inaccessible source(s)."
+            return (
+                MoveResult(
+                    message=(
+                        f"ERROR: Could not fetch the following source(s): {urls}. "
+                        "Find a different, accessible source that supports "
+                        "the same information, or modify the claim so it "
+                        "does not rely on the inaccessible source(s)."
+                    ),
+                    created_page_id="",
                 ),
-                created_page_id="",
+                None,
             )
         inp = {**inp, "source_urls": resolved}
 
@@ -285,7 +297,13 @@ async def execute_with_source_creation(
         try:
             inp = {**inp, "content": rewrite_url_citations(content, source_cache)}
         except ValueError as exc:
-            return MoveResult(message=f"ERROR: {exc}", created_page_id="")
+            return MoveResult(message=f"ERROR: {exc}", created_page_id=""), None
 
     payload = CreateClaimPayload(**inp)
-    return await execute(payload, call, db)
+    result = await execute(payload, call, db)
+
+    new_source_ids = [sid for sid in source_cache.values() if sid not in known_sources_before]
+    if new_source_ids:
+        result.extra_created_ids = [*(result.extra_created_ids or []), *new_source_ids]
+
+    return result, payload

--- a/src/rumil/moves/create_claim.py
+++ b/src/rumil/moves/create_claim.py
@@ -263,6 +263,16 @@ async def execute_with_source_creation(
     not included).
     """
     known_sources_before = set(source_cache.values())
+
+    def _attach_new_sources(result: MoveResult) -> MoveResult:
+        # Surface SOURCE pages scraped during this call even on error returns,
+        # so the wrapper can register them in state.created_page_ids and they
+        # don't become invisible-but-persisted DB rows.
+        new_source_ids = [sid for sid in source_cache.values() if sid not in known_sources_before]
+        if new_source_ids:
+            result.extra_created_ids = [*(result.extra_created_ids or []), *new_source_ids]
+        return result
+
     source_urls = inp.get("source_urls", [])
     if source_urls:
         resolved: list[str] = []
@@ -279,14 +289,16 @@ async def execute_with_source_creation(
         if failed_urls:
             urls = ", ".join(failed_urls)
             return (
-                MoveResult(
-                    message=(
-                        f"ERROR: Could not fetch the following source(s): {urls}. "
-                        "Find a different, accessible source that supports "
-                        "the same information, or modify the claim so it "
-                        "does not rely on the inaccessible source(s)."
-                    ),
-                    created_page_id="",
+                _attach_new_sources(
+                    MoveResult(
+                        message=(
+                            f"ERROR: Could not fetch the following source(s): {urls}. "
+                            "Find a different, accessible source that supports "
+                            "the same information, or modify the claim so it "
+                            "does not rely on the inaccessible source(s)."
+                        ),
+                        created_page_id="",
+                    )
                 ),
                 None,
             )
@@ -297,13 +309,11 @@ async def execute_with_source_creation(
         try:
             inp = {**inp, "content": rewrite_url_citations(content, source_cache)}
         except ValueError as exc:
-            return MoveResult(message=f"ERROR: {exc}", created_page_id=""), None
+            return (
+                _attach_new_sources(MoveResult(message=f"ERROR: {exc}", created_page_id="")),
+                None,
+            )
 
     payload = CreateClaimPayload(**inp)
     result = await execute(payload, call, db)
-
-    new_source_ids = [sid for sid in source_cache.values() if sid not in known_sources_before]
-    if new_source_ids:
-        result.extra_created_ids = [*(result.extra_created_ids or []), *new_source_ids]
-
-    return result, payload
+    return _attach_new_sources(result), payload

--- a/tests/test_scrape_failure.py
+++ b/tests/test_scrape_failure.py
@@ -27,7 +27,7 @@ async def test_create_claim_errors_when_source_url_unscrapable(
         return_value=None,
     )
 
-    result = await execute_with_source_creation(
+    result, payload = await execute_with_source_creation(
         {
             "headline": "Some claim",
             "content": "Claim content",
@@ -38,6 +38,7 @@ async def test_create_claim_errors_when_source_url_unscrapable(
         source_cache={},
     )
 
+    assert payload is None
     assert "unreachable.example.com" in result.message
     assert "different" in result.message.lower()
     assert result.created_page_id == ""
@@ -55,7 +56,7 @@ async def test_create_claim_succeeds_when_no_source_urls(
     )
     await tmp_db.save_call(call)
 
-    result = await execute_with_source_creation(
+    result, payload = await execute_with_source_creation(
         {
             "headline": "Some claim",
             "content": "Claim content",
@@ -69,5 +70,6 @@ async def test_create_claim_succeeds_when_no_source_urls(
         source_cache={},
     )
 
+    assert payload is not None
     assert result.created_page_id != ""
     assert "ERROR" not in result.message

--- a/tests/test_scrape_failure.py
+++ b/tests/test_scrape_failure.py
@@ -1,5 +1,7 @@
 """Test that execute_with_source_creation handles scrape failures correctly."""
 
+import time
+
 from rumil.models import (
     Call,
     CallStatus,
@@ -7,6 +9,7 @@ from rumil.models import (
     Workspace,
 )
 from rumil.moves.create_claim import execute_with_source_creation
+from rumil.scraper import ScrapedPage
 
 
 async def test_create_claim_errors_when_source_url_unscrapable(
@@ -73,3 +76,56 @@ async def test_create_claim_succeeds_when_no_source_urls(
     assert payload is not None
     assert result.created_page_id != ""
     assert "ERROR" not in result.message
+
+
+async def test_partially_scraped_sources_surface_on_failure(
+    tmp_db,
+    question_page,
+    mocker,
+):
+    """When some URLs scrape and a later one fails, the successfully-scraped
+    sources are still surfaced via extra_created_ids so the wrapper can
+    register them in state.created_page_ids. Otherwise they become orphan DB
+    rows invisible to the closing review.
+    """
+    successful = ScrapedPage(
+        url="https://good.example.com/page",
+        title="Good page",
+        content="Some real content.",
+        fetched_at=str(time.time()),
+    )
+
+    async def fake_scrape(url, **_kwargs):
+        return successful if "good" in url else None
+
+    mocker.patch("rumil.moves.create_claim.scrape_url", side_effect=fake_scrape)
+
+    call = Call(
+        call_type=CallType.WEB_RESEARCH,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question_page.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+
+    source_cache: dict[str, str] = {}
+    result, payload = await execute_with_source_creation(
+        {
+            "headline": "Some claim",
+            "content": "Claim content",
+            "source_urls": [
+                "https://good.example.com/page",
+                "https://unreachable.example.com/article",
+            ],
+        },
+        call,
+        tmp_db,
+        source_cache=source_cache,
+    )
+
+    assert payload is None
+    assert result.created_page_id == ""
+    assert "unreachable.example.com" in result.message
+    assert result.extra_created_ids
+    assert len(result.extra_created_ids) == 1
+    assert result.extra_created_ids[0] in source_cache.values()

--- a/tests/test_web_research_moves.py
+++ b/tests/test_web_research_moves.py
@@ -13,7 +13,7 @@ import pytest_asyncio
 from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
 
 from rumil.calls.page_creators import WebResearchLoop
-from rumil.calls.stages import ContextResult
+from rumil.calls.stages import CallInfra, ContextResult
 from rumil.llm import APIResponse
 from rumil.models import (
     Call,
@@ -25,7 +25,9 @@ from rumil.models import (
     PageType,
     Workspace,
 )
+from rumil.moves.base import MoveState
 from rumil.scraper import ScrapedPage
+from rumil.tracing.tracer import CallTrace
 
 
 @pytest_asyncio.fixture
@@ -130,10 +132,6 @@ async def test_create_claim_tool_use_records_a_move(
             _end_turn_response(),
         ],
     )
-
-    from rumil.calls.stages import CallInfra
-    from rumil.moves.base import MoveState
-    from rumil.tracing.tracer import CallTrace
 
     state = MoveState(web_research_call, tmp_db)
     trace = CallTrace(web_research_call.id, tmp_db)

--- a/tests/test_web_research_moves.py
+++ b/tests/test_web_research_moves.py
@@ -1,0 +1,170 @@
+"""Regression: WebResearchLoop must record CREATE_CLAIM moves into MoveState.
+
+The earlier wrapper rebuilt the create_claim Tool with a custom fn that bypassed
+MoveDef.bind, leaving infra.state.moves empty even when the model successfully
+created claim pages. That broke trace UI's MovesExecutedEvent and made the
+closing-review prompt internally contradictory (claimed "no moves" while listing
+the created pages directly below).
+"""
+
+import time
+
+import pytest_asyncio
+from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
+
+from rumil.calls.page_creators import WebResearchLoop
+from rumil.calls.stages import ContextResult
+from rumil.llm import APIResponse
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    MoveType,
+    Page,
+    PageLayer,
+    PageType,
+    Workspace,
+)
+from rumil.scraper import ScrapedPage
+
+
+@pytest_asyncio.fixture
+async def web_question(tmp_db):
+    page = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="What did the Apollo 11 mission accomplish?",
+        headline="What did the Apollo 11 mission accomplish?",
+    )
+    await tmp_db.save_page(page)
+    return page
+
+
+@pytest_asyncio.fixture
+async def web_research_call(tmp_db, web_question):
+    call = Call(
+        call_type=CallType.WEB_RESEARCH,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=web_question.id,
+        status=CallStatus.PENDING,
+    )
+    await tmp_db.save_call(call)
+    return call
+
+
+def _tool_use_response(tool_use_id: str, claim_args: dict) -> APIResponse:
+    msg = Message(
+        id="msg_1",
+        type="message",
+        role="assistant",
+        model="claude-test",
+        content=[
+            ToolUseBlock(type="tool_use", id=tool_use_id, name="create_claim", input=claim_args)
+        ],
+        stop_reason="tool_use",
+        stop_sequence=None,
+        usage=Usage(input_tokens=100, output_tokens=50),
+    )
+    return APIResponse(message=msg, duration_ms=10)
+
+
+def _end_turn_response() -> APIResponse:
+    msg = Message(
+        id="msg_2",
+        type="message",
+        role="assistant",
+        model="claude-test",
+        content=[TextBlock(type="text", text="Done.")],
+        stop_reason="end_turn",
+        stop_sequence=None,
+        usage=Usage(input_tokens=110, output_tokens=10),
+    )
+    return APIResponse(message=msg, duration_ms=10)
+
+
+async def test_create_claim_tool_use_records_a_move(
+    tmp_db,
+    web_question,
+    web_research_call,
+    mocker,
+):
+    """A single create_claim tool use must produce a Move on infra.state.moves."""
+    mocker.patch(
+        "rumil.settings.Settings.require_anthropic_key",
+        return_value="test-key",
+    )
+    mocker.patch(
+        "rumil.moves.create_claim.scrape_url",
+        return_value=ScrapedPage(
+            url="https://example.com/apollo",
+            title="Apollo 11",
+            content="Apollo 11 was the first crewed mission to land on the Moon, in 1969.",
+            fetched_at=str(time.time()),
+        ),
+    )
+    mocker.patch(
+        "rumil.calls.page_creators.call_anthropic_api",
+        side_effect=[
+            _tool_use_response(
+                tool_use_id="toolu_1",
+                claim_args={
+                    "headline": "Apollo 11 was the first crewed lunar landing",
+                    "content": (
+                        "Apollo 11 landed on the Moon in July 1969 [https://example.com/apollo]."
+                    ),
+                    "credence": 9,
+                    "credence_reasoning": "Well-documented historical event.",
+                    "robustness": 5,
+                    "robustness_reasoning": "Backed by primary sources.",
+                    "source_urls": ["https://example.com/apollo"],
+                    "links": [
+                        {
+                            "question_id": web_question.id,
+                            "strength": 4,
+                            "reasoning": "Directly answers the question.",
+                        }
+                    ],
+                },
+            ),
+            _end_turn_response(),
+        ],
+    )
+
+    from rumil.calls.stages import CallInfra
+    from rumil.moves.base import MoveState
+    from rumil.tracing.tracer import CallTrace
+
+    state = MoveState(web_research_call, tmp_db)
+    trace = CallTrace(web_research_call.id, tmp_db)
+    infra = CallInfra(
+        question_id=web_question.id,
+        call=web_research_call,
+        db=tmp_db,
+        trace=trace,
+        state=state,
+    )
+    context = ContextResult(context_text="ctx", working_page_ids=[web_question.id])
+
+    loop = WebResearchLoop()
+    result = await loop.update_workspace(infra, context)
+
+    assert len(result.moves) == 1
+    assert result.moves[0].move_type == MoveType.CREATE_CLAIM
+    assert state.moves == result.moves
+    assert len(state.move_created_ids) == 1
+    assert state.move_created_ids[0], "Move should have at least one created page recorded"
+    assert state.last_created_id is not None
+
+    claim_pages = [
+        pid
+        for pid in result.created_page_ids
+        if (await tmp_db.get_page(pid)).page_type == PageType.CLAIM
+    ]
+    source_pages = [
+        pid
+        for pid in result.created_page_ids
+        if (await tmp_db.get_page(pid)).page_type == PageType.SOURCE
+    ]
+    assert len(claim_pages) == 1
+    assert len(source_pages) == 1


### PR DESCRIPTION
## Summary

`WebResearchLoop._wrap_create_claim` rebuilt the `create_claim` Tool with a custom fn so it could resolve `[url]` citations and scrape source pages — but the rebuilt Tool bypassed `MoveDef.bind`, so `infra.state.moves` never recorded the create_claim moves even when the model successfully created claim pages.

Two visible consequences:
- **Trace UI**: every `CREATE_CLAIM` move is dropped from the call's `MovesExecutedEvent`. On a recent local pre-fix call, 7 `create_claim` tool uses produced 0 `CREATE_CLAIM` move records (`LOAD_PAGE` and `LINK_CONSIDERATION` moves go through `MoveDef.bind` directly and record fine; the wrapper is `create_claim`-specific). The event itself can be present (with the non-create-claim moves) or absent entirely depending on what else the call did.
- **Closing-review prompt** was internally contradictory: the rendered moves block read `(no moves)` / "This call recorded no structural moves…" *while* listing the created pages directly below.

Pre-existing on `main`. Originally introduced in `076df381` ("grounding-updating agent"), when `_wrap_create_claim` was rewritten to call a freshly-extracted `execute_with_source_creation` directly and dropped the `_orig` delegation that previously routed through `MoveDef.bind`. (Earlier `d6a0552e` "add web-search call" was *not* buggy — it preserved the delegation.) A partial fix landed in `a4ac13c9` for the `created_page_ids` half of the bookkeeping; this PR completes the fix for `state.moves`, `move_created_ids`, `move_trace_extras`, `last_created_id`, and `context_page_ids`.

## What changed

- `execute_with_source_creation` now returns `(MoveResult, CreateClaimPayload | None)`. The validated payload (with URLs swapped for source page IDs) flows back to the wrapper so it can record a faithful `Move`. Newly-created SOURCE pages are placed in `result.extra_created_ids`. Already-cached sources are excluded.
- `_wrap_create_claim` does the `MoveDef.bind`-style bookkeeping after each successful call: appends to `state.moves`, `state.move_created_ids`, `state.move_trace_extras`, updates `state.last_created_id` / `state.context_page_ids`. **Deliberate divergence from `MoveDef.bind`:** new SOURCE pages are also appended to `state.created_page_ids` (not only `move_page_ids`). This preserves prior `a4ac13c9` semantics — sources show up in the closing review's "you created the following pages" list. The error short-circuit path (scrape failure or unmatched `[url]` citations) skips the move record but still surfaces the error to the model.
- `_resolve_last_created` and `context_check` from `MoveDef.bind` are not replicated. Both are inert for `create_claim` today (only `supersedes` could resolve to `LAST_CREATED`, and `create_claim` has no `context_check`), but the wrapper would silently bypass them if either grew. Option B (below) makes this category of issue impossible.
- Other callers of `execute_with_source_creation` (`clean/grounding.py`, `tests/test_scrape_failure.py`) updated for the new tuple return.
- New regression test `tests/test_web_research_moves.py`: mocks `call_anthropic_api` to return one `create_claim` tool use, asserts a `Move` lands on `state.moves`. Verified to fail pre-fix (`assert 0 == 1`) and pass post-fix.

## Verification

End-to-end smoke test on Haiku post-fix produced a `moves_executed` trace event with 4 `CREATE_CLAIM` entries (matches the 4 `create_claim` tool uses 1:1). Closing-review prompt now lists the moves with claim headlines instead of `(no moves)`.

## Considered alternative — Option B (cleaner long-term)

Instead of putting bookkeeping into the wrapper, **make per-call payload mutation a first-class concept on `MoveDef`** by adding a `pre_execute` hook that runs after schema validation and before `execute()`. The hook can mutate the validated payload (resolve URLs, rewrite citations) and short-circuit with a `MoveResult` on failure. Roughly:

```python
@dataclass
class MoveDef:
    ...
    pre_execute: Callable[[S, MoveState], Awaitable[S | MoveResult]] | None = None

    def bind(self, state):
        async def fn(inp):
            validated = self.schema(**inp)
            if self.pre_execute:
                hook_result = await self.pre_execute(validated, state)
                if isinstance(hook_result, MoveResult):
                    return hook_result.message
                validated = hook_result
            result = await self.execute(validated, state.call, state.db)
            # bookkeeping always runs
```

Web_research would then register a per-call `MoveDef` for `create_claim` whose `pre_execute` does the URL resolution today done by `execute_with_source_creation`, and `_wrap_create_claim` disappears entirely. Bookkeeping stays in `MoveDef.bind` so it can't be skipped — *no future bypass is possible*, and `_resolve_last_created` / `context_check` automatically apply.

**Why not now:** B touches `MoveDef.bind` (on every call's hot path), needs API design (sync vs. async, mutate-in-place vs. return new payload, short-circuit semantics), and would benefit from auditing the rest of the calls package for similar wrappers ripe for migration. Better as a standalone refactor PR. A is the focused fix to stop the bleeding now; the extraction pattern from `076df381` has now produced two missing-bookkeeping bugs (`a4ac13c9` and this one) — Option B is the structural fix that prevents a third.

## Audit

Searched for other call-type wrappers that rebuild a move's `Tool`. Only this one. Other custom `Tool(...)` constructions in the codebase are either read-only exploration tools (`load_page` non-move version, `search_workspace`, self_improve), non-move payloads (linker submit, dispatch defs), or use `MoveDef.bind` correctly (`global_prio.py`).

## Test plan
- [x] Unit test catches the bug pre-fix and passes post-fix
- [x] Existing `test_scrape_failure.py` still passes after tuple-return signature change
- [x] Live smoke test (Haiku, smoke-test mode): 4 CREATE_CLAIM moves recorded in trace; closing-review prompt no longer contradicts itself
- [ ] Reviewer confirms wrapper bookkeeping matches `MoveDef.bind` semantics (and that the deliberate `extra_created_ids` divergence is desired)