### PR TITLE
docs: note CI handles prod migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ uv run python main.py "Your question here" --workspace test-scratch --smoke-test
 
 Tests: `uv run pytest`.
 
-**Database:** Runs against local Supabase by default (`supabase start`). Pass `--prod` to any command to target production. Migrations live in `supabase/migrations/` and are pushed to prod with `supabase db push`.
+**Database:** Runs against local Supabase by default (`supabase start`). Pass `--prod` to any command to target production. Migrations live in `supabase/migrations/`; CI runs `supabase db push` against prod on merge to `main` (see `.github/workflows/ci.yml`), so it's not necessary to push manually.
 Always use the supabase cli to create new migrations: `supabase migration new`.
 
 **Row-Level Security:** RLS is enabled on all tables with **no policies**. This means:


### PR DESCRIPTION
CLAUDE.md said migrations are "pushed to prod with `supabase db push`", which read like a necessary manual step to claude. CI now runs that on merge to main, so the line is updated to reflect that pushing manually isn't necessary.