### PR TITLE
fix(agent-loop): execute tool_use blocks even when stop_reason=end_turn

### DIFF
--- a/src/rumil/calls/common.py
+++ b/src/rumil/calls/common.py
@@ -333,11 +333,18 @@ async def run_agent_loop(
             elif isinstance(block, ToolUseBlock):
                 tool_uses.append(block)
 
-        if response.stop_reason == "end_turn" or not tool_uses:
-            log.debug(
-                "run_agent_loop ending: stop_reason=%s, tool_uses=%d, rounds_used=%d",
-                response.stop_reason,
+        if response.stop_reason == "end_turn" and tool_uses:
+            log.warning(
+                "Model returned stop_reason=end_turn with %d pending tool call(s); "
+                "executing them anyway (round %d).",
                 len(tool_uses),
+                round_num + 1,
+            )
+
+        if not tool_uses:
+            log.debug(
+                "run_agent_loop ending: stop_reason=%s, tool_uses=0, rounds_used=%d",
+                response.stop_reason,
                 round_num + 1,
             )
             rr = RoundRecord(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -4,11 +4,14 @@ These call the real LLM (Haiku in test mode) to verify the loop
 works end-to-end without coupling to Anthropic response internals.
 """
 
+from unittest.mock import AsyncMock
+
+import anthropic.types
 import pytest
 from pydantic import BaseModel, Field
 
 from rumil.calls.common import run_agent_loop
-from rumil.llm import Tool, structured_call, text_call
+from rumil.llm import APIResponse, Tool, structured_call, text_call
 from rumil.moves.base import MoveState
 
 
@@ -122,6 +125,92 @@ async def test_max_rounds_limits_tool_calls(tmp_db, scout_call):
     )
     # max_rounds=2 means at most 3 rounds (0, 1, 2), so tool calls are bounded
     assert len(call_count) <= 4
+
+
+async def test_end_turn_with_tool_uses_still_executes_them(
+    tmp_db, scout_call, mocker, caplog
+):
+    """If the API returns stop_reason=end_turn together with tool_use blocks
+    (which extended-thinking Opus 4.7 has been observed to do), the agent loop
+    must still execute the tool calls rather than dropping them on the floor."""
+    add_calls: list[dict] = []
+
+    async def add_recording(inp: dict) -> str:
+        add_calls.append(inp)
+        return str(inp["a"] + inp["b"])
+
+    add_tool = Tool(
+        name="add",
+        description="Add two numbers.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a", "b"],
+        },
+        fn=add_recording,
+    )
+
+    end_turn_with_tool = APIResponse(
+        message=anthropic.types.Message(
+            id="msg_round0",
+            type="message",
+            role="assistant",
+            content=[
+                anthropic.types.TextBlock(type="text", text="Calling add."),
+                anthropic.types.ToolUseBlock(
+                    type="tool_use",
+                    id="toolu_01",
+                    name="add",
+                    input={"a": 3, "b": 7},
+                ),
+            ],
+            model="claude-opus-4-7",
+            stop_reason="end_turn",
+            usage=anthropic.types.Usage(input_tokens=10, output_tokens=5),
+        ),
+        duration_ms=1,
+    )
+    end_turn_no_tool = APIResponse(
+        message=anthropic.types.Message(
+            id="msg_round1",
+            type="message",
+            role="assistant",
+            content=[anthropic.types.TextBlock(type="text", text="Done.")],
+            model="claude-opus-4-7",
+            stop_reason="end_turn",
+            usage=anthropic.types.Usage(input_tokens=12, output_tokens=2),
+        ),
+        duration_ms=1,
+    )
+    mock_api = AsyncMock(side_effect=[end_turn_with_tool, end_turn_no_tool])
+    mocker.patch("rumil.calls.common.call_anthropic_api", mock_api)
+    mocker.patch("rumil.settings.Settings.require_anthropic_key", return_value="fake")
+
+    state = MoveState(scout_call, tmp_db)
+    with caplog.at_level("WARNING", logger="rumil.calls.common"):
+        result = await run_agent_loop(
+            "You are a calculator.",
+            "Add 3 and 7.",
+            tools=[add_tool],
+            call_id=scout_call.id,
+            db=tmp_db,
+            state=state,
+            max_rounds=3,
+        )
+
+    assert add_calls == [{"a": 3, "b": 7}], (
+        "tool_use must be executed even when stop_reason is end_turn"
+    )
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "add"
+    assert result.tool_calls[0].result == "10"
+    assert any(
+        "stop_reason=end_turn" in rec.message and "pending tool call" in rec.message
+        for rec in caplog.records
+    ), "expected a warning when end_turn arrives with pending tool calls"
 
 
 @pytest.mark.llm

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -127,9 +127,7 @@ async def test_max_rounds_limits_tool_calls(tmp_db, scout_call):
     assert len(call_count) <= 4
 
 
-async def test_end_turn_with_tool_uses_still_executes_them(
-    tmp_db, scout_call, mocker, caplog
-):
+async def test_end_turn_with_tool_uses_still_executes_them(tmp_db, scout_call, mocker, caplog):
     """If the API returns stop_reason=end_turn together with tool_use blocks
     (which extended-thinking Opus 4.7 has been observed to do), the agent loop
     must still execute the tool calls rather than dropping them on the floor."""


### PR DESCRIPTION
## Summary

- Anthropic's extended-thinking models (observed on Opus 4.7) sometimes return `stop_reason=\"end_turn\"` together with `tool_use` blocks in the same assistant message.
- The agent loop's break condition (`if response.stop_reason == \"end_turn\" or not tool_uses`) treated that as \"stop without executing,\" silently dropping the pending tool calls.
- Symptom on prod: `create_view` runs that emitted well-formed `create_view_item` tool calls but created zero pages. Two such calls in run `71fbdc0b…` had Round 0 only (24 and 14 dropped tool calls respectively); successful peers had Round 0 + Round 1.

## Fix

Split the break condition so the loop only stops when there are no pending `tool_use` blocks. When `end_turn` arrives alongside tool_uses, log a warning and execute them anyway — the next round will surface the tool results and let the model wrap up normally.

## Test plan

- [x] Unit test that mocks `call_anthropic_api` to return `stop_reason=end_turn` with a `tool_use` block, asserts the tool fn was actually invoked, and asserts the warning was logged.
- [x] Verified the test fails on `main` (without the fix) and passes after.
- [x] `uv run pyright` clean on changed files.
- [ ] Frequency monitoring: the new warning lets us measure how often end_turn-with-tool_uses fires in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)