### PR TITLE
fix integration tests: orphaned sources, budget, fixture mismatch

### DIFF
--- a/src/rumil/moves/create_claim.py
+++ b/src/rumil/moves/create_claim.py
@@ -4,7 +4,7 @@ import logging
 import re
 from collections.abc import Sequence
 
-from pydantic import Field
+from pydantic import Field, ValidationError
 
 from rumil.database import DB
 from rumil.models import (
@@ -314,6 +314,15 @@ async def execute_with_source_creation(
                 None,
             )
 
-    payload = CreateClaimPayload(**inp)
+    try:
+        payload = CreateClaimPayload(**inp)
+    except ValidationError as exc:
+        # Sources may already have been scraped above; surface them on the
+        # error path so they're tracked in state.created_page_ids instead of
+        # becoming invisible-but-persisted DB rows.
+        return (
+            _attach_new_sources(MoveResult(message=f"ERROR: {exc}", created_page_id="")),
+            None,
+        )
     result = await execute(payload, call, db)
     return _attach_new_sources(result), payload

--- a/tests/test_cites_links.py
+++ b/tests/test_cites_links.py
@@ -21,13 +21,22 @@ from rumil.moves.create_claim import MoveType
 
 @pytest_asyncio.fixture
 async def source_page(tmp_db):
+    content = (
+        "A 2024 study by Acemoglu and Restrepo estimates that LLM-based tools "
+        "have already automated roughly 5% of routine cognitive labour in "
+        "white-collar industries, and projects that share could rise to 25% "
+        "by 2030 under continued frontier-model progress. The authors note "
+        "that the pace is gated by integration friction (procurement cycles, "
+        "regulatory review, internal change management) more than by raw "
+        "capability."
+    )
     page = Page(
         page_type=PageType.SOURCE,
         layer=PageLayer.SQUIDGY,
         workspace=Workspace.RESEARCH,
-        content="The sky appears blue due to Rayleigh scattering of sunlight.",
-        headline="Rayleigh scattering explains blue sky",
-        extra={"filename": "sky-science.txt", "char_count": 58},
+        content=content,
+        headline="LLMs and the pace of cognitive-labour automation (Acemoglu & Restrepo 2024)",
+        extra={"filename": "acemoglu-restrepo-2024.txt", "char_count": len(content)},
     )
     await tmp_db.save_page(page)
     return page
@@ -35,13 +44,18 @@ async def source_page(tmp_db):
 
 @pytest_asyncio.fixture
 async def second_source_page(tmp_db):
+    content = (
+        "Internal benchmark data from a major consulting firm shows that "
+        "junior-level analyst tasks now take 40% less time when augmented "
+        "with frontier LLMs, while senior strategy work shows little speedup."
+    )
     page = Page(
         page_type=PageType.SOURCE,
         layer=PageLayer.SQUIDGY,
         workspace=Workspace.RESEARCH,
-        content="Shorter wavelengths scatter more in the atmosphere.",
-        headline="Wavelength dependence of atmospheric scattering",
-        extra={"filename": "optics-101.txt", "char_count": 50},
+        content=content,
+        headline="Consulting-firm benchmark: LLM speedups concentrate at junior levels",
+        extra={"filename": "consulting-benchmark.txt", "char_count": len(content)},
     )
     await tmp_db.save_page(page)
     return page

--- a/tests/test_cites_links.py
+++ b/tests/test_cites_links.py
@@ -67,10 +67,10 @@ async def test_cites_link_created_for_source(tmp_db, scout_call, source_page):
     tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
     await tool.fn(
         {
-            "headline": "Blue sky from scattering",
-            "content": "Rayleigh scattering causes blue sky.",
+            "headline": "LLMs already automate ~5% of routine cognitive labour",
+            "content": "Frontier LLMs have already displaced a measurable share of routine white-collar tasks.",
             "credence": 6,
-            "credence_reasoning": "Rayleigh scattering is textbook physics.",
+            "credence_reasoning": "Headline figure from a recent Acemoglu/Restrepo estimate.",
             "robustness": 3,
             "robustness_reasoning": "Sourced from a single page; cross-check would firm it.",
             "source_urls": [source_page.id[:8]],
@@ -122,8 +122,8 @@ async def test_multiple_cites_links(
     tool = MOVES[MoveType.CREATE_CLAIM].bind(state)
     await tool.fn(
         {
-            "headline": "Combined scattering evidence",
-            "content": "Multiple sources confirm scattering.",
+            "headline": "LLM speedups concentrate at junior-analyst tasks",
+            "content": "Independent estimates and firm-internal benchmarks both show LLM gains skewed toward routine junior work.",
             "credence": 6,
             "credence_reasoning": "Multiple converging sources.",
             "robustness": 3,

--- a/tests/test_investigate.py
+++ b/tests/test_investigate.py
@@ -22,7 +22,7 @@ async def test_investigate_creates_pages(tmp_db):
     )
     await tmp_db.save_page(question)
 
-    await tmp_db.init_budget(4)
+    await tmp_db.init_budget(8)
     orch = Orchestrator(tmp_db)
     await orch.run(question.id)
 


### PR DESCRIPTION
## Summary

Three failing integration tests, three different root causes:

- **`test_web_research_creates_sourced_claims`** — real bug. In `execute_with_source_creation`, if the LLM passed valid HTTP URLs in `source_urls` (which scraped successfully into SOURCE pages and got cached) but the rest of the payload was malformed (e.g. missing required `credence`), `CreateClaimPayload(**inp)` raised `ValidationError` *past* `_attach_new_sources`. The freshly-created SOURCE pages were left in `source_cache` but never propagated to `state.created_page_ids` — invisible-but-persisted DB rows. Now caught: error response carries the new sources back through the wrapper.

- **`test_investigate_creates_pages`** — budget too low. With `ENABLE_GLOBAL_PRIO=true` (set in `.env`), `GlobalPrioOrchestrator` splits budget into global (≥`MIN_GLOBAL_PRIO_BUDGET=3`) and local (≥`MIN_TWOPHASE_BUDGET=4`). `init_budget(4)` left local at 1 → disabled, and global alone found no cross-cutting opportunity on a fresh one-question graph. Bumped to 8.

- **`test_ingest_creates_cites_links`** — fixture mismatch. `source_page` was about Rayleigh scattering / blue sky; `question_page` (from conftest) is about AI automating cognitive labour. The LLM correctly extracted nothing relevant. Replaced both source fixtures with AI-automation content; the unit tests in the same file just pass `source_page.id[:8]`, so the content swap is inert for them.

## Test plan

- [x] `uv run pytest tests/test_cites_links.py::test_ingest_creates_cites_links tests/test_investigate.py::test_investigate_creates_pages tests/test_web_research.py::test_web_research_creates_sourced_claims --integration` — all 3 pass
- [x] `uv run pytest tests/test_cites_links.py tests/test_investigate.py tests/test_web_research.py tests/test_inline_citations.py tests/test_web_research_moves.py` — 15 passed, 4 skipped (integration), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)