### PR TITLE
versus prod support: --prod plumbing, /versus UI in deployed API

### DIFF
--- a/deploy/Dockerfile.api
+++ b/deploy/Dockerfile.api
@@ -12,6 +12,11 @@ RUN uv sync --frozen --no-dev --no-editable
 FROM python:3.13-slim
 
 ENV PATH="/app/.venv/bin:$PATH"
+# The /versus router resolves config via VERSUS_CONFIG_PATH, falling back
+# to a path relative to its source file. Inside the container the package
+# is installed under .venv/lib/, so the fallback misses; set the env var
+# explicitly to the runtime-copied config below.
+ENV VERSUS_CONFIG_PATH=/app/versus/config.yaml
 EXPOSE 8000
 CMD ["uvicorn", "rumil.api.app:app", "--host", "0.0.0.0", "--port", "8000"]
 
@@ -20,3 +25,4 @@ COPY --from=build /app/.venv .venv
 # main.py is the entrypoint when this image is run as an orchestrator Job
 # (see src/rumil/k8s/submit.py). It is not used by the API container itself.
 COPY main.py ./
+COPY versus/config.yaml ./versus/config.yaml

--- a/src/rumil/api/versus_router.py
+++ b/src/rumil/api/versus_router.py
@@ -187,7 +187,7 @@ def _per_essay_load(kind: str, essay_id: str) -> list[dict]:
     cached = _PER_ESSAY_CACHE.get(key)
     if cached is not None and now - cached[0] < _LIGHT_CACHE_TTL_S:
         return cached[1]
-    client = versus_db.get_client()
+    client = _versus_client()
     if kind == "judgments":
         rows = list(versus_db.iter_judgments(client, essay_id=essay_id))
     elif kind == "texts":
@@ -209,7 +209,7 @@ def _load_essay_rows() -> list[dict]:
     cached = _LIGHT_CACHE.get("essays")
     if cached is not None and now - cached[0] < _LIGHT_CACHE_TTL_S:
         return cached[1]
-    client = versus_db.get_client()
+    client = _versus_client()
     rows = list(versus_db.iter_essays(client))
     _LIGHT_CACHE["essays"] = (now, rows)
     return rows
@@ -221,7 +221,7 @@ def _light_load(kind: str) -> list[dict]:
     cached = _LIGHT_CACHE.get(kind)
     if cached is not None and now - cached[0] < _LIGHT_CACHE_TTL_S:
         return cached[1]
-    client = versus_db.get_client()
+    client = _versus_client()
     if kind == "judgments":
         rows = list(versus_db.iter_judgments(client, light=True))
     elif kind == "texts":
@@ -230,6 +230,16 @@ def _light_load(kind: str) -> list[dict]:
         raise ValueError(f"unknown kind: {kind}")
     _LIGHT_CACHE[kind] = (now, rows)
     return rows
+
+
+def _versus_client():
+    """Versus DB client for the current API process.
+
+    Mirrors the pattern in ``app.get_db_dependency`` / ``get_realtime_config``:
+    targets prod when ``USE_PROD_DB`` is set, local otherwise. Centralized
+    here so endpoints don't each have to thread the flag through.
+    """
+    return versus_db.get_client(prod=get_settings().is_prod_db)
 
 
 def _config_path() -> pathlib.Path:
@@ -1325,7 +1335,7 @@ def get_judgment_by_key(key: str) -> JudgmentDetail:
     is the row's primary-key UUID, so this is a direct lookup — no scan.
     """
     _cfg_required()
-    client = versus_db.get_client()
+    client = _versus_client()
     resp = client.table("versus_judgments").select("*").eq("id", key).limit(1).execute()
     if not resp.data:
         raise HTTPException(404, f"judgment key not found: {key}")

--- a/versus/scripts/backfill_db.py
+++ b/versus/scripts/backfill_db.py
@@ -310,6 +310,15 @@ def main() -> None:
     parser.add_argument(
         "--prod", action="store_true", help="Target prod (DO NOT use without intent)"
     )
+    parser.add_argument(
+        "--essays-only",
+        action="store_true",
+        help=(
+            "Import versus_essays only and exit; skip the legacy JSONL replay "
+            "into versus_texts / versus_judgments. Useful for seeding a fresh "
+            "DB (e.g. prod) without dragging archival completion/judgment data."
+        ),
+    )
     args = parser.parse_args()
 
     client = get_client(prod=args.prod)
@@ -319,6 +328,9 @@ def main() -> None:
     t_essays = time.time()
     import_essays(client)
     print(f"  essays: {time.time() - t_essays:.1f}s")
+
+    if args.essays_only:
+        return
 
     existing_texts = client.table("versus_texts").select("id", count="exact").limit(1).execute()
     existing_judgments = (

--- a/versus/scripts/fetch_essays.py
+++ b/versus/scripts/fetch_essays.py
@@ -48,6 +48,14 @@ def main() -> None:
         default=None,
         help="only fetch from these source ids (repeatable). Default: all configured.",
     )
+    p.add_argument(
+        "--prod",
+        action="store_true",
+        help=(
+            "Mirror parsed essays + verdicts to the production Supabase "
+            "database (default: local). Filesystem cache is written either way."
+        ),
+    )
     args = p.parse_args()
 
     cfg = config.load("config.yaml")
@@ -65,6 +73,7 @@ def main() -> None:
         source_cfgs=source_cfgs,
         cache_dir=cfg.essays.cache_dir,
         raw_html_dir=raw_html_dir,
+        prod=args.prod,
     )
 
     thresholds = {s.id: s for s in source_cfgs}
@@ -120,6 +129,7 @@ def main() -> None:
                 markdown=e.markdown,
                 cache_dir=cfg.essays.cache_dir,
                 force=args.revalidate,
+                prod=args.prod,
             )
         except Exception as exc:
             print(f"  [err]  {e.id}: validator response unparseable — {exc}")

--- a/versus/scripts/run_completions.py
+++ b/versus/scripts/run_completions.py
@@ -96,17 +96,28 @@ def main() -> None:
     )
     ap.add_argument(
         "--prefix-label",
+        action="append",
         default=None,
         help=(
-            "Run completions under a specific prefix variant (default: "
-            "the canonical `prefix:` entry). Sibling variants are listed "
-            "under `prefix_variants:` in config.yaml; pass their `id` here."
+            "Run completions under a specific prefix variant. Repeatable: "
+            "pass once per variant to run multiple in one invocation. "
+            "Default: the canonical `prefix:` entry. Sibling variants are "
+            "listed under `prefix_variants:` in config.yaml; pass their `id`."
         ),
+    )
+    ap.add_argument(
+        "--prod",
+        action="store_true",
+        help="Target the production Supabase database (default: local).",
     )
     args = ap.parse_args()
 
     cfg = config.load(args.config)
-    prefix_cfg = prepare.resolve_prefix_cfg(cfg, args.prefix_label)
+    prefix_cfgs = (
+        [prepare.resolve_prefix_cfg(cfg, label) for label in args.prefix_label]
+        if args.prefix_label
+        else [prepare.resolve_prefix_cfg(cfg, None)]
+    )
     if not cfg.essays.cache_dir.is_absolute():
         cfg.essays.cache_dir = VERSUS_ROOT / cfg.essays.cache_dir
     if not cfg.storage.paraphrases_log.is_absolute():
@@ -147,8 +158,10 @@ def main() -> None:
             print(f"[err] no models matched --model {args.model}; check config.yaml")
             sys.exit(1)
 
-    print(f"[prefix] using variant {prefix_cfg.id!r}")
-    complete.run(cfg, essays, prefix_cfg=prefix_cfg)
+    target = "prod" if args.prod else "local"
+    for prefix_cfg in prefix_cfgs:
+        print(f"[prefix] using variant {prefix_cfg.id!r} (db={target})")
+        complete.run(cfg, essays, prefix_cfg=prefix_cfg, prod=args.prod)
 
 
 if __name__ == "__main__":

--- a/versus/scripts/run_completions.py
+++ b/versus/scripts/run_completions.py
@@ -134,7 +134,19 @@ def main() -> None:
     essays = [e for e in essays if e.id not in exclude]
 
     if args.active:
+        # --active is a hard list of the canonical eval set, not an
+        # intersection with fetch_all. Active essays that have rolled
+        # off the source's live feed but are still valid in cache should
+        # be loaded directly so the run honors --active in full.
         active = prepare.active_essay_ids(cfg.essays.exclude_ids)
+        fetched_ids = {e.id for e in essays}
+        for missing_id in sorted(active - fetched_ids):
+            cached = _load_essay_from_cache(cfg.essays.cache_dir, missing_id)
+            if cached is None:
+                print(f"[warn] --active {missing_id}: not in cache or schema mismatch; skipping")
+                continue
+            print(f"[essay] {missing_id}: loaded from cache (off live feed)")
+            essays.append(cached)
         essays = [e for e in essays if e.id in active]
     if args.essay:
         # --essay is a hard list, not an intersection with fetch_all.

--- a/versus/scripts/run_completions.py
+++ b/versus/scripts/run_completions.py
@@ -36,7 +36,7 @@ except ModuleNotFoundError:
     )
     raise SystemExit(1) from None
 
-from versus import complete, config, prepare, sources  # noqa: E402
+from versus import complete, config, prepare, sources, versus_db  # noqa: E402
 from versus import essay as versus_essay  # noqa: E402
 
 
@@ -128,6 +128,7 @@ def main() -> None:
         source_cfgs=cfg.essays.sources,
         cache_dir=cfg.essays.cache_dir,
         raw_html_dir=raw_html_dir,
+        prod=args.prod,
     )
 
     exclude = set(cfg.essays.exclude_ids)
@@ -138,7 +139,9 @@ def main() -> None:
         # intersection with fetch_all. Active essays that have rolled
         # off the source's live feed but are still valid in cache should
         # be loaded directly so the run honors --active in full.
-        active = prepare.active_essay_ids(cfg.essays.exclude_ids)
+        active = prepare.active_essay_ids(
+            cfg.essays.exclude_ids, client=versus_db.get_client(prod=args.prod)
+        )
         fetched_ids = {e.id for e in essays}
         for missing_id in sorted(active - fetched_ids):
             cached = _load_essay_from_cache(cfg.essays.cache_dir, missing_id)

--- a/versus/scripts/run_rumil_judgments.py
+++ b/versus/scripts/run_rumil_judgments.py
@@ -54,7 +54,7 @@ envcascade.apply(
 )
 
 from rumil.settings import RUMIL_MODEL_ALIASES, resolve_model_alias  # noqa: E402
-from versus import config, judge, prepare, rumil_judge  # noqa: E402
+from versus import config, judge, prepare, rumil_judge, versus_db  # noqa: E402
 
 DEFAULT_DIMENSIONS = ("general_quality",)
 
@@ -213,7 +213,9 @@ def main() -> None:
         cfg.essays.cache_dir = VERSUS_ROOT / cfg.essays.cache_dir
 
     if args.active:
-        active = prepare.active_essay_ids(cfg.essays.exclude_ids)
+        active = prepare.active_essay_ids(
+            cfg.essays.exclude_ids, client=versus_db.get_client(prod=args.prod)
+        )
         essay_ids = sorted(active & set(args.essay)) if args.essay else sorted(active)
     else:
         essay_ids = args.essay

--- a/versus/scripts/run_rumil_judgments.py
+++ b/versus/scripts/run_rumil_judgments.py
@@ -167,14 +167,26 @@ def main() -> None:
     )
     ap.add_argument(
         "--prefix-label",
+        action="append",
         default=None,
         help=(
-            "Restrict planning to a specific prefix variant. When set, only "
-            "rows whose prefix_hash matches that variant's current hash are "
-            "enumerated — stale rows under that variant are excluded too. "
-            "Without this flag, every prefix_hash present in versus_texts "
-            "is eligible. Sibling variants live under `prefix_variants:` "
-            "in config.yaml; pass their `id`."
+            "Restrict planning to a specific prefix variant. Repeatable on "
+            "the blind path: pass once per variant to plan multiple in one "
+            "invocation. When set, only rows whose prefix_hash matches that "
+            "variant's current hash are enumerated — stale rows under that "
+            "variant are excluded too. Without this flag, every prefix_hash "
+            "present in versus_texts is eligible. Sibling variants live "
+            "under `prefix_variants:` in config.yaml; pass their `id`. "
+            "ws/orch variants currently take at most one --prefix-label."
+        ),
+    )
+    ap.add_argument(
+        "--prod",
+        action="store_true",
+        help=(
+            "Target the production Supabase database for versus_texts / "
+            "versus_judgments (default: local). Blind path only — ws/orch "
+            "still hit local rumil DB."
         ),
     )
     ap.add_argument(
@@ -206,13 +218,13 @@ def main() -> None:
     else:
         essay_ids = args.essay
 
-    prefix_cfg = (
-        prepare.resolve_prefix_cfg(cfg, args.prefix_label)
-        if args.prefix_label is not None
+    prefix_cfgs = (
+        [prepare.resolve_prefix_cfg(cfg, label) for label in args.prefix_label]
+        if args.prefix_label
         else None
     )
-    if prefix_cfg is not None:
-        print(f"[prefix] restricting to variant {prefix_cfg.id!r}")
+    if prefix_cfgs is not None:
+        print(f"[prefix] restricting to variants {[p.id for p in prefix_cfgs]!r}")
 
     if args.variant is None:
         # Blind path: route claude-* direct to Anthropic, others via OpenRouter.
@@ -233,7 +245,8 @@ def main() -> None:
             contestants=contestants,
             vs_human=args.vs_human,
             current_only=args.current_only,
-            prefix_cfg=prefix_cfg,
+            prefix_cfgs=prefix_cfgs,
+            prod=args.prod,
         )
         return
 
@@ -246,6 +259,20 @@ def main() -> None:
 
     if not args.workspace:
         ap.error(f"--workspace is required for --variant {args.variant}")
+
+    if args.prod:
+        ap.error(
+            f"--prod is not yet wired through --variant {args.variant}; "
+            "the blind path is the only prod-aware judge today. ws/orch "
+            "would need DB.create(prod=...) plumbing in rumil_judge.py too."
+        )
+
+    if prefix_cfgs is not None and len(prefix_cfgs) > 1:
+        ap.error(
+            f"--variant {args.variant} takes at most one --prefix-label "
+            f"(got {len(prefix_cfgs)}). Run separately per prefix variant."
+        )
+    prefix_cfg_one = prefix_cfgs[0] if prefix_cfgs else None
 
     dimensions = tuple(args.dimension) if args.dimension else DEFAULT_DIMENSIONS
 
@@ -263,7 +290,7 @@ def main() -> None:
                 contestants=contestants,
                 vs_human=args.vs_human,
                 current_only=args.current_only,
-                prefix_cfg=prefix_cfg,
+                prefix_cfg=prefix_cfg_one,
                 persist=args.persist,
             )
         )
@@ -282,7 +309,7 @@ def main() -> None:
                 contestants=contestants,
                 vs_human=args.vs_human,
                 current_only=args.current_only,
-                prefix_cfg=prefix_cfg,
+                prefix_cfg=prefix_cfg_one,
                 persist=args.persist,
             )
         )

--- a/versus/scripts/status.py
+++ b/versus/scripts/status.py
@@ -40,9 +40,10 @@ from versus import config, judge, prepare, versus_db  # noqa: E402
 from versus import essay as versus_essay  # noqa: E402
 
 
-def _load_essays(cfg: config.Config) -> dict[str, versus_essay.Essay]:
+def _load_essays(cfg: config.Config, *, prod: bool = False) -> dict[str, versus_essay.Essay]:
     exclude = set(cfg.essays.exclude_ids)
-    return {e.id: e for e in prepare.load_essays() if e.id not in exclude}
+    client = versus_db.get_client(prod=prod)
+    return {e.id: e for e in prepare.load_essays(client) if e.id not in exclude}
 
 
 def _current_prefix_hashes(
@@ -63,13 +64,13 @@ def _current_prefix_hashes(
     return out
 
 
-def _scan_texts() -> list[dict]:
-    client = versus_db.get_client()
+def _scan_texts(*, prod: bool = False) -> list[dict]:
+    client = versus_db.get_client(prod=prod)
     return list(versus_db.iter_texts(client))
 
 
-def _scan_judgments() -> list[dict]:
-    client = versus_db.get_client()
+def _scan_judgments(*, prod: bool = False) -> list[dict]:
+    client = versus_db.get_client(prod=prod)
     return list(versus_db.iter_judgments(client))
 
 
@@ -146,20 +147,26 @@ def _judgments_per_variant(
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--json", action="store_true", help="machine-readable output")
+    p.add_argument(
+        "--prod",
+        action="store_true",
+        help="Inspect the production Supabase database (default: local).",
+    )
     args = p.parse_args()
 
     cfg = config.load(str(VERSUS_ROOT / "config.yaml"))
     if not cfg.essays.cache_dir.is_absolute():
         cfg.essays.cache_dir = VERSUS_ROOT / cfg.essays.cache_dir
-    essays = _load_essays(cfg)
+    essays = _load_essays(cfg, prod=args.prod)
     if not essays:
-        print("no cached essays — run scripts/fetch_essays.py first")
+        target = "prod" if args.prod else "local"
+        print(f"no essays in {target} versus_essays — run backfill_db.py / fetch_essays.py first")
         sys.exit(1)
     variants = prepare.active_prefix_configs(cfg)
     variant_hashes = {v.id: _current_prefix_hashes(cfg, essays, prefix_cfg=v) for v in variants}
 
-    completions = _scan_texts()
-    judgments = _scan_judgments()
+    completions = _scan_texts(prod=args.prod)
+    judgments = _scan_judgments(prod=args.prod)
 
     comp_per_variant, comp_orphaned, comp_unknown = _completions_per_variant(
         completions, variant_hashes

--- a/versus/src/versus/complete.py
+++ b/versus/src/versus/complete.py
@@ -171,9 +171,10 @@ def run(
     essays: list[versus_essay.Essay],
     *,
     prefix_cfg: config.PrefixCfg | None = None,
+    prod: bool = False,
 ) -> None:
     pcfg = prefix_cfg if prefix_cfg is not None else cfg.prefix
-    db = versus_db.get_client()
+    db = versus_db.get_client(prod=prod)
     existing = _existing_lookup(db)
 
     tasks_to_run: list = []

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -473,9 +473,10 @@ def run_blind(
     contestants: Sequence[str] | None = None,
     vs_human: bool = False,
     current_only: bool = False,
-    prefix_cfg: config.PrefixCfg | None = None,
+    prefix_cfgs: Sequence[config.PrefixCfg] | None = None,
     limit: int | None = None,
     dry_run: bool = False,
+    prod: bool = False,
 ) -> None:
     """Run pairwise blind judgments across a mixed list of models.
 
@@ -492,7 +493,7 @@ def run_blind(
         print("[info] no models passed to run_blind; nothing to do")
         return
 
-    db = versus_db.get_client()
+    db = versus_db.get_client(prod=prod)
     groups, prefix_texts = load_sources_by_essay(db)
     existing = _existing_judgment_keys(db)
 
@@ -501,17 +502,26 @@ def run_blind(
     )
     essay_id_set = set(essay_ids) if essay_ids else None
     contestants_set = set(contestants) if contestants else None
-    current_hashes = (
-        prepare.current_prefix_hashes(cfg, prefix_cfg=prefix_cfg)
-        if (current_only or prefix_cfg is not None)
-        else None
-    )
+    # Build the union of allowed (essay_id, prefix_hash) pairs across the
+    # selected prefix variants. None means "any prefix in versus_texts".
+    # current_only=True with no explicit prefix_cfgs falls back to the
+    # canonical cfg.prefix variant.
+    allowed_prefix_pairs: set[tuple[str, str]] | None
+    if prefix_cfgs:
+        allowed_prefix_pairs = set()
+        for pc in prefix_cfgs:
+            for eid, ph in prepare.current_prefix_hashes(cfg, prefix_cfg=pc).items():
+                allowed_prefix_pairs.add((eid, ph))
+    elif current_only:
+        allowed_prefix_pairs = {(eid, ph) for eid, ph in prepare.current_prefix_hashes(cfg).items()}
+    else:
+        allowed_prefix_pairs = None
 
     tasks: list[_BlindTask] = []
     for (essay_id, prefix_hash), sources in groups.items():
         if essay_id_set is not None and essay_id not in essay_id_set:
             continue
-        if current_hashes is not None and current_hashes.get(essay_id) != prefix_hash:
+        if allowed_prefix_pairs is not None and (essay_id, prefix_hash) not in allowed_prefix_pairs:
             continue
         source_ids = list(sources.keys())
         if not cfg.judging.include_human_as_contestant:

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -510,10 +510,12 @@ def run_blind(
     if prefix_cfgs:
         allowed_prefix_pairs = set()
         for pc in prefix_cfgs:
-            for eid, ph in prepare.current_prefix_hashes(cfg, prefix_cfg=pc).items():
+            for eid, ph in prepare.current_prefix_hashes(cfg, prefix_cfg=pc, client=db).items():
                 allowed_prefix_pairs.add((eid, ph))
     elif current_only:
-        allowed_prefix_pairs = {(eid, ph) for eid, ph in prepare.current_prefix_hashes(cfg).items()}
+        allowed_prefix_pairs = {
+            (eid, ph) for eid, ph in prepare.current_prefix_hashes(cfg, client=db).items()
+        }
     else:
         allowed_prefix_pairs = None
 

--- a/versus/src/versus/sources/__init__.py
+++ b/versus/src/versus/sources/__init__.py
@@ -29,6 +29,8 @@ def fetch_all(
     cache_dir: pathlib.Path,
     raw_html_dir: pathlib.Path,
     client: httpx.Client | None = None,
+    *,
+    prod: bool = False,
 ) -> list[Essay]:
     """Iterate configured sources in declaration order and concatenate results.
 
@@ -53,6 +55,7 @@ def fetch_all(
                     cache_dir=cache_dir,
                     raw_html_dir=raw_html_dir,
                     client=client,
+                    prod=prod,
                 )
             )
         return essays

--- a/versus/src/versus/sources/carlsmith.py
+++ b/versus/src/versus/sources/carlsmith.py
@@ -134,6 +134,7 @@ def fetch(
     cache_dir: pathlib.Path,
     raw_html_dir: pathlib.Path,
     client: httpx.Client,
+    prod: bool = False,
 ) -> list[Essay]:
     cache_dir.mkdir(parents=True, exist_ok=True)
     raw_html_dir.mkdir(parents=True, exist_ok=True)
@@ -194,6 +195,6 @@ def fetch(
         )
         with open(json_path, "w") as f:
             json.dump(essay.to_json(), f, indent=2)
-        versus_db.mirror_essay(essay, raw_html=html)
+        versus_db.mirror_essay(essay, raw_html=html, prod=prod)
         essays.append(essay)
     return essays

--- a/versus/src/versus/sources/forethought.py
+++ b/versus/src/versus/sources/forethought.py
@@ -238,6 +238,7 @@ def fetch(
     cache_dir: pathlib.Path,
     raw_html_dir: pathlib.Path,
     client: httpx.Client,
+    prod: bool = False,
 ) -> list[Essay]:
     cache_dir.mkdir(parents=True, exist_ok=True)
     raw_html_dir.mkdir(parents=True, exist_ok=True)
@@ -298,6 +299,6 @@ def fetch(
         )
         with open(json_path, "w") as f:
             json.dump(essay.to_json(), f, indent=2)
-        versus_db.mirror_essay(essay, raw_html=html)
+        versus_db.mirror_essay(essay, raw_html=html, prod=prod)
         essays.append(essay)
     return essays

--- a/versus/src/versus/sources/redwood.py
+++ b/versus/src/versus/sources/redwood.py
@@ -191,6 +191,7 @@ def fetch(
     cache_dir: pathlib.Path,
     raw_html_dir: pathlib.Path,
     client: httpx.Client,
+    prod: bool = False,
 ) -> list[Essay]:
     cache_dir.mkdir(parents=True, exist_ok=True)
     raw_html_dir.mkdir(parents=True, exist_ok=True)
@@ -252,6 +253,6 @@ def fetch(
         )
         with open(json_path, "w") as f:
             json.dump(essay.to_json(), f, indent=2)
-        versus_db.mirror_essay(essay, raw_html=html)
+        versus_db.mirror_essay(essay, raw_html=html, prod=prod)
         essays.append(essay)
     return essays

--- a/versus/src/versus/validate_essay.py
+++ b/versus/src/versus/validate_essay.py
@@ -165,6 +165,7 @@ def validate(
     cache_dir: pathlib.Path,
     *,
     force: bool = False,
+    prod: bool = False,
 ) -> dict:
     """Return the verdict dict, calling Sonnet only when the cache misses.
 
@@ -210,7 +211,7 @@ def validate(
     path.write_text(json.dumps(verdict, indent=2, ensure_ascii=False))
     try:
         versus_db.upsert_essay_verdict(
-            versus_db.get_client(),
+            versus_db.get_client(prod=prod),
             essay_id=essay_id,
             clean=verdict["clean"],
             issues=verdict["issues"],

--- a/versus/src/versus/versus_db.py
+++ b/versus/src/versus/versus_db.py
@@ -72,7 +72,7 @@ def upsert_essay(
     client.table("versus_essays").upsert(row, on_conflict="id").execute()
 
 
-def mirror_essay(essay: Any, raw_html: str | None = None) -> None:
+def mirror_essay(essay: Any, raw_html: str | None = None, *, prod: bool = False) -> None:
     """Upsert a parsed Essay into versus_essays from a fresh-fetcher path.
 
     Shared helper for the per-source fetchers so they don't each
@@ -81,7 +81,7 @@ def mirror_essay(essay: Any, raw_html: str | None = None) -> None:
     essay.
     """
     try:
-        client = get_client()
+        client = get_client(prod=prod)
         upsert_essay(
             client,
             id=essay.id,


### PR DESCRIPTION
## Summary

Lets versus's authoring scripts and the deployed /versus UI talk to the prod Supabase DB.

- Plumbs `--prod` through `run_completions.py`, `run_rumil_judgments.py` (blind path), `status.py`, `fetch_essays.py`, and per-source fetchers/validator. Adds `--essays-only` to `backfill_db.py` so prod can be seeded without replaying legacy JSONL.
- Makes `--prefix-label` repeatable on the blind judgments + completions scripts so a single invocation can cover multiple prefix variants.
- Wires `versus_router.py` to honor `get_settings().is_prod_db` (matches the existing pattern used for the rumil DB in `app.get_db_dependency`).
- `deploy/Dockerfile.api` now ships `versus/config.yaml` and sets `VERSUS_CONFIG_PATH`; the `__file__`-relative fallback doesn't resolve when the package is installed under `.venv/lib/`.
- `--active` was silently dropping cache-only essays (the canonical-set ones that have rolled off the source's live RSS feed). Mirrors the `--essay` cache fallback so the active set is honored in full.

ws/orch judging variants stay local-only; the script errors out clearly if `--prod` or multiple `--prefix-label` are passed with `--variant ws|orch`. Threading prod through `DB.create()` for those is a larger change for another PR.

## Verified

Ran all four phases against prod end-to-end:

1. `backfill_db.py --essays-only --prod` seeded 37 essays (29 active) + 32 verdicts
2. `run_completions.py --prod --active` (flash, both prefixes) → 58 humans + 58 completions in versus_texts
3. `run_rumil_judgments.py --prod --active --vs-human --contestants human,flash` (flash judge) → 58 verdicts in versus_judgments
4. Locally with `USE_PROD_DB=1`, `/api/versus/results` returns the expected bundle (58 judgments, 116 completions, 29 essays, both prefixes)

## Test plan
- [ ] Navigate to https://rumil.ink/versus/results — page should render flash×human matrix
- [ ] /versus/inspect on a specific essay should show the judgment with reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)