### PR TITLE
versus: model registry, inspect-page fixes, script QoL

### DIFF
--- a/.claude/skills/rumil-versus-generate/SKILL.md
+++ b/.claude/skills/rumil-versus-generate/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: rumil-versus-generate
-description: Run versus's generation scripts — completions and paraphrases — via versus/scripts/run_{completions,paraphrases}.py. Each model in the config routes to its provider (OpenRouter for non-claude ids today; claude-* may route direct to Anthropic in future iterations). Handles the uv --with dance, --config / path anchoring, and --active. Use when the user wants to produce or top up versus completion/paraphrase rows. **Judgments are not in this skill** — the unified judge entry point lives in rumil-versus-judge.
+description: Run versus's generation scripts — completions and paraphrases — via versus/scripts/run_{completions,paraphrases}.py. Each model in the config routes to its provider (OpenRouter for non-claude ids today; claude-* may route direct to Anthropic in future iterations). Handles the uv --with dance and --config / path anchoring. Default scope is the canonical active essay set; pass --include-stale to widen. Use when the user wants to produce or top up versus completion/paraphrase rows. **Judgments are not in this skill** — the unified judge entry point lives in rumil-versus-judge.
 allowed-tools: Bash, Read
-argument-hint: "--op completions|paraphrases [--model <id>...] [--essay <id>...] [--active] [--limit N] [--current-only] [--dry-run]"
+argument-hint: "--op completions|paraphrases [--model <id>...] [--essay <id>...] [--include-stale] [--limit N] [--current-only] [--dry-run]"
 ---
 
 # rumil-versus-generate
@@ -42,20 +42,20 @@ rows reference OLD essay text or outdated prompts. Topups against stale
 rows silently extend that staleness — re-run paraphrases + completions
 first if the user isn't explicit. Same gate `/versus` uses in the UI.
 
-## The `--active` flag
+## Active-set default and `--include-stale`
 
-Both scripts support `--active` — restrict to the canonical eval set:
-current `schema_version` and not in `cfg.essays.exclude_ids`. This is
-the 25-essay set `/versus` enumerates.
+Both scripts default to the canonical eval set: current
+`schema_version` and not in `cfg.essays.exclude_ids` — the same gate
+`/versus` applies in the UI (currently a 25-essay set).
 
-Without `--active`, the scripts still honor `exclude_ids` (so excluded
-essays never get rows), but they'll happily touch older-schema essays
-if those are still in the cache. Use `--active` to mirror what the UI
-sees — the default for "run flash across the active set" style tasks.
+Pass `--include-stale` to widen scope to every essay returned by the
+source fetchers (still minus `exclude_ids`). This pulls in off-feed
+or older-schema rows — useful for backfill or debugging, but those
+won't surface in `/versus`.
 
-`--active` composes with `--essay`: both act as filters (AND). So
-`--active --essay forethought__broad-timelines` means "the essay, only
-if it's also in the active set."
+Default scope composes with `--essay` (AND): `--essay forethought__broad-timelines`
+means "that essay, only if it's also in the active set". With
+`--include-stale`, `--essay` is the only filter.
 
 ## Invocation
 
@@ -72,17 +72,17 @@ scripts fail with `ModuleNotFoundError: httpx` or similar.
 
 ## Typical invocations
 
-**Flash completion across the active set** (the 25-essay canonical
-set, ~30 API calls at flash rates):
+**Flash completion across the active set** (the canonical 25-essay
+set is the default):
 
 ```
---op completions --active --model google/gemini-3-flash-preview
+--op completions --model google/gemini-3-flash-preview
 ```
 
 **Top up paraphrases** (when prompt is bumped or new essays land):
 
 ```
---op paraphrases --active
+--op paraphrases
 ```
 
 Default configured models come from `versus/config.yaml` `completion.models`
@@ -96,7 +96,7 @@ Override with `--model` (repeatable).
 ## Filter flags
 
 - `--essay <id>` (repeatable) — restrict to specific essays.
-- `--active` — the 25-essay canonical set.
+- `--include-stale` — opt out of the active-set default; widen to every fetched essay (still minus `exclude_ids`).
 - `--limit N` — cap number of calls.
 - `--dry-run` — print the plan and exit.
 

--- a/.claude/skills/rumil-versus-generate/SKILL.md
+++ b/.claude/skills/rumil-versus-generate/SKILL.md
@@ -137,12 +137,15 @@ config and re-running fills gaps without clobbering.
 
 ## Env
 
-- `OPENROUTER_API_KEY` — required for all three. Not in any `.env`
-  in the repo; must be in the shell environment. If the user hits
-  `RuntimeError: OPENROUTER_API_KEY not set`, point at their shell
-  profile — don't try to write it into `.env`.
-- `ANTHROPIC_API_KEY` — only needed by `rumil-versus-judge`, not this
-  skill.
+Both keys are needed depending on which models run:
+
+- `OPENROUTER_API_KEY` — required for any non-claude model
+  (gemini, gpt-5.4, etc.). Routed via OpenRouter.
+- `ANTHROPIC_API_KEY` — required for any `claude-*` / `anthropic/...`
+  model. Both `run_completions.py` and `run_paraphrases.py` apply
+  the env cascade (versus/.env, then rumil/.env, then process env),
+  matching what `run_rumil_judgments.py` does, so per-project `.env`
+  files take precedence over the shell env.
 
 ## Common gotchas
 

--- a/.claude/skills/rumil-versus-judge/SKILL.md
+++ b/.claude/skills/rumil-versus-judge/SKILL.md
@@ -149,17 +149,30 @@ default; the user must name one. For the `ws` / `orch` variants to do
 better than text-only judgment, that workspace should have material
 relevant to the essays' topics.
 
-By default `ws` / `orch` runs are **staged** (`staged=True` on
-rumil's DB). The agent still reads baseline workspace material
-normally, but any pages versus creates during the run (the per-pair
-Question, plus the orchestrator's research subtree for `orch`) are
-scoped to the run's staged view — invisible to other readers of the
-workspace. Pass `--persist` to disable staging and write pages to the
-baseline. Pages are also tagged `extra.source = "versus"` in both
-modes, so filtering after the fact is possible.
+**Prod has a dedicated `versus` workspace** (intentionally empty) for
+ws/orch runs from versus. Pass `--workspace versus --prod` to use it.
+Reusing one shared workspace keeps the staged subtrees from each run
+discoverable in one place. New workspaces must be created explicitly
+via rumil's main.py before a `--prod` ws/orch run — the resolver
+fails-loud on missing names (typo protection).
 
-Supabase must be running locally (`supabase start` in the rumil repo)
-for both `ws` and `orch` variants.
+By default `ws` / `orch` runs are **staged** (`staged=True` on
+rumil's DB) on both local and prod. The agent still reads baseline
+workspace material normally, but any pages versus creates during the
+run (the per-pair Question, plus the orchestrator's research subtree
+for `orch`) are scoped to the run's staged view — invisible to other
+readers of the workspace. Pass `--persist` to disable staging and
+write pages to the baseline. Pages are also tagged
+`extra.source = "versus"` in both modes, so filtering after the fact
+is possible.
+
+For local runs, Supabase must be running (`supabase start` in the
+rumil repo). For `--prod` runs, no local Supabase needed — the script
+writes to prod versus_db AND prod rumil DB. Note: with prod runs, the
+trace URL printed (`/traces/<run_id>`) points at the local frontend's
+configured `frontend_url` — you may need to point your local frontend
+at the prod API or visit `rumil.ink/traces/<run_id>` directly to see
+the trace.
 
 ## Invocation
 

--- a/.claude/skills/rumil-versus-judge/SKILL.md
+++ b/.claude/skills/rumil-versus-judge/SKILL.md
@@ -32,11 +32,15 @@ template — see `rumil/versus_prompts.py` for the substitution dicts.
 Each row carries a structured `judge_inputs: dict`; the DB generates
 `judge_inputs_hash` from its canonical-form JSON. The blob is built by
 `versus.judge_config.make_judge_config` and covers every input the
-judge saw — model, sampling, prompt content, tool descriptions, pair
-surface, code fingerprint, workspace state, budget, closer config —
-plus `text_a_id` / `text_b_id` and `order` added at write time. Any
-change in any of those auto-forks the hash; no manual version bump to
-remember. See `versus/AGENT.md` for the full schema.
+judge saw — model, dimension, the per-model `model_config` snapshot
+(sampling, thinking, effort, max_thinking_tokens, service_tier — full
+`ModelConfig.to_record_dict()` from the registry), prompt content,
+tool descriptions, pair surface, code fingerprint, workspace state,
+budget, closer config — plus `text_a_id` / `text_b_id` and `order`
+added at write time. Editing the registry, swapping a prompt, or
+touching any code the fingerprint covers auto-forks the hash; no
+manual version bump to remember. See `versus/AGENT.md` for the full
+schema and the registry shape.
 
 ## When to use
 
@@ -301,10 +305,13 @@ over-read any single number:
   (`TwoPhaseOrchestrator` rejects anything smaller with a clear
   error).
 - **Re-running is free.** Dedup keys include the variant, model,
-  workspace, dimension (or versus criterion), budget, sampling params
-  (via `:s<hash>`), tool-prompt contents (via `:t<hash>` for ws/orch),
+  workspace, dimension (or versus criterion), budget, the full
+  per-model `model_config` snapshot from the registry (via
+  `:m<hash>`), tool-prompt contents (via `:t<hash>` for ws/orch),
   and `order` slot — so any combination change produces fresh rows
-  without clobbering existing ones. `order` is currently always
+  without clobbering existing ones. Editing `versus/config.yaml`
+  `models:` for the judge model forks the hash naturally; old rows
+  stay valid as the prior config. `order` is currently always
   single-order; the slot exists so mirror-mode can be switched on
   without a migration.
 - **Rumil trace UI requires rumil's frontend** (`./scripts/dev-api.sh`

--- a/.claude/skills/rumil-versus-judge/SKILL.md
+++ b/.claude/skills/rumil-versus-judge/SKILL.md
@@ -2,7 +2,7 @@
 name: rumil-versus-judge
 description: Run pairwise judgments on versus essay-continuation pairs. Default mode is the unified blind path (single-turn LLM call, no tools, no DB) — claude-* models route direct to Anthropic, others through OpenRouter. --variant ws adds a rumil SDK agent with workspace-exploration tools; --variant orch fires a full TwoPhaseOrchestrator run per pair. Use when the user wants to measure how rumil discriminates on pairs with known ground truth (human continuation vs. model continuations), compare blind judges against workspace-aware ones, or top up pending judgments after adding new dimensions or models.
 allowed-tools: Bash, Read
-argument-hint: "[--variant ws|orch] [--workspace <name>] [--model opus|sonnet|haiku|<full-id> ...] [--dimension <name>...] [--essay <id>...] [--contestants <csv>] [--vs-human] [--budget N] [--limit N] [--concurrency N] [--current-only] [--persist] [--dry-run]"
+argument-hint: "[--variant ws|orch] [--workspace <name>] [--model opus|sonnet|haiku|<full-id> ...] [--dimension <name>...] [--essay <id>...] [--include-stale] [--contestants <csv>] [--vs-human] [--budget N] [--limit N] [--concurrency N] [--current-only] [--persist] [--dry-run]"
 ---
 
 # rumil-versus-judge
@@ -120,6 +120,12 @@ essay. For focused comparisons (especially expensive paths like orch)
 use these filters — all shared across ws and orch:
 
 - `--essay <id>` (repeatable) — restrict to specific essays.
+- `--include-stale` — opt out of the active-set default. By default
+  the planner restricts to the canonical active essay set (current
+  `schema_version`, not in `cfg.essays.exclude_ids` — same gate
+  `/versus` applies). Pass this to widen to every essay with rows in
+  `versus_texts`, including off-feed or older-schema rows. Composes
+  with `--essay` (intersected when not stale).
 - `--contestants <csv>` — only pairs where BOTH source_ids are in the
   list. Controls which contestants get compared against each other.
 - `--vs-human` — only pairs where one side is `human`.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3542,6 +3542,18 @@
           "thinking_off": {
             "type": "boolean",
             "title": "Thinking Off"
+          },
+          "original_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Config"
           }
         },
         "type": "object",
@@ -3556,7 +3568,8 @@
           "temperature",
           "max_tokens",
           "has_thinking",
-          "thinking_off"
+          "thinking_off",
+          "original_config"
         ],
         "title": "BaseExchangeOut",
         "description": "Reconstructed base exchange \u2014 what the fork editor pre-populates."
@@ -5795,6 +5808,18 @@
             "type": "object",
             "title": "Sampling"
           },
+          "model_config_snapshot": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Config Snapshot"
+          },
           "criterion": {
             "type": "string",
             "title": "Criterion"
@@ -5971,6 +5996,7 @@
           "config_hash",
           "prompt_hash",
           "sampling",
+          "model_config_snapshot",
           "criterion",
           "source_a",
           "source_b",
@@ -6050,6 +6076,18 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Sampling"
+          },
+          "model_config_snapshot": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Config Snapshot"
           },
           "verdict": {
             "anyOf": [
@@ -6230,6 +6268,7 @@
           "config_hash",
           "prompt_hash",
           "sampling",
+          "model_config_snapshot",
           "verdict",
           "winner_source",
           "preference_label",

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -296,6 +296,12 @@ export type BaseExchangeOut = {
      * Thinking Off
      */
     thinking_off: boolean;
+    /**
+     * Original Config
+     */
+    original_config: {
+        [key: string]: unknown;
+    } | null;
 };
 
 /**
@@ -1668,6 +1674,12 @@ export type Judgment = {
         [key: string]: unknown;
     };
     /**
+     * Model Config Snapshot
+     */
+    model_config_snapshot: {
+        [key: string]: unknown;
+    } | null;
+    /**
      * Criterion
      */
     criterion: string;
@@ -1818,6 +1830,12 @@ export type JudgmentDetail = {
     sampling: {
         [key: string]: unknown;
     };
+    /**
+     * Model Config Snapshot
+     */
+    model_config_snapshot: {
+        [key: string]: unknown;
+    } | null;
     /**
      * Verdict
      */

--- a/frontend/src/app/traces/[runId]/fork-panel.tsx
+++ b/frontend/src/app/traces/[runId]/fork-panel.tsx
@@ -65,6 +65,52 @@ function modelHasAdaptiveThinking(model: string): boolean {
   );
 }
 
+// Original-config readout helpers — show what the captured exchange
+// actually applied on the wire, so the fork editor exposes the full
+// condition (not just temperature/max_tokens). Each returns null on
+// legacy rows whose ``original_config`` is missing or whose field is
+// unset, so the row is simply skipped from the meta display.
+function renderThinking(orig: { [k: string]: unknown } | null | undefined): string {
+  const t = orig?.["thinking"];
+  if (!t || typeof t !== "object") return "on";
+  const th = t as { type?: string; display?: string };
+  if (!th.type) return "on";
+  return th.display ? `${th.type} (${th.display})` : th.type;
+}
+
+function renderEffortRow(orig: { [k: string]: unknown } | null | undefined) {
+  const e = orig?.["effort"];
+  if (typeof e !== "string") return null;
+  return (
+    <>
+      <span className="fork-readonly-meta-label">effort</span>
+      <span className="fork-readonly-meta-value">{e}</span>
+    </>
+  );
+}
+
+function renderMaxThinkingTokensRow(orig: { [k: string]: unknown } | null | undefined) {
+  const m = orig?.["max_thinking_tokens"];
+  if (typeof m !== "number") return null;
+  return (
+    <>
+      <span className="fork-readonly-meta-label">max_thinking_tokens</span>
+      <span className="fork-readonly-meta-value">{m}</span>
+    </>
+  );
+}
+
+function renderServiceTierRow(orig: { [k: string]: unknown } | null | undefined) {
+  const s = orig?.["service_tier"];
+  if (typeof s !== "string") return null;
+  return (
+    <>
+      <span className="fork-readonly-meta-label">service_tier</span>
+      <span className="fork-readonly-meta-value">{s}</span>
+    </>
+  );
+}
+
 type Tool = { name: string; description: string; input_schema: unknown };
 type Msg = { role: string; content: unknown };
 
@@ -772,10 +818,13 @@ function RequestView({ base }: { base: BaseExchangeOut | null }) {
               <>
                 <span className="fork-readonly-meta-label">adaptive thinking</span>
                 <span className="fork-readonly-meta-value">
-                  {base.thinking_off ? "off" : "on"}
+                  {base.thinking_off ? "off" : renderThinking(base.original_config)}
                 </span>
               </>
             )}
+            {renderEffortRow(base.original_config)}
+            {renderMaxThinkingTokensRow(base.original_config)}
+            {renderServiceTierRow(base.original_config)}
           </div>
         </div>
       )}

--- a/frontend/src/app/versus/inspect/page.tsx
+++ b/frontend/src/app/versus/inspect/page.tsx
@@ -451,24 +451,23 @@ export default async function VersusInspectPage({
 }
 
 type WinAccum = {
-  wins: number;
+  humanWins: number;
   ties: number;
-  losses: number;
+  genWins: number;
   n: number;
   score7Sum: number;
   score7N: number;
 };
 
 function emptyAccum(): WinAccum {
-  return { wins: 0, ties: 0, losses: 0, n: 0, score7Sum: 0, score7N: 0 };
+  return { humanWins: 0, ties: 0, genWins: 0, n: 0, score7Sum: 0, score7N: 0 };
 }
 
 /** Aggregate one judgment into a (gen, judge) accum where gen is the
- *  non-human side and the verdict is reframed as: gen wins iff
- *  winner_source == gen, gen loses iff winner_source == "human", tie
- *  otherwise. Returns null when neither side is human (block 1 only
- *  cares about gen-vs-human pairings). */
-function genVsHumanAccum(j: Judgment): { gen: string; outcome: "win" | "tie" | "loss" } | null {
+ *  non-human side. Outcome is human-centric ("human" wins, "gen" wins,
+ *  or tie) so downstream cell formulas can compute pick-human rate
+ *  without re-inverting. Returns null when neither side is human. */
+function genVsHumanAccum(j: Judgment): { gen: string; outcome: "human" | "tie" | "gen" } | null {
   const aHuman = j.source_a === "human";
   const bHuman = j.source_b === "human";
   if (aHuman === bHuman) return null;
@@ -476,8 +475,8 @@ function genVsHumanAccum(j: Judgment): { gen: string; outcome: "win" | "tie" | "
   if (j.verdict === "tie" || j.winner_source === "tie" || !j.winner_source) {
     return { gen, outcome: "tie" };
   }
-  if (j.winner_source === "human") return { gen, outcome: "loss" };
-  return { gen, outcome: "win" };
+  if (j.winner_source === "human") return { gen, outcome: "human" };
+  return { gen, outcome: "gen" };
 }
 
 /** Mirrors versus.analyze.cell_color so inspect win-matrix cells use
@@ -614,9 +613,9 @@ function ResultsWinMatrix({ variantBundles }: { variantBundles: VariantBundle[] 
             const row = acc.get(r.gen) ?? new Map<string, WinAccum>();
             const cell = row.get(judge) ?? emptyAccum();
             cell.n += 1;
-            if (r.outcome === "win") cell.wins += 1;
+            if (r.outcome === "human") cell.humanWins += 1;
             else if (r.outcome === "tie") cell.ties += 1;
-            else cell.losses += 1;
+            else cell.genWins += 1;
             const s7 = humanScore7pt(j);
             if (s7 !== null) {
               cell.score7Sum += s7;
@@ -664,13 +663,13 @@ function ResultsWinMatrix({ variantBundles }: { variantBundles: VariantBundle[] 
                           if (!cell || cell.n === 0) {
                             return <td key={jb} className="matrix-cell-empty"></td>;
                           }
-                          const pct = (cell.wins + 0.5 * cell.ties) / cell.n;
+                          const pct = (cell.humanWins + 0.5 * cell.ties) / cell.n;
                           const colors = pctColor(pct, cell.n);
                           const lowN = cell.n < 5;
                           const pct7 = cell.score7N > 0 ? cell.score7Sum / cell.score7N : null;
                           const tooltip =
                             `pick-human ${Math.round(pct * 100)}% (binary, ties=½) · n=${cell.n}` +
-                            ` (${cell.wins}H / ${cell.ties}T / ${cell.losses}M)` +
+                            ` (${cell.humanWins}H / ${cell.ties}T / ${cell.genWins}M)` +
                             (pct7 !== null
                               ? ` · 7pt-avg ${(pct7 * 100).toFixed(1)}% (n=${cell.score7N})`
                               : "");
@@ -842,15 +841,15 @@ function ResultsOutlier({
       if (!r) continue;
       const slot = perGen.get(r.gen) ?? emptyAccum();
       slot.n += 1;
-      if (r.outcome === "win") slot.wins += 1;
-      else if (r.outcome === "loss") slot.losses += 1;
+      if (r.outcome === "human") slot.humanWins += 1;
+      else if (r.outcome === "gen") slot.genWins += 1;
       else slot.ties += 1;
       perGen.set(r.gen, slot);
     }
     const corpus = corpusByVariant.get(v.id);
     for (const [gen, acc] of perGen) {
       if (acc.n === 0) continue;
-      const essayPct = (acc.wins + 0.5 * acc.ties) / acc.n;
+      const essayPct = (acc.humanWins + 0.5 * acc.ties) / acc.n;
       const corpusPct = corpus?.get(gen) ?? null;
       const deltaPp = corpusPct === null ? null : (essayPct - corpusPct) * 100;
       rows.push({ variantId: v.id, gen, essayPct, corpusPct, deltaPp, n: acc.n });

--- a/frontend/src/app/versus/inspect/page.tsx
+++ b/frontend/src/app/versus/inspect/page.tsx
@@ -600,14 +600,14 @@ function ResultsWinMatrix({ variantBundles }: { variantBundles: VariantBundle[] 
           const acc = new Map<string, Map<string, WinAccum>>();
           const judgesSet = new Set<string>();
           const gensSet = new Set<string>();
-          // Local config_hash -> judge_model_id map so column headers
-          // render the model name rather than the opaque hex hash.
-          const judgeModelIdByHash = new Map<string, string>();
           for (const j of v.judgments) {
-            judgeModelIdByHash.set(j.config_hash, j.judge_model_id);
             const r = genVsHumanAccum(j);
             if (!r) continue;
-            const judge = j.config_hash;
+            // Group columns by judge identity (judge_model_id), not the
+            // per-row judge_inputs_hash exposed as config_hash — otherwise
+            // every judgment gets its own column and identical-judge cells
+            // appear duplicated.
+            const judge = j.judge_model_id;
             judgesSet.add(judge);
             gensSet.add(r.gen);
             const row = acc.get(r.gen) ?? new Map<string, WinAccum>();
@@ -645,7 +645,7 @@ function ResultsWinMatrix({ variantBundles }: { variantBundles: VariantBundle[] 
                       <th></th>
                       {judges.map((jb) => (
                         <th key={jb} title={jb}>
-                          {shortModel(judgeModelIdByHash.get(jb) ?? jb)}
+                          {shortModel(jb)}
                         </th>
                       ))}
                     </tr>
@@ -942,11 +942,14 @@ function ResultsVariantFlip({ variantBundles }: { variantBundles: VariantBundle[
   const byKey = new Map<string, Pair>();
   for (const v of variantBundles) {
     for (const j of v.judgments) {
-      const k = `${j.config_hash}|${j.criterion}|${j.source_a}|${j.source_b}`;
+      // Bucket by judge_model_id so the same (judge identity, pair, criterion)
+      // groups across variants — using per-row config_hash would never match
+      // across variants and the section would always report 0 comparable.
+      const k = `${j.judge_model_id}|${j.criterion}|${j.source_a}|${j.source_b}`;
       const slot = byKey.get(k) ?? {
         gen: [j.source_a, j.source_b].filter((s) => s !== "human").map(modelOf).join("+") ||
           "human",
-        judge: j.config_hash,
+        judge: j.judge_model_id,
         criterion: j.criterion,
         source_a: j.source_a,
         source_b: j.source_b,

--- a/frontend/src/app/versus/inspect/page.tsx
+++ b/frontend/src/app/versus/inspect/page.tsx
@@ -80,6 +80,38 @@ function shortModel(id: string): string {
   return id.startsWith("paraphrase:") ? `para:${shortModel(modelOf(id))}` : after;
 }
 
+/** Trailing config-hash chunk on a legacy compound judge_model_id, e.g.
+ *  "blind:claude-haiku-4-5:general_quality:c19517145" → "c19517145". Returns
+ *  the empty string when the id has no recognizable suffix (raw model id). */
+function configHashSuffix(judgeModelId: string): string {
+  const parts = judgeModelId.split(":");
+  const last = parts[parts.length - 1];
+  return last.startsWith("c") && last.length > 1 ? last : "";
+}
+
+/** Build a map id → display label, appending the config-hash suffix when two
+ *  ids would otherwise share the same short name. Used so thinking/effort
+ *  variants of the same model render as distinct columns instead of two
+ *  visually-identical labels. */
+function disambiguatedLabels(judgeModelIds: string[]): Map<string, string> {
+  const labels = new Map<string, string>();
+  const baseCounts = new Map<string, number>();
+  for (const id of judgeModelIds) {
+    const base = shortModel(id);
+    baseCounts.set(base, (baseCounts.get(base) ?? 0) + 1);
+  }
+  for (const id of judgeModelIds) {
+    const base = shortModel(id);
+    if ((baseCounts.get(base) ?? 0) > 1) {
+      const suffix = configHashSuffix(id);
+      labels.set(id, suffix ? `${base}:${suffix}` : base);
+    } else {
+      labels.set(id, base);
+    }
+  }
+  return labels;
+}
+
 type VariantBundle = {
   id: string;
   detail: EssayDetail;
@@ -643,11 +675,14 @@ function ResultsWinMatrix({ variantBundles }: { variantBundles: VariantBundle[] 
                   <thead>
                     <tr>
                       <th></th>
-                      {judges.map((jb) => (
-                        <th key={jb} title={jb}>
-                          {shortModel(jb)}
-                        </th>
-                      ))}
+                      {(() => {
+                        const labels = disambiguatedLabels(judges);
+                        return judges.map((jb) => (
+                          <th key={jb} title={jb}>
+                            {labels.get(jb) ?? shortModel(jb)}
+                          </th>
+                        ));
+                      })()}
                     </tr>
                   </thead>
                   <tbody>
@@ -980,7 +1015,9 @@ function ResultsVariantFlip({ variantBundles }: { variantBundles: VariantBundle[
       </p>
       {flips.length > 0 && (
         <ul className="inspect-flip-list">
-          {flips.map((p, idx) => {
+          {(() => {
+            const judgeLabels = disambiguatedLabels(flips.map((p) => p.judge));
+            return flips.map((p, idx) => {
             const sides = [p.source_a, p.source_b].filter((s) => s !== "human").map(modelOf);
             const dataModel = sides.length > 0 ? sides.join(" ") : "";
             const alwaysShow = sides.length === 0 ? "1" : undefined;
@@ -993,7 +1030,7 @@ function ResultsVariantFlip({ variantBundles }: { variantBundles: VariantBundle[
                 data-always-show={alwaysShow}
               >
                 <div className="inspect-flip-pair">
-                  <span className="versus-mono">{shortModel(p.judge)}</span>{" "}
+                  <span className="versus-mono">{judgeLabels.get(p.judge) ?? shortModel(p.judge)}</span>{" "}
                   <span className="versus-muted">·</span>{" "}
                   <span className="versus-muted" style={{ fontSize: 11 }}>{p.criterion}</span>{" "}
                   <span className="versus-muted">·</span>{" "}
@@ -1019,7 +1056,8 @@ function ResultsVariantFlip({ variantBundles }: { variantBundles: VariantBundle[
                 </div>
               </li>
             );
-          })}
+            });
+          })()}
         </ul>
       )}
     </section>
@@ -1324,18 +1362,25 @@ function InspectToc({
           <li>
             <a href="#judgments">judgments</a>
             <ul>
-              {judgeOrder.map((jb) => (
-                <li
-                  key={jb}
-                  data-filterable
-                  data-model={jb}
-                  data-always-show="1"
-                >
-                  <a href={`#${anchorId("judge", jb)}`}>
-                    {shortModel(judgeModelIdByHash.get(jb) ?? jb)}
-                  </a>
-                </li>
-              ))}
+              {(() => {
+                const ids = judgeOrder.map((jb) => judgeModelIdByHash.get(jb) ?? jb);
+                const labels = disambiguatedLabels(ids);
+                return judgeOrder.map((jb) => {
+                  const id = judgeModelIdByHash.get(jb) ?? jb;
+                  return (
+                    <li
+                      key={jb}
+                      data-filterable
+                      data-model={jb}
+                      data-always-show="1"
+                    >
+                      <a href={`#${anchorId("judge", jb)}`}>
+                        {labels.get(id) ?? shortModel(id)}
+                      </a>
+                    </li>
+                  );
+                });
+              })()}
             </ul>
           </li>
         )}

--- a/frontend/src/app/versus/inspect/page.tsx
+++ b/frontend/src/app/versus/inspect/page.tsx
@@ -1188,9 +1188,9 @@ function JudgmentRow({
               {sample.prompt_hash}
             </span>
           )}
-          {sample.sampling && (
+          {(sample.model_config_snapshot || sample.sampling) && (
             <span className="versus-muted versus-mono" style={{ fontSize: 11 }}>
-              {samplingTag(sample.sampling)}
+              {modelConfigTag(sample.model_config_snapshot, sample.sampling)}
             </span>
           )}
         </div>
@@ -1392,12 +1392,37 @@ function InspectToc({
   );
 }
 
-function samplingTag(sampling: { [k: string]: unknown }): string {
+function modelConfigTag(
+  modelConfig: { [k: string]: unknown } | null | undefined,
+  sampling: { [k: string]: unknown } | null | undefined,
+): string {
+  // Prefer the full ModelConfig snapshot (post-registry rows). Fall back
+  // to the legacy sampling-only field for rows written before the schema
+  // migration. Renders the per-row condition compactly:
+  //   T=0 · mt=32000 · think=adaptive · effort=xhigh · tier=priority
+  // Empty bits are dropped so the tag stays short on plain rows.
+  const src = modelConfig ?? sampling ?? {};
   const bits: string[] = [];
-  const t = sampling["temperature"];
-  const m = sampling["max_tokens"];
+  const t = src["temperature"];
+  const m = src["max_tokens"];
   if (t !== undefined && t !== null) bits.push(`T=${t as number | string}`);
   if (m !== undefined && m !== null) bits.push(`mt=${m as number | string}`);
+  const thinking = src["thinking"];
+  if (thinking && typeof thinking === "object") {
+    const th = thinking as { type?: string; display?: string };
+    const label = th.type
+      ? th.display
+        ? `${th.type}/${th.display}`
+        : th.type
+      : "on";
+    bits.push(`think=${label}`);
+  }
+  const effort = src["effort"];
+  if (typeof effort === "string") bits.push(`effort=${effort}`);
+  const mtt = src["max_thinking_tokens"];
+  if (typeof mtt === "number") bits.push(`mtt=${mtt}`);
+  const tier = src["service_tier"];
+  if (typeof tier === "string") bits.push(`tier=${tier}`);
   return bits.join(" · ");
 }
 

--- a/src/rumil/api/forks_router.py
+++ b/src/rumil/api/forks_router.py
@@ -30,6 +30,14 @@ class BaseExchangeOut(BaseModel):
     max_tokens: int
     has_thinking: bool
     thinking_off: bool
+    # Full ``ModelConfig`` snapshot captured on
+    # ``call_llm_exchanges.request_kwargs`` at exchange-write time, or
+    # null on legacy rows that predate the request_kwargs migration.
+    # Carries thinking / effort / max_thinking_tokens / service_tier
+    # alongside the flat sampling fields above so the fork UI can show
+    # the full original condition without having to re-derive from
+    # current rules.
+    original_config: dict | None
 
 
 class ForkOut(BaseModel):
@@ -85,6 +93,7 @@ async def get_base(exchange_id: str, db: DB = Depends(_get_admin_db)) -> BaseExc
         max_tokens=base.max_tokens,
         has_thinking=base.has_thinking,
         thinking_off=base.thinking_off,
+        original_config=base.original_config.to_record_dict() if base.original_config else None,
     )
 
 

--- a/src/rumil/api/versus_router.py
+++ b/src/rumil/api/versus_router.py
@@ -85,7 +85,18 @@ def _legacy_judgment_dict(row: dict) -> dict:
         "duration_s": row.get("duration_s"),
         "config": judge_inputs,
         "config_hash": row.get("judge_inputs_hash"),
-        "sampling": judge_inputs.get("sampling"),
+        # Inspect-page legacy: surfaces just temperature + max_tokens for the
+        # row's "T=… · mt=…" tag. The full ModelConfig snapshot now lives at
+        # judge_inputs.model_config; consumers wanting thinking / effort /
+        # service_tier should read from there.
+        "sampling": (
+            {
+                "temperature": judge_inputs.get("model_config", {}).get("temperature"),
+                "max_tokens": judge_inputs.get("model_config", {}).get("max_tokens"),
+            }
+            if judge_inputs.get("model_config")
+            else None
+        ),
         "rumil_call_id": row.get("rumil_call_id"),
         "rumil_run_id": row.get("run_id"),
         "rumil_question_id": row.get("rumil_question_id"),

--- a/src/rumil/api/versus_router.py
+++ b/src/rumil/api/versus_router.py
@@ -448,6 +448,11 @@ class Judgment(pydantic.BaseModel):
     config_hash: str
     prompt_hash: str
     sampling: dict
+    # Full ModelConfig snapshot from the registry — null on legacy rows
+    # written before the nested-shape migration. Carries thinking, effort,
+    # max_thinking_tokens, service_tier alongside the sampling fields the
+    # legacy ``sampling`` field already exposes.
+    model_config_snapshot: dict | None
     criterion: str
     source_a: str
     source_b: str
@@ -493,6 +498,7 @@ class JudgmentDetail(pydantic.BaseModel):
     config_hash: str
     prompt_hash: str
     sampling: dict
+    model_config_snapshot: dict | None
     verdict: str | None
     winner_source: str | None
     preference_label: str | None
@@ -942,7 +948,8 @@ def get_essay_judgments(essay_id: str, prefix_label: str | None = None) -> Essay
                 judge_model_id=row_cfg["model"],
                 config_hash=row["config_hash"],
                 prompt_hash=f"p{row_cfg['prompts']['shell_hash']}",
-                sampling=row_cfg["sampling"] or row.get("sampling") or {},
+                sampling=row.get("sampling") or {},
+                model_config_snapshot=row_cfg.get("model_config"),
                 criterion=row.get("criterion", ""),
                 source_a=row.get("source_a", ""),
                 source_b=row.get("source_b", ""),
@@ -1369,7 +1376,8 @@ def get_judgment_by_key(key: str) -> JudgmentDetail:
         judge_model_id=row_cfg["model"],
         config_hash=row["config_hash"],
         prompt_hash=f"p{row_cfg['prompts']['shell_hash']}",
-        sampling=row_cfg["sampling"] or row.get("sampling") or {},
+        sampling=row.get("sampling") or {},
+        model_config_snapshot=row_cfg.get("model_config"),
         verdict=row.get("verdict"),
         winner_source=row.get("winner_source"),
         preference_label=(row.get("preference_label") or row.get("rumil_preference_label")),

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -2825,6 +2825,7 @@ class DB:
         cache_creation_input_tokens: int | None = None,
         cache_read_input_tokens: int | None = None,
         user_messages: Sequence[dict] | None = None,
+        model: str | None = None,
     ) -> str:
         exchange_id = str(uuid.uuid4())
         row: dict[str, Any] = {
@@ -2843,6 +2844,7 @@ class DB:
             "duration_ms": duration_ms,
             "cache_creation_input_tokens": cache_creation_input_tokens,
             "cache_read_input_tokens": cache_read_input_tokens,
+            "model": model,
         }
         if user_messages is not None:
             row["user_messages"] = user_messages

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -2826,6 +2826,7 @@ class DB:
         cache_read_input_tokens: int | None = None,
         user_messages: Sequence[dict] | None = None,
         model: str | None = None,
+        request_kwargs: dict[str, Any] | None = None,
     ) -> str:
         exchange_id = str(uuid.uuid4())
         row: dict[str, Any] = {
@@ -2848,6 +2849,8 @@ class DB:
         }
         if user_messages is not None:
             row["user_messages"] = user_messages
+        if request_kwargs is not None:
+            row["request_kwargs"] = request_kwargs
         await self._execute(self.client.table("call_llm_exchanges").insert(row))
         return exchange_id
 

--- a/src/rumil/forks.py
+++ b/src/rumil/forks.py
@@ -146,9 +146,12 @@ async def resolve_base(db: DB, base_exchange_id: str) -> BaseExchange:
     available_moves preset — exchange rows don't store tools directly, so
     this is a best-effort reconstruction.
 
-    The model isn't stored on the exchange row either, so we fall back to
-    ``settings.model`` — operators can override explicitly if they want
-    something else.
+    The model is read from the exchange row's ``model`` column (added in
+    migration 20260501000019). For pre-migration rows where it's NULL, fall
+    back to the run config — versus runs put it at
+    ``runs.config['judge_config']['model']``, normal runs at
+    ``runs.config['model']`` (captured by ``Settings.capture_config()``).
+    Last resort is ``settings.model``.
     """
     row = await db.get_llm_exchange(base_exchange_id)
     if row is None:
@@ -176,6 +179,17 @@ async def resolve_base(db: DB, base_exchange_id: str) -> BaseExchange:
                 )
 
     settings = get_settings()
+    model = row.get("model")
+    if not model and row.get("run_id"):
+        run = await db.get_run(row["run_id"])
+        cfg = (run or {}).get("config") or {}
+        judge_cfg = cfg.get("judge_config") if isinstance(cfg, dict) else None
+        if isinstance(judge_cfg, dict) and judge_cfg.get("model"):
+            model = judge_cfg["model"]
+        elif isinstance(cfg, dict) and cfg.get("model"):
+            model = cfg["model"]
+    if not model:
+        model = settings.model
     return BaseExchange(
         exchange_id=base_exchange_id,
         call_id=row.get("call_id", ""),
@@ -183,10 +197,10 @@ async def resolve_base(db: DB, base_exchange_id: str) -> BaseExchange:
         system_prompt=row.get("system_prompt") or "",
         user_messages=list(user_messages),
         tools=tools,
-        model=settings.model,
-        temperature=DEFAULT_TEMPERATURE if _supports_sampling_params(settings.model) else None,
+        model=model,
+        temperature=DEFAULT_TEMPERATURE if _supports_sampling_params(model) else None,
         max_tokens=DEFAULT_MAX_TOKENS,
-        has_thinking=_thinking_config(settings.model) is not None,
+        has_thinking=_thinking_config(model) is not None,
         thinking_off=False,
     )
 

--- a/src/rumil/forks.py
+++ b/src/rumil/forks.py
@@ -32,11 +32,11 @@ from rumil.database import DB
 from rumil.llm import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_TEMPERATURE,
-    _effort_level,
     _is_retryable,
     _log_before_retry,
     _stop_after_status_retries,
     _supports_sampling_params,
+    effort_level,
     thinking_config,
 )
 from rumil.models import CallType
@@ -81,7 +81,17 @@ class ForkOverrides(BaseModel):
 
 @dataclass
 class BaseExchange:
-    """Reconstructed base exchange — what the original API call sent."""
+    """Reconstructed base exchange — what the original API call sent.
+
+    ``original_kwargs`` holds the verbatim request-condition fields that
+    were sent on the wire (thinking, output_config, temperature,
+    max_tokens), captured at exchange-write time. When non-None, fork
+    rebuilds prefer it over recomputing from current
+    ``thinking_config`` / ``effort_level`` rules — so a fork reproduces
+    the original condition even if rules changed since. Cleared when
+    the user overrides the model (captured kwargs would be wrong for
+    the new model).
+    """
 
     exchange_id: str
     call_id: str
@@ -94,6 +104,7 @@ class BaseExchange:
     max_tokens: int
     has_thinking: bool
     thinking_off: bool
+    original_kwargs: dict | None = None
 
 
 @dataclass
@@ -190,6 +201,13 @@ async def resolve_base(db: DB, base_exchange_id: str) -> BaseExchange:
             model = cfg["model"]
     if not model:
         model = settings.model
+    captured = row.get("request_kwargs") if isinstance(row.get("request_kwargs"), dict) else None
+    captured_temp = captured.get("temperature") if captured else None
+    captured_max_tokens = captured.get("max_tokens") if captured else None
+    if captured is not None and "thinking" in captured:
+        has_thinking = captured["thinking"] is not None
+    else:
+        has_thinking = thinking_config(model) is not None
     return BaseExchange(
         exchange_id=base_exchange_id,
         call_id=row.get("call_id", ""),
@@ -198,16 +216,30 @@ async def resolve_base(db: DB, base_exchange_id: str) -> BaseExchange:
         user_messages=list(user_messages),
         tools=tools,
         model=model,
-        temperature=DEFAULT_TEMPERATURE if _supports_sampling_params(model) else None,
-        max_tokens=DEFAULT_MAX_TOKENS,
-        has_thinking=thinking_config(model) is not None,
+        temperature=captured_temp
+        if captured is not None
+        else (DEFAULT_TEMPERATURE if _supports_sampling_params(model) else None),
+        max_tokens=captured_max_tokens if captured_max_tokens is not None else DEFAULT_MAX_TOKENS,
+        has_thinking=has_thinking,
         thinking_off=False,
+        original_kwargs=captured,
     )
 
 
 def merge_overrides(base: BaseExchange, overrides: ForkOverrides) -> BaseExchange:
-    """Apply non-null override fields onto the base."""
+    """Apply non-null override fields onto the base.
+
+    A model override drops ``original_kwargs`` since the captured thinking /
+    effort were tied to the original model and don't transfer cleanly. Same
+    model: captured kwargs survive so build_kwargs can reproduce them.
+    """
+    model_overridden = overrides.model is not None and overrides.model != base.model
     merged_model = overrides.model if overrides.model is not None else base.model
+    captured = None if model_overridden else base.original_kwargs
+    if captured is not None and "thinking" in captured:
+        has_thinking = captured["thinking"] is not None
+    else:
+        has_thinking = thinking_config(merged_model) is not None
     return BaseExchange(
         exchange_id=base.exchange_id,
         call_id=base.call_id,
@@ -224,15 +256,24 @@ def merge_overrides(base: BaseExchange, overrides: ForkOverrides) -> BaseExchang
         if overrides.temperature is not None
         else base.temperature,
         max_tokens=overrides.max_tokens if overrides.max_tokens is not None else base.max_tokens,
-        has_thinking=thinking_config(merged_model) is not None,
+        has_thinking=has_thinking,
         thinking_off=overrides.thinking_off
         if overrides.thinking_off is not None
         else base.thinking_off,
+        original_kwargs=captured,
     )
 
 
 def build_kwargs(merged: BaseExchange) -> dict:
-    """Build Anthropic messages.create kwargs from a merged base+overrides."""
+    """Build Anthropic messages.create kwargs from a merged base+overrides.
+
+    When ``original_kwargs`` is present (captured at exchange-write time),
+    thinking and output_config are read from there so a fork reproduces the
+    original condition even if ``thinking_config`` / ``effort_level`` rules
+    have changed since. ``thinking_off=True`` still wins (an explicit user
+    override). Otherwise we fall back to recomputing from current rules,
+    matching the pre-capture behavior.
+    """
     kwargs: dict = {
         "model": merged.model,
         "max_tokens": merged.max_tokens,
@@ -241,9 +282,16 @@ def build_kwargs(merged: BaseExchange) -> dict:
     }
     if _supports_sampling_params(merged.model) and merged.temperature is not None:
         kwargs["temperature"] = merged.temperature
-    if not merged.thinking_off and (thinking := thinking_config(merged.model)) is not None:
+    captured = merged.original_kwargs
+    if captured is not None and "thinking" in captured:
+        if not merged.thinking_off and captured["thinking"] is not None:
+            kwargs["thinking"] = captured["thinking"]
+    elif not merged.thinking_off and (thinking := thinking_config(merged.model)) is not None:
         kwargs["thinking"] = thinking
-    if (effort := _effort_level(merged.model)) is not None:
+    if captured is not None and "output_config" in captured:
+        if captured["output_config"] is not None:
+            kwargs["output_config"] = captured["output_config"]
+    elif (effort := effort_level(merged.model)) is not None:
         kwargs["output_config"] = {"effort": effort}
     if merged.tools:
         kwargs["tools"] = merged.tools

--- a/src/rumil/forks.py
+++ b/src/rumil/forks.py
@@ -37,7 +37,7 @@ from rumil.llm import (
     _log_before_retry,
     _stop_after_status_retries,
     _supports_sampling_params,
-    _thinking_config,
+    thinking_config,
 )
 from rumil.models import CallType
 from rumil.moves.registry import MOVES
@@ -200,7 +200,7 @@ async def resolve_base(db: DB, base_exchange_id: str) -> BaseExchange:
         model=model,
         temperature=DEFAULT_TEMPERATURE if _supports_sampling_params(model) else None,
         max_tokens=DEFAULT_MAX_TOKENS,
-        has_thinking=_thinking_config(model) is not None,
+        has_thinking=thinking_config(model) is not None,
         thinking_off=False,
     )
 
@@ -224,7 +224,7 @@ def merge_overrides(base: BaseExchange, overrides: ForkOverrides) -> BaseExchang
         if overrides.temperature is not None
         else base.temperature,
         max_tokens=overrides.max_tokens if overrides.max_tokens is not None else base.max_tokens,
-        has_thinking=_thinking_config(merged_model) is not None,
+        has_thinking=thinking_config(merged_model) is not None,
         thinking_off=overrides.thinking_off
         if overrides.thinking_off is not None
         else base.thinking_off,
@@ -241,7 +241,7 @@ def build_kwargs(merged: BaseExchange) -> dict:
     }
     if _supports_sampling_params(merged.model) and merged.temperature is not None:
         kwargs["temperature"] = merged.temperature
-    if not merged.thinking_off and (thinking := _thinking_config(merged.model)) is not None:
+    if not merged.thinking_off and (thinking := thinking_config(merged.model)) is not None:
         kwargs["thinking"] = thinking
     if (effort := _effort_level(merged.model)) is not None:
         kwargs["output_config"] = {"effort": effort}

--- a/src/rumil/forks.py
+++ b/src/rumil/forks.py
@@ -15,7 +15,7 @@ import hashlib
 import json
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import anthropic
 from anthropic.types import (
@@ -36,9 +36,10 @@ from rumil.llm import (
     _log_before_retry,
     _stop_after_status_retries,
     _supports_sampling_params,
-    effort_level,
+    derive_model_config,
     thinking_config,
 )
+from rumil.model_config import ModelConfig, model_config_from_record
 from rumil.models import CallType
 from rumil.moves.registry import MOVES
 from rumil.pricing import compute_cost
@@ -83,14 +84,17 @@ class ForkOverrides(BaseModel):
 class BaseExchange:
     """Reconstructed base exchange — what the original API call sent.
 
-    ``original_kwargs`` holds the verbatim request-condition fields that
-    were sent on the wire (thinking, output_config, temperature,
-    max_tokens), captured at exchange-write time. When non-None, fork
-    rebuilds prefer it over recomputing from current
-    ``thinking_config`` / ``effort_level`` rules — so a fork reproduces
-    the original condition even if rules changed since. Cleared when
-    the user overrides the model (captured kwargs would be wrong for
-    the new model).
+    ``original_config`` holds the typed ``ModelConfig`` that was
+    actually applied on the wire (sampling, thinking, effort), captured
+    at exchange-write time. When non-None, fork rebuilds prefer it over
+    re-deriving from current rules — so a fork reproduces the original
+    condition even if rules changed since. Cleared when the user
+    overrides the model (a captured config is tied to its model).
+
+    The flat ``temperature`` / ``max_tokens`` / ``has_thinking`` /
+    ``thinking_off`` fields stay on this dataclass for back-compat with
+    the existing fork UI / overrides flow, but the source of truth at
+    the point of replay is ``original_config`` when present.
     """
 
     exchange_id: str
@@ -104,7 +108,7 @@ class BaseExchange:
     max_tokens: int
     has_thinking: bool
     thinking_off: bool
-    original_kwargs: dict | None = None
+    original_config: ModelConfig | None = None
 
 
 @dataclass
@@ -201,13 +205,13 @@ async def resolve_base(db: DB, base_exchange_id: str) -> BaseExchange:
             model = cfg["model"]
     if not model:
         model = settings.model
-    captured = row.get("request_kwargs") if isinstance(row.get("request_kwargs"), dict) else None
-    captured_temp = captured.get("temperature") if captured else None
-    captured_max_tokens = captured.get("max_tokens") if captured else None
-    if captured is not None and "thinking" in captured:
-        has_thinking = captured["thinking"] is not None
-    else:
-        has_thinking = thinking_config(model) is not None
+    raw_kwargs = row.get("request_kwargs") if isinstance(row.get("request_kwargs"), dict) else None
+    captured = model_config_from_record(raw_kwargs) if raw_kwargs is not None else None
+    has_thinking = (
+        captured.thinking is not None
+        if captured is not None
+        else thinking_config(model) is not None
+    )
     return BaseExchange(
         exchange_id=base_exchange_id,
         call_id=row.get("call_id", ""),
@@ -216,30 +220,31 @@ async def resolve_base(db: DB, base_exchange_id: str) -> BaseExchange:
         user_messages=list(user_messages),
         tools=tools,
         model=model,
-        temperature=captured_temp
+        temperature=captured.temperature
         if captured is not None
         else (DEFAULT_TEMPERATURE if _supports_sampling_params(model) else None),
-        max_tokens=captured_max_tokens if captured_max_tokens is not None else DEFAULT_MAX_TOKENS,
+        max_tokens=captured.max_tokens if captured is not None else DEFAULT_MAX_TOKENS,
         has_thinking=has_thinking,
         thinking_off=False,
-        original_kwargs=captured,
+        original_config=captured,
     )
 
 
 def merge_overrides(base: BaseExchange, overrides: ForkOverrides) -> BaseExchange:
     """Apply non-null override fields onto the base.
 
-    A model override drops ``original_kwargs`` since the captured thinking /
+    A model override drops ``original_config`` since the captured thinking /
     effort were tied to the original model and don't transfer cleanly. Same
-    model: captured kwargs survive so build_kwargs can reproduce them.
+    model: the captured config survives so build_kwargs can reproduce it.
     """
     model_overridden = overrides.model is not None and overrides.model != base.model
     merged_model = overrides.model if overrides.model is not None else base.model
-    captured = None if model_overridden else base.original_kwargs
-    if captured is not None and "thinking" in captured:
-        has_thinking = captured["thinking"] is not None
-    else:
-        has_thinking = thinking_config(merged_model) is not None
+    captured = None if model_overridden else base.original_config
+    has_thinking = (
+        captured.thinking is not None
+        if captured is not None
+        else thinking_config(merged_model) is not None
+    )
     return BaseExchange(
         exchange_id=base.exchange_id,
         call_id=base.call_id,
@@ -260,39 +265,53 @@ def merge_overrides(base: BaseExchange, overrides: ForkOverrides) -> BaseExchang
         thinking_off=overrides.thinking_off
         if overrides.thinking_off is not None
         else base.thinking_off,
-        original_kwargs=captured,
+        original_config=captured,
     )
 
 
 def build_kwargs(merged: BaseExchange) -> dict:
     """Build Anthropic messages.create kwargs from a merged base+overrides.
 
-    When ``original_kwargs`` is present (captured at exchange-write time),
-    thinking and output_config are read from there so a fork reproduces the
-    original condition even if ``thinking_config`` / ``effort_level`` rules
-    have changed since. ``thinking_off=True`` still wins (an explicit user
-    override). Otherwise we fall back to recomputing from current rules,
+    When ``original_config`` is present (captured at exchange-write time),
+    its ``to_anthropic_kwargs()`` is the source of truth — thinking and
+    output_config track the original even if the underlying rules changed
+    since. ``thinking_off=True`` still wins as an explicit user override.
+    Without a captured config we fall back to ``derive_model_config(model)``,
     matching the pre-capture behavior.
     """
     kwargs: dict = {
         "model": merged.model,
-        "max_tokens": merged.max_tokens,
         "system": merged.system_prompt,
         "messages": merged.user_messages,
     }
-    if _supports_sampling_params(merged.model) and merged.temperature is not None:
-        kwargs["temperature"] = merged.temperature
-    captured = merged.original_kwargs
-    if captured is not None and "thinking" in captured:
-        if not merged.thinking_off and captured["thinking"] is not None:
-            kwargs["thinking"] = captured["thinking"]
-    elif not merged.thinking_off and (thinking := thinking_config(merged.model)) is not None:
-        kwargs["thinking"] = thinking
-    if captured is not None and "output_config" in captured:
-        if captured["output_config"] is not None:
-            kwargs["output_config"] = captured["output_config"]
-    elif (effort := effort_level(merged.model)) is not None:
-        kwargs["output_config"] = {"effort": effort}
+    captured = merged.original_config
+    if captured is not None:
+        # Override the temperature from BaseExchange when one was set explicitly,
+        # otherwise let the captured config carry it.
+        cfg = captured
+        if merged.thinking_off:
+            cfg = replace(cfg, thinking=None)
+        kwargs.update(cfg.to_anthropic_kwargs())
+        # An explicit fork-time temperature override (different from captured)
+        # still wins, mirroring the pre-capture override behavior.
+        if (
+            _supports_sampling_params(merged.model)
+            and merged.temperature is not None
+            and merged.temperature != cfg.temperature
+        ):
+            kwargs["temperature"] = merged.temperature
+        if merged.max_tokens != cfg.max_tokens:
+            kwargs["max_tokens"] = merged.max_tokens
+    else:
+        cfg = derive_model_config(merged.model, max_tokens=merged.max_tokens)
+        if merged.thinking_off:
+            cfg = replace(cfg, thinking=None)
+        # Honor an explicit override-time temperature even on the recompute path.
+        if merged.temperature is not None and _supports_sampling_params(merged.model):
+            cfg = replace(cfg, temperature=merged.temperature)
+        elif not _supports_sampling_params(merged.model):
+            cfg = replace(cfg, temperature=None)
+        kwargs.update(cfg.to_anthropic_kwargs())
     if merged.tools:
         kwargs["tools"] = merged.tools
     return kwargs

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -91,8 +91,6 @@ def derive_model_config(model: str, *, max_tokens: int | None = None) -> ModelCo
     model-id-driven helpers. ``max_tokens`` overrides the default cap
     when provided.
     """
-    from rumil.model_config import ModelConfig
-
     return ModelConfig(
         temperature=DEFAULT_TEMPERATURE if _supports_sampling_params(model) else None,
         max_tokens=max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -67,10 +67,10 @@ def _supports_sampling_params(model: str) -> bool:
     # 1.0 — we'd rather skip it than set 1.0, so gate on thinking being off.
     if model.startswith("claude-opus-4-7"):
         return False
-    return _thinking_config(model) is None
+    return thinking_config(model) is None
 
 
-def _thinking_config(model: str) -> dict | None:
+def thinking_config(model: str) -> dict | None:
     # Adaptive thinking: Opus 4.7/4.6 and Sonnet 4.6. Haiku and older Sonnet
     # don't support adaptive. On 4.7, thinking text is omitted by default —
     # ask for summarized so sdk_agent can still capture it.
@@ -563,7 +563,7 @@ async def call_anthropic_api(
     }
     if _supports_sampling_params(model):
         kwargs["temperature"] = DEFAULT_TEMPERATURE
-    if (thinking := _thinking_config(model)) is not None:
+    if (thinking := thinking_config(model)) is not None:
         kwargs["thinking"] = thinking
     base_effort = _effort_level(model)
     # Caller can override only when the model actually supports `effort`;
@@ -1258,7 +1258,7 @@ async def _structured_call_parse(
     if _supports_sampling_params(model):
         parse_kwargs["temperature"] = DEFAULT_TEMPERATURE
     if not disable_thinking:
-        if (thinking := _thinking_config(model)) is not None:
+        if (thinking := thinking_config(model)) is not None:
             parse_kwargs["thinking"] = thinking
         if (effort := _effort_level(model)) is not None:
             parse_kwargs["output_config"] = {"effort": effort}

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -81,7 +81,7 @@ def thinking_config(model: str) -> dict | None:
     return None
 
 
-def _effort_level(model: str) -> str | None:
+def effort_level(model: str) -> str | None:
     # xhigh is Opus 4.7-only; high is the best shared setting elsewhere.
     # Haiku and Sonnet 4.5 don't support the effort parameter at all.
     if model.startswith("claude-opus-4-7"):
@@ -385,6 +385,21 @@ class AgentResult:
     messages: list[dict] = field(default_factory=list)
 
 
+_CONDITION_KWARGS = ("temperature", "max_tokens", "thinking", "output_config")
+
+
+def _capture_request_kwargs(kwargs: dict) -> dict:
+    """Extract the request-condition fields worth persisting on the exchange row.
+
+    Skips bulky fields (messages, system, tools) — those live in their own
+    columns or are rebuildable. Keeps the small dicts (thinking, output_config)
+    plus sampling so forks can reproduce the original condition without
+    relying on whatever ``thinking_config`` / ``effort_level`` rules currently
+    say for the model.
+    """
+    return {k: kwargs[k] for k in _CONDITION_KWARGS if k in kwargs}
+
+
 @dataclass
 class LLMExchangeMetadata:
     """Context for automatically saving an LLM exchange to the database.
@@ -417,6 +432,7 @@ async def _save_exchange(
     cache_creation_input_tokens: int = 0,
     cache_read_input_tokens: int = 0,
     user_messages: Sequence[dict] | None = None,
+    request_kwargs: dict | None = None,
 ) -> None:
     """Persist an LLM exchange and record a trace event."""
     exchange_id = await db.save_llm_exchange(
@@ -434,6 +450,7 @@ async def _save_exchange(
         cache_read_input_tokens=cache_read_input_tokens or None,
         user_messages=user_messages,
         model=model,
+        request_kwargs=request_kwargs,
     )
     cost_usd = compute_cost(
         model=model,
@@ -565,9 +582,9 @@ async def call_anthropic_api(
         kwargs["temperature"] = DEFAULT_TEMPERATURE
     if (thinking := thinking_config(model)) is not None:
         kwargs["thinking"] = thinking
-    base_effort = _effort_level(model)
+    base_effort = effort_level(model)
     # Caller can override only when the model actually supports `effort`;
-    # for Haiku/older Sonnet `_effort_level` returns None and the param is
+    # for Haiku/older Sonnet `effort_level` returns None and the param is
     # not accepted by the API.
     effective_effort = effort if (effort is not None and base_effort is not None) else base_effort
     if effective_effort is not None:
@@ -650,6 +667,7 @@ async def call_anthropic_api(
                 or 0,
                 cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
                 user_messages=serialized,
+                request_kwargs=_capture_request_kwargs(kwargs),
             )
         except Exception as exc:
             log.error(
@@ -1260,7 +1278,7 @@ async def _structured_call_parse(
     if not disable_thinking:
         if (thinking := thinking_config(model)) is not None:
             parse_kwargs["thinking"] = thinking
-        if (effort := _effort_level(model)) is not None:
+        if (effort := effort_level(model)) is not None:
             parse_kwargs["output_config"] = {"effort": effort}
     if response_model is not None:
         parse_kwargs["output_format"] = response_model
@@ -1311,6 +1329,7 @@ async def _structured_call_parse(
             or 0,
             cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
             user_messages=serialized,
+            request_kwargs=_capture_request_kwargs(parse_kwargs),
         )
     if response.parsed_output is not None:
         log.debug(

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -22,7 +22,7 @@ import re
 import sys
 import time
 from collections.abc import Awaitable, Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import date
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 
@@ -43,6 +43,7 @@ from tenacity import (
     wait_exponential,
 )
 
+from rumil.model_config import ModelConfig
 from rumil.pricing import compute_cost
 from rumil.prompts import PROMPTS_DIR
 from rumil.settings import get_settings
@@ -79,6 +80,25 @@ def thinking_config(model: str) -> dict | None:
     if model.startswith(("claude-opus-4-6", "claude-sonnet-4-6")):
         return {"type": "adaptive"}
     return None
+
+
+def derive_model_config(model: str, *, max_tokens: int | None = None) -> ModelConfig:
+    """Default ``ModelConfig`` for ``model``, derived from rumil rules.
+
+    What rumil's call paths use when no explicit override is passed:
+    sampling defaults from ``_supports_sampling_params`` /
+    ``DEFAULT_TEMPERATURE``, plus thinking + effort from the
+    model-id-driven helpers. ``max_tokens`` overrides the default cap
+    when provided.
+    """
+    from rumil.model_config import ModelConfig
+
+    return ModelConfig(
+        temperature=DEFAULT_TEMPERATURE if _supports_sampling_params(model) else None,
+        max_tokens=max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
+        thinking=thinking_config(model),
+        effort=effort_level(model),
+    )
 
 
 def effort_level(model: str) -> str | None:
@@ -385,19 +405,15 @@ class AgentResult:
     messages: list[dict] = field(default_factory=list)
 
 
-_CONDITION_KWARGS = ("temperature", "max_tokens", "thinking", "output_config")
+def _capture_request_kwargs(cfg: ModelConfig) -> dict:
+    """Persist the ``ModelConfig`` that was applied on the wire.
 
-
-def _capture_request_kwargs(kwargs: dict) -> dict:
-    """Extract the request-condition fields worth persisting on the exchange row.
-
-    Skips bulky fields (messages, system, tools) — those live in their own
-    columns or are rebuildable. Keeps the small dicts (thinking, output_config)
-    plus sampling so forks can reproduce the original condition without
-    relying on whatever ``thinking_config`` / ``effort_level`` rules currently
-    say for the model.
+    Stored in the ``request_kwargs`` column on ``call_llm_exchanges``.
+    ``ModelConfig.to_record_dict()`` is null-preserving so the same
+    config produces the same JSONB regardless of how it landed on the
+    wire. Forks read this back via :func:`model_config_from_record`.
     """
-    return {k: kwargs[k] for k in _CONDITION_KWARGS if k in kwargs}
+    return cfg.to_record_dict()
 
 
 @dataclass
@@ -563,32 +579,39 @@ async def call_anthropic_api(
     db: DB | None = None,
     cache: bool = False,
     effort: str | None = None,
+    model_config: ModelConfig | None = None,
 ) -> APIResponse:
     """Make a single Anthropic API call with retry logic.
 
     If metadata and db are provided, the exchange is automatically saved
     to the database and a trace event is recorded.
+
+    Pass ``model_config`` to override the per-model defaults that
+    :func:`derive_model_config` would otherwise pick (sampling, thinking,
+    effort). The legacy ``effort`` kwarg is honored only when
+    ``model_config`` is None — pass effort via ``model_config.effort``
+    in new code.
     """
     if bool(metadata) != bool(db):
         raise ValueError("metadata and db must be provided together")
+    if model_config is not None and effort is not None:
+        raise ValueError("pass effort via model_config.effort, not both")
+    if model_config is None:
+        cfg = derive_model_config(model)
+        # Caller can override effort only when the model actually supports it;
+        # for Haiku/older Sonnet effort_level returns None and the API rejects
+        # the param.
+        if effort is not None and cfg.effort is not None:
+            cfg = replace(cfg, effort=effort)
+    else:
+        cfg = model_config
     system_prompt = _with_date_suffix(system_prompt)
     kwargs: dict = {
         "model": model,
-        "max_tokens": DEFAULT_MAX_TOKENS,
         "system": system_prompt,
         "messages": _add_cache_breakpoint(messages) if cache else messages,
+        **cfg.to_anthropic_kwargs(),
     }
-    if _supports_sampling_params(model):
-        kwargs["temperature"] = DEFAULT_TEMPERATURE
-    if (thinking := thinking_config(model)) is not None:
-        kwargs["thinking"] = thinking
-    base_effort = effort_level(model)
-    # Caller can override only when the model actually supports `effort`;
-    # for Haiku/older Sonnet `effort_level` returns None and the param is
-    # not accepted by the API.
-    effective_effort = effort if (effort is not None and base_effort is not None) else base_effort
-    if effective_effort is not None:
-        kwargs["output_config"] = {"effort": effective_effort}
     if tools:
         kwargs["tools"] = tools
 
@@ -667,7 +690,7 @@ async def call_anthropic_api(
                 or 0,
                 cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
                 user_messages=serialized,
-                request_kwargs=_capture_request_kwargs(kwargs),
+                request_kwargs=_capture_request_kwargs(cfg),
             )
         except Exception as exc:
             log.error(
@@ -1267,19 +1290,15 @@ async def _structured_call_parse(
     model = model or settings.model
     system_prompt = _with_date_suffix(system_prompt)
 
+    cfg = derive_model_config(model, max_tokens=max_tokens)
+    if disable_thinking:
+        cfg = replace(cfg, thinking=None, effort=None)
     parse_kwargs: dict = {
         "model": model,
-        "max_tokens": max_tokens if max_tokens is not None else DEFAULT_MAX_TOKENS,
         "system": system_prompt,
         "messages": _add_cache_breakpoint(msg_list) if cache else msg_list,
+        **cfg.to_anthropic_kwargs(),
     }
-    if _supports_sampling_params(model):
-        parse_kwargs["temperature"] = DEFAULT_TEMPERATURE
-    if not disable_thinking:
-        if (thinking := thinking_config(model)) is not None:
-            parse_kwargs["thinking"] = thinking
-        if (effort := effort_level(model)) is not None:
-            parse_kwargs["output_config"] = {"effort": effort}
     if response_model is not None:
         parse_kwargs["output_format"] = response_model
     if tools is not None:
@@ -1329,7 +1348,7 @@ async def _structured_call_parse(
             or 0,
             cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
             user_messages=serialized,
-            request_kwargs=_capture_request_kwargs(parse_kwargs),
+            request_kwargs=_capture_request_kwargs(cfg),
         )
     if response.parsed_output is not None:
         log.debug(

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -433,6 +433,7 @@ async def _save_exchange(
         cache_creation_input_tokens=cache_creation_input_tokens or None,
         cache_read_input_tokens=cache_read_input_tokens or None,
         user_messages=user_messages,
+        model=model,
     )
     cost_usd = compute_cost(
         model=model,

--- a/src/rumil/model_config.py
+++ b/src/rumil/model_config.py
@@ -30,9 +30,14 @@ class ModelConfig:
     ``thinking`` is the Anthropic adaptive/extended-thinking dict (e.g.
     ``{"type": "adaptive", "display": "summarized"}``) or ``None``.
     ``effort`` is wrapped on the wire as ``output_config.effort``.
-    Direct anthropic_client paths today set both to ``None``; bridge
-    paths populate them from rumil's model rules (or, with the versus
-    registry, from the operator's declarative config).
+    ``max_thinking_tokens`` caps extended-thinking budget when applicable.
+    ``service_tier`` selects priority/standard queueing (``"auto"`` /
+    ``"standard_only"`` / ``"priority"``). All optional fields default
+    to ``None``; on the wire they're emitted only when set.
+
+    Forward-looking: when adding a new condition field to track
+    (top_k, stop_sequences, etc.), add it here as optional. The
+    canonical record dict and dedup hash fork naturally on first use.
     """
 
     temperature: float | None
@@ -40,6 +45,8 @@ class ModelConfig:
     top_p: float | None = None
     thinking: dict[str, Any] | None = None
     effort: str | None = None
+    max_thinking_tokens: int | None = None
+    service_tier: str | None = None
 
     def to_anthropic_kwargs(self) -> dict[str, Any]:
         """Build the messages.create kwargs subset for this config.
@@ -55,9 +62,14 @@ class ModelConfig:
         if self.top_p is not None:
             kwargs["top_p"] = self.top_p
         if self.thinking is not None:
-            kwargs["thinking"] = dict(self.thinking)
+            thinking = dict(self.thinking)
+            if self.max_thinking_tokens is not None:
+                thinking["budget_tokens"] = self.max_thinking_tokens
+            kwargs["thinking"] = thinking
         if self.effort is not None:
             kwargs["output_config"] = {"effort": self.effort}
+        if self.service_tier is not None:
+            kwargs["service_tier"] = self.service_tier
         return kwargs
 
     def to_record_dict(self) -> dict[str, Any]:
@@ -85,4 +97,6 @@ def model_config_from_record(record: dict[str, Any]) -> ModelConfig:
         top_p=record.get("top_p"),
         thinking=record.get("thinking"),
         effort=record.get("effort"),
+        max_thinking_tokens=record.get("max_thinking_tokens"),
+        service_tier=record.get("service_tier"),
     )

--- a/src/rumil/model_config.py
+++ b/src/rumil/model_config.py
@@ -1,0 +1,88 @@
+"""Per-call model condition: sampling, thinking, effort.
+
+A frozen bundle of every non-prompt condition that affects the response.
+Single source of truth for the shape across rumil internals
+(``call_anthropic_api`` / ``structured_call``), forks reproduction,
+versus's per-model registry, and any test fixture that previously
+constructed loose dicts of the same five fields.
+
+The dataclass itself is pure data — no dependency on
+``rumil.llm.thinking_config`` or ``effort_level``. The factory that
+derives a default config from a model id lives in :mod:`rumil.llm`
+(``derive_model_config``) since that's where the rules live.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    """Complete non-prompt request condition for one LLM call.
+
+    Captures the kwargs that influence the response other than the
+    prompt content itself. Frozen so the same instance can be passed
+    safely between layers (registry → bridge → rumil → exchange row)
+    without mutation surprises.
+
+    ``thinking`` is the Anthropic adaptive/extended-thinking dict (e.g.
+    ``{"type": "adaptive", "display": "summarized"}``) or ``None``.
+    ``effort`` is wrapped on the wire as ``output_config.effort``.
+    Direct anthropic_client paths today set both to ``None``; bridge
+    paths populate them from rumil's model rules (or, with the versus
+    registry, from the operator's declarative config).
+    """
+
+    temperature: float | None
+    max_tokens: int
+    top_p: float | None = None
+    thinking: dict[str, Any] | None = None
+    effort: str | None = None
+
+    def to_anthropic_kwargs(self) -> dict[str, Any]:
+        """Build the messages.create kwargs subset for this config.
+
+        Only emits keys that should actually go on the wire — None values
+        are dropped (the API rejects null thinking, etc.). Callers merge
+        this into the full kwargs dict (with model, system, messages,
+        tools).
+        """
+        kwargs: dict[str, Any] = {"max_tokens": self.max_tokens}
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        if self.top_p is not None:
+            kwargs["top_p"] = self.top_p
+        if self.thinking is not None:
+            kwargs["thinking"] = dict(self.thinking)
+        if self.effort is not None:
+            kwargs["output_config"] = {"effort": self.effort}
+        return kwargs
+
+    def to_record_dict(self) -> dict[str, Any]:
+        """Canonical dict for storage and hashing.
+
+        Always includes every field — None values are kept so the
+        canonical hash forks deterministically when a previously-None
+        condition becomes set (or vice versa). Mirror of
+        ``to_anthropic_kwargs`` but null-preserving.
+        """
+        return asdict(self)
+
+
+def model_config_from_record(record: dict[str, Any]) -> ModelConfig:
+    """Inverse of ``ModelConfig.to_record_dict`` for stored rows.
+
+    Tolerant of missing fields so legacy rows (pre-this-schema) parse
+    sensibly. Callers handle the "no record at all" case (returning
+    ``None``); this just deserializes a dict that's already known to
+    represent a config.
+    """
+    return ModelConfig(
+        temperature=record.get("temperature"),
+        max_tokens=record["max_tokens"],
+        top_p=record.get("top_p"),
+        thinking=record.get("thinking"),
+        effort=record.get("effort"),
+    )

--- a/src/rumil/sdk_agent.py
+++ b/src/rumil/sdk_agent.py
@@ -314,6 +314,7 @@ async def run_sdk_agent(config: SdkAgentConfig) -> SdkAgentResult:
                         round_num=turn_num,
                         cache_creation_input_tokens=turn.cache_creation_input_tokens or None,
                         cache_read_input_tokens=turn.cache_read_input_tokens or None,
+                        model=settings.model,
                     )
                     await child_trace.record(
                         LLMExchangeEvent(
@@ -509,6 +510,7 @@ async def run_sdk_agent(config: SdkAgentConfig) -> SdkAgentResult:
                             round_num=turn_counter,
                             cache_creation_input_tokens=cache_creation,
                             cache_read_input_tokens=cache_read,
+                            model=settings.model,
                         )
                         await config.trace.record(
                             LLMExchangeEvent(

--- a/src/rumil/sdk_agent.py
+++ b/src/rumil/sdk_agent.py
@@ -25,6 +25,7 @@ from claude_agent_sdk import (
 from claude_agent_sdk.types import HookEvent, SyncHookJSONOutput
 
 from rumil.database import DB
+from rumil.model_config import ModelConfig
 from rumil.models import Call, CallStatus, CallType
 from rumil.pricing import compute_cost
 from rumil.settings import get_settings
@@ -62,6 +63,12 @@ class SdkAgentConfig:
     agents: dict[str, AgentDefinition] = field(default_factory=dict)
     extra_hooks: dict[HookEvent, list[HookMatcher]] = field(default_factory=dict)
     output_format: dict[str, Any] | None = None
+    # Optional ModelConfig override. When set, the SDK agent applies the
+    # caller's thinking / effort / max_thinking_tokens choices instead of
+    # falling back to the SDK's per-model defaults. Versus passes the
+    # registry-derived ModelConfig here so bridge wire behavior matches
+    # what versus's config.yaml says.
+    model_config: ModelConfig | None = None
 
 
 @dataclass
@@ -426,17 +433,30 @@ async def run_sdk_agent(config: SdkAgentConfig) -> SdkAgentResult:
     for hook_type, matchers in config.extra_hooks.items():
         hooks.setdefault(hook_type, []).extend(matchers)
 
-    options = ClaudeAgentOptions(
-        system_prompt=config.system_prompt,
-        mcp_servers={config.server_name: server},
-        allowed_tools=allowed,
-        disallowed_tools=list(config.disallowed_tools),
-        agents=config.agents,
-        hooks=hooks,
-        max_turns=settings.sdk_agent_max_turns,
-        model=settings.model,
-        output_format=config.output_format,
-    )
+    sdk_options: dict[str, Any] = {
+        "system_prompt": config.system_prompt,
+        "mcp_servers": {config.server_name: server},
+        "allowed_tools": allowed,
+        "disallowed_tools": list(config.disallowed_tools),
+        "agents": config.agents,
+        "hooks": hooks,
+        "max_turns": settings.sdk_agent_max_turns,
+        "model": settings.model,
+        "output_format": config.output_format,
+    }
+    # Versus / other callers can pin thinking, effort, max-thinking-tokens
+    # via a ModelConfig override. ClaudeAgentOptions exposes the fields
+    # natively (claude_agent_sdk version 2025-11+); pass them through only
+    # when set so older versions or default behavior aren't disturbed.
+    if config.model_config is not None:
+        mc = config.model_config
+        if mc.thinking is not None:
+            sdk_options["thinking"] = dict(mc.thinking)
+        if mc.effort is not None:
+            sdk_options["effort"] = mc.effort
+        if mc.max_thinking_tokens is not None:
+            sdk_options["max_thinking_tokens"] = mc.max_thinking_tokens
+    options = ClaudeAgentOptions(**sdk_options)
 
     await config.trace.record(
         AgentStartedEvent(

--- a/src/rumil/versus_bridge.py
+++ b/src/rumil/versus_bridge.py
@@ -37,6 +37,7 @@ from unittest.mock import MagicMock
 
 from rumil.context import format_page, render_view
 from rumil.database import DB
+from rumil.model_config import ModelConfig
 from rumil.models import (
     Call,
     CallStatus,
@@ -315,6 +316,7 @@ async def judge_pair_ws_aware(
     task_body: str,
     model: str,
     broadcaster: Broadcaster | None = None,
+    model_config: ModelConfig | None = None,
 ) -> JudgeResult:
     """Run a single VERSUS_JUDGE agent call with single-arm workspace tools.
 
@@ -327,10 +329,20 @@ async def judge_pair_ws_aware(
     a scoped :func:`override_settings` block so downstream rumil code
     (sdk_agent, text_call, any nested calls) reads the same value. No
     env-var gymnastics.
+
+    ``model_config`` (optional) pins thinking / effort /
+    max_thinking_tokens for the SDK agent's underlying Anthropic call.
+    Versus's bridge passes the registry-derived ModelConfig so wire
+    behavior matches versus's config.yaml; without it, the SDK falls
+    back to its own per-model defaults.
     """
     with override_settings(rumil_model_override=model):
         return await _judge_pair_ws_aware_inner(
-            db, pair, task_body=task_body, broadcaster=broadcaster
+            db,
+            pair,
+            task_body=task_body,
+            broadcaster=broadcaster,
+            model_config=model_config,
         )
 
 
@@ -340,6 +352,7 @@ async def _judge_pair_ws_aware_inner(
     *,
     task_body: str,
     broadcaster: Broadcaster | None,
+    model_config: ModelConfig | None = None,
 ) -> JudgeResult:
     question_id = await ensure_versus_question(db, pair)
     call = await db.create_call(
@@ -379,6 +392,7 @@ async def _judge_pair_ws_aware_inner(
         broadcaster=broadcaster,
         allowed_tools=allowed,
         disallowed_tools=["Write", "Edit", "Glob"],
+        model_config=model_config,
     )
 
     try:
@@ -507,6 +521,7 @@ async def _run_orch_closer(
     broadcaster: Broadcaster | None,
     *,
     render_fn: Callable[[DB, str], Awaitable[str]] | None = None,
+    model_config: ModelConfig | None = None,
 ) -> tuple[str, Call, str, str]:
     """Small closing call: read the orchestrator's research on ``question_id``
     and emit a 7-point preference label.
@@ -567,6 +582,7 @@ async def _run_orch_closer(
         broadcaster=broadcaster,
         allowed_tools=allowed,
         disallowed_tools=list(_CLOSER_DISALLOWED_TOOLS),
+        model_config=model_config,
     )
 
     try:
@@ -600,6 +616,7 @@ async def judge_pair_orch(
     model: str,
     budget: int,
     broadcaster: Broadcaster | None = None,
+    model_config: ModelConfig | None = None,
 ) -> JudgeResult:
     """Create a per-pair Question, run TwoPhaseOrchestrator against it, then
     fire a closing call to extract the 7-point label.
@@ -610,6 +627,13 @@ async def judge_pair_orch(
     :func:`override_settings` block around the entire orchestrator run +
     closer call so the orchestrator's internal LLM calls all see the
     caller's chosen model.
+
+    ``model_config`` (optional) pins thinking / effort / max_thinking_tokens
+    for the closing call (which goes through call_anthropic_api). The
+    orchestrator's research calls go through call_anthropic_api too, but
+    we don't currently override those — they pick up rumil's defaults
+    for the model. The recorded judge_inputs reflects model_config so
+    operators can see what versus intended on the wire.
     """
     with override_settings(rumil_model_override=model):
         question_id = await ensure_versus_question(db, pair)
@@ -633,6 +657,7 @@ async def judge_pair_orch(
             question_id,
             task_body=task_body,
             broadcaster=broadcaster,
+            model_config=model_config,
         )
 
     label = extract_preference(report_text)

--- a/supabase/migrations/20260501000019_add_model_to_llm_exchanges.sql
+++ b/supabase/migrations/20260501000019_add_model_to_llm_exchanges.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.call_llm_exchanges ADD COLUMN model TEXT;

--- a/supabase/migrations/20260501054034_add_request_kwargs_to_llm_exchanges.sql
+++ b/supabase/migrations/20260501054034_add_request_kwargs_to_llm_exchanges.sql
@@ -1,0 +1,6 @@
+-- Captures the effective non-bulky request-condition fields (thinking,
+-- output_config, temperature, max_tokens) at exchange-write time so
+-- forks (and any future audit) can reproduce the original condition
+-- regardless of whether rumil.llm.thinking_config / effort_level rules
+-- have changed since.
+ALTER TABLE public.call_llm_exchanges ADD COLUMN request_kwargs JSONB;

--- a/supabase/migrations/20260501064910_versus_judge_inputs_nest_model_config.sql
+++ b/supabase/migrations/20260501064910_versus_judge_inputs_nest_model_config.sql
@@ -1,0 +1,32 @@
+-- Collapse versus_judgments.judge_inputs's loose sampling / thinking /
+-- effort keys into a single nested ``model_config`` dict matching
+-- :class:`rumil.model_config.ModelConfig`. Done in-place so the schema
+-- is uniform across all rows; ``judge_inputs_hash`` (a STORED
+-- GENERATED column over the canonicalized blob) recomputes
+-- automatically on UPDATE.
+--
+-- Old shape:
+--   judge_inputs.sampling = {temperature, max_tokens}
+--   judge_inputs.thinking = {...} | null
+--   judge_inputs.effort = "..." | null
+-- New shape:
+--   judge_inputs.model_config = {temperature, max_tokens, top_p,
+--     thinking, effort, max_thinking_tokens, service_tier}
+UPDATE versus_judgments
+SET judge_inputs = (
+    -- Drop the old sampling/thinking/effort keys, add nested model_config.
+    (judge_inputs - 'sampling' - 'thinking' - 'effort')
+    || jsonb_build_object(
+        'model_config',
+        jsonb_build_object(
+            'temperature', judge_inputs->'sampling'->'temperature',
+            'max_tokens', (judge_inputs->'sampling'->>'max_tokens')::int,
+            'top_p', null,
+            'thinking', COALESCE(judge_inputs->'thinking', 'null'::jsonb),
+            'effort', judge_inputs->>'effort',
+            'max_thinking_tokens', null,
+            'service_tier', null
+        )
+    )
+)
+WHERE judge_inputs ? 'sampling';

--- a/supabase/migrations/20260501065648_versus_texts_model_config_hash.sql
+++ b/supabase/migrations/20260501065648_versus_texts_model_config_hash.sql
@@ -1,0 +1,22 @@
+-- Add model_config_hash to versus_texts so analytics can distinguish
+-- two rows produced under different model conditions. Generated
+-- naturally as the canonicalized SHA256 of ``request->'model_config'``,
+-- so it forks deterministically when the registry's per-model config
+-- changes (sampling, thinking, effort, max_thinking_tokens, etc.).
+--
+-- Older rows (pre-registry) don't have ``model_config`` in their
+-- request blob; they get NULL and form an implicit "legacy" bucket.
+-- Aggregations grouping on (source_id, model_config_hash) treat
+-- NULL-hash rows as their own variant, which is the right default
+-- given the legacy rows were produced under a different code path.
+
+ALTER TABLE versus_texts ADD COLUMN model_config_hash TEXT GENERATED ALWAYS AS (
+    CASE
+        WHEN request ? 'model_config'
+        THEN encode(digest((request->'model_config')::text, 'sha256'), 'hex')
+        ELSE NULL
+    END
+) STORED;
+
+CREATE INDEX idx_versus_texts_model_config_hash
+    ON versus_texts (source_id, model_config_hash);

--- a/tests/test_forks.py
+++ b/tests/test_forks.py
@@ -146,6 +146,79 @@ def test_build_kwargs_omits_tools_when_empty():
     assert "tools" not in k
 
 
+def test_build_kwargs_uses_captured_thinking_over_recompute():
+    # Captured original_kwargs has a different thinking dict than the current
+    # rules would produce — fork must reproduce the original, not the new one.
+    captured_thinking = {"type": "adaptive", "display": "summarized", "marker": "old"}
+    base = _base(
+        model="claude-opus-4-7",
+        has_thinking=True,
+        original_kwargs={"thinking": captured_thinking, "output_config": {"effort": "old-xhigh"}},
+    )
+    k = build_kwargs(base)
+    assert k["thinking"] == captured_thinking
+    assert k["output_config"] == {"effort": "old-xhigh"}
+
+
+def test_build_kwargs_falls_back_to_rules_when_no_capture():
+    # Old row without request_kwargs: behavior should match pre-capture defaults.
+    base = _base(model="claude-opus-4-7", has_thinking=True, original_kwargs=None)
+    k = build_kwargs(base)
+    assert k["thinking"] == {"type": "adaptive", "display": "summarized"}
+    assert k["output_config"] == {"effort": "xhigh"}
+
+
+def test_build_kwargs_thinking_off_overrides_captured():
+    # An explicit thinking_off on the fork still wins, even when captured had it.
+    base = _base(
+        model="claude-opus-4-7",
+        has_thinking=True,
+        thinking_off=True,
+        original_kwargs={"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}},
+    )
+    k = build_kwargs(base)
+    assert "thinking" not in k
+    # output_config tracks the captured value regardless of thinking_off — those
+    # are independent knobs on the API and the recorded effort still applied.
+    assert k["output_config"] == {"effort": "high"}
+
+
+def test_build_kwargs_captured_none_thinking_omits_block():
+    # A row that captured thinking=None means "the original explicitly didn't
+    # send a thinking block". Reproduce: omit it.
+    base = _base(
+        model="claude-haiku-4-5-20251001",
+        has_thinking=False,
+        original_kwargs={"thinking": None, "output_config": None},
+    )
+    k = build_kwargs(base)
+    assert "thinking" not in k
+    assert "output_config" not in k
+
+
+def test_merge_overrides_drops_capture_when_model_changes():
+    # Captured thinking is tied to the old model; switching models means the
+    # capture is no longer the right reproduction target. Fall back to recompute.
+    base = _base(
+        model="claude-opus-4-7",
+        has_thinking=True,
+        original_kwargs={"thinking": {"type": "adaptive"}, "output_config": {"effort": "xhigh"}},
+    )
+    merged = merge_overrides(base, ForkOverrides(model="claude-haiku-4-5-20251001"))
+    assert merged.original_kwargs is None
+    assert merged.has_thinking is False
+
+
+def test_merge_overrides_preserves_capture_when_model_unchanged():
+    base = _base(
+        model="claude-opus-4-7",
+        has_thinking=True,
+        original_kwargs={"thinking": {"type": "adaptive"}},
+    )
+    merged = merge_overrides(base, ForkOverrides(temperature=0.5))
+    assert merged.original_kwargs == {"thinking": {"type": "adaptive"}}
+
+
 _FORK_DEFAULTS = dict(
     overrides={},
     model="claude-haiku-4-5-20251001",

--- a/tests/test_forks.py
+++ b/tests/test_forks.py
@@ -164,7 +164,11 @@ _FORK_DEFAULTS = dict(
 
 
 async def _seed_exchange(
-    db, call_id: str, system_prompt: str = "sys", user_message: str = "hi"
+    db,
+    call_id: str,
+    system_prompt: str = "sys",
+    user_message: str = "hi",
+    model: str | None = None,
 ) -> str:
     return await db.save_llm_exchange(
         call_id=call_id,
@@ -175,6 +179,7 @@ async def _seed_exchange(
         tool_calls=[],
         input_tokens=10,
         output_tokens=5,
+        model=model,
     )
 
 
@@ -275,6 +280,57 @@ async def test_resolve_base_reconstructs_inputs(tmp_db, scout_call):
 async def test_resolve_base_raises_on_missing_id(tmp_db):
     with pytest.raises(ValueError):
         await resolve_base(tmp_db, "00000000-0000-0000-0000-000000000000")
+
+
+async def test_resolve_base_reads_model_from_exchange_row(tmp_db, scout_call):
+    exchange_id = await _seed_exchange(tmp_db, scout_call.id, model="claude-sonnet-4-6")
+    base = await resolve_base(tmp_db, exchange_id)
+    assert base.model == "claude-sonnet-4-6"
+
+
+async def test_resolve_base_falls_back_to_judge_config_model(tmp_db, scout_call):
+    """Versus runs store the actual judge model at runs.config['judge_config']['model']."""
+    await tmp_db.create_run(
+        name="versus-test",
+        question_id=None,
+        config={"judge_config": {"model": "claude-sonnet-4-6"}},
+    )
+    exchange_id = await _seed_exchange(tmp_db, scout_call.id)
+    base = await resolve_base(tmp_db, exchange_id)
+    assert base.model == "claude-sonnet-4-6"
+
+
+async def test_resolve_base_falls_back_to_run_config_model(tmp_db, scout_call):
+    """Normal runs store the captured model at runs.config['model'] via Settings.capture_config()."""
+    await tmp_db.create_run(
+        name="normal-test",
+        question_id=None,
+        config={"model": "claude-opus-4-6"},
+    )
+    exchange_id = await _seed_exchange(tmp_db, scout_call.id)
+    base = await resolve_base(tmp_db, exchange_id)
+    assert base.model == "claude-opus-4-6"
+
+
+async def test_resolve_base_falls_back_to_settings_model(tmp_db, scout_call):
+    """When neither the exchange row nor the run config carries a model, fall back to settings.model."""
+    from rumil.settings import get_settings
+
+    exchange_id = await _seed_exchange(tmp_db, scout_call.id)
+    base = await resolve_base(tmp_db, exchange_id)
+    assert base.model == get_settings().model
+
+
+async def test_resolve_base_prefers_row_model_over_run_config(tmp_db, scout_call):
+    """Row-level model wins even when run config has a different one."""
+    await tmp_db.create_run(
+        name="conflict-test",
+        question_id=None,
+        config={"judge_config": {"model": "claude-sonnet-4-6"}, "model": "claude-opus-4-6"},
+    )
+    exchange_id = await _seed_exchange(tmp_db, scout_call.id, model="claude-haiku-4-5-20251001")
+    base = await resolve_base(tmp_db, exchange_id)
+    assert base.model == "claude-haiku-4-5-20251001"
 
 
 @pytest.mark.llm

--- a/tests/test_forks.py
+++ b/tests/test_forks.py
@@ -13,6 +13,7 @@ from rumil.forks import (
     merge_overrides,
     resolve_base,
 )
+from rumil.model_config import ModelConfig
 from rumil.models import CallType
 from rumil.settings import get_settings
 
@@ -147,13 +148,18 @@ def test_build_kwargs_omits_tools_when_empty():
 
 
 def test_build_kwargs_uses_captured_thinking_over_recompute():
-    # Captured original_kwargs has a different thinking dict than the current
+    # Captured original_config has a different thinking dict than the current
     # rules would produce — fork must reproduce the original, not the new one.
     captured_thinking = {"type": "adaptive", "display": "summarized", "marker": "old"}
     base = _base(
         model="claude-opus-4-7",
         has_thinking=True,
-        original_kwargs={"thinking": captured_thinking, "output_config": {"effort": "old-xhigh"}},
+        original_config=ModelConfig(
+            temperature=None,
+            max_tokens=1000,
+            thinking=captured_thinking,
+            effort="old-xhigh",
+        ),
     )
     k = build_kwargs(base)
     assert k["thinking"] == captured_thinking
@@ -162,7 +168,7 @@ def test_build_kwargs_uses_captured_thinking_over_recompute():
 
 def test_build_kwargs_falls_back_to_rules_when_no_capture():
     # Old row without request_kwargs: behavior should match pre-capture defaults.
-    base = _base(model="claude-opus-4-7", has_thinking=True, original_kwargs=None)
+    base = _base(model="claude-opus-4-7", has_thinking=True, original_config=None)
     k = build_kwargs(base)
     assert k["thinking"] == {"type": "adaptive", "display": "summarized"}
     assert k["output_config"] == {"effort": "xhigh"}
@@ -174,7 +180,9 @@ def test_build_kwargs_thinking_off_overrides_captured():
         model="claude-opus-4-7",
         has_thinking=True,
         thinking_off=True,
-        original_kwargs={"thinking": {"type": "adaptive"}, "output_config": {"effort": "high"}},
+        original_config=ModelConfig(
+            temperature=None, max_tokens=1000, thinking={"type": "adaptive"}, effort="high"
+        ),
     )
     k = build_kwargs(base)
     assert "thinking" not in k
@@ -189,7 +197,7 @@ def test_build_kwargs_captured_none_thinking_omits_block():
     base = _base(
         model="claude-haiku-4-5-20251001",
         has_thinking=False,
-        original_kwargs={"thinking": None, "output_config": None},
+        original_config=ModelConfig(temperature=0.0, max_tokens=1000, thinking=None, effort=None),
     )
     k = build_kwargs(base)
     assert "thinking" not in k
@@ -202,21 +210,22 @@ def test_merge_overrides_drops_capture_when_model_changes():
     base = _base(
         model="claude-opus-4-7",
         has_thinking=True,
-        original_kwargs={"thinking": {"type": "adaptive"}, "output_config": {"effort": "xhigh"}},
+        original_config=ModelConfig(
+            temperature=None, max_tokens=1000, thinking={"type": "adaptive"}, effort="xhigh"
+        ),
     )
     merged = merge_overrides(base, ForkOverrides(model="claude-haiku-4-5-20251001"))
-    assert merged.original_kwargs is None
+    assert merged.original_config is None
     assert merged.has_thinking is False
 
 
 def test_merge_overrides_preserves_capture_when_model_unchanged():
-    base = _base(
-        model="claude-opus-4-7",
-        has_thinking=True,
-        original_kwargs={"thinking": {"type": "adaptive"}},
+    captured = ModelConfig(
+        temperature=None, max_tokens=1000, thinking={"type": "adaptive"}, effort=None
     )
+    base = _base(model="claude-opus-4-7", has_thinking=True, original_config=captured)
     merged = merge_overrides(base, ForkOverrides(temperature=0.5))
-    assert merged.original_kwargs == {"thinking": {"type": "adaptive"}}
+    assert merged.original_config == captured
 
 
 _FORK_DEFAULTS = dict(

--- a/tests/test_forks.py
+++ b/tests/test_forks.py
@@ -14,6 +14,7 @@ from rumil.forks import (
     resolve_base,
 )
 from rumil.models import CallType
+from rumil.settings import get_settings
 
 
 def test_hash_overrides_drops_nulls():
@@ -314,8 +315,6 @@ async def test_resolve_base_falls_back_to_run_config_model(tmp_db, scout_call):
 
 async def test_resolve_base_falls_back_to_settings_model(tmp_db, scout_call):
     """When neither the exchange row nor the run config carries a model, fall back to settings.model."""
-    from rumil.settings import get_settings
-
     exchange_id = await _seed_exchange(tmp_db, scout_call.id)
     base = await resolve_base(tmp_db, exchange_id)
     assert base.model == get_settings().model

--- a/tests/test_versus_judge_config.py
+++ b/tests/test_versus_judge_config.py
@@ -28,15 +28,16 @@ from versus.judge_config import (  # noqa: E402
     project_config_to_axes,
 )
 
+from rumil.model_config import ModelConfig  # noqa: E402
 from versus import mainline as versus_mainline  # noqa: E402
+
+_BASE_MC = ModelConfig(temperature=None, max_tokens=1024)
 
 _BLIND_KW: dict[str, Any] = {
     "model": "claude-opus-4-7",
     "dimension": "general_quality",
-    "sampling": {"temperature": None, "max_tokens": 1024},
+    "model_config": _BASE_MC,
     "prompt_hash": "deadbeef",
-    "thinking": None,
-    "effort": None,
 }
 
 _WS_KW: dict[str, Any] = {
@@ -67,10 +68,19 @@ def test_config_hash_is_deterministic_for_identical_inputs():
     (
         ("model", "claude-sonnet-4-6"),
         ("dimension", "grounding"),
-        ("sampling", {"temperature": 0.2, "max_tokens": 1024}),
         ("prompt_hash", "abcd1234"),
-        ("thinking", {"type": "adaptive"}),
-        ("effort", "high"),
+        (
+            "model_config",
+            ModelConfig(temperature=0.2, max_tokens=1024),
+        ),
+        (
+            "model_config",
+            ModelConfig(temperature=None, max_tokens=1024, thinking={"type": "adaptive"}),
+        ),
+        (
+            "model_config",
+            ModelConfig(temperature=None, max_tokens=1024, effort="high"),
+        ),
     ),
 )
 def test_config_hash_changes_when_any_input_changes(override_key, override_value):
@@ -80,28 +90,22 @@ def test_config_hash_changes_when_any_input_changes(override_key, override_value
     assert base_hash != bumped_hash
 
 
-def test_thinking_field_recorded_when_non_none():
-    kw = {**_BLIND_KW, "thinking": {"type": "adaptive", "display": "summarized"}}
-    cfg, _, _ = make_judge_config("blind", **kw)
-    assert cfg["thinking"] == {"type": "adaptive", "display": "summarized"}
-
-
-def test_thinking_field_present_as_none_when_omitted():
-    cfg, _, _ = make_judge_config("blind", **_BLIND_KW)
-    assert "thinking" in cfg
-    assert cfg["thinking"] is None
-
-
-def test_effort_field_recorded_when_non_none():
-    kw = {**_BLIND_KW, "effort": "xhigh"}
-    cfg, _, _ = make_judge_config("blind", **kw)
-    assert cfg["effort"] == "xhigh"
-
-
-def test_effort_field_present_as_none_when_omitted():
-    cfg, _, _ = make_judge_config("blind", **_BLIND_KW)
-    assert "effort" in cfg
-    assert cfg["effort"] is None
+def test_model_config_recorded_as_nested_dict():
+    mc = ModelConfig(
+        temperature=None,
+        max_tokens=1024,
+        thinking={"type": "adaptive", "display": "summarized"},
+        effort="xhigh",
+    )
+    cfg, _, _ = make_judge_config("blind", **{**_BLIND_KW, "model_config": mc})
+    assert cfg["model_config"] == mc.to_record_dict()
+    # Sanity-check that thinking/effort live inside the nested dict, not
+    # as siblings of "model" / "dimension".
+    assert "thinking" not in cfg
+    assert "effort" not in cfg
+    assert "sampling" not in cfg
+    assert cfg["model_config"]["thinking"] == {"type": "adaptive", "display": "summarized"}
+    assert cfg["model_config"]["effort"] == "xhigh"
 
 
 def test_orch_config_hash_changes_when_code_fingerprint_changes():
@@ -220,10 +224,10 @@ _CONFIG_FIELD_TO_AXIS = {
     "closer_hash": "judge_closer_hash",
 }
 # Top-level keys deliberately not exposed as their own axis (covered
-# by other axes implicitly). ``thinking`` and ``effort`` project only
-# when non-None, matching ``sampling`` — all three are folded into
-# config_hash but only surface as a separate axis when set.
-_CONFIG_FIELDS_OPAQUE = {"variant", "sampling", "prompts", "thinking", "effort"}
+# by other axes implicitly). ``model_config`` is the nested ModelConfig
+# snapshot; folded into config_hash and surfaced as
+# ``judge_model_config_hash`` axis on demand.
+_CONFIG_FIELDS_OPAQUE = {"variant", "model_config", "prompts"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_versus_judge_config.py
+++ b/tests/test_versus_judge_config.py
@@ -35,6 +35,7 @@ _BLIND_KW: dict[str, Any] = {
     "dimension": "general_quality",
     "sampling": {"temperature": None, "max_tokens": 1024},
     "prompt_hash": "deadbeef",
+    "thinking": None,
 }
 
 _WS_KW: dict[str, Any] = {
@@ -67,6 +68,7 @@ def test_config_hash_is_deterministic_for_identical_inputs():
         ("dimension", "grounding"),
         ("sampling", {"temperature": 0.2, "max_tokens": 1024}),
         ("prompt_hash", "abcd1234"),
+        ("thinking", {"type": "adaptive"}),
     ),
 )
 def test_config_hash_changes_when_any_input_changes(override_key, override_value):
@@ -74,6 +76,18 @@ def test_config_hash_changes_when_any_input_changes(override_key, override_value
     bumped_kw = {**_BLIND_KW, override_key: override_value}
     _, bumped_hash, _ = make_judge_config("blind", **bumped_kw)
     assert base_hash != bumped_hash
+
+
+def test_thinking_field_recorded_when_non_none():
+    kw = {**_BLIND_KW, "thinking": {"type": "adaptive", "display": "summarized"}}
+    cfg, _, _ = make_judge_config("blind", **kw)
+    assert cfg["thinking"] == {"type": "adaptive", "display": "summarized"}
+
+
+def test_thinking_field_present_as_none_when_omitted():
+    cfg, _, _ = make_judge_config("blind", **_BLIND_KW)
+    assert "thinking" in cfg
+    assert cfg["thinking"] is None
 
 
 def test_orch_config_hash_changes_when_code_fingerprint_changes():
@@ -192,8 +206,10 @@ _CONFIG_FIELD_TO_AXIS = {
     "closer_hash": "judge_closer_hash",
 }
 # Top-level keys deliberately not exposed as their own axis (covered
-# by other axes implicitly).
-_CONFIG_FIELDS_OPAQUE = {"variant", "sampling", "prompts"}
+# by other axes implicitly). ``thinking`` projects only when non-None,
+# matching ``sampling`` — both are folded into config_hash but only
+# surface as a separate axis when set.
+_CONFIG_FIELDS_OPAQUE = {"variant", "sampling", "prompts", "thinking"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_versus_judge_config.py
+++ b/tests/test_versus_judge_config.py
@@ -36,6 +36,7 @@ _BLIND_KW: dict[str, Any] = {
     "sampling": {"temperature": None, "max_tokens": 1024},
     "prompt_hash": "deadbeef",
     "thinking": None,
+    "effort": None,
 }
 
 _WS_KW: dict[str, Any] = {
@@ -69,6 +70,7 @@ def test_config_hash_is_deterministic_for_identical_inputs():
         ("sampling", {"temperature": 0.2, "max_tokens": 1024}),
         ("prompt_hash", "abcd1234"),
         ("thinking", {"type": "adaptive"}),
+        ("effort", "high"),
     ),
 )
 def test_config_hash_changes_when_any_input_changes(override_key, override_value):
@@ -88,6 +90,18 @@ def test_thinking_field_present_as_none_when_omitted():
     cfg, _, _ = make_judge_config("blind", **_BLIND_KW)
     assert "thinking" in cfg
     assert cfg["thinking"] is None
+
+
+def test_effort_field_recorded_when_non_none():
+    kw = {**_BLIND_KW, "effort": "xhigh"}
+    cfg, _, _ = make_judge_config("blind", **kw)
+    assert cfg["effort"] == "xhigh"
+
+
+def test_effort_field_present_as_none_when_omitted():
+    cfg, _, _ = make_judge_config("blind", **_BLIND_KW)
+    assert "effort" in cfg
+    assert cfg["effort"] is None
 
 
 def test_orch_config_hash_changes_when_code_fingerprint_changes():
@@ -206,10 +220,10 @@ _CONFIG_FIELD_TO_AXIS = {
     "closer_hash": "judge_closer_hash",
 }
 # Top-level keys deliberately not exposed as their own axis (covered
-# by other axes implicitly). ``thinking`` projects only when non-None,
-# matching ``sampling`` — both are folded into config_hash but only
-# surface as a separate axis when set.
-_CONFIG_FIELDS_OPAQUE = {"variant", "sampling", "prompts", "thinking"}
+# by other axes implicitly). ``thinking`` and ``effort`` project only
+# when non-None, matching ``sampling`` — all three are folded into
+# config_hash but only surface as a separate axis when set.
+_CONFIG_FIELDS_OPAQUE = {"variant", "sampling", "prompts", "thinking", "effort"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_versus_judge_staleness.py
+++ b/tests/test_versus_judge_staleness.py
@@ -18,7 +18,7 @@ import pathlib
 
 import pytest
 from versus.judge_config import compute_judge_code_fingerprint, make_judge_config
-from versus.model_config import get_model_config
+from versus.model_config import get_judge_model_config
 
 from rumil.model_config import ModelConfig
 from versus import config as versus_config
@@ -61,13 +61,13 @@ def _make_ws_row(*, model: str, model_config: ModelConfig) -> dict:
 
 
 def test_blind_row_with_registry_config_is_current(versus_cfg):
-    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    mc = get_judge_model_config("claude-haiku-4-5", cfg=versus_cfg)
     row = _make_blind_row(model="claude-haiku-4-5", model_config=mc)
     assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is True
 
 
 def test_blind_row_with_drifted_temperature_is_stale(versus_cfg):
-    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    mc = get_judge_model_config("claude-haiku-4-5", cfg=versus_cfg)
     drifted = ModelConfig(
         temperature=0.7,
         max_tokens=mc.max_tokens,
@@ -80,7 +80,7 @@ def test_blind_row_with_drifted_temperature_is_stale(versus_cfg):
 
 
 def test_blind_row_with_unexpected_thinking_is_stale(versus_cfg):
-    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    mc = get_judge_model_config("claude-haiku-4-5", cfg=versus_cfg)
     drifted = ModelConfig(
         temperature=mc.temperature,
         max_tokens=mc.max_tokens,
@@ -92,7 +92,7 @@ def test_blind_row_with_unexpected_thinking_is_stale(versus_cfg):
 
 
 def test_ws_row_for_opus_with_registry_config_is_current(versus_cfg):
-    mc = get_model_config("claude-opus-4-7", cfg=versus_cfg)
+    mc = get_judge_model_config("claude-opus-4-7", cfg=versus_cfg)
     row = _make_ws_row(model="claude-opus-4-7", model_config=mc)
     assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is True
 
@@ -101,7 +101,7 @@ def test_ws_row_for_opus_with_dropped_thinking_is_stale(versus_cfg):
     # Captured thinking=None but registry says opus 4.7 should run with
     # adaptive thinking. Stale because the row's recorded condition no
     # longer matches what versus would send today.
-    mc = get_model_config("claude-opus-4-7", cfg=versus_cfg)
+    mc = get_judge_model_config("claude-opus-4-7", cfg=versus_cfg)
     drifted = ModelConfig(
         temperature=mc.temperature,
         max_tokens=mc.max_tokens,
@@ -113,7 +113,7 @@ def test_ws_row_for_opus_with_dropped_thinking_is_stale(versus_cfg):
 
 
 def test_ws_row_for_opus_with_dropped_effort_is_stale(versus_cfg):
-    mc = get_model_config("claude-opus-4-7", cfg=versus_cfg)
+    mc = get_judge_model_config("claude-opus-4-7", cfg=versus_cfg)
     drifted = ModelConfig(
         temperature=mc.temperature,
         max_tokens=mc.max_tokens,
@@ -125,7 +125,7 @@ def test_ws_row_for_opus_with_dropped_effort_is_stale(versus_cfg):
 
 
 def test_unrelated_dimension_returns_false(versus_cfg):
-    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    mc = get_judge_model_config("claude-haiku-4-5", cfg=versus_cfg)
     row = _make_blind_row(model="claude-haiku-4-5", model_config=mc)
     # An unknown dimension makes compute_judge_prompt_hash raise; helper
     # returns False so unknown rows show up as stale rather than crashing.
@@ -135,6 +135,6 @@ def test_unrelated_dimension_returns_false(versus_cfg):
 def test_unknown_model_returns_false(versus_cfg):
     # Row references a model that's been removed from the registry —
     # versus can't reproduce the config, treat as stale.
-    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    mc = get_judge_model_config("claude-haiku-4-5", cfg=versus_cfg)
     row = _make_blind_row(model="not-a-registered-model", model_config=mc)
     assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is False

--- a/tests/test_versus_judge_staleness.py
+++ b/tests/test_versus_judge_staleness.py
@@ -1,41 +1,56 @@
 """Tests for ``versus.judge.judge_config_is_current``.
 
-The staleness detector fails False when any code-side input to the
+The staleness detector returns False when any code-side input to the
 judge has drifted from what a fresh run would produce — prompt shell
-hash, code fingerprint (ws/orch), or thinking config (per
-:func:`rumil.llm.thinking_config`).
+hash, code fingerprint (ws/orch), or the recorded ``model_config``
+snapshot vs. what the versus model registry currently says for that
+model.
+
+Tests construct judgment rows via ``make_judge_config`` using a
+ModelConfig that matches (or deliberately differs from) what versus's
+registry returns for the given model id. The staleness detector loads
+versus/config.yaml from the repo root.
 """
 
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 from versus.judge_config import compute_judge_code_fingerprint, make_judge_config
+from versus.model_config import get_model_config
 
+from rumil.model_config import ModelConfig
+from versus import config as versus_config
 from versus import judge as versus_judge
 
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_VERSUS_CFG_PATH = _REPO_ROOT / "versus" / "config.yaml"
 
-def _make_blind_row(*, model: str, thinking: dict | None = None, effort: str | None = None) -> dict:
+
+@pytest.fixture
+def versus_cfg() -> versus_config.Config:
+    return versus_config.load(_VERSUS_CFG_PATH)
+
+
+def _make_blind_row(*, model: str, model_config: ModelConfig) -> dict:
     cfg, _, _ = make_judge_config(
         "blind",
         model=model,
         dimension="general_quality",
-        sampling={"temperature": 0.0, "max_tokens": 1024},
+        model_config=model_config,
         prompt_hash=versus_judge.compute_judge_prompt_hash("general_quality", with_tools=False),
-        thinking=thinking,
-        effort=effort,
     )
     return {"judge_inputs": cfg}
 
 
-def _make_ws_row(*, model: str, thinking: dict | None, effort: str | None = None) -> dict:
+def _make_ws_row(*, model: str, model_config: ModelConfig) -> dict:
     cfg, _, _ = make_judge_config(
         "ws",
         model=model,
         dimension="general_quality",
-        sampling={"temperature": 0.0, "max_tokens": 1024},
+        model_config=model_config,
         prompt_hash=versus_judge.compute_judge_prompt_hash("general_quality", with_tools=True),
-        thinking=thinking,
-        effort=effort,
         tool_prompt_hash="11111111",
         pair_surface_hash="22222222",
         workspace_id="abcd1234",
@@ -45,104 +60,81 @@ def _make_ws_row(*, model: str, thinking: dict | None, effort: str | None = None
     return {"judge_inputs": cfg}
 
 
-def test_blind_row_with_thinking_none_is_current():
-    row = _make_blind_row(model="claude-haiku-4-5", thinking=None)
-    assert versus_judge.judge_config_is_current(row, "general_quality") is True
+def test_blind_row_with_registry_config_is_current(versus_cfg):
+    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    row = _make_blind_row(model="claude-haiku-4-5", model_config=mc)
+    assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is True
 
 
-def test_blind_row_with_unexpected_thinking_is_stale():
-    row = _make_blind_row(model="claude-haiku-4-5", thinking={"type": "adaptive"})
-    assert versus_judge.judge_config_is_current(row, "general_quality") is False
-
-
-def test_ws_row_for_haiku_with_no_thinking_is_current():
-    # haiku doesn't get adaptive thinking — recorded None matches expected None.
-    row = _make_ws_row(model="claude-haiku-4-5", thinking=None)
-    assert versus_judge.judge_config_is_current(row, "general_quality") is True
-
-
-def test_ws_row_for_opus_47_with_adaptive_thinking_is_current():
-    row = _make_ws_row(
-        model="claude-opus-4-7-20251001",
-        thinking={"type": "adaptive", "display": "summarized"},
-        effort="xhigh",
+def test_blind_row_with_drifted_temperature_is_stale(versus_cfg):
+    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    drifted = ModelConfig(
+        temperature=0.7,
+        max_tokens=mc.max_tokens,
+        top_p=mc.top_p,
+        thinking=mc.thinking,
+        effort=mc.effort,
     )
-    assert versus_judge.judge_config_is_current(row, "general_quality") is True
+    row = _make_blind_row(model="claude-haiku-4-5", model_config=drifted)
+    assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is False
 
 
-def test_ws_row_for_opus_47_missing_thinking_is_stale():
-    # An older row predating thinking-recording: thinking field missing →
-    # treated as None, but expected is the adaptive dict for opus 4.7 → stale.
-    row = _make_ws_row(model="claude-opus-4-7-20251001", thinking=None)
-    assert versus_judge.judge_config_is_current(row, "general_quality") is False
-
-
-def test_ws_row_with_wrong_thinking_dict_is_stale():
-    row = _make_ws_row(
-        model="claude-opus-4-7-20251001",
-        thinking={"type": "adaptive"},  # missing the display field opus 4.7 sets
+def test_blind_row_with_unexpected_thinking_is_stale(versus_cfg):
+    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    drifted = ModelConfig(
+        temperature=mc.temperature,
+        max_tokens=mc.max_tokens,
+        thinking={"type": "adaptive"},
+        effort=mc.effort,
     )
-    assert versus_judge.judge_config_is_current(row, "general_quality") is False
+    row = _make_blind_row(model="claude-haiku-4-5", model_config=drifted)
+    assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is False
 
 
-def test_unrelated_dimension_returns_false():
-    row = _make_blind_row(model="claude-haiku-4-5", thinking=None)
-    # An unknown dimension makes compute_judge_prompt_hash raise; helper
-    # returns False so unknown rows show up as stale rather than crashing.
-    assert versus_judge.judge_config_is_current(row, "no-such-dimension") is False
+def test_ws_row_for_opus_with_registry_config_is_current(versus_cfg):
+    mc = get_model_config("claude-opus-4-7", cfg=versus_cfg)
+    row = _make_ws_row(model="claude-opus-4-7", model_config=mc)
+    assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is True
 
 
-@pytest.mark.parametrize(
-    ("model", "expected_thinking"),
-    (
-        ("claude-haiku-4-5", None),
-        ("claude-opus-4-7-20251001", {"type": "adaptive", "display": "summarized"}),
-        ("claude-sonnet-4-6", {"type": "adaptive"}),
-    ),
-)
-def test_thinking_check_uses_rumil_thinking_config(model, expected_thinking):
-    # Records the rumil rules at the time of writing. If thinking_config
-    # changes for any of these models, this test breaks deliberately so
-    # the impact on staleness semantics gets reviewed.
-    from rumil.llm import thinking_config
-
-    assert thinking_config(model) == expected_thinking
-
-
-def test_blind_row_with_unexpected_effort_is_stale():
-    row = _make_blind_row(model="claude-haiku-4-5", effort="high")
-    assert versus_judge.judge_config_is_current(row, "general_quality") is False
-
-
-def test_ws_row_for_opus_47_with_xhigh_effort_is_current():
-    row = _make_ws_row(
-        model="claude-opus-4-7-20251001",
-        thinking={"type": "adaptive", "display": "summarized"},
-        effort="xhigh",
+def test_ws_row_for_opus_with_dropped_thinking_is_stale(versus_cfg):
+    # Captured thinking=None but registry says opus 4.7 should run with
+    # adaptive thinking. Stale because the row's recorded condition no
+    # longer matches what versus would send today.
+    mc = get_model_config("claude-opus-4-7", cfg=versus_cfg)
+    drifted = ModelConfig(
+        temperature=mc.temperature,
+        max_tokens=mc.max_tokens,
+        thinking=None,
+        effort=mc.effort,
     )
-    assert versus_judge.judge_config_is_current(row, "general_quality") is True
+    row = _make_ws_row(model="claude-opus-4-7", model_config=drifted)
+    assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is False
 
 
-def test_ws_row_for_opus_47_missing_effort_is_stale():
-    row = _make_ws_row(
-        model="claude-opus-4-7-20251001",
-        thinking={"type": "adaptive", "display": "summarized"},
+def test_ws_row_for_opus_with_dropped_effort_is_stale(versus_cfg):
+    mc = get_model_config("claude-opus-4-7", cfg=versus_cfg)
+    drifted = ModelConfig(
+        temperature=mc.temperature,
+        max_tokens=mc.max_tokens,
+        thinking=mc.thinking,
         effort=None,
     )
-    assert versus_judge.judge_config_is_current(row, "general_quality") is False
+    row = _make_ws_row(model="claude-opus-4-7", model_config=drifted)
+    assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is False
 
 
-@pytest.mark.parametrize(
-    ("model", "expected_effort"),
-    (
-        ("claude-haiku-4-5", None),
-        ("claude-opus-4-7-20251001", "xhigh"),
-        ("claude-sonnet-4-6", "high"),
-    ),
-)
-def test_effort_check_uses_rumil_effort_level(model, expected_effort):
-    # Same idea as the thinking version: pin current rules so silent drift
-    # in effort_level forces a deliberate test update.
-    from rumil.llm import effort_level
+def test_unrelated_dimension_returns_false(versus_cfg):
+    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    row = _make_blind_row(model="claude-haiku-4-5", model_config=mc)
+    # An unknown dimension makes compute_judge_prompt_hash raise; helper
+    # returns False so unknown rows show up as stale rather than crashing.
+    assert versus_judge.judge_config_is_current(row, "no-such-dimension", cfg=versus_cfg) is False
 
-    assert effort_level(model) == expected_effort
+
+def test_unknown_model_returns_false(versus_cfg):
+    # Row references a model that's been removed from the registry —
+    # versus can't reproduce the config, treat as stale.
+    mc = get_model_config("claude-haiku-4-5", cfg=versus_cfg)
+    row = _make_blind_row(model="not-a-registered-model", model_config=mc)
+    assert versus_judge.judge_config_is_current(row, "general_quality", cfg=versus_cfg) is False

--- a/tests/test_versus_judge_staleness.py
+++ b/tests/test_versus_judge_staleness.py
@@ -1,0 +1,106 @@
+"""Tests for ``versus.judge.judge_config_is_current``.
+
+The staleness detector fails False when any code-side input to the
+judge has drifted from what a fresh run would produce — prompt shell
+hash, code fingerprint (ws/orch), or thinking config (per
+:func:`rumil.llm.thinking_config`).
+"""
+
+from __future__ import annotations
+
+import pytest
+from versus.judge_config import compute_judge_code_fingerprint, make_judge_config
+
+from versus import judge as versus_judge
+
+
+def _make_blind_row(*, model: str, thinking: dict | None = None) -> dict:
+    cfg, _, _ = make_judge_config(
+        "blind",
+        model=model,
+        dimension="general_quality",
+        sampling={"temperature": 0.0, "max_tokens": 1024},
+        prompt_hash=versus_judge.compute_judge_prompt_hash("general_quality", with_tools=False),
+        thinking=thinking,
+    )
+    return {"judge_inputs": cfg}
+
+
+def _make_ws_row(*, model: str, thinking: dict | None) -> dict:
+    cfg, _, _ = make_judge_config(
+        "ws",
+        model=model,
+        dimension="general_quality",
+        sampling={"temperature": 0.0, "max_tokens": 1024},
+        prompt_hash=versus_judge.compute_judge_prompt_hash("general_quality", with_tools=True),
+        thinking=thinking,
+        tool_prompt_hash="11111111",
+        pair_surface_hash="22222222",
+        workspace_id="abcd1234",
+        code_fingerprint=compute_judge_code_fingerprint(),
+        workspace_state_hash="0011223344556677",
+    )
+    return {"judge_inputs": cfg}
+
+
+def test_blind_row_with_thinking_none_is_current():
+    row = _make_blind_row(model="claude-haiku-4-5", thinking=None)
+    assert versus_judge.judge_config_is_current(row, "general_quality") is True
+
+
+def test_blind_row_with_unexpected_thinking_is_stale():
+    row = _make_blind_row(model="claude-haiku-4-5", thinking={"type": "adaptive"})
+    assert versus_judge.judge_config_is_current(row, "general_quality") is False
+
+
+def test_ws_row_for_haiku_with_no_thinking_is_current():
+    # haiku doesn't get adaptive thinking — recorded None matches expected None.
+    row = _make_ws_row(model="claude-haiku-4-5", thinking=None)
+    assert versus_judge.judge_config_is_current(row, "general_quality") is True
+
+
+def test_ws_row_for_opus_47_with_adaptive_thinking_is_current():
+    row = _make_ws_row(
+        model="claude-opus-4-7-20251001",
+        thinking={"type": "adaptive", "display": "summarized"},
+    )
+    assert versus_judge.judge_config_is_current(row, "general_quality") is True
+
+
+def test_ws_row_for_opus_47_missing_thinking_is_stale():
+    # An older row predating thinking-recording: thinking field missing →
+    # treated as None, but expected is the adaptive dict for opus 4.7 → stale.
+    row = _make_ws_row(model="claude-opus-4-7-20251001", thinking=None)
+    assert versus_judge.judge_config_is_current(row, "general_quality") is False
+
+
+def test_ws_row_with_wrong_thinking_dict_is_stale():
+    row = _make_ws_row(
+        model="claude-opus-4-7-20251001",
+        thinking={"type": "adaptive"},  # missing the display field opus 4.7 sets
+    )
+    assert versus_judge.judge_config_is_current(row, "general_quality") is False
+
+
+def test_unrelated_dimension_returns_false():
+    row = _make_blind_row(model="claude-haiku-4-5", thinking=None)
+    # An unknown dimension makes compute_judge_prompt_hash raise; helper
+    # returns False so unknown rows show up as stale rather than crashing.
+    assert versus_judge.judge_config_is_current(row, "no-such-dimension") is False
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_thinking"),
+    (
+        ("claude-haiku-4-5", None),
+        ("claude-opus-4-7-20251001", {"type": "adaptive", "display": "summarized"}),
+        ("claude-sonnet-4-6", {"type": "adaptive"}),
+    ),
+)
+def test_thinking_check_uses_rumil_thinking_config(model, expected_thinking):
+    # Records the rumil rules at the time of writing. If thinking_config
+    # changes for any of these models, this test breaks deliberately so
+    # the impact on staleness semantics gets reviewed.
+    from rumil.llm import thinking_config
+
+    assert thinking_config(model) == expected_thinking

--- a/tests/test_versus_judge_staleness.py
+++ b/tests/test_versus_judge_staleness.py
@@ -14,7 +14,7 @@ from versus.judge_config import compute_judge_code_fingerprint, make_judge_confi
 from versus import judge as versus_judge
 
 
-def _make_blind_row(*, model: str, thinking: dict | None = None) -> dict:
+def _make_blind_row(*, model: str, thinking: dict | None = None, effort: str | None = None) -> dict:
     cfg, _, _ = make_judge_config(
         "blind",
         model=model,
@@ -22,11 +22,12 @@ def _make_blind_row(*, model: str, thinking: dict | None = None) -> dict:
         sampling={"temperature": 0.0, "max_tokens": 1024},
         prompt_hash=versus_judge.compute_judge_prompt_hash("general_quality", with_tools=False),
         thinking=thinking,
+        effort=effort,
     )
     return {"judge_inputs": cfg}
 
 
-def _make_ws_row(*, model: str, thinking: dict | None) -> dict:
+def _make_ws_row(*, model: str, thinking: dict | None, effort: str | None = None) -> dict:
     cfg, _, _ = make_judge_config(
         "ws",
         model=model,
@@ -34,6 +35,7 @@ def _make_ws_row(*, model: str, thinking: dict | None) -> dict:
         sampling={"temperature": 0.0, "max_tokens": 1024},
         prompt_hash=versus_judge.compute_judge_prompt_hash("general_quality", with_tools=True),
         thinking=thinking,
+        effort=effort,
         tool_prompt_hash="11111111",
         pair_surface_hash="22222222",
         workspace_id="abcd1234",
@@ -63,6 +65,7 @@ def test_ws_row_for_opus_47_with_adaptive_thinking_is_current():
     row = _make_ws_row(
         model="claude-opus-4-7-20251001",
         thinking={"type": "adaptive", "display": "summarized"},
+        effort="xhigh",
     )
     assert versus_judge.judge_config_is_current(row, "general_quality") is True
 
@@ -104,3 +107,42 @@ def test_thinking_check_uses_rumil_thinking_config(model, expected_thinking):
     from rumil.llm import thinking_config
 
     assert thinking_config(model) == expected_thinking
+
+
+def test_blind_row_with_unexpected_effort_is_stale():
+    row = _make_blind_row(model="claude-haiku-4-5", effort="high")
+    assert versus_judge.judge_config_is_current(row, "general_quality") is False
+
+
+def test_ws_row_for_opus_47_with_xhigh_effort_is_current():
+    row = _make_ws_row(
+        model="claude-opus-4-7-20251001",
+        thinking={"type": "adaptive", "display": "summarized"},
+        effort="xhigh",
+    )
+    assert versus_judge.judge_config_is_current(row, "general_quality") is True
+
+
+def test_ws_row_for_opus_47_missing_effort_is_stale():
+    row = _make_ws_row(
+        model="claude-opus-4-7-20251001",
+        thinking={"type": "adaptive", "display": "summarized"},
+        effort=None,
+    )
+    assert versus_judge.judge_config_is_current(row, "general_quality") is False
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_effort"),
+    (
+        ("claude-haiku-4-5", None),
+        ("claude-opus-4-7-20251001", "xhigh"),
+        ("claude-sonnet-4-6", "high"),
+    ),
+)
+def test_effort_check_uses_rumil_effort_level(model, expected_effort):
+    # Same idea as the thinking version: pin current rules so silent drift
+    # in effort_level forces a deliberate test update.
+    from rumil.llm import effort_level
+
+    assert effort_level(model) == expected_effort

--- a/tests/test_versus_legacy_translators.py
+++ b/tests/test_versus_legacy_translators.py
@@ -66,7 +66,15 @@ def _judgment_row(**overrides):
         "response": None,
         "judge_inputs": {
             "model": "google/gemini-3-flash-preview",
-            "sampling": {"temperature": 0.0, "max_tokens": 2048},
+            "model_config": {
+                "temperature": 0.0,
+                "max_tokens": 2048,
+                "top_p": None,
+                "thinking": None,
+                "effort": None,
+                "max_thinking_tokens": None,
+                "service_tier": None,
+            },
             "variant": "blind",
         },
         "judge_inputs_hash": "deadbeef",

--- a/tests/test_versus_prefix_variants.py
+++ b/tests/test_versus_prefix_variants.py
@@ -22,12 +22,16 @@ from versus import config, prepare  # noqa: E402
 
 
 def _make_cfg(prefix: dict, variants: list[dict] | None = None) -> config.Config:
+    placeholder = config.VersusModelConfig(
+        sampling=config.SamplingCfg(temperature=0, max_tokens=1024)
+    )
     return config.Config(
         essays=config.EssaysCfg(),
         prefix=config.PrefixCfg(**prefix),
         prefix_variants=[config.PrefixCfg(**v) for v in (variants or [])],
         completion=config.CompletionCfg(models=[config.ModelCfg(id="m")]),
         judging=config.JudgingCfg(models=["j"]),
+        models={"m": placeholder, "j": placeholder},
         storage=config.StorageCfg(),
     )
 

--- a/tests/test_versus_retry.py
+++ b/tests/test_versus_retry.py
@@ -1,0 +1,143 @@
+"""Tests for versus.complete._with_transient_retry.
+
+Behavior pinned: retries on httpx 5xx + transient connection/timeout
+errors, passes through 4xx and non-httpx errors immediately, exhausts
+after ``max_retries + 1`` attempts and re-raises the last error.
+
+Tests use ``base_delay=0.0`` to avoid sleeping. The retry helper is
+pure (no I/O of its own — caller's ``fn`` does any I/O), so we drive
+it with stub callables that increment a counter and selectively raise.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from versus import complete
+
+
+def _make_response(status: int) -> httpx.Response:
+    return httpx.Response(status_code=status, request=httpx.Request("POST", "https://example/"))
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    resp = _make_response(status)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=resp.request, response=resp)
+
+
+def test_returns_value_on_first_attempt() -> None:
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        return "ok"
+
+    result = complete._with_transient_retry(fn, label="t", base_delay=0.0)
+
+    assert result == "ok"
+    assert calls["n"] == 1
+
+
+def test_succeeds_after_transient_5xx() -> None:
+    seq = iter([_http_status_error(503), _http_status_error(500), "ok"])
+
+    def fn():
+        item = next(seq)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    result = complete._with_transient_retry(fn, label="t", base_delay=0.0, max_retries=3)
+    assert result == "ok"
+
+
+def test_exhausts_then_reraises_last_error() -> None:
+    err = _http_status_error(500)
+
+    def fn():
+        raise err
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        complete._with_transient_retry(fn, label="t", base_delay=0.0, max_retries=2)
+
+    assert exc_info.value is err
+
+
+def test_attempt_count_is_max_retries_plus_one(mocker) -> None:
+    fn = mocker.Mock(side_effect=_http_status_error(503))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        complete._with_transient_retry(fn, label="t", base_delay=0.0, max_retries=3)
+
+    assert fn.call_count == 4
+
+
+@pytest.mark.parametrize("status", (400, 401, 403, 404, 422, 429))
+def test_4xx_is_not_retried(status: int, mocker) -> None:
+    fn = mocker.Mock(side_effect=_http_status_error(status))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        complete._with_transient_retry(fn, label="t", base_delay=0.0, max_retries=3)
+
+    assert fn.call_count == 1
+
+
+def test_non_httpx_error_is_not_retried(mocker) -> None:
+    fn = mocker.Mock(side_effect=ValueError("nope"))
+
+    with pytest.raises(ValueError):
+        complete._with_transient_retry(fn, label="t", base_delay=0.0, max_retries=3)
+
+    assert fn.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "exc_factory",
+    (
+        lambda: httpx.TimeoutException("timed out"),
+        lambda: httpx.ReadError("read failed"),
+        lambda: httpx.ConnectError("connect failed"),
+        lambda: httpx.RemoteProtocolError("protocol error"),
+    ),
+)
+def test_transient_httpx_errors_are_retried(exc_factory) -> None:
+    seq = [exc_factory(), exc_factory(), "ok"]
+    idx = {"i": 0}
+
+    def fn():
+        i = idx["i"]
+        idx["i"] += 1
+        item = seq[i]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    result = complete._with_transient_retry(fn, label="t", base_delay=0.0, max_retries=3)
+    assert result == "ok"
+
+
+def test_label_appears_in_retry_log(capsys) -> None:
+    seq = iter([_http_status_error(503), "ok"])
+
+    def fn():
+        item = next(seq)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    complete._with_transient_retry(fn, label="my-essay | claude-haiku", base_delay=0.0)
+
+    out = capsys.readouterr().out
+    assert "[retry]" in out
+    assert "my-essay | claude-haiku" in out
+    assert "503" in out
+
+
+def test_zero_max_retries_means_one_attempt(mocker) -> None:
+    fn = mocker.Mock(side_effect=_http_status_error(503))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        complete._with_transient_retry(fn, label="t", base_delay=0.0, max_retries=0)
+
+    assert fn.call_count == 1

--- a/tests/test_versus_run_summary.py
+++ b/tests/test_versus_run_summary.py
@@ -1,0 +1,138 @@
+"""Tests for versus.run_summary.RunSummary.
+
+The accumulator pulls token totals from either Anthropic-shaped
+(input_tokens / output_tokens) or OpenRouter-shaped (prompt_tokens /
+completion_tokens) usage dicts, and accepts an optional cost_usd for
+rumil-mediated paths where we have a real $ figure.
+"""
+
+from __future__ import annotations
+
+import pytest
+from versus.run_summary import RunSummary
+
+
+def test_initial_state_is_zero() -> None:
+    s = RunSummary()
+    assert s.n_done == 0
+    assert s.n_err == 0
+    assert s.in_tokens == 0
+    assert s.out_tokens == 0
+    assert s.cost_usd == 0.0
+
+
+def test_record_success_with_anthropic_usage() -> None:
+    s = RunSummary()
+    s.record_success({"usage": {"input_tokens": 1200, "output_tokens": 340}})
+    assert s.n_done == 1
+    assert s.in_tokens == 1200
+    assert s.out_tokens == 340
+
+
+def test_record_success_with_openrouter_usage() -> None:
+    s = RunSummary()
+    s.record_success({"usage": {"prompt_tokens": 800, "completion_tokens": 200}})
+    assert s.n_done == 1
+    assert s.in_tokens == 800
+    assert s.out_tokens == 200
+
+
+def test_record_success_accumulates_across_calls() -> None:
+    s = RunSummary()
+    s.record_success({"usage": {"input_tokens": 100, "output_tokens": 50}})
+    s.record_success({"usage": {"prompt_tokens": 200, "completion_tokens": 75}})
+    assert s.n_done == 2
+    assert s.in_tokens == 300
+    assert s.out_tokens == 125
+
+
+def test_record_success_with_none_response_increments_count_only() -> None:
+    s = RunSummary()
+    s.record_success(None)
+    assert s.n_done == 1
+    assert s.in_tokens == 0
+    assert s.out_tokens == 0
+
+
+def test_record_success_with_no_usage_field_is_safe() -> None:
+    s = RunSummary()
+    s.record_success({"id": "msg_123", "content": []})
+    assert s.n_done == 1
+    assert s.in_tokens == 0
+    assert s.out_tokens == 0
+
+
+@pytest.mark.parametrize("garbage", ("not-a-dict", 42, [1, 2, 3], object()))
+def test_record_success_with_non_dict_response_is_safe(garbage) -> None:
+    s = RunSummary()
+    s.record_success(garbage)
+    assert s.n_done == 1
+    assert s.in_tokens == 0
+
+
+def test_record_success_with_non_dict_usage_is_safe() -> None:
+    s = RunSummary()
+    s.record_success({"usage": "broken"})
+    assert s.n_done == 1
+    assert s.in_tokens == 0
+
+
+def test_record_success_with_cost_usd_accumulates() -> None:
+    s = RunSummary()
+    s.record_success(cost_usd=0.0123)
+    s.record_success(cost_usd=0.4567)
+    assert s.n_done == 2
+    assert s.cost_usd == pytest.approx(0.469)
+
+
+def test_record_error_increments_only_error_count() -> None:
+    s = RunSummary()
+    s.record_error()
+    s.record_error()
+    assert s.n_err == 2
+    assert s.n_done == 0
+    assert s.in_tokens == 0
+
+
+def test_print_emits_summary_line_with_label_and_counts(capsys) -> None:
+    s = RunSummary()
+    s.record_success({"usage": {"input_tokens": 1000, "output_tokens": 500}})
+    s.record_error()
+    s.print("completions")
+
+    out = capsys.readouterr().out
+    assert "[summary]" in out
+    assert "completions" in out
+    assert "1 done" in out
+    assert "1 errors" in out
+    assert "1,000" in out
+    assert "500" in out
+    assert "wall" in out
+
+
+def test_print_omits_tokens_section_when_no_tokens_recorded(capsys) -> None:
+    s = RunSummary()
+    s.record_success(None)
+    s.print("orch judgments")
+
+    out = capsys.readouterr().out
+    assert "tokens" not in out
+    assert "1 done" in out
+
+
+def test_print_includes_cost_when_nonzero(capsys) -> None:
+    s = RunSummary()
+    s.record_success(cost_usd=1.2345)
+    s.print("ws judgments")
+
+    out = capsys.readouterr().out
+    assert "$1.2345" in out
+
+
+def test_print_omits_cost_when_zero(capsys) -> None:
+    s = RunSummary()
+    s.record_success({"usage": {"input_tokens": 10, "output_tokens": 5}})
+    s.print("completions")
+
+    out = capsys.readouterr().out
+    assert "$" not in out

--- a/versus/AGENT.md
+++ b/versus/AGENT.md
@@ -11,7 +11,7 @@ Library lives at `versus/src/versus/`; CLI entry points at `versus/scripts/`; ca
 Two Postgres tables, accessed through `versus.versus_db`:
 
 - `versus_texts` — every essay-shaped contestant: human baselines and model continuations (paraphrase support is deferred, see below). Columns include `request` / `response` (raw provider-shaped JSONB for the API call that produced the text), `text` (extracted continuation), and a generated `request_hash` over the canonical request body.
-- `versus_judgments` — pairwise verdicts. `request` / `response` capture the blind judge's literal API call; `judge_inputs` is the canonical condition blob (model, sampling, prompt content, tool descriptions, pair surface, workspace state, code fingerprint, budget, closer config, plus `text_a_id` / `text_b_id` so re-judging different completion samples naturally forks). `judge_inputs_hash` is generated. `winner_source` is generated from `verdict` + `display_first` + `(source_a, source_b)`.
+- `versus_judgments` — pairwise verdicts. `request` / `response` capture the blind judge's literal API call; `judge_inputs` is the canonical condition blob (model, dimension, nested `model_config` from the per-model registry, prompt content, tool descriptions, pair surface, workspace state, code fingerprint, budget, closer config, plus `text_a_id` / `text_b_id` so re-judging different completion samples naturally forks). `judge_inputs_hash` is generated. `winner_source` is generated from `verdict` + `display_first` + `(source_a, source_b)`.
 
 JSONL archives still live under `versus/data/*.jsonl` as a frozen historical record; nothing in the current pipeline reads them. The `versus.jsonl` helper module is dormant — the deferred paraphrase code path imports it, nothing else.
 
@@ -34,11 +34,19 @@ There's no DB-level uniqueness on either table. "Skip if exists" semantics live 
 
 The blob covers, per variant:
 
-- **blind**: `model`, `dimension`, `sampling`, `prompts.shell_hash` (sha8 of the composed shell + dimension body). claude-* models route direct to Anthropic; everything else through OpenRouter.
+- **blind**: `model`, `dimension`, `model_config` (nested ModelConfig snapshot — sampling, thinking, effort, etc.), `prompts.shell_hash` (sha8 of the composed shell + dimension body). claude-* models route direct to Anthropic; everything else through OpenRouter.
 - **ws**: blind fields + `workspace_id`, `tool_descriptions_hash`, `pair_surface_hash`, `code_fingerprint`, `workspace_state_hash`.
 - **orch**: ws fields + `budget`, `closer_hash`.
 
 At write time, the runner adds `text_a_id` / `text_b_id` (and `order` for rumil rows) before computing the hash. Adding a new "thing the LLM saw" is one place: extend `make_judge_config` (and the corresponding axis in `project_config_to_axes` so the provenance panel surfaces it).
+
+## Per-model registry
+
+`versus/config.yaml` `models:` is the source of truth for what each model gets on the wire — `sampling.temperature`, `sampling.max_tokens`, `sampling.top_p`, `thinking`, `effort`, `max_thinking_tokens`, `service_tier`. Validator on Config catches typos: every model used by `completion.models` / `judging.models` must have a registry entry.
+
+`versus.model_config.get_model_config(model_id, cfg=cfg)` resolves the entry into a `rumil.model_config.ModelConfig`. `get_judge_model_config(model_id, cfg=cfg)` is the same with `cfg.judging.max_tokens` layered on top — judges typically need more output headroom than completion-purpose calls. Both are read everywhere downstream: completions, paraphrases, blind/ws/orch judges, the staleness detector, and `mainline.current_values_summary` for the provenance panel.
+
+Editing a registry entry forks `request_hash` / `judge_inputs_hash` deterministically, so prior data stays valid as the prior config and topup runs land fresh rows under the new condition. `models[<id>].sampling.max_tokens` ignored on direct-Anthropic claude-opus-4-7 because `temperature` is null — the wire kwargs builder drops null fields.
 
 ## Sources, unified
 

--- a/versus/config.yaml
+++ b/versus/config.yaml
@@ -95,6 +95,66 @@ judging:
   include_human_as_contestant: true
   max_tokens: 64000           # reasoning judges (gpt-5.4) can chew through tokens
 
+# Per-model effective config — what versus actually sends on the wire.
+# Source of truth for sampling, thinking block, effort level. Editing
+# any entry here forks model_config_hash on subsequent rows; previous
+# data stays valid as the prior config. Every model used by
+# completion.models or judging.models must have an entry below.
+#
+# Sampling notes:
+# - Anthropic models running adaptive thinking require temperature=null
+#   (Anthropic API rejects explicit temp when thinking is on).
+# - Opus 4.7 deprecates the temperature param entirely.
+#
+# Thinking + effort:
+# - Anthropic Opus 4.7 / 4.6, Sonnet 4.6 currently get adaptive thinking
+#   + effort high/xhigh. Haiku and older Sonnet don't support either.
+# - OpenRouter-routed models (gemini, gpt) don't use these blocks.
+models:
+  google/gemini-3-flash-preview:
+    sampling: { temperature: 0, max_tokens: 32000 }
+    thinking: null
+    effort: null
+  openai/gpt-5.4-mini:
+    sampling: { temperature: 0, max_tokens: 32000 }
+    thinking: null
+    effort: null
+  openai/gpt-5.4:
+    sampling: { temperature: 0, max_tokens: 64000 }   # reasoning model — extra headroom
+    thinking: null
+    effort: null
+  anthropic/claude-haiku-4-5:
+    sampling: { temperature: 0, max_tokens: 32000 }
+    thinking: null
+    effort: null
+  anthropic/claude-sonnet-4-6:
+    sampling: { temperature: null, max_tokens: 32000 }
+    thinking: { type: adaptive }
+    effort: high
+  anthropic/claude-opus-4-7:
+    sampling: { temperature: null, max_tokens: 32000 }
+    thinking: { type: adaptive, display: summarized }
+    effort: xhigh
+  google/gemini-3.1-pro-preview:
+    sampling: { temperature: 0, max_tokens: 32000 }
+    thinking: null
+    effort: null
+  # Bare-claude judge ids (route_judge_model strips anthropic/ prefix
+  # from the equivalent above; included separately so judging.models
+  # entries match by exact key).
+  claude-haiku-4-5:
+    sampling: { temperature: 0, max_tokens: 32000 }
+    thinking: null
+    effort: null
+  claude-sonnet-4-6:
+    sampling: { temperature: null, max_tokens: 32000 }
+    thinking: { type: adaptive }
+    effort: high
+  claude-opus-4-7:
+    sampling: { temperature: null, max_tokens: 32000 }
+    thinking: { type: adaptive, display: summarized }
+    effort: xhigh
+
 storage:
   # Completions and judgments live in versus_texts / versus_judgments
   # (Postgres). Only paraphrase rows still use a file log; that code path

--- a/versus/config.yaml
+++ b/versus/config.yaml
@@ -43,34 +43,20 @@ prefix_variants:
 
 completion:
   length_tolerance: 0.10 # target = original remainder word count, allow +/- this fraction
-  # Each entry is one generation model. paraphrase=true also runs the model
-  # against the paraphrase axis (paraphrasing.enabled gates that globally).
+  # Selects which models run completions and which also produce paraphrases.
+  # Per-model sampling / thinking / effort live under `models:` below — this
+  # list is just identity + the paraphrase-axis toggle.
   models:
     - id: google/gemini-3-flash-preview
-      temperature: 0
-      max_tokens: 32000
       paraphrase: true
     - id: openai/gpt-5.4-mini
-      temperature: 0
-      max_tokens: 32000
       paraphrase: true
     - id: openai/gpt-5.4
-      temperature: 0
-      max_tokens: 64000    # reasoning model: reasoning tokens count against this
       paraphrase: true
     - id: anthropic/claude-sonnet-4-6
-      temperature: 0
-      max_tokens: 32000
     - id: anthropic/claude-opus-4-7
-      temperature: 0
-      max_tokens: 32000    # opus 4.7 deprecates explicit temperature; complete.py
-                           # drops it (and top_p) when routing direct to Anthropic
     - id: anthropic/claude-haiku-4-5
-      temperature: 0
-      max_tokens: 32000
     - id: google/gemini-3.1-pro-preview
-      temperature: 0
-      max_tokens: 32000
 
 paraphrasing:
   enabled: true

--- a/versus/scripts/run_completions.py
+++ b/versus/scripts/run_completions.py
@@ -1,15 +1,17 @@
-"""Run completions for all cached essays.
+"""Run completions for the canonical active essay set.
+
+Default scope is the same gate ``/versus`` applies: current
+``schema_version`` and not in ``cfg.essays.exclude_ids``. Pass
+``--include-stale`` to instead run over every essay returned by the
+source fetchers (minus ``exclude_ids``) — useful for backfill or
+debugging old-schema rows.
 
 Filters mirror run_judgments.py so targeted runs are possible without
 editing config.yaml:
   --model <id>    (repeatable)  restrict to specific completion models
   --essay <id>    (repeatable)  restrict to specific essays
-  --active                      canonical eval set only (current schema, not excluded)
+  --include-stale               run over all fetched essays, not just the active set
   --prefix-label <id>           target a specific prefix variant (default: canonical)
-
-``cfg.essays.exclude_ids`` is always honored, so excluded essays never
-get completions even without ``--active``. Run from any cwd — paths
-resolve relative to versus/.
 """
 
 from __future__ import annotations
@@ -86,12 +88,14 @@ def main() -> None:
         help="Restrict to specified essay_id(s). Repeatable.",
     )
     ap.add_argument(
-        "--active",
+        "--include-stale",
         action="store_true",
         help=(
-            "Restrict to the canonical active set: current schema_version and "
-            "not in cfg.essays.exclude_ids. Same gate /versus applies. "
-            "Composes with --essay (both act as filters)."
+            "Default behavior is the canonical active set (current "
+            "schema_version, not in cfg.essays.exclude_ids — same gate "
+            "/versus applies). Pass this to run over every fetched essay "
+            "instead, including off-feed or old-schema rows. "
+            "exclude_ids is still honored."
         ),
     )
     ap.add_argument(
@@ -134,11 +138,11 @@ def main() -> None:
     exclude = set(cfg.essays.exclude_ids)
     essays = [e for e in essays if e.id not in exclude]
 
-    if args.active:
-        # --active is a hard list of the canonical eval set, not an
-        # intersection with fetch_all. Active essays that have rolled
-        # off the source's live feed but are still valid in cache should
-        # be loaded directly so the run honors --active in full.
+    if not args.include_stale:
+        # Default: restrict to the canonical eval set. This is a hard
+        # list, not an intersection with fetch_all — active essays that
+        # have rolled off the source's live feed but are still valid in
+        # cache get loaded directly so the run honors --active in full.
         active = prepare.active_essay_ids(
             cfg.essays.exclude_ids, client=versus_db.get_client(prod=args.prod)
         )
@@ -146,7 +150,7 @@ def main() -> None:
         for missing_id in sorted(active - fetched_ids):
             cached = _load_essay_from_cache(cfg.essays.cache_dir, missing_id)
             if cached is None:
-                print(f"[warn] --active {missing_id}: not in cache or schema mismatch; skipping")
+                print(f"[warn] active {missing_id}: not in cache or schema mismatch; skipping")
                 continue
             print(f"[essay] {missing_id}: loaded from cache (off live feed)")
             essays.append(cached)

--- a/versus/scripts/run_completions.py
+++ b/versus/scripts/run_completions.py
@@ -121,6 +121,11 @@ def main() -> None:
         action="store_true",
         help="Target the production Supabase database (default: local).",
     )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned completion calls and exit without firing API requests.",
+    )
     args = ap.parse_args()
 
     cfg = config.load(args.config)
@@ -187,7 +192,7 @@ def main() -> None:
     target = "prod" if args.prod else "local"
     for prefix_cfg in prefix_cfgs:
         print(f"[prefix] using variant {prefix_cfg.id!r} (db={target})")
-        complete.run(cfg, essays, prefix_cfg=prefix_cfg, prod=args.prod)
+        complete.run(cfg, essays, prefix_cfg=prefix_cfg, prod=args.prod, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/versus/scripts/run_completions.py
+++ b/versus/scripts/run_completions.py
@@ -22,6 +22,7 @@ import pathlib
 import sys
 
 VERSUS_ROOT = pathlib.Path(__file__).resolve().parent.parent
+RUMIL_ROOT = VERSUS_ROOT.parent
 
 sys.path.insert(0, str(VERSUS_ROOT / "src"))
 
@@ -34,12 +35,18 @@ except ModuleNotFoundError:
     sys.stderr.write(
         "[err] rumil isn't importable from this venv. Run from the rumil "
         "repo root, not versus/:\n"
-        f"      cd {VERSUS_ROOT.parent} && uv run python versus/scripts/run_completions.py ...\n"
+        f"      cd {RUMIL_ROOT} && uv run python versus/scripts/run_completions.py ...\n"
     )
     raise SystemExit(1) from None
 
-from versus import complete, config, prepare, sources, versus_db  # noqa: E402
+from versus import complete, config, envcascade, prepare, sources, versus_db  # noqa: E402
 from versus import essay as versus_essay  # noqa: E402
+
+envcascade.apply(
+    ("ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"),
+    versus_root=VERSUS_ROOT,
+    rumil_root=RUMIL_ROOT,
+)
 
 
 def _load_essay_from_cache(cache_dir: pathlib.Path, essay_id: str) -> versus_essay.Essay | None:

--- a/versus/scripts/run_paraphrases.py
+++ b/versus/scripts/run_paraphrases.py
@@ -16,6 +16,7 @@ import pathlib
 import sys
 
 VERSUS_ROOT = pathlib.Path(__file__).resolve().parent.parent
+RUMIL_ROOT = VERSUS_ROOT.parent
 
 sys.path.insert(0, str(VERSUS_ROOT / "src"))
 
@@ -25,11 +26,17 @@ except ModuleNotFoundError:
     sys.stderr.write(
         "[err] rumil isn't importable from this venv. Run from the rumil "
         "repo root, not versus/:\n"
-        f"      cd {VERSUS_ROOT.parent} && uv run python versus/scripts/run_paraphrases.py ...\n"
+        f"      cd {RUMIL_ROOT} && uv run python versus/scripts/run_paraphrases.py ...\n"
     )
     raise SystemExit(1) from None
 
-from versus import config, paraphrase, prepare, sources  # noqa: E402
+from versus import config, envcascade, paraphrase, prepare, sources  # noqa: E402
+
+envcascade.apply(
+    ("ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"),
+    versus_root=VERSUS_ROOT,
+    rumil_root=RUMIL_ROOT,
+)
 
 
 def main() -> None:

--- a/versus/scripts/run_paraphrases.py
+++ b/versus/scripts/run_paraphrases.py
@@ -1,11 +1,12 @@
-"""Generate model paraphrases for all cached essays.
+"""Generate model paraphrases for the canonical active essay set.
+
+Default scope is the same gate ``/versus`` applies: current
+``schema_version`` and not in ``cfg.essays.exclude_ids``. Pass
+``--include-stale`` to instead run over every essay returned by the
+source fetchers (minus ``exclude_ids``).
 
   --essay <id>    (repeatable)  restrict to specific essays
-  --active                      canonical eval set only (current schema, not excluded)
-
-``cfg.essays.exclude_ids`` is always honored, so excluded essays never
-get paraphrases even without ``--active``. Run from any cwd — paths
-resolve relative to versus/.
+  --include-stale               run over all fetched essays, not just the active set
 """
 
 from __future__ import annotations
@@ -41,11 +42,14 @@ def main() -> None:
         help="Restrict to specified essay_id(s). Repeatable.",
     )
     ap.add_argument(
-        "--active",
+        "--include-stale",
         action="store_true",
         help=(
-            "Restrict to the canonical active set: current schema_version and "
-            "not in cfg.essays.exclude_ids. Same gate /versus applies."
+            "Default behavior is the canonical active set (current "
+            "schema_version, not in cfg.essays.exclude_ids — same gate "
+            "/versus applies). Pass this to run over every fetched essay "
+            "instead, including off-feed or old-schema rows. "
+            "exclude_ids is still honored."
         ),
     )
     args = ap.parse_args()
@@ -66,7 +70,7 @@ def main() -> None:
     exclude = set(cfg.essays.exclude_ids)
     essays = [e for e in essays if e.id not in exclude]
 
-    if args.active:
+    if not args.include_stale:
         active = prepare.active_essay_ids(cfg.essays.exclude_ids)
         essays = [e for e in essays if e.id in active]
     if args.essay:

--- a/versus/scripts/run_paraphrases.py
+++ b/versus/scripts/run_paraphrases.py
@@ -59,6 +59,11 @@ def main() -> None:
             "exclude_ids is still honored."
         ),
     )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned paraphrase calls and exit without firing API requests.",
+    )
     args = ap.parse_args()
 
     cfg = config.load(args.config)
@@ -84,7 +89,7 @@ def main() -> None:
         keep = set(args.essay)
         essays = [e for e in essays if e.id in keep]
 
-    paraphrase.run(cfg, essays)
+    paraphrase.run(cfg, essays, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/versus/scripts/run_rumil_judgments.py
+++ b/versus/scripts/run_rumil_judgments.py
@@ -187,8 +187,12 @@ def main() -> None:
         action="store_true",
         help=(
             "Target the production Supabase database for versus_texts / "
-            "versus_judgments (default: local). Blind path only — ws/orch "
-            "still hit local rumil DB."
+            "versus_judgments AND, on ws/orch, the rumil workspace + run "
+            "tables (default: local for both). On ws/orch, the workspace "
+            "named via --workspace must already exist on the target DB "
+            "(typo protection — create via rumil main.py first). ws/orch "
+            "runs are still staged by default; pass --persist to write the "
+            "per-pair Question + research subtree to baseline."
         ),
     )
     ap.add_argument(
@@ -264,13 +268,6 @@ def main() -> None:
     if not args.workspace:
         ap.error(f"--workspace is required for --variant {args.variant}")
 
-    if args.prod:
-        ap.error(
-            f"--prod is not yet wired through --variant {args.variant}; "
-            "the blind path is the only prod-aware judge today. ws/orch "
-            "would need DB.create(prod=...) plumbing in rumil_judge.py too."
-        )
-
     if prefix_cfgs is not None and len(prefix_cfgs) > 1:
         ap.error(
             f"--variant {args.variant} takes at most one --prefix-label "
@@ -296,6 +293,7 @@ def main() -> None:
                 current_only=args.current_only,
                 prefix_cfg=prefix_cfg_one,
                 persist=args.persist,
+                prod=args.prod,
             )
         )
     elif args.variant == "orch":
@@ -315,6 +313,7 @@ def main() -> None:
                 current_only=args.current_only,
                 prefix_cfg=prefix_cfg_one,
                 persist=args.persist,
+                prod=args.prod,
             )
         )
 

--- a/versus/scripts/run_rumil_judgments.py
+++ b/versus/scripts/run_rumil_judgments.py
@@ -135,12 +135,14 @@ def main() -> None:
         help="Restrict planning to specified essay_id(s). Repeatable. Honored on blind, ws, and orch.",
     )
     ap.add_argument(
-        "--active",
+        "--include-stale",
         action="store_true",
         help=(
-            "Restrict to the canonical active set: current schema_version "
-            "and not in cfg.essays.exclude_ids. Same gate /versus applies. "
-            "Composes with --essay (intersected)."
+            "Default behavior is the canonical active set (current "
+            "schema_version, not in cfg.essays.exclude_ids — same gate "
+            "/versus applies). Pass this to plan against every essay "
+            "with rows in versus_texts instead, including off-feed or "
+            "old-schema rows. Composes with --essay (intersected)."
         ),
     )
     ap.add_argument(
@@ -212,13 +214,13 @@ def main() -> None:
     if not cfg.essays.cache_dir.is_absolute():
         cfg.essays.cache_dir = VERSUS_ROOT / cfg.essays.cache_dir
 
-    if args.active:
+    if args.include_stale:
+        essay_ids = args.essay
+    else:
         active = prepare.active_essay_ids(
             cfg.essays.exclude_ids, client=versus_db.get_client(prod=args.prod)
         )
         essay_ids = sorted(active & set(args.essay)) if args.essay else sorted(active)
-    else:
-        essay_ids = args.essay
 
     prefix_cfgs = (
         [prepare.resolve_prefix_cfg(cfg, label) for label in args.prefix_label]

--- a/versus/src/versus/anthropic_client.py
+++ b/versus/src/versus/anthropic_client.py
@@ -45,8 +45,17 @@ def chat(
     client: httpx.Client | None = None,
     retries: int = 2,
     system: str | None = None,
+    thinking: dict | None = None,
+    output_config: dict | None = None,
 ) -> dict:
-    """Return full response JSON. Retries on transient empty-text failures."""
+    """Return full response JSON. Retries on transient empty-text failures.
+
+    ``thinking`` is the Anthropic adaptive/extended-thinking dict (e.g.
+    ``{"type": "adaptive"}``) or None. ``output_config`` carries
+    ``{"effort": "..."}`` when applicable. Both default to None — pass
+    them explicitly when the versus model registry says the model
+    should run with them.
+    """
     payload: dict = {
         "model": model,
         "messages": messages,
@@ -58,6 +67,10 @@ def chat(
         payload["top_p"] = top_p
     if system is not None:
         payload["system"] = system
+    if thinking is not None:
+        payload["thinking"] = thinking
+    if output_config is not None:
+        payload["output_config"] = output_config
 
     close = client is None
     client = client or httpx.Client(timeout=timeout)

--- a/versus/src/versus/complete.py
+++ b/versus/src/versus/complete.py
@@ -205,6 +205,10 @@ def _call_one_completion_inner(task, prompt, m, request_body, client):
             "duration_s": round(time.time() - t0, 2),
             "ts": dt.datetime.utcnow().isoformat() + "Z",
             "provider": provider,
+            # Direct anthropic_client doesn't send a thinking block; record
+            # explicitly so future callers can tell. See rumil.llm.thinking_config
+            # for the rules that apply on bridge paths.
+            "thinking": None,
         },
     }
 

--- a/versus/src/versus/complete.py
+++ b/versus/src/versus/complete.py
@@ -11,9 +11,11 @@ from typing import Any
 
 import httpx
 
+from rumil.model_config import ModelConfig
 from versus import anthropic_client, config, openrouter, prepare, versus_db
 from versus import essay as versus_essay
 from versus.judge import route_judge_model
+from versus.model_config import get_model_config
 from versus.run_summary import RunSummary
 
 HUMAN_SOURCE_ID = "human"
@@ -35,39 +37,21 @@ def extract_continuation(text: str) -> str:
     return text.strip()
 
 
-def build_request_body(
-    model_id: str,
-    prompt: str,
-    *,
-    temperature: float | None,
-    top_p: float | None,
-    max_tokens: int | None,
-    thinking: dict[str, Any] | None,
-    output_config: dict[str, Any] | None,
-) -> dict[str, Any]:
+def build_request_body(model_id: str, prompt: str, *, cfg: ModelConfig) -> dict[str, Any]:
     """The canonical 'what we asked for' dict — used for both dedup hashing and storage.
 
-    Provider-shaped (OpenAI/Anthropic-compatible). Independent of the exact
-    on-wire bytes the SDK constructs (those vary across SDK versions and
-    aren't part of the eval condition).
-
-    ``thinking`` and ``output_config`` always appear in the dict (None or
-    populated) so the canonical hash forks if direct-path callers ever start
-    sending either. Today versus.anthropic_client doesn't include them on the
-    wire — None records the actual condition, not a hypothetical.
+    Provider-shaped (OpenAI/Anthropic-compatible). The recorded request
+    body always includes the full ``ModelConfig`` snapshot
+    (sampling + thinking + effort) so request_hash forks deterministically
+    on any registry change. Independent of the exact on-wire bytes the
+    SDK constructs (those vary across SDK versions and aren't part of
+    the eval condition).
     """
     body: dict[str, Any] = {
         "model": model_id,
         "messages": [{"role": "user", "content": prompt}],
-        "thinking": thinking,
-        "output_config": output_config,
+        "model_config": cfg.to_record_dict(),
     }
-    if temperature is not None:
-        body["temperature"] = temperature
-    if top_p is not None:
-        body["top_p"] = top_p
-    if max_tokens is not None:
-        body["max_tokens"] = max_tokens
     return body
 
 
@@ -107,17 +91,6 @@ def ensure_human_baseline(
         params={"target_words": task.target_words},
     )
     existing.add(key)
-
-
-def _model_sampling(m: config.ModelCfg, canonical_model: str) -> tuple[float | None, float | None]:
-    """Resolve (temperature, top_p) honoring per-provider quirks.
-
-    Opus 4.7 deprecates explicit temperature on Messages (returns 400); top_p
-    behaviour isn't documented, so drop both out of caution.
-    """
-    if canonical_model.startswith("claude-opus-4-7"):
-        return None, None
-    return m.temperature, m.top_p
 
 
 _TRANSIENT_HTTPX_ERRORS = (
@@ -166,33 +139,38 @@ def _call_one_completion(
     request_body,
     client,
     semaphore: threading.BoundedSemaphore,
+    mc: ModelConfig,
 ):
     with semaphore:
-        return _call_one_completion_inner(task, prompt, m, request_body, client)
+        return _call_one_completion_inner(task, prompt, m, request_body, client, mc)
 
 
-def _call_one_completion_inner(task, prompt, m, request_body, client):
+def _call_one_completion_inner(task, prompt, m, request_body, client, mc: ModelConfig):
     t0 = time.time()
     provider, canonical_model = route_judge_model(m.id)
-    temp, top_p = _model_sampling(m, canonical_model)
+    output_cfg = {"effort": mc.effort} if mc.effort is not None else None
 
     def _provider_call():
         if provider == "anthropic":
             r = anthropic_client.chat(
                 model=canonical_model,
                 messages=[{"role": "user", "content": prompt}],
-                temperature=temp,
-                max_tokens=m.max_tokens,
-                top_p=top_p,
+                temperature=mc.temperature,
+                max_tokens=mc.max_tokens,
+                top_p=mc.top_p,
+                thinking=mc.thinking,
+                output_config=output_cfg,
                 client=client,
             )
             return r, anthropic_client.extract_text(r)
+        # OpenRouter ignores thinking/output_config; registry entries for
+        # OpenRouter-routed models have them as None anyway.
         r = openrouter.chat(
             model=canonical_model,
             messages=[{"role": "user", "content": prompt}],
-            temperature=m.temperature,
-            max_tokens=m.max_tokens,
-            top_p=m.top_p,
+            temperature=mc.temperature,
+            max_tokens=mc.max_tokens,
+            top_p=mc.top_p,
             client=client,
         )
         return r, openrouter.extract_text(r)
@@ -214,12 +192,10 @@ def _call_one_completion_inner(task, prompt, m, request_body, client):
             "duration_s": round(time.time() - t0, 2),
             "ts": dt.datetime.utcnow().isoformat() + "Z",
             "provider": provider,
-            # Direct anthropic_client doesn't send a thinking block or
-            # output_config.effort; record both explicitly so future callers
-            # can tell. See rumil.llm.thinking_config / effort_level for the
-            # rules that apply on bridge paths.
-            "thinking": None,
-            "effort": None,
+            # The full ModelConfig snapshot from the versus registry. Folded
+            # into request_hash via build_request_body too; recorded here in
+            # params for direct introspection without re-hashing.
+            "model_config": mc.to_record_dict(),
         },
     }
 
@@ -252,44 +228,32 @@ def run(
             tolerance=cfg.completion.length_tolerance,
         )
         for m in cfg.completion.models:
-            _, canonical_model = route_judge_model(m.id)
-            temp, top_p = _model_sampling(m, canonical_model)
-            # thinking/output_config: direct anthropic_client doesn't send
-            # either today, so the canonical request records None. The fields
-            # sit in the body so a future flip naturally forks request_hash.
-            request_body = build_request_body(
-                m.id,
-                prompt,
-                temperature=temp,
-                top_p=top_p,
-                max_tokens=m.max_tokens,
-                thinking=None,
-                output_config=None,
-            )
+            mc = get_model_config(m.id, cfg=cfg)
+            request_body = build_request_body(m.id, prompt, cfg=mc)
             request_hash = versus_db.compute_canonical_hash(request_body)
             key = (task.essay_id, m.id, request_hash)
             if key in existing:
                 print(f"[skip] {task.essay_id} | {m.id} | {request_hash[:12]}")
                 continue
-            tasks_to_run.append((task, prompt, m, request_body))
+            tasks_to_run.append((task, prompt, m, request_body, mc))
             existing.add(key)
 
     if not tasks_to_run:
         return
     if dry_run:
-        models_in_plan = sorted({m.id for _, _, m, _ in tasks_to_run})
+        models_in_plan = sorted({m.id for _, _, m, _, _ in tasks_to_run})
         print(
             f"[plan] {len(tasks_to_run)} completion calls "
             f"(per_model_concurrency={cfg.per_model_concurrency}, "
             f"models={len(models_in_plan)})"
         )
-        for task, _prompt, m, _rb in tasks_to_run:
+        for task, _prompt, m, _rb, _mc in tasks_to_run:
             print(f"  * {task.essay_id} | {m.id}")
         return
     # Per-model semaphores so a slow reasoning model can't block fast lanes.
     semaphores: dict[str, threading.BoundedSemaphore] = {
         m_id: threading.BoundedSemaphore(cfg.per_model_concurrency)
-        for m_id in {m.id for _, _, m, _ in tasks_to_run}
+        for m_id in {m.id for _, _, m, _, _ in tasks_to_run}
     }
     total_workers = cfg.per_model_concurrency * len(semaphores)
     print(
@@ -302,8 +266,8 @@ def run(
     try:
         with ThreadPoolExecutor(max_workers=total_workers) as pool:
             futures = {
-                pool.submit(_call_one_completion, t, p, m, rb, http, semaphores[m.id]): (t, m)
-                for (t, p, m, rb) in tasks_to_run
+                pool.submit(_call_one_completion, t, p, m, rb, http, semaphores[m.id], mc): (t, m)
+                for (t, p, m, rb, mc) in tasks_to_run
             }
             for fut in as_completed(futures):
                 t_essay_id, m = futures[fut][0].essay_id, futures[fut][1]

--- a/versus/src/versus/complete.py
+++ b/versus/src/versus/complete.py
@@ -305,4 +305,4 @@ def run(
                 print(f"[done] {row['essay_id']} | {m.id}")
     finally:
         http.close()
-    summary.print("completions")
+        summary.print("completions")

--- a/versus/src/versus/complete.py
+++ b/versus/src/versus/complete.py
@@ -14,6 +14,7 @@ import httpx
 from versus import anthropic_client, config, openrouter, prepare, versus_db
 from versus import essay as versus_essay
 from versus.judge import route_judge_model
+from versus.run_summary import RunSummary
 
 HUMAN_SOURCE_ID = "human"
 
@@ -110,6 +111,45 @@ def _model_sampling(m: config.ModelCfg, canonical_model: str) -> tuple[float | N
     return m.temperature, m.top_p
 
 
+_TRANSIENT_HTTPX_ERRORS = (
+    httpx.TimeoutException,
+    httpx.ReadError,
+    httpx.ConnectError,
+    httpx.RemoteProtocolError,
+)
+
+
+def _with_transient_retry(fn, *, label: str, max_retries: int = 3, base_delay: float = 2.0):
+    """Retry transient errors (5xx, timeouts, connection drops) with exponential backoff.
+
+    base_delay * 2**attempt → 2s, 4s, 8s for attempts 0/1/2. 4xx errors and
+    other exceptions are not retried — they're not transient.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            return fn()
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status < 500 or attempt >= max_retries:
+                raise
+            wait = base_delay * (2**attempt)
+            print(
+                f"[retry] {label}: {status} "
+                f"(attempt {attempt + 1}/{max_retries + 1}, sleeping {wait:.0f}s)"
+            )
+            time.sleep(wait)
+        except _TRANSIENT_HTTPX_ERRORS as e:
+            if attempt >= max_retries:
+                raise
+            wait = base_delay * (2**attempt)
+            print(
+                f"[retry] {label}: {type(e).__name__} "
+                f"(attempt {attempt + 1}/{max_retries + 1}, sleeping {wait:.0f}s)"
+            )
+            time.sleep(wait)
+    raise RuntimeError("unreachable")  # pyright: ignore[reportUnreachable]
+
+
 def _call_one_completion(
     task,
     prompt,
@@ -126,18 +166,19 @@ def _call_one_completion_inner(task, prompt, m, request_body, client):
     t0 = time.time()
     provider, canonical_model = route_judge_model(m.id)
     temp, top_p = _model_sampling(m, canonical_model)
-    if provider == "anthropic":
-        resp = anthropic_client.chat(
-            model=canonical_model,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=temp,
-            max_tokens=m.max_tokens,
-            top_p=top_p,
-            client=client,
-        )
-        raw_text = anthropic_client.extract_text(resp)
-    else:
-        resp = openrouter.chat(
+
+    def _provider_call():
+        if provider == "anthropic":
+            r = anthropic_client.chat(
+                model=canonical_model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=temp,
+                max_tokens=m.max_tokens,
+                top_p=top_p,
+                client=client,
+            )
+            return r, anthropic_client.extract_text(r)
+        r = openrouter.chat(
             model=canonical_model,
             messages=[{"role": "user", "content": prompt}],
             temperature=m.temperature,
@@ -145,7 +186,9 @@ def _call_one_completion_inner(task, prompt, m, request_body, client):
             top_p=m.top_p,
             client=client,
         )
-        raw_text = openrouter.extract_text(resp)
+        return r, openrouter.extract_text(r)
+
+    resp, raw_text = _with_transient_retry(_provider_call, label=f"{task.essay_id} | {m.id}")
     text = extract_continuation(raw_text)
     return {
         "essay_id": task.essay_id,
@@ -172,6 +215,7 @@ def run(
     *,
     prefix_cfg: config.PrefixCfg | None = None,
     prod: bool = False,
+    dry_run: bool = False,
 ) -> None:
     pcfg = prefix_cfg if prefix_cfg is not None else cfg.prefix
     db = versus_db.get_client(prod=prod)
@@ -185,7 +229,8 @@ def run(
             include_headers=pcfg.include_headers,
             length_tolerance=cfg.completion.length_tolerance,
         )
-        ensure_human_baseline(db, task, existing)
+        if not dry_run:
+            ensure_human_baseline(db, task, existing)
         prompt = prepare.render_prompt(
             task,
             include_headers=pcfg.include_headers,
@@ -207,6 +252,16 @@ def run(
 
     if not tasks_to_run:
         return
+    if dry_run:
+        models_in_plan = sorted({m.id for _, _, m, _ in tasks_to_run})
+        print(
+            f"[plan] {len(tasks_to_run)} completion calls "
+            f"(per_model_concurrency={cfg.per_model_concurrency}, "
+            f"models={len(models_in_plan)})"
+        )
+        for task, _prompt, m, _rb in tasks_to_run:
+            print(f"  * {task.essay_id} | {m.id}")
+        return
     # Per-model semaphores so a slow reasoning model can't block fast lanes.
     semaphores: dict[str, threading.BoundedSemaphore] = {
         m_id: threading.BoundedSemaphore(cfg.per_model_concurrency)
@@ -218,6 +273,7 @@ def run(
         f"(per_model_concurrency={cfg.per_model_concurrency}, "
         f"models={len(semaphores)}, total_workers={total_workers})"
     )
+    summary = RunSummary()
     http = httpx.Client(timeout=600.0)
     try:
         with ThreadPoolExecutor(max_workers=total_workers) as pool:
@@ -231,6 +287,7 @@ def run(
                     row = fut.result()
                 except Exception as e:
                     print(f"[err ] {t_essay_id} | {m.id}: {e}")
+                    summary.record_error()
                     continue
                 versus_db.insert_text(
                     db,
@@ -244,6 +301,8 @@ def run(
                     response=row["response"],
                     params=row["params"],
                 )
+                summary.record_success(row.get("response"))
                 print(f"[done] {row['essay_id']} | {m.id}")
     finally:
         http.close()
+    summary.print("completions")

--- a/versus/src/versus/complete.py
+++ b/versus/src/versus/complete.py
@@ -42,16 +42,25 @@ def build_request_body(
     temperature: float | None,
     top_p: float | None,
     max_tokens: int | None,
+    thinking: dict[str, Any] | None,
+    output_config: dict[str, Any] | None,
 ) -> dict[str, Any]:
     """The canonical 'what we asked for' dict — used for both dedup hashing and storage.
 
     Provider-shaped (OpenAI/Anthropic-compatible). Independent of the exact
     on-wire bytes the SDK constructs (those vary across SDK versions and
     aren't part of the eval condition).
+
+    ``thinking`` and ``output_config`` always appear in the dict (None or
+    populated) so the canonical hash forks if direct-path callers ever start
+    sending either. Today versus.anthropic_client doesn't include them on the
+    wire — None records the actual condition, not a hypothetical.
     """
     body: dict[str, Any] = {
         "model": model_id,
         "messages": [{"role": "user", "content": prompt}],
+        "thinking": thinking,
+        "output_config": output_config,
     }
     if temperature is not None:
         body["temperature"] = temperature
@@ -205,10 +214,12 @@ def _call_one_completion_inner(task, prompt, m, request_body, client):
             "duration_s": round(time.time() - t0, 2),
             "ts": dt.datetime.utcnow().isoformat() + "Z",
             "provider": provider,
-            # Direct anthropic_client doesn't send a thinking block; record
-            # explicitly so future callers can tell. See rumil.llm.thinking_config
-            # for the rules that apply on bridge paths.
+            # Direct anthropic_client doesn't send a thinking block or
+            # output_config.effort; record both explicitly so future callers
+            # can tell. See rumil.llm.thinking_config / effort_level for the
+            # rules that apply on bridge paths.
             "thinking": None,
+            "effort": None,
         },
     }
 
@@ -243,8 +254,17 @@ def run(
         for m in cfg.completion.models:
             _, canonical_model = route_judge_model(m.id)
             temp, top_p = _model_sampling(m, canonical_model)
+            # thinking/output_config: direct anthropic_client doesn't send
+            # either today, so the canonical request records None. The fields
+            # sit in the body so a future flip naturally forks request_hash.
             request_body = build_request_body(
-                m.id, prompt, temperature=temp, top_p=top_p, max_tokens=m.max_tokens
+                m.id,
+                prompt,
+                temperature=temp,
+                top_p=top_p,
+                max_tokens=m.max_tokens,
+                thinking=None,
+                output_config=None,
             )
             request_hash = versus_db.compute_canonical_hash(request_body)
             key = (task.essay_id, m.id, request_hash)

--- a/versus/src/versus/config.py
+++ b/versus/src/versus/config.py
@@ -31,10 +31,13 @@ class PrefixCfg(pydantic.BaseModel):
 
 
 class ModelCfg(pydantic.BaseModel):
+    """Per-model entry in ``completion.models`` — selects the model and its
+    paraphrase axis flag. Sampling / thinking / effort live in the
+    registry under ``Config.models[id]``; we keep this entry minimal so
+    the registry is the unambiguous source of truth.
+    """
+
     id: str
-    temperature: float = 0.7
-    max_tokens: int = 4000
-    top_p: float | None = None
     # When True, this model also produces paraphrases (in addition to
     # completions). Default False so the same list serves the completion
     # axis directly while paraphrases stay opt-in per-model.

--- a/versus/src/versus/config.py
+++ b/versus/src/versus/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+from typing import Any
 
 import pydantic
 import yaml
@@ -56,6 +57,29 @@ class JudgingCfg(pydantic.BaseModel):
     max_tokens: int = 32000
 
 
+class SamplingCfg(pydantic.BaseModel):
+    temperature: float | None
+    max_tokens: int
+    top_p: float | None = None
+
+
+class VersusModelConfig(pydantic.BaseModel):
+    """Per-model effective config that versus applies on the wire.
+
+    Source of truth for what gets sent to the provider — sampling
+    defaults, Anthropic thinking block, effort level. Direct paths
+    (completions, paraphrases, blind judge) and bridge paths (ws/orch)
+    both read from this registry, so a single yaml edit changes the
+    effective condition everywhere consistently. The recorded
+    ``model_config_hash`` on each row forks naturally on any change,
+    keeping old rows reproducible.
+    """
+
+    sampling: SamplingCfg
+    thinking: dict[str, Any] | None = None
+    effort: str | None = None
+
+
 class StorageCfg(pydantic.BaseModel):
     # Completions and judgments live in versus_texts / versus_judgments
     # (Postgres) — see versus.versus_db. Only the dormant paraphrase code
@@ -74,6 +98,13 @@ class Config(pydantic.BaseModel):
     completion: CompletionCfg
     paraphrasing: ParaphrasingCfg = pydantic.Field(default_factory=ParaphrasingCfg)
     judging: JudgingCfg
+    # Per-model effective config registry, keyed by model id. Every
+    # model that appears in ``completion.models`` or ``judging.models``
+    # must have an entry here (validated on load). Source of truth for
+    # what versus actually sends; both direct and bridge call paths
+    # read from this registry rather than recomputing from rumil's
+    # implicit rules.
+    models: dict[str, VersusModelConfig] = pydantic.Field(default_factory=dict)
     storage: StorageCfg
     concurrency: int = 20
     # Per-model concurrency cap. Each unique completion/judge model id
@@ -89,6 +120,25 @@ class Config(pydantic.BaseModel):
         dupes = {i for i in ids if ids.count(i) > 1}
         if dupes:
             raise ValueError(f"duplicate prefix variant ids: {sorted(dupes)}")
+        return self
+
+    @pydantic.model_validator(mode="after")
+    def _check_model_registry_coverage(self) -> Config:
+        """Every model used by completion / judging needs a registry entry.
+
+        Catches typos and forgotten registry updates at load time rather
+        than at first-call time when the row would silently fall back to
+        rumil's implicit rules.
+        """
+        used: set[str] = {m.id for m in self.completion.models}
+        used.update(self.judging.models)
+        missing = sorted(used - set(self.models.keys()))
+        if missing:
+            raise ValueError(
+                "config.models is missing entries for: "
+                + ", ".join(missing)
+                + ". Add a per-model VersusModelConfig under `models:` for each."
+            )
         return self
 
 

--- a/versus/src/versus/config.py
+++ b/versus/src/versus/config.py
@@ -57,7 +57,15 @@ class JudgingCfg(pydantic.BaseModel):
     models: list[str]
     criteria: list[str] = pydantic.Field(default_factory=lambda: ["standalone_quality"])
     include_human_as_contestant: bool = True
-    max_tokens: int = 32000
+    # Purpose-specific override of ``models[<id>].sampling.max_tokens``
+    # for judge calls (blind, ws, orch). Reasoning judges (gpt-5.4,
+    # claude with thinking on) need more output headroom than
+    # completion-purpose calls on the same model. None means "use the
+    # registry's per-model max_tokens"; a value layers as
+    # ``replace(model_config, max_tokens=...)`` at each judge call site.
+    # Applied uniformly across judge models — for per-model judging
+    # caps, upgrade to a nested per-purpose registry shape.
+    max_tokens: int | None = 64000
 
 
 class SamplingCfg(pydantic.BaseModel):

--- a/versus/src/versus/config.py
+++ b/versus/src/versus/config.py
@@ -66,18 +66,27 @@ class SamplingCfg(pydantic.BaseModel):
 class VersusModelConfig(pydantic.BaseModel):
     """Per-model effective config that versus applies on the wire.
 
-    Source of truth for what gets sent to the provider — sampling
-    defaults, Anthropic thinking block, effort level. Direct paths
-    (completions, paraphrases, blind judge) and bridge paths (ws/orch)
-    both read from this registry, so a single yaml edit changes the
-    effective condition everywhere consistently. The recorded
+    Source of truth for what gets sent to the provider — sampling,
+    Anthropic thinking block, effort level, optional max-thinking
+    budget, optional service tier. Direct paths (completions,
+    paraphrases, blind judge) and bridge paths (ws/orch) both read
+    from this registry, so a single yaml edit changes the effective
+    condition everywhere consistently. The recorded
     ``model_config_hash`` on each row forks naturally on any change,
     keeping old rows reproducible.
+
+    Forward-looking optional fields (top_k, stop_sequences, etc.) get
+    added here when they become relevant. ``service_tier`` is most
+    useful on prod (``"priority"`` for cost-tolerant lower-latency
+    runs); ``max_thinking_tokens`` caps explicit thinking budget when
+    a model supports extended thinking with a budget knob.
     """
 
     sampling: SamplingCfg
     thinking: dict[str, Any] | None = None
     effort: str | None = None
+    max_thinking_tokens: int | None = None
+    service_tier: str | None = None
 
 
 class StorageCfg(pydantic.BaseModel):

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -129,12 +129,16 @@ def build_blind_judge_config(
     """
     from versus.judge_config import make_judge_config
 
+    # Blind path uses versus.anthropic_client directly, which never sends a
+    # thinking block. Recording None explicitly so the dedup hash forks if
+    # blind ever starts sending one.
     return make_judge_config(
         "blind",
         model=canonical_model,
         dimension=dimension,
         sampling=sampling,
         prompt_hash=compute_judge_prompt_hash(dimension, with_tools=False),
+        thinking=None,
     )
 
 
@@ -147,10 +151,14 @@ def judge_config_is_current(row: dict, criterion: str) -> bool:
 
     Checks the prompt shell hash for all variants, plus the
     ``code_fingerprint`` for ws/orch — that fingerprint catches semantic
-    non-prompt edits (parser changes, SDK migrations, etc.). Doesn't
+    non-prompt edits (parser changes, SDK migrations, etc.) — and the
+    ``thinking`` block (None for blind, ``rumil.llm.thinking_config`` for
+    ws/orch) so changes to thinking rules surface as stale rows. Doesn't
     check ``workspace_state_hash``: that's a per-row baseline watermark,
     not a staleness signal — every row would flap.
     """
+    from rumil.llm import thinking_config
+
     cfg = row["judge_inputs"]
     is_tools = cfg["variant"] in ("ws", "orch")
     try:
@@ -165,6 +173,9 @@ def judge_config_is_current(row: dict, criterion: str) -> bool:
 
         if cfg.get("code_fingerprint") != compute_judge_code_fingerprint():
             return False
+    expected_thinking = None if cfg["variant"] == "blind" else thinking_config(cfg["model"])
+    if cfg.get("thinking") != expected_thinking:
+        return False
     return True
 
 

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -130,8 +130,8 @@ def build_blind_judge_config(
     from versus.judge_config import make_judge_config
 
     # Blind path uses versus.anthropic_client directly, which never sends a
-    # thinking block. Recording None explicitly so the dedup hash forks if
-    # blind ever starts sending one.
+    # thinking block or output_config.effort. Recording None explicitly so the
+    # dedup hash forks if blind ever starts sending either.
     return make_judge_config(
         "blind",
         model=canonical_model,
@@ -139,6 +139,7 @@ def build_blind_judge_config(
         sampling=sampling,
         prompt_hash=compute_judge_prompt_hash(dimension, with_tools=False),
         thinking=None,
+        effort=None,
     )
 
 
@@ -151,13 +152,14 @@ def judge_config_is_current(row: dict, criterion: str) -> bool:
 
     Checks the prompt shell hash for all variants, plus the
     ``code_fingerprint`` for ws/orch — that fingerprint catches semantic
-    non-prompt edits (parser changes, SDK migrations, etc.) — and the
-    ``thinking`` block (None for blind, ``rumil.llm.thinking_config`` for
-    ws/orch) so changes to thinking rules surface as stale rows. Doesn't
-    check ``workspace_state_hash``: that's a per-row baseline watermark,
-    not a staleness signal — every row would flap.
+    non-prompt edits (parser changes, SDK migrations, etc.) — and both
+    the ``thinking`` block and ``effort`` level (None for blind, the
+    rules-driven values from ``rumil.llm`` for ws/orch) so changes to
+    those rules surface as stale rows. Doesn't check
+    ``workspace_state_hash``: that's a per-row baseline watermark, not
+    a staleness signal — every row would flap.
     """
-    from rumil.llm import thinking_config
+    from rumil.llm import effort_level, thinking_config
 
     cfg = row["judge_inputs"]
     is_tools = cfg["variant"] in ("ws", "orch")
@@ -173,8 +175,12 @@ def judge_config_is_current(row: dict, criterion: str) -> bool:
 
         if cfg.get("code_fingerprint") != compute_judge_code_fingerprint():
             return False
-    expected_thinking = None if cfg["variant"] == "blind" else thinking_config(cfg["model"])
+    is_blind = cfg["variant"] == "blind"
+    expected_thinking = None if is_blind else thinking_config(cfg["model"])
     if cfg.get("thinking") != expected_thinking:
+        return False
+    expected_effort = None if is_blind else effort_level(cfg["model"])
+    if cfg.get("effort") != expected_effort:
         return False
     return True
 

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -107,10 +107,7 @@ def route_judge_model(model: str) -> tuple[Provider, str]:
 def build_blind_judge_config(
     canonical_model: str,
     dimension: str,
-    sampling: dict,
-    *,
-    thinking: dict | None = None,
-    effort: str | None = None,
+    model_config: ModelConfig,
 ) -> tuple[dict, str, str]:
     """Build ``(config, config_hash, judge_model)`` for one blind judgment.
 
@@ -120,11 +117,9 @@ def build_blind_judge_config(
     of truth. The returned ``config_hash`` is computed independently of
     DB-side text_a_id/text_b_id; callers fold those in before persisting.
 
-    ``thinking`` and ``effort`` come from the versus model registry —
-    blind path now applies them on the wire (via versus.anthropic_client),
-    so judge_inputs records what was actually sent. Defaults are None
-    for the no-thinking / no-effort case (most non-claude models, plus
-    haiku and older sonnet).
+    ``model_config`` is the registry-resolved ModelConfig versus applies
+    on the wire — sampling, thinking, effort, etc. The whole bundle
+    lives under ``judge_inputs.model_config`` and feeds the dedup hash.
     """
     from versus.judge_config import make_judge_config
 
@@ -132,14 +127,12 @@ def build_blind_judge_config(
         "blind",
         model=canonical_model,
         dimension=dimension,
-        sampling=sampling,
+        model_config=model_config,
         prompt_hash=compute_judge_prompt_hash(dimension, with_tools=False),
-        thinking=thinking,
-        effort=effort,
     )
 
 
-def judge_config_is_current(row: dict, criterion: str) -> bool:
+def judge_config_is_current(row: dict, criterion: str, *, cfg: config.Config | None = None) -> bool:
     """Return False if any code-side input to the judge has drifted.
 
     Status.py uses this to surface stale rows in the STALE banner.
@@ -148,35 +141,36 @@ def judge_config_is_current(row: dict, criterion: str) -> bool:
 
     Checks the prompt shell hash for all variants, plus the
     ``code_fingerprint`` for ws/orch — that fingerprint catches semantic
-    non-prompt edits (parser changes, SDK migrations, etc.) — and both
-    the ``thinking`` block and ``effort`` level (None for blind, the
-    rules-driven values from ``rumil.llm`` for ws/orch) so changes to
-    those rules surface as stale rows. Doesn't check
+    non-prompt edits (parser changes, SDK migrations, etc.) — and the
+    full ``model_config`` snapshot against the versus model registry,
+    so any registry edit (sampling, thinking, effort, max_thinking_tokens,
+    service_tier) surfaces as stale rows. Doesn't check
     ``workspace_state_hash``: that's a per-row baseline watermark, not
     a staleness signal — every row would flap.
     """
-    from rumil.llm import effort_level, thinking_config
+    from versus.model_config import get_model_config
 
-    cfg = row["judge_inputs"]
-    is_tools = cfg["variant"] in ("ws", "orch")
+    inputs = row["judge_inputs"]
+    is_tools = inputs["variant"] in ("ws", "orch")
     try:
         expected_ph = compute_judge_prompt_hash(criterion, with_tools=is_tools)
     except ValueError:
         return False
-    if cfg["prompts"]["shell_hash"] != expected_ph:
+    if inputs["prompts"]["shell_hash"] != expected_ph:
         return False
     if is_tools:
         # circular: rumil.versus_bridge -> versus.judge_config -> versus.judge
         from versus.judge_config import compute_judge_code_fingerprint
 
-        if cfg.get("code_fingerprint") != compute_judge_code_fingerprint():
+        if inputs.get("code_fingerprint") != compute_judge_code_fingerprint():
             return False
-    is_blind = cfg["variant"] == "blind"
-    expected_thinking = None if is_blind else thinking_config(cfg["model"])
-    if cfg.get("thinking") != expected_thinking:
+    try:
+        expected_mc = get_model_config(inputs["model"], cfg=cfg)
+    except KeyError:
+        # Model no longer in the registry; row references a config that
+        # versus can't reproduce. Stale by definition.
         return False
-    expected_effort = None if is_blind else effort_level(cfg["model"])
-    if cfg.get("effort") != expected_effort:
+    if inputs.get("model_config") != expected_mc.to_record_dict():
         return False
     return True
 
@@ -567,17 +561,10 @@ def run_blind(
                 for base_model in models:
                     provider, canonical_model = route_judge_model(base_model)
                     mc = get_model_config(base_model, cfg=cfg)
-                    sampling = {
-                        "temperature": mc.temperature,
-                        "max_tokens": mc.max_tokens,
-                    }
                     base_config, _, judge_model = build_blind_judge_config(
-                        canonical_model,
-                        dimension,
-                        sampling,
-                        thinking=mc.thinking,
-                        effort=mc.effort,
+                        canonical_model, dimension, mc
                     )
+                    sampling = {"temperature": mc.temperature, "max_tokens": mc.max_tokens}
                     judge_inputs, judge_inputs_hash = _build_judge_inputs(
                         base_config, src_a.text_id, src_b.text_id, order
                     )

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -34,7 +34,7 @@ from rumil.versus_prompts import (
     label_to_verdict,
 )
 from versus import anthropic_client, config, openrouter, versus_db
-from versus.model_config import get_model_config
+from versus.model_config import get_judge_model_config
 from versus.run_summary import RunSummary
 
 Provider = Literal["anthropic", "openrouter"]
@@ -153,7 +153,6 @@ def judge_config_is_current(row: dict, criterion: str, *, cfg: config.Config | N
     ``workspace_state_hash``: that's a per-row baseline watermark, not
     a staleness signal — every row would flap.
     """
-    from versus.model_config import get_model_config
 
     inputs = row["judge_inputs"]
     is_tools = inputs["variant"] in ("ws", "orch")
@@ -170,7 +169,7 @@ def judge_config_is_current(row: dict, criterion: str, *, cfg: config.Config | N
         if inputs.get("code_fingerprint") != compute_judge_code_fingerprint():
             return False
     try:
-        expected_mc = get_model_config(inputs["model"], cfg=cfg)
+        expected_mc = get_judge_model_config(inputs["model"], cfg=cfg)
     except KeyError:
         # Model no longer in the registry; row references a config that
         # versus can't reproduce. Stale by definition.
@@ -563,7 +562,7 @@ def run_blind(
             for dimension in effective_dimensions:
                 for base_model in models:
                     provider, canonical_model = route_judge_model(base_model)
-                    mc = get_model_config(base_model, cfg=cfg)
+                    mc = get_judge_model_config(base_model, cfg=cfg)
                     base_config, _, judge_model = build_blind_judge_config(
                         canonical_model, dimension, mc
                     )

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -174,9 +174,7 @@ def judge_config_is_current(row: dict, criterion: str, *, cfg: config.Config | N
         # Model no longer in the registry; row references a config that
         # versus can't reproduce. Stale by definition.
         return False
-    if inputs.get("model_config") != expected_mc.to_record_dict():
-        return False
-    return True
+    return inputs.get("model_config") == expected_mc.to_record_dict()
 
 
 def parse_verdict_from_label(text: str) -> tuple[str | None, str | None]:
@@ -251,9 +249,7 @@ def is_refusal(row: dict) -> bool:
         if fr in REFUSAL_FINISH_REASONS or nfr in REFUSAL_NATIVE_REASONS:
             return True
     text = (row.get("text") or "").strip()
-    if not text or len(text.split()) < _MIN_RESPONSE_WORDS:
-        return True
-    return False
+    return not text or len(text.split()) < _MIN_RESPONSE_WORDS
 
 
 def _prefix_text_from_request(request: dict | None) -> str:
@@ -348,7 +344,6 @@ class _BlindTask:
     system_prompt: str
     user_prompt: str
     order: Order
-    sampling: dict
     model_config: ModelConfig
     judge_inputs: dict  # canonical condition blob — hash is judge_inputs_hash
     judge_inputs_hash: str
@@ -380,7 +375,7 @@ def _build_judge_request(
     canonical_model: str,
     system_prompt: str,
     user_prompt: str,
-    sampling: dict,
+    model_config: ModelConfig,
 ) -> dict[str, Any]:
     """Canonical provider-shaped request body for storage on the row.
 
@@ -397,10 +392,10 @@ def _build_judge_request(
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
         ]
-    if sampling.get("temperature") is not None:
-        body["temperature"] = sampling["temperature"]
-    if sampling.get("max_tokens") is not None:
-        body["max_tokens"] = sampling["max_tokens"]
+    if model_config.temperature is not None:
+        body["temperature"] = model_config.temperature
+    if model_config.max_tokens is not None:
+        body["max_tokens"] = model_config.max_tokens
     return body
 
 
@@ -443,7 +438,7 @@ def _call_one_blind(task: _BlindTask, client: httpx.Client) -> dict:
         canonical_model=task.canonical_model,
         system_prompt=task.system_prompt,
         user_prompt=task.user_prompt,
-        sampling=task.sampling,
+        model_config=task.model_config,
     )
     return {
         "essay_id": task.essay_id,
@@ -566,7 +561,6 @@ def run_blind(
                     base_config, _, judge_model = build_blind_judge_config(
                         canonical_model, dimension, mc
                     )
-                    sampling = {"temperature": mc.temperature, "max_tokens": mc.max_tokens}
                     judge_inputs, judge_inputs_hash = _build_judge_inputs(
                         base_config, src_a.text_id, src_b.text_id, order
                     )
@@ -604,7 +598,6 @@ def run_blind(
                             system_prompt=system_prompt,
                             user_prompt=user_prompt,
                             order=order,
-                            sampling=sampling,
                             model_config=mc,
                             judge_inputs=judge_inputs,
                             judge_inputs_hash=judge_inputs_hash,

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -47,6 +47,11 @@ class Source:
     source_id: str  # "human" or the model id
     text: str  # the completion text
     text_id: str  # versus_texts.id — threaded through so judgments can FK to it
+    # SHA256 hash of versus_texts.request->'model_config'. Distinguishes
+    # rows produced under different registry configs (same source_id,
+    # different conditions). NULL for legacy rows that predate the
+    # registry. Aggregations / UI can use this to bucket variants.
+    model_config_hash: str | None = None
 
 
 def pair_order_seed(essay_id: str, a: str, b: str) -> int:
@@ -318,6 +323,7 @@ def load_sources_by_essay(
             source_id=row["source_id"],
             text=row["text"],
             text_id=row["id"],
+            model_config_hash=row.get("model_config_hash"),
         )
     if skipped:
         for essay_id, source_id in skipped:

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -33,6 +33,7 @@ from rumil.versus_prompts import (
     label_to_verdict,
 )
 from versus import anthropic_client, config, openrouter, versus_db
+from versus.run_summary import RunSummary
 
 Provider = Literal["anthropic", "openrouter"]
 
@@ -614,6 +615,7 @@ def run_blind(
             print(f"  ... and {len(tasks) - 20} more")
         return
 
+    summary = RunSummary()
     http = httpx.Client(timeout=600.0)
     try:
         with ThreadPoolExecutor(max_workers=total_workers) as pool:
@@ -631,6 +633,7 @@ def run_blind(
                     row = fut.result()
                 except Exception as e:
                     print(f"[err ] {t.essay_id} {t.a_id} vs {t.b_id} [{t.dimension}]: {e}")
+                    summary.record_error()
                     continue
                 versus_db.insert_judgment(
                     db,
@@ -653,12 +656,14 @@ def run_blind(
                     duration_s=row["duration_s"],
                 )
                 done += 1
+                summary.record_success(row.get("response"))
                 print(
                     f"[done {done}/{total}] {t.essay_id} {t.a_id} vs {t.b_id} "
                     f"[{t.dimension}] verdict={row['verdict']}"
                 )
     finally:
         http.close()
+    summary.print("blind judgments")
 
 
 def _call_with_semaphore(sem: threading.BoundedSemaphore, fn, *args, **kwargs):

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -25,6 +25,7 @@ from typing import Any, Literal
 
 import httpx
 
+from rumil.model_config import ModelConfig
 from rumil.versus_prompts import (
     build_system_prompt,
     compute_prompt_hash,
@@ -33,6 +34,7 @@ from rumil.versus_prompts import (
     label_to_verdict,
 )
 from versus import anthropic_client, config, openrouter, versus_db
+from versus.model_config import get_model_config
 from versus.run_summary import RunSummary
 
 Provider = Literal["anthropic", "openrouter"]
@@ -102,22 +104,13 @@ def route_judge_model(model: str) -> tuple[Provider, str]:
     return ("openrouter", model)
 
 
-def _sampling_for(provider: Provider, canonical_model: str, max_tokens: int) -> dict:
-    """Per-provider sampling defaults.
-
-    Anthropic-direct: temperature is omitted for opus 4.7 (the Messages API
-    deprecated the param and 400s on it); 0.0 elsewhere. OpenRouter: always
-    0.0. Folded into the judge_inputs blob so a topup at a different temp
-    forks the hash and re-judges.
-    """
-    if provider == "anthropic":
-        use_temp = None if canonical_model.startswith("claude-opus-4-7") else 0.0
-        return {"temperature": use_temp, "max_tokens": max_tokens}
-    return {"temperature": JUDGE_TEMPERATURE, "max_tokens": max_tokens}
-
-
 def build_blind_judge_config(
-    canonical_model: str, dimension: str, sampling: dict
+    canonical_model: str,
+    dimension: str,
+    sampling: dict,
+    *,
+    thinking: dict | None = None,
+    effort: str | None = None,
 ) -> tuple[dict, str, str]:
     """Build ``(config, config_hash, judge_model)`` for one blind judgment.
 
@@ -126,20 +119,23 @@ def build_blind_judge_config(
     config dict and the legacy-shape ``judge_model`` come from one source
     of truth. The returned ``config_hash`` is computed independently of
     DB-side text_a_id/text_b_id; callers fold those in before persisting.
+
+    ``thinking`` and ``effort`` come from the versus model registry —
+    blind path now applies them on the wire (via versus.anthropic_client),
+    so judge_inputs records what was actually sent. Defaults are None
+    for the no-thinking / no-effort case (most non-claude models, plus
+    haiku and older sonnet).
     """
     from versus.judge_config import make_judge_config
 
-    # Blind path uses versus.anthropic_client directly, which never sends a
-    # thinking block or output_config.effort. Recording None explicitly so the
-    # dedup hash forks if blind ever starts sending either.
     return make_judge_config(
         "blind",
         model=canonical_model,
         dimension=dimension,
         sampling=sampling,
         prompt_hash=compute_judge_prompt_hash(dimension, with_tools=False),
-        thinking=None,
-        effort=None,
+        thinking=thinking,
+        effort=effort,
     )
 
 
@@ -357,6 +353,7 @@ class _BlindTask:
     user_prompt: str
     order: Order
     sampling: dict
+    model_config: ModelConfig
     judge_inputs: dict  # canonical condition blob — hash is judge_inputs_hash
     judge_inputs_hash: str
 
@@ -414,25 +411,33 @@ def _build_judge_request(
 def _call_one_blind(task: _BlindTask, client: httpx.Client) -> dict:
     """Run one blind judgment, dispatching by provider, return DB-shaped row."""
     t0 = time.time()
+    mc = task.model_config
+    output_cfg = {"effort": mc.effort} if mc.effort is not None else None
     if task.provider == "anthropic":
         resp = anthropic_client.chat(
             model=task.canonical_model,
             system=task.system_prompt,
             messages=[{"role": "user", "content": task.user_prompt}],
-            temperature=task.sampling["temperature"],
-            max_tokens=task.sampling["max_tokens"],
+            temperature=mc.temperature,
+            max_tokens=mc.max_tokens,
+            top_p=mc.top_p,
+            thinking=mc.thinking,
+            output_config=output_cfg,
             client=client,
         )
         text = anthropic_client.extract_text(resp)
     else:
+        # OpenRouter path: thinking / output_config aren't supported here;
+        # registry entries for OpenRouter-routed judges set them to None.
         resp = openrouter.chat(
             model=task.canonical_model,
             messages=[
                 {"role": "system", "content": task.system_prompt},
                 {"role": "user", "content": task.user_prompt},
             ],
-            temperature=task.sampling["temperature"],
-            max_tokens=task.sampling["max_tokens"],
+            temperature=mc.temperature,
+            max_tokens=mc.max_tokens,
+            top_p=mc.top_p,
             client=client,
         )
         text = openrouter.extract_text(resp)
@@ -561,9 +566,17 @@ def run_blind(
             for dimension in effective_dimensions:
                 for base_model in models:
                     provider, canonical_model = route_judge_model(base_model)
-                    sampling = _sampling_for(provider, canonical_model, cfg.judging.max_tokens)
+                    mc = get_model_config(base_model, cfg=cfg)
+                    sampling = {
+                        "temperature": mc.temperature,
+                        "max_tokens": mc.max_tokens,
+                    }
                     base_config, _, judge_model = build_blind_judge_config(
-                        canonical_model, dimension, sampling
+                        canonical_model,
+                        dimension,
+                        sampling,
+                        thinking=mc.thinking,
+                        effort=mc.effort,
                     )
                     judge_inputs, judge_inputs_hash = _build_judge_inputs(
                         base_config, src_a.text_id, src_b.text_id, order
@@ -603,6 +616,7 @@ def run_blind(
                             user_prompt=user_prompt,
                             order=order,
                             sampling=sampling,
+                            model_config=mc,
                             judge_inputs=judge_inputs,
                             judge_inputs_hash=judge_inputs_hash,
                         )

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -663,7 +663,7 @@ def run_blind(
                 )
     finally:
         http.close()
-    summary.print("blind judgments")
+        summary.print("blind judgments")
 
 
 def _call_with_semaphore(sem: threading.BoundedSemaphore, fn, *args, **kwargs):

--- a/versus/src/versus/judge.py
+++ b/versus/src/versus/judge.py
@@ -331,9 +331,6 @@ def load_sources_by_essay(
     return groups, prefix_text_by_group
 
 
-JUDGE_TEMPERATURE = 0.0
-
-
 @dataclass(frozen=True)
 class _BlindTask:
     essay_id: str

--- a/versus/src/versus/judge_config.py
+++ b/versus/src/versus/judge_config.py
@@ -169,6 +169,7 @@ def make_judge_config(
     sampling: dict[str, Any] | None,
     prompt_hash: str,
     thinking: dict[str, Any] | None,
+    effort: str | None,
     tool_prompt_hash: str | None = None,
     pair_surface_hash: str | None = None,
     workspace_id: str | None = None,
@@ -185,12 +186,16 @@ def make_judge_config(
     string.
 
     ``thinking`` is the Anthropic thinking-block dict (e.g. ``{"type":
-    "adaptive"}``) or ``None``. Direct anthropic_client paths (blind)
-    pass ``None`` because they don't send a thinking block. Bridge
-    paths (ws/orch) pass the dict that ``rumil.llm.thinking_config``
-    returns for the model — the same dict that lands on the wire.
-    Recorded so changes to thinking rules naturally fork the dedup
-    hash; see CLAUDE.local.md "Records" principle.
+    "adaptive"}``) or ``None``. ``effort`` is the reasoning-effort
+    string (e.g. ``"xhigh"``, ``"high"``) wrapped as
+    ``output_config.effort`` on the request, or ``None``. Direct
+    anthropic_client paths (blind) pass ``None`` for both because
+    they don't send those blocks. Bridge paths (ws/orch) pass the
+    dict / string that ``rumil.llm.thinking_config`` and
+    ``rumil.llm.effort_level`` return for the model — what actually
+    lands on the wire. Both are folded into the canonical config so
+    rule changes naturally fork the dedup hash; see CLAUDE.local.md
+    "Records" principle.
 
     Per-variant required args (asserted):
     - blind: ``sampling``, ``prompt_hash``
@@ -204,6 +209,7 @@ def make_judge_config(
         "dimension": dimension,
         "sampling": dict(sampling) if sampling is not None else None,
         "thinking": dict(thinking) if thinking is not None else None,
+        "effort": effort,
         "prompts": {"shell_hash": prompt_hash},
     }
     if variant in ("ws", "orch"):
@@ -275,6 +281,8 @@ def project_config_to_axes(
             json.dumps(thinking, sort_keys=True, default=str).encode()
         ).hexdigest()[:8]
         out["judge_thinking_hash"] = f"t{th_hash}"
+    if (effort := config.get("effort")) is not None:
+        out["judge_effort"] = f"e{effort}"
     if variant in ("ws", "orch"):
         out["judge_workspace_id"] = config["workspace_id"]
         out["judge_tool_hash"] = f"t{config['tool_descriptions_hash']}"

--- a/versus/src/versus/judge_config.py
+++ b/versus/src/versus/judge_config.py
@@ -26,6 +26,8 @@ import pathlib
 from collections.abc import Sequence
 from typing import Any, Literal
 
+from rumil.model_config import ModelConfig
+
 Variant = Literal["blind", "ws", "orch"]
 
 
@@ -166,10 +168,8 @@ def make_judge_config(
     *,
     model: str,
     dimension: str,
-    sampling: dict[str, Any] | None,
+    model_config: ModelConfig,
     prompt_hash: str,
-    thinking: dict[str, Any] | None,
-    effort: str | None,
     tool_prompt_hash: str | None = None,
     pair_surface_hash: str | None = None,
     workspace_id: str | None = None,
@@ -185,20 +185,15 @@ def make_judge_config(
     primitive, ``judge_model`` is a short human-readable display
     string.
 
-    ``thinking`` is the Anthropic thinking-block dict (e.g. ``{"type":
-    "adaptive"}``) or ``None``. ``effort`` is the reasoning-effort
-    string (e.g. ``"xhigh"``, ``"high"``) wrapped as
-    ``output_config.effort`` on the request, or ``None``. Direct
-    anthropic_client paths (blind) pass ``None`` for both because
-    they don't send those blocks. Bridge paths (ws/orch) pass the
-    dict / string that ``rumil.llm.thinking_config`` and
-    ``rumil.llm.effort_level`` return for the model — what actually
-    lands on the wire. Both are folded into the canonical config so
-    rule changes naturally fork the dedup hash; see CLAUDE.local.md
-    "Records" principle.
+    ``model_config`` is the full rumil ``ModelConfig`` versus applied
+    on the wire — sampling, thinking, effort, max_thinking_tokens,
+    service_tier. Stored canonically as a nested ``model_config`` dict
+    on the row; the dedup hash forks naturally on any field change.
+    Direct paths (blind) build it from the versus model registry;
+    bridge paths (ws/orch) do too — single source of truth.
 
     Per-variant required args (asserted):
-    - blind: ``sampling``, ``prompt_hash``
+    - blind: ``model_config``, ``prompt_hash``
     - ws: blind + ``workspace_id``, ``tool_prompt_hash``, ``pair_surface_hash``,
       ``code_fingerprint``, ``workspace_state_hash``
     - orch: ws + ``budget``, ``closer_hash``
@@ -207,9 +202,7 @@ def make_judge_config(
         "variant": variant,
         "model": model,
         "dimension": dimension,
-        "sampling": dict(sampling) if sampling is not None else None,
-        "thinking": dict(thinking) if thinking is not None else None,
-        "effort": effort,
+        "model_config": model_config.to_record_dict(),
         "prompts": {"shell_hash": prompt_hash},
     }
     if variant in ("ws", "orch"):
@@ -272,17 +265,14 @@ def project_config_to_axes(
         "judge_dimension": config["dimension"],
         "judge_prompt_hash": f"p{config['prompts']['shell_hash']}",
     }
-    if (sh := compute_sampling_hash(config.get("sampling"))) is not None:
-        out["judge_sampling_hash"] = f"s{sh}"
-    if (thinking := config.get("thinking")) is not None:
-        # Same shape as sampling: short content hash so changing thinking rules
-        # surfaces as a fresh axis bucket in mainline rollups.
-        th_hash = hashlib.sha256(
-            json.dumps(thinking, sort_keys=True, default=str).encode()
-        ).hexdigest()[:8]
-        out["judge_thinking_hash"] = f"t{th_hash}"
-    if (effort := config.get("effort")) is not None:
-        out["judge_effort"] = f"e{effort}"
+    # The full ModelConfig hash collapses sampling/thinking/effort/etc
+    # into one axis. Editing any field of the registry forks this hash
+    # naturally, so cross-config rollups stay distinct.
+    if (mc := config.get("model_config")) is not None:
+        mc_hash = hashlib.sha256(json.dumps(mc, sort_keys=True, default=str).encode()).hexdigest()[
+            :8
+        ]
+        out["judge_model_config_hash"] = f"m{mc_hash}"
     if variant in ("ws", "orch"):
         out["judge_workspace_id"] = config["workspace_id"]
         out["judge_tool_hash"] = f"t{config['tool_descriptions_hash']}"

--- a/versus/src/versus/judge_config.py
+++ b/versus/src/versus/judge_config.py
@@ -144,25 +144,6 @@ def compute_config_hash(config: dict[str, Any]) -> str:
     return hashlib.sha256(blob.encode()).hexdigest()[:16]
 
 
-def compute_sampling_hash(sampling: dict | None) -> str | None:
-    """Short deterministic hash of sampling params for judge_model dedup.
-
-    Sorted-key JSON so key order doesn't fork the hash. Returns None when
-    ``sampling`` is None. 8 hex chars is enough to distinguish
-    temperature / max_tokens combos without cluttering the key.
-
-    Per CLAUDE.local.md: "if some judgements were made at 0 or at 0.2
-    temp, we want that to be in the data." Without folding sampling
-    into the dedup key, a ``--topup`` at a different temperature
-    silently no-ops against existing rows judged at the old
-    temperature.
-    """
-    if sampling is None:
-        return None
-    blob = json.dumps(sampling, sort_keys=True, default=str)
-    return hashlib.sha256(blob.encode()).hexdigest()[:8]
-
-
 def make_judge_config(
     variant: Variant,
     *,

--- a/versus/src/versus/judge_config.py
+++ b/versus/src/versus/judge_config.py
@@ -168,6 +168,7 @@ def make_judge_config(
     dimension: str,
     sampling: dict[str, Any] | None,
     prompt_hash: str,
+    thinking: dict[str, Any] | None,
     tool_prompt_hash: str | None = None,
     pair_surface_hash: str | None = None,
     workspace_id: str | None = None,
@@ -183,6 +184,14 @@ def make_judge_config(
     primitive, ``judge_model`` is a short human-readable display
     string.
 
+    ``thinking`` is the Anthropic thinking-block dict (e.g. ``{"type":
+    "adaptive"}``) or ``None``. Direct anthropic_client paths (blind)
+    pass ``None`` because they don't send a thinking block. Bridge
+    paths (ws/orch) pass the dict that ``rumil.llm.thinking_config``
+    returns for the model — the same dict that lands on the wire.
+    Recorded so changes to thinking rules naturally fork the dedup
+    hash; see CLAUDE.local.md "Records" principle.
+
     Per-variant required args (asserted):
     - blind: ``sampling``, ``prompt_hash``
     - ws: blind + ``workspace_id``, ``tool_prompt_hash``, ``pair_surface_hash``,
@@ -194,6 +203,7 @@ def make_judge_config(
         "model": model,
         "dimension": dimension,
         "sampling": dict(sampling) if sampling is not None else None,
+        "thinking": dict(thinking) if thinking is not None else None,
         "prompts": {"shell_hash": prompt_hash},
     }
     if variant in ("ws", "orch"):
@@ -258,6 +268,13 @@ def project_config_to_axes(
     }
     if (sh := compute_sampling_hash(config.get("sampling"))) is not None:
         out["judge_sampling_hash"] = f"s{sh}"
+    if (thinking := config.get("thinking")) is not None:
+        # Same shape as sampling: short content hash so changing thinking rules
+        # surfaces as a fresh axis bucket in mainline rollups.
+        th_hash = hashlib.sha256(
+            json.dumps(thinking, sort_keys=True, default=str).encode()
+        ).hexdigest()[:8]
+        out["judge_thinking_hash"] = f"t{th_hash}"
     if variant in ("ws", "orch"):
         out["judge_workspace_id"] = config["workspace_id"]
         out["judge_tool_hash"] = f"t{config['tool_descriptions_hash']}"

--- a/versus/src/versus/mainline.py
+++ b/versus/src/versus/mainline.py
@@ -117,6 +117,7 @@ def current_values_summary(cfg: versus_config.Config) -> dict[str, list[str]]:
     )
     from versus import judge as versus_judge
     from versus.judge_config import make_judge_config, project_config_to_axes
+    from versus.model_config import get_model_config
 
     out: dict[str, set[str]] = {axis: set() for axis in AXES_ORDER}
     thash = compute_tool_prompt_hash()
@@ -125,14 +126,14 @@ def current_values_summary(cfg: versus_config.Config) -> dict[str, list[str]]:
 
     for criterion in cfg.judging.criteria:
         for model in cfg.judging.models:
-            provider, canonical = versus_judge.route_judge_model(model)
-            sampling = versus_judge._sampling_for(provider, canonical, cfg.judging.max_tokens)
+            _, canonical = versus_judge.route_judge_model(model)
+            mc = get_model_config(model, cfg=cfg)
             samples = []
             blind_cfg, _, _ = make_judge_config(
                 "blind",
                 model=canonical,
                 dimension=criterion,
-                sampling=sampling,
+                model_config=mc,
                 prompt_hash=versus_judge.compute_judge_prompt_hash(criterion, with_tools=False),
             )
             samples.append(blind_cfg)
@@ -141,7 +142,7 @@ def current_values_summary(cfg: versus_config.Config) -> dict[str, list[str]]:
                 "ws",
                 model=canonical,
                 dimension=criterion,
-                sampling=sampling,
+                model_config=mc,
                 prompt_hash=tools_ph,
                 tool_prompt_hash=thash,
                 pair_surface_hash=qhash,
@@ -154,7 +155,7 @@ def current_values_summary(cfg: versus_config.Config) -> dict[str, list[str]]:
                 "orch",
                 model=canonical,
                 dimension=criterion,
-                sampling=sampling,
+                model_config=mc,
                 prompt_hash=tools_ph,
                 tool_prompt_hash=thash,
                 pair_surface_hash=qhash,

--- a/versus/src/versus/mainline.py
+++ b/versus/src/versus/mainline.py
@@ -45,7 +45,11 @@ AXIS_DESCRIPTIONS: dict[str, str] = {
         "body, with or without the workspace-tools section). Bumps "
         "when any of the source files change."
     ),
-    "judge_sampling_hash": ("Hash of model sampling params (temperature, max_tokens, top_p)."),
+    "judge_model_config_hash": (
+        "Hash of the per-model registry config (sampling, thinking, effort, "
+        "max_thinking_tokens, service_tier) — the full ``ModelConfig`` "
+        "snapshot. Bumps on any registry edit for the judge model."
+    ),
     "judge_tool_hash": (
         "Hash of the {tool_name -> description} map for the workspace "
         "exploration tools. ws/orch only."

--- a/versus/src/versus/mainline.py
+++ b/versus/src/versus/mainline.py
@@ -117,7 +117,7 @@ def current_values_summary(cfg: versus_config.Config) -> dict[str, list[str]]:
     )
     from versus import judge as versus_judge
     from versus.judge_config import make_judge_config, project_config_to_axes
-    from versus.model_config import get_model_config
+    from versus.model_config import get_judge_model_config
 
     out: dict[str, set[str]] = {axis: set() for axis in AXES_ORDER}
     thash = compute_tool_prompt_hash()
@@ -127,7 +127,7 @@ def current_values_summary(cfg: versus_config.Config) -> dict[str, list[str]]:
     for criterion in cfg.judging.criteria:
         for model in cfg.judging.models:
             _, canonical = versus_judge.route_judge_model(model)
-            mc = get_model_config(model, cfg=cfg)
+            mc = get_judge_model_config(model, cfg=cfg)
             samples = []
             blind_cfg, _, _ = make_judge_config(
                 "blind",

--- a/versus/src/versus/model_config.py
+++ b/versus/src/versus/model_config.py
@@ -44,3 +44,25 @@ def get_model_config(model_id: str, *, cfg: versus_config.Config | None = None) 
         max_thinking_tokens=entry.max_thinking_tokens,
         service_tier=entry.service_tier,
     )
+
+
+def get_judge_model_config(
+    model_id: str, *, cfg: versus_config.Config | None = None
+) -> ModelConfig:
+    """``get_model_config`` with the judge-purpose max_tokens override applied.
+
+    Judges typically need more output headroom than completions on the
+    same model (reasoning judges chew through tokens). The registry
+    holds a sane completion-purpose default; this layer replaces
+    ``max_tokens`` with ``cfg.judging.max_tokens`` when set, leaving
+    everything else (temperature, thinking, effort, etc.) intact.
+    """
+    if cfg is None:
+        cfg = versus_config.load("config.yaml")
+    mc = get_model_config(model_id, cfg=cfg)
+    override = cfg.judging.max_tokens
+    if override is not None and override != mc.max_tokens:
+        from dataclasses import replace
+
+        mc = replace(mc, max_tokens=override)
+    return mc

--- a/versus/src/versus/model_config.py
+++ b/versus/src/versus/model_config.py
@@ -41,4 +41,6 @@ def get_model_config(model_id: str, *, cfg: versus_config.Config | None = None) 
         top_p=entry.sampling.top_p,
         thinking=dict(entry.thinking) if entry.thinking is not None else None,
         effort=entry.effort,
+        max_thinking_tokens=entry.max_thinking_tokens,
+        service_tier=entry.service_tier,
     )

--- a/versus/src/versus/model_config.py
+++ b/versus/src/versus/model_config.py
@@ -1,0 +1,44 @@
+"""Versus per-model registry — the operator's lever for what gets sent.
+
+Maps a model id (as it appears in CLI / config) to the effective
+``rumil.model_config.ModelConfig`` versus applies on the wire. Both
+direct paths (completions, paraphrases, blind judge) and bridge paths
+(ws/orch) read from here, so a single yaml edit changes the effective
+condition everywhere consistently. Every row records its model_config
+snapshot, so the dedup hash forks naturally on any change.
+
+Why versus has its own registry instead of leaning on
+``rumil.llm.thinking_config`` / ``effort_level``: those are rumil's
+defaults for non-versus callers. Versus wants explicit control so the
+operator can tune (e.g.) "haiku with thinking on" without touching
+rumil's main path.
+"""
+
+from __future__ import annotations
+
+from rumil.model_config import ModelConfig
+from versus import config as versus_config
+
+
+def get_model_config(model_id: str, *, cfg: versus_config.Config | None = None) -> ModelConfig:
+    """Resolve the effective ``ModelConfig`` for ``model_id``.
+
+    Reads from ``cfg.models[model_id]`` and translates into the
+    rumil-side ``ModelConfig`` shape. Raises ``KeyError`` with a
+    pointer to the registry on miss; the Config validator catches
+    typos at load time, so a runtime miss should be rare.
+    """
+    if cfg is None:
+        cfg = versus_config.load("config.yaml")
+    entry = cfg.models.get(model_id)
+    if entry is None:
+        raise KeyError(
+            f"model {model_id!r} not in versus models registry — add an entry to config.yaml"
+        )
+    return ModelConfig(
+        temperature=entry.sampling.temperature,
+        max_tokens=entry.sampling.max_tokens,
+        top_p=entry.sampling.top_p,
+        thinking=dict(entry.thinking) if entry.thinking is not None else None,
+        effort=entry.effort,
+    )

--- a/versus/src/versus/paraphrase.py
+++ b/versus/src/versus/paraphrase.py
@@ -21,6 +21,7 @@ import httpx
 from versus import anthropic_client, config, jsonl, openrouter
 from versus import essay as versus_essay
 from versus.judge import route_judge_model
+from versus.model_config import get_model_config
 from versus.run_summary import RunSummary
 from versus.versions import PARAPHRASE_PROMPT_VERSION
 
@@ -83,22 +84,19 @@ def markdown_to_blocks(md: str) -> list[versus_essay.Block]:
     return out
 
 
-def _call_one_paraphrase(essay, m, sh, k, prompt, client):
+def _call_one_paraphrase(essay, m, sh, k, prompt, client, mc):
     t0 = time.time()
     provider, canonical_model = route_judge_model(m.id)
     if provider == "anthropic":
-        # Opus 4.7 deprecates explicit temperature; drop top_p too out of caution
-        # (see complete.py for context).
-        if canonical_model.startswith("claude-opus-4-7"):
-            temp, top_p = None, None
-        else:
-            temp, top_p = m.temperature, m.top_p
+        output_cfg = {"effort": mc.effort} if mc.effort is not None else None
         resp = anthropic_client.chat(
             model=canonical_model,
             messages=[{"role": "user", "content": prompt}],
-            temperature=temp,
-            max_tokens=m.max_tokens,
-            top_p=top_p,
+            temperature=mc.temperature,
+            max_tokens=mc.max_tokens,
+            top_p=mc.top_p,
+            thinking=mc.thinking,
+            output_config=output_cfg,
             client=client,
         )
         text = anthropic_client.extract_text(resp)
@@ -106,9 +104,9 @@ def _call_one_paraphrase(essay, m, sh, k, prompt, client):
         resp = openrouter.chat(
             model=canonical_model,
             messages=[{"role": "user", "content": prompt}],
-            temperature=m.temperature,
-            max_tokens=m.max_tokens,
-            top_p=m.top_p,
+            temperature=mc.temperature,
+            max_tokens=mc.max_tokens,
+            top_p=mc.top_p,
             client=client,
         )
         text = openrouter.extract_text(resp)
@@ -118,11 +116,10 @@ def _call_one_paraphrase(essay, m, sh, k, prompt, client):
         "essay_id": essay.id,
         "model_id": m.id,
         "sampling_hash": sh,
-        # thinking=None / effort=None: paraphrase routes through
-        # anthropic_client/openrouter directly, neither of which sends a
-        # thinking block or output_config.effort today. Record explicitly so a
-        # future change is visible from the row.
-        "params": {**m.model_dump(exclude={"id"}), "thinking": None, "effort": None},
+        # Full ModelConfig snapshot from the versus registry, recorded for
+        # traceability. ModelCfg's old loose fields (temperature/top_p/etc.)
+        # remain in params for back-compat with legacy reads.
+        "params": {**m.model_dump(exclude={"id"}), "model_config": mc.to_record_dict()},
         "prompt": prompt,
         "response_text": text,
         "response_words": len(text.split()),
@@ -155,14 +152,15 @@ def run(cfg: config.Config, essays: list[versus_essay.Essay], *, dry_run: bool =
             if k in existing:
                 print(f"[skip] paraphrase {k}")
                 continue
-            tasks_to_run.append((essay, m, sh, k, prompt))
+            mc = get_model_config(m.id, cfg=cfg)
+            tasks_to_run.append((essay, m, sh, k, prompt, mc))
             existing.add(k)
 
     if not tasks_to_run:
         return
     if dry_run:
         print(f"[plan] {len(tasks_to_run)} paraphrase calls (concurrency={cfg.concurrency})")
-        for e, m, _sh, k, _p in tasks_to_run:
+        for e, m, _sh, k, _p, _mc in tasks_to_run:
             print(f"  * {e.id} | {m.id} | {k}")
         return
     print(f"[run ] {len(tasks_to_run)} paraphrase calls (concurrency={cfg.concurrency})")
@@ -171,8 +169,8 @@ def run(cfg: config.Config, essays: list[versus_essay.Essay], *, dry_run: bool =
     try:
         with ThreadPoolExecutor(max_workers=cfg.concurrency) as pool:
             futures = {
-                pool.submit(_call_one_paraphrase, e, m, sh, k, p, client): k
-                for (e, m, sh, k, p) in tasks_to_run
+                pool.submit(_call_one_paraphrase, e, m, sh, k, p, client, mc): k
+                for (e, m, sh, k, p, mc) in tasks_to_run
             }
             for fut in as_completed(futures):
                 k = futures[fut]

--- a/versus/src/versus/paraphrase.py
+++ b/versus/src/versus/paraphrase.py
@@ -118,10 +118,11 @@ def _call_one_paraphrase(essay, m, sh, k, prompt, client):
         "essay_id": essay.id,
         "model_id": m.id,
         "sampling_hash": sh,
-        # thinking=None: paraphrase routes through anthropic_client/openrouter
-        # directly, neither of which sends a thinking block today. Record
-        # explicitly so a future change is visible from the row.
-        "params": {**m.model_dump(exclude={"id"}), "thinking": None},
+        # thinking=None / effort=None: paraphrase routes through
+        # anthropic_client/openrouter directly, neither of which sends a
+        # thinking block or output_config.effort today. Record explicitly so a
+        # future change is visible from the row.
+        "params": {**m.model_dump(exclude={"id"}), "thinking": None, "effort": None},
         "prompt": prompt,
         "response_text": text,
         "response_words": len(text.split()),

--- a/versus/src/versus/paraphrase.py
+++ b/versus/src/versus/paraphrase.py
@@ -21,6 +21,7 @@ import httpx
 from versus import anthropic_client, config, jsonl, openrouter
 from versus import essay as versus_essay
 from versus.judge import route_judge_model
+from versus.run_summary import RunSummary
 from versus.versions import PARAPHRASE_PROMPT_VERSION
 
 PARAPHRASE_INSTRUCTIONS = (
@@ -133,7 +134,7 @@ def paraphrase_models(cfg: config.Config) -> list[config.ModelCfg]:
     return [m for m in cfg.completion.models if m.paraphrase]
 
 
-def run(cfg: config.Config, essays: list[versus_essay.Essay]) -> None:
+def run(cfg: config.Config, essays: list[versus_essay.Essay], *, dry_run: bool = False) -> None:
     models = paraphrase_models(cfg)
     if not cfg.paraphrasing.enabled or not models:
         print("[paraphrase] disabled or no models flagged paraphrase=true; skipping")
@@ -155,7 +156,13 @@ def run(cfg: config.Config, essays: list[versus_essay.Essay]) -> None:
 
     if not tasks_to_run:
         return
+    if dry_run:
+        print(f"[plan] {len(tasks_to_run)} paraphrase calls (concurrency={cfg.concurrency})")
+        for e, m, _sh, k, _p in tasks_to_run:
+            print(f"  * {e.id} | {m.id} | {k}")
+        return
     print(f"[run ] {len(tasks_to_run)} paraphrase calls (concurrency={cfg.concurrency})")
+    summary = RunSummary()
     client = httpx.Client(timeout=600.0)
     try:
         with ThreadPoolExecutor(max_workers=cfg.concurrency) as pool:
@@ -169,8 +176,11 @@ def run(cfg: config.Config, essays: list[versus_essay.Essay]) -> None:
                     row = fut.result()
                 except Exception as ex:
                     print(f"[err ] paraphrase {k}: {ex}")
+                    summary.record_error()
                     continue
                 jsonl.append(log, row)
+                summary.record_success(row.get("raw_response"))
                 print(f"[done] paraphrase {k}")
     finally:
         client.close()
+    summary.print("paraphrases")

--- a/versus/src/versus/paraphrase.py
+++ b/versus/src/versus/paraphrase.py
@@ -118,7 +118,10 @@ def _call_one_paraphrase(essay, m, sh, k, prompt, client):
         "essay_id": essay.id,
         "model_id": m.id,
         "sampling_hash": sh,
-        "params": m.model_dump(exclude={"id"}),
+        # thinking=None: paraphrase routes through anthropic_client/openrouter
+        # directly, neither of which sends a thinking block today. Record
+        # explicitly so a future change is visible from the row.
+        "params": {**m.model_dump(exclude={"id"}), "thinking": None},
         "prompt": prompt,
         "response_text": text,
         "response_words": len(text.split()),

--- a/versus/src/versus/paraphrase.py
+++ b/versus/src/versus/paraphrase.py
@@ -18,6 +18,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import httpx
 
+from rumil.model_config import ModelConfig
 from versus import anthropic_client, config, jsonl, openrouter
 from versus import essay as versus_essay
 from versus.judge import route_judge_model
@@ -48,9 +49,14 @@ PARAPHRASE_INSTRUCTIONS = (
 HEADING_RE = re.compile(r"^(#{2,4})\s+(.+?)\s*$")
 
 
-def sampling_hash(model_cfg: config.ModelCfg) -> str:
+def sampling_hash(model_config: ModelConfig) -> str:
+    """Stable hash of the per-model registry config + paraphrase prompt
+    version. Forks deterministically when either the model's registry
+    entry (sampling, thinking, effort, etc.) or the paraphrase prompt
+    changes — drives the dedup key on paraphrase rows.
+    """
     payload = {
-        "params": model_cfg.model_dump(exclude={"id"}),
+        "model_config": model_config.to_record_dict(),
         "prompt_version": PARAPHRASE_PROMPT_VERSION,
     }
     blob = json.dumps(payload, sort_keys=True)
@@ -116,9 +122,9 @@ def _call_one_paraphrase(essay, m, sh, k, prompt, client, mc):
         "essay_id": essay.id,
         "model_id": m.id,
         "sampling_hash": sh,
-        # Full ModelConfig snapshot from the versus registry, recorded for
-        # traceability. ModelCfg's old loose fields (temperature/top_p/etc.)
-        # remain in params for back-compat with legacy reads.
+        # Full ModelConfig snapshot from the versus registry — what
+        # actually went on the wire. Plus the loose paraphrase-axis
+        # flag from the completion-models entry.
         "params": {**m.model_dump(exclude={"id"}), "model_config": mc.to_record_dict()},
         "prompt": prompt,
         "response_text": text,
@@ -147,12 +153,12 @@ def run(cfg: config.Config, essays: list[versus_essay.Essay], *, dry_run: bool =
     for essay in essays:
         prompt = PARAPHRASE_INSTRUCTIONS.format(markdown=essay.markdown)
         for m in models:
-            sh = sampling_hash(m)
+            mc = get_model_config(m.id, cfg=cfg)
+            sh = sampling_hash(mc)
             k = paraphrase_key(essay.id, m.id, sh)
             if k in existing:
                 print(f"[skip] paraphrase {k}")
                 continue
-            mc = get_model_config(m.id, cfg=cfg)
             tasks_to_run.append((essay, m, sh, k, prompt, mc))
             existing.add(k)
 

--- a/versus/src/versus/paraphrase.py
+++ b/versus/src/versus/paraphrase.py
@@ -183,4 +183,4 @@ def run(cfg: config.Config, essays: list[versus_essay.Essay], *, dry_run: bool =
                 print(f"[done] paraphrase {k}")
     finally:
         client.close()
-    summary.print("paraphrases")
+        summary.print("paraphrases")

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -343,6 +343,12 @@ async def run_ws(
     workspace_state_hash = await compute_workspace_state_hash(probe_db)
 
     sampling = _anthropic_sampling(model, cfg.judging.max_tokens)
+    # rumil's call_anthropic_api applies thinking_config() to the model
+    # automatically; record the same dict here so judge_inputs reflects the
+    # actual condition and the dedup hash forks if rules change.
+    from rumil.llm import thinking_config
+
+    thinking = thinking_config(model)
 
     def _compose_config(task_name: str, is_versus_crit: bool) -> tuple[dict, str, str]:
         dim = f"versus_{task_name}" if is_versus_crit else task_name
@@ -353,6 +359,7 @@ async def run_ws(
             dimension=dim,
             sampling=sampling,
             prompt_hash=ph,
+            thinking=thinking,
             tool_prompt_hash=thash,
             pair_surface_hash=qhash,
             workspace_id=ws_short,
@@ -583,6 +590,11 @@ async def run_orch(
     workspace_state_hash = await compute_workspace_state_hash(probe_db)
 
     sampling = _anthropic_sampling(model, cfg.judging.max_tokens)
+    # rumil applies thinking_config() to the orchestrator's research calls AND
+    # the closer; mirror it here so judge_inputs reflects the actual condition.
+    from rumil.llm import thinking_config
+
+    thinking = thinking_config(model)
 
     def _compose_config(task_name: str, is_versus_crit: bool) -> tuple[dict, str, str]:
         dim = f"versus_{task_name}" if is_versus_crit else task_name
@@ -593,6 +605,7 @@ async def run_orch(
             dimension=dim,
             sampling=sampling,
             prompt_hash=ph,
+            thinking=thinking,
             tool_prompt_hash=thash,
             pair_surface_hash=qhash,
             workspace_id=ws_short,

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -343,12 +343,13 @@ async def run_ws(
     workspace_state_hash = await compute_workspace_state_hash(probe_db)
 
     sampling = _anthropic_sampling(model, cfg.judging.max_tokens)
-    # rumil's call_anthropic_api applies thinking_config() to the model
-    # automatically; record the same dict here so judge_inputs reflects the
-    # actual condition and the dedup hash forks if rules change.
-    from rumil.llm import thinking_config
+    # rumil's call_anthropic_api applies thinking_config() and effort_level()
+    # to the model automatically; record the same values here so judge_inputs
+    # reflects the actual condition and the dedup hash forks if rules change.
+    from rumil.llm import effort_level, thinking_config
 
     thinking = thinking_config(model)
+    effort = effort_level(model)
 
     def _compose_config(task_name: str, is_versus_crit: bool) -> tuple[dict, str, str]:
         dim = f"versus_{task_name}" if is_versus_crit else task_name
@@ -360,6 +361,7 @@ async def run_ws(
             sampling=sampling,
             prompt_hash=ph,
             thinking=thinking,
+            effort=effort,
             tool_prompt_hash=thash,
             pair_surface_hash=qhash,
             workspace_id=ws_short,
@@ -590,11 +592,13 @@ async def run_orch(
     workspace_state_hash = await compute_workspace_state_hash(probe_db)
 
     sampling = _anthropic_sampling(model, cfg.judging.max_tokens)
-    # rumil applies thinking_config() to the orchestrator's research calls AND
-    # the closer; mirror it here so judge_inputs reflects the actual condition.
-    from rumil.llm import thinking_config
+    # rumil applies thinking_config() AND effort_level() to the orchestrator's
+    # research calls AND the closer; mirror both here so judge_inputs reflects
+    # the actual condition.
+    from rumil.llm import effort_level, thinking_config
 
     thinking = thinking_config(model)
+    effort = effort_level(model)
 
     def _compose_config(task_name: str, is_versus_crit: bool) -> tuple[dict, str, str]:
         dim = f"versus_{task_name}" if is_versus_crit else task_name
@@ -606,6 +610,7 @@ async def run_orch(
             sampling=sampling,
             prompt_hash=ph,
             thinking=thinking,
+            effort=effort,
             tool_prompt_hash=thash,
             pair_surface_hash=qhash,
             workspace_id=ws_short,

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from versus import config, judge, versus_db
+from versus.run_summary import RunSummary
 
 
 def _anthropic_sampling(model: str, max_tokens: int) -> dict:
@@ -394,6 +395,7 @@ async def run_ws(
     done = 0
     total = len(tasks)
     lock = asyncio.Lock()
+    summary = RunSummary()
 
     versus_client = versus_db.get_client()
 
@@ -458,6 +460,7 @@ async def run_ws(
                 result = await judge_pair_ws_aware(db, pair_ctx, task_body=task_body, model=model)
             except Exception as e:
                 print(f"[err ] {pair.essay_id} {task_name}: {type(e).__name__}: {e}")
+                summary.record_error()
                 return
             criterion_value = f"versus_{task_name}" if is_versus_crit else f"rumil_{task_name}"
             row = _mirror_row(
@@ -494,6 +497,7 @@ async def run_ws(
                     rumil_cost_usd=row["rumil_cost_usd"],
                 )
                 done += 1
+                summary.record_success(cost_usd=result.cost_usd or 0.0)
                 print(
                     f"[done {done}/{total}] {pair.essay_id} {pair.source_a_id} vs "
                     f"{pair.source_b_id} [{criterion_value}] "
@@ -501,6 +505,7 @@ async def run_ws(
                 )
 
     await asyncio.gather(*[_exec_one(pj) for pj in tasks])
+    summary.print("ws judgments")
 
 
 async def run_orch(
@@ -629,6 +634,7 @@ async def run_orch(
     total = len(tasks)
     sem = asyncio.Semaphore(effective_concurrency)
     lock = asyncio.Lock()
+    summary = RunSummary()
 
     versus_client = versus_db.get_client()
 
@@ -692,6 +698,7 @@ async def run_orch(
                 )
             except Exception as e:
                 print(f"[err ] {pair.essay_id} {task_name}: {type(e).__name__}: {e}")
+                summary.record_error()
                 return
             criterion_value = f"versus_{task_name}" if is_versus_crit else f"rumil_{task_name}"
             row = _mirror_row(
@@ -728,6 +735,7 @@ async def run_orch(
                     rumil_cost_usd=row["rumil_cost_usd"],
                 )
                 done += 1
+                summary.record_success(cost_usd=result.cost_usd or 0.0)
                 print(
                     f"[done {done}/{total}] {pair.essay_id} {pair.source_a_id} vs "
                     f"{pair.source_b_id} [{criterion_value}] "
@@ -735,3 +743,4 @@ async def run_orch(
                 )
 
     await asyncio.gather(*[_exec_one(pj) for pj in tasks])
+    summary.print("orch judgments")

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -33,16 +33,6 @@ from versus import config, judge, versus_db
 from versus.run_summary import RunSummary
 
 
-def _anthropic_sampling(model: str, max_tokens: int) -> dict:
-    """Sampling dict for ws/orch direct-Anthropic calls.
-
-    Opus 4.7 deprecates the temperature param on the Messages API (returns
-    400), so we omit it. Sonnet/Haiku use temperature=0.0 for determinism.
-    """
-    use_temp = None if model.startswith("claude-opus-4-7") else 0.0
-    return {"temperature": use_temp, "max_tokens": max_tokens}
-
-
 @dataclass
 class _PendingPair:
     essay_id: str

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -342,14 +342,19 @@ async def run_ws(
     # concurrent pairs see the same baseline.
     workspace_state_hash = await compute_workspace_state_hash(probe_db)
 
-    sampling = _anthropic_sampling(model, cfg.judging.max_tokens)
-    # rumil's call_anthropic_api applies thinking_config() and effort_level()
-    # to the model automatically; record the same values here so judge_inputs
-    # reflects the actual condition and the dedup hash forks if rules change.
-    from rumil.llm import effort_level, thinking_config
+    # Versus model registry is the source of truth for what versus sends on
+    # the wire. Look up once; the same ModelConfig is passed to the bridge
+    # (which threads it into the SDK agent + closer) AND recorded in
+    # judge_inputs so the dedup hash forks on registry edits.
+    from versus.model_config import get_model_config
 
-    thinking = thinking_config(model)
-    effort = effort_level(model)
+    mc = get_model_config(model, cfg=cfg)
+    sampling = {
+        "temperature": mc.temperature,
+        "max_tokens": mc.max_tokens,
+    }
+    thinking = mc.thinking
+    effort = mc.effort
 
     def _compose_config(task_name: str, is_versus_crit: bool) -> tuple[dict, str, str]:
         dim = f"versus_{task_name}" if is_versus_crit else task_name
@@ -358,10 +363,8 @@ async def run_ws(
             "ws",
             model=model,
             dimension=dim,
-            sampling=sampling,
+            model_config=mc,
             prompt_hash=ph,
-            thinking=thinking,
-            effort=effort,
             tool_prompt_hash=thash,
             pair_surface_hash=qhash,
             workspace_id=ws_short,
@@ -469,7 +472,9 @@ async def run_ws(
                     },
                 )
                 print(f"[run] {settings.frontend_url.rstrip('/')}/traces/{run_id}")
-                result = await judge_pair_ws_aware(db, pair_ctx, task_body=task_body, model=model)
+                result = await judge_pair_ws_aware(
+                    db, pair_ctx, task_body=task_body, model=model, model_config=mc
+                )
             except Exception as e:
                 print(f"[err ] {pair.essay_id} {task_name}: {type(e).__name__}: {e}")
                 summary.record_error()
@@ -591,14 +596,16 @@ async def run_orch(
     code_fingerprint = compute_judge_code_fingerprint()
     workspace_state_hash = await compute_workspace_state_hash(probe_db)
 
-    sampling = _anthropic_sampling(model, cfg.judging.max_tokens)
-    # rumil applies thinking_config() AND effort_level() to the orchestrator's
-    # research calls AND the closer; mirror both here so judge_inputs reflects
-    # the actual condition.
-    from rumil.llm import effort_level, thinking_config
+    # Versus model registry as source of truth (see run_ws above).
+    from versus.model_config import get_model_config
 
-    thinking = thinking_config(model)
-    effort = effort_level(model)
+    mc = get_model_config(model, cfg=cfg)
+    sampling = {
+        "temperature": mc.temperature,
+        "max_tokens": mc.max_tokens,
+    }
+    thinking = mc.thinking
+    effort = mc.effort
 
     def _compose_config(task_name: str, is_versus_crit: bool) -> tuple[dict, str, str]:
         dim = f"versus_{task_name}" if is_versus_crit else task_name
@@ -607,10 +614,8 @@ async def run_orch(
             "orch",
             model=model,
             dimension=dim,
-            sampling=sampling,
+            model_config=mc,
             prompt_hash=ph,
-            thinking=thinking,
-            effort=effort,
             tool_prompt_hash=thash,
             pair_surface_hash=qhash,
             workspace_id=ws_short,
@@ -719,7 +724,12 @@ async def run_orch(
                 )
                 print(f"[run] {settings.frontend_url.rstrip('/')}/traces/{run_id}")
                 result = await judge_pair_orch(
-                    db, pair_ctx, task_body=task_body, model=model, budget=budget
+                    db,
+                    pair_ctx,
+                    task_body=task_body,
+                    model=model,
+                    budget=budget,
+                    model_config=mc,
                 )
             except Exception as e:
                 print(f"[err ] {pair.essay_id} {task_name}: {type(e).__name__}: {e}")

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -504,8 +504,10 @@ async def run_ws(
                     f"label={result.preference_label!r} trace={result.trace_url}"
                 )
 
-    await asyncio.gather(*[_exec_one(pj) for pj in tasks])
-    summary.print("ws judgments")
+    try:
+        await asyncio.gather(*[_exec_one(pj) for pj in tasks])
+    finally:
+        summary.print("ws judgments")
 
 
 async def run_orch(
@@ -742,5 +744,7 @@ async def run_orch(
                     f"label={result.preference_label!r} trace={result.trace_url}"
                 )
 
-    await asyncio.gather(*[_exec_one(pj) for pj in tasks])
-    summary.print("orch judgments")
+    try:
+        await asyncio.gather(*[_exec_one(pj) for pj in tasks])
+    finally:
+        summary.print("orch judgments")

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -447,8 +447,11 @@ async def run_ws(
                         "workspace": workspace,
                         "task_name": effective_task,
                         "essay_id": pair.essay_id,
+                        # ``judge_config`` already carries the full ModelConfig
+                        # under judge_config['model_config'] (max_tokens,
+                        # thinking, effort, etc.); no need to duplicate
+                        # individual knobs at the runs.config top level.
                         "judge_config": pj.base_config,
-                        "judging_max_tokens": cfg.judging.max_tokens,
                         # Canonical alphabetical order for dedup-key
                         # purposes, NOT display order. display_first /
                         # order live on the judgment row in
@@ -698,8 +701,9 @@ async def run_orch(
                         "workspace": workspace,
                         "task_name": effective_task,
                         "essay_id": pair.essay_id,
+                        # See run_ws above: judge_config carries the full
+                        # ModelConfig already.
                         "judge_config": pj.base_config,
-                        "judging_max_tokens": cfg.judging.max_tokens,
                         # Canonical alphabetical order for dedup-key
                         # purposes, NOT display order. display_first /
                         # order live on the judgment row in

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -339,12 +339,6 @@ async def run_ws(
     from versus.model_config import get_judge_model_config
 
     mc = get_judge_model_config(model, cfg=cfg)
-    sampling = {
-        "temperature": mc.temperature,
-        "max_tokens": mc.max_tokens,
-    }
-    thinking = mc.thinking
-    effort = mc.effort
 
     def _compose_config(task_name: str, is_versus_crit: bool) -> tuple[dict, str, str]:
         dim = f"versus_{task_name}" if is_versus_crit else task_name
@@ -593,12 +587,6 @@ async def run_orch(
     from versus.model_config import get_judge_model_config
 
     mc = get_judge_model_config(model, cfg=cfg)
-    sampling = {
-        "temperature": mc.temperature,
-        "max_tokens": mc.max_tokens,
-    }
-    thinking = mc.thinking
-    effort = mc.effort
 
     def _compose_config(task_name: str, is_versus_crit: bool) -> tuple[dict, str, str]:
         dim = f"versus_{task_name}" if is_versus_crit else task_name

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -336,9 +336,9 @@ async def run_ws(
     # the wire. Look up once; the same ModelConfig is passed to the bridge
     # (which threads it into the SDK agent + closer) AND recorded in
     # judge_inputs so the dedup hash forks on registry edits.
-    from versus.model_config import get_model_config
+    from versus.model_config import get_judge_model_config
 
-    mc = get_model_config(model, cfg=cfg)
+    mc = get_judge_model_config(model, cfg=cfg)
     sampling = {
         "temperature": mc.temperature,
         "max_tokens": mc.max_tokens,
@@ -587,9 +587,9 @@ async def run_orch(
     workspace_state_hash = await compute_workspace_state_hash(probe_db)
 
     # Versus model registry as source of truth (see run_ws above).
-    from versus.model_config import get_model_config
+    from versus.model_config import get_judge_model_config
 
-    mc = get_model_config(model, cfg=cfg)
+    mc = get_judge_model_config(model, cfg=cfg)
     sampling = {
         "temperature": mc.temperature,
         "max_tokens": mc.max_tokens,

--- a/versus/src/versus/rumil_judge.py
+++ b/versus/src/versus/rumil_judge.py
@@ -86,6 +86,7 @@ def _plan_rumil_pairs(
     vs_human: bool = False,
     current_only: bool = False,
     prefix_cfg: config.PrefixCfg | None = None,
+    prod: bool = False,
 ) -> list[_PendingJudgment]:
     """Enumerate pending judgments (skipping ones already in versus_judgments).
 
@@ -110,12 +111,12 @@ def _plan_rumil_pairs(
 
     essay_id_set = set(essay_ids) if essay_ids else None
     contestants_set = set(contestants) if contestants else None
+    db = versus_db.get_client(prod=prod)
     current_hashes = (
-        prepare.current_prefix_hashes(cfg, prefix_cfg=prefix_cfg)
+        prepare.current_prefix_hashes(cfg, prefix_cfg=prefix_cfg, client=db)
         if (current_only or prefix_cfg is not None)
         else None
     )
-    db = versus_db.get_client()
     groups, prefix_texts = judge.load_sources_by_essay(db)
     existing = judge._existing_judgment_keys(db)
     out: list[_PendingJudgment] = []
@@ -284,6 +285,7 @@ async def run_ws(
     current_only: bool = False,
     prefix_cfg: config.PrefixCfg | None = None,
     persist: bool = False,
+    prod: bool = False,
 ) -> None:
     """Run the workspace-aware rumil judge against pending pairs.
 
@@ -311,7 +313,7 @@ async def run_ws(
     # Probe DB just for project lookup — projects live outside any run's
     # staged view, and the per-pair DBs below inherit db.project_id through
     # their explicit constructor arg.
-    probe_db = await DB.create(run_id=str(uuid.uuid4()), prod=False, staged=False)
+    probe_db = await DB.create(run_id=str(uuid.uuid4()), prod=prod, staged=False)
     project = await _resolve_workspace(probe_db, workspace)
     probe_db.project_id = project.id
     ws_short = project.id[:8]
@@ -367,6 +369,7 @@ async def run_ws(
         vs_human=vs_human,
         current_only=current_only,
         prefix_cfg=prefix_cfg,
+        prod=prod,
     )
     if limit is not None:
         tasks = tasks[:limit]
@@ -397,7 +400,7 @@ async def run_ws(
     lock = asyncio.Lock()
     summary = RunSummary()
 
-    versus_client = versus_db.get_client()
+    versus_client = versus_db.get_client(prod=prod)
 
     async def _exec_one(pj: _PendingJudgment) -> None:
         nonlocal done
@@ -413,7 +416,7 @@ async def run_ws(
             # the shared DB no longer thrashes across pairs.
             run_id = str(uuid.uuid4())
             db = await DB.create(
-                run_id=run_id, prod=False, project_id=project.id, staged=not persist
+                run_id=run_id, prod=prod, project_id=project.id, staged=not persist
             )
             try:
                 task_body = _resolve_task_body(task_name, is_versus_crit)
@@ -526,6 +529,7 @@ async def run_orch(
     persist: bool = False,
     current_only: bool = False,
     prefix_cfg: config.PrefixCfg | None = None,
+    prod: bool = False,
 ) -> None:
     """Run the orchestrator rumil judge against pending pairs.
 
@@ -551,7 +555,7 @@ async def run_orch(
 
     # Probe is always non-staged: project lookup isn't per-run and
     # needs to see baseline rows.
-    probe_db = await DB.create(run_id=str(uuid.uuid4()), prod=False, staged=False)
+    probe_db = await DB.create(run_id=str(uuid.uuid4()), prod=prod, staged=False)
     project = await _resolve_workspace(probe_db, workspace)
     probe_db.project_id = project.id
     ws_short = project.id[:8]
@@ -607,6 +611,7 @@ async def run_orch(
         vs_human=vs_human,
         current_only=current_only,
         prefix_cfg=prefix_cfg,
+        prod=prod,
     )
     if limit is not None:
         tasks = tasks[:limit]
@@ -638,7 +643,7 @@ async def run_orch(
     lock = asyncio.Lock()
     summary = RunSummary()
 
-    versus_client = versus_db.get_client()
+    versus_client = versus_db.get_client(prod=prod)
 
     async def _exec_one(pj: _PendingJudgment) -> None:
         nonlocal done
@@ -652,7 +657,7 @@ async def run_orch(
             # per-run so concurrent pairs don't contaminate each other's
             # staged views.
             db = await DB.create(
-                run_id=run_id, prod=False, project_id=project.id, staged=not persist
+                run_id=run_id, prod=prod, project_id=project.id, staged=not persist
             )
             try:
                 task_body = _resolve_task_body(task_name, is_versus_crit)

--- a/versus/src/versus/run_summary.py
+++ b/versus/src/versus/run_summary.py
@@ -1,0 +1,47 @@
+"""Lightweight per-script call tally — counts, token totals, optional cost, wall time.
+
+Used by run_completions / run_paraphrases / run_rumil_judgments to print
+a closing line so the operator sees what happened without scrolling
+back through [done] lines. Direct-LLM paths (blind judges, completions,
+paraphrases) report tokens; rumil-mediated paths (ws/orch) have a
+real $ figure on the result and report cost_usd instead.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+class RunSummary:
+    def __init__(self) -> None:
+        self.t_start = time.monotonic()
+        self.n_done = 0
+        self.n_err = 0
+        self.in_tokens = 0
+        self.out_tokens = 0
+        self.cost_usd = 0.0
+
+    def record_success(self, response: Any = None, *, cost_usd: float = 0.0) -> None:
+        self.n_done += 1
+        self.cost_usd += cost_usd
+        if not isinstance(response, dict):
+            return
+        usage = response.get("usage") or {}
+        if not isinstance(usage, dict):
+            return
+        self.in_tokens += usage.get("input_tokens") or usage.get("prompt_tokens") or 0
+        self.out_tokens += usage.get("output_tokens") or usage.get("completion_tokens") or 0
+
+    def record_error(self) -> None:
+        self.n_err += 1
+
+    def print(self, label: str) -> None:
+        elapsed = time.monotonic() - self.t_start
+        parts = [f"{self.n_done} done, {self.n_err} errors"]
+        if self.in_tokens or self.out_tokens:
+            parts.append(f"in={self.in_tokens:,} out={self.out_tokens:,} tokens")
+        if self.cost_usd > 0:
+            parts.append(f"${self.cost_usd:.4f}")
+        parts.append(f"{elapsed:.1f}s wall")
+        print(f"[summary] {label}: " + " · ".join(parts))

--- a/versus/src/versus/versus_db.py
+++ b/versus/src/versus/versus_db.py
@@ -297,7 +297,8 @@ def find_judgments(
 #     response_words for /results — that count now lives in the generated
 #     response_words column on versus_texts.
 _TEXT_LIGHT_SELECT = (
-    "id,essay_id,kind,source_id,prefix_hash,model_id,response_words,params,request_hash,created_at"
+    "id,essay_id,kind,source_id,prefix_hash,model_id,response_words,params,request_hash,"
+    "model_config_hash,created_at"
 )
 _JUDGMENT_LIGHT_SELECT = (
     "id,essay_id,prefix_hash,source_a,source_b,display_first,text_a_id,text_b_id,"


### PR DESCRIPTION
## Summary

- **Default scripts to the canonical active essay set.** `run_completions.py`, `run_paraphrases.py`, and `run_rumil_judgments.py` previously required `--active` to scope to the same essays the `/versus` UI gates on; default was every cached essay (minus `exclude_ids`), which silently included off-feed and old-schema rows. Flipped: active is the default, `--include-stale` opts back into the wider scope. Skills + script docstrings updated to match. Generation scripts now also call `envcascade.apply` so per-project `.env` keys take precedence over the shell env.
- **Two UI bugs in `/versus/inspect`.** (1) `ResultsWinMatrix` and `ResultsOutlier` displayed gen-win % under the label "pick-human %"; renamed `WinAccum.wins/losses` → `humanWins/genWins` so the accumulator matches the label by construction. (2) Win-matrix columns and variant-flip buckets were keyed on `config_hash` (per-row), so identical-judge cells appeared as separate columns and variant flips never bucketed; switched both to `judge_model_id`. DB `winner_source` was always correct — only the UI aggregation was buggy.
- **Script QoL.** `--dry-run` on `run_completions.py` / `run_paraphrases.py` (symmetric with judgments). Transient-5xx retry on completions: up to 3 retries with exponential backoff (2s/4s/8s) covering `httpx` 5xx + transient connection errors. End-of-run summary printed by all four scripts: counts, tokens, wall time, and `$cost_usd` on ws/orch.
- **Forks panel "original" column showed the wrong model** for runs that scoped a per-call override (versus orch on sonnet rendered as opus). Added `model` to `call_llm_exchanges`, threaded through `save_llm_exchange` / `_save_exchange` (+ both sdk_agent sites). `resolve_base` reads it directly; legacy NULL rows fall back to `runs.config['judge_config']['model']` → `runs.config['model']` → `settings.model`.
- **`--prod` works on ws/orch judgments.** Plumbed `prod` through `run_ws` / `run_orch` → `_plan_rumil_pairs` → `DB.create(prod=...)` and `versus_db.get_client(prod=...)`. Also created the empty `versus` workspace on prod rumil for shared use across runs.
- **Bridge paths now read from a per-model registry.** New `models:` section in `versus/config.yaml` declares the effective per-model condition (sampling, thinking, effort, max_thinking_tokens, service_tier). Validator catches typos at load. Direct paths (completions, paraphrases, blind judge) and bridge paths (ws / orch closer) both look up `versus.model_config.get_model_config(model_id)` — single source of truth. Threaded into `SdkAgentConfig` (Claude Agent SDK natively supports `thinking` / `effort` / `max_thinking_tokens` on `ClaudeAgentOptions`) and through `_run_orch_closer`. Editing the yaml forks `request_hash` / `judge_inputs_hash` deterministically; old data stays valid as the prior config.
- **`ModelConfig` is the canonical type.** New frozen dataclass in `rumil.model_config` bundling all non-prompt request conditions. `rumil.llm.call_anthropic_api` and `structured_call` accept it as override; defaults fall back to `derive_model_config(model)` (the existing implicit rules). `forks.BaseExchange.original_config: ModelConfig | None` replaces a loose `original_kwargs` dict — fork replay is typed end-to-end. `call_llm_exchanges.request_kwargs` persists `cfg.to_record_dict()` so forks reproduce the original condition even if rules change later.
- **`judge_inputs` schema collapses to nested `model_config`.** Replaces the loose `sampling` / `thinking` / `effort` keys with a single `model_config` dict (`ModelConfig.to_record_dict()` shape). Migration `20260501064910` rewrites existing rows in place; `judge_inputs_hash` (STORED GENERATED) recomputes naturally. `judge_config_is_current` compares `inputs.model_config` against `get_model_config(inputs.model)` — any registry edit (sampling, thinking, effort, max_thinking_tokens, service_tier) surfaces as stale. `project_config_to_axes` exposes a single `judge_model_config_hash` axis covering the full bundle.
- **`versus_texts` gains `model_config_hash`.** Generated TEXT column computed as `sha256(request->'model_config'::text)` (NULL for legacy rows whose request doesn't carry model_config). Indexed on `(source_id, model_config_hash)` so future aggregations can bucket "haiku with thinking on" separately from "haiku with thinking off". `judge.Source` carries the hash through `load_sources_by_essay`. Pair planner + UI disambiguation for the multi-variant-per-source case is documented as a dormant follow-up — today no operator runs same-source-id-different-config completions.

## Test plan

- [x] Pyright + ruff clean across touched files; frontend `tsc --noEmit` clean
- [x] `pytest tests/test_versus_retry.py tests/test_versus_run_summary.py` — retry helper + RunSummary tests
- [x] `pytest tests/test_versus_judge_config.py tests/test_versus_judge_staleness.py tests/test_forks.py` — judge_inputs schema (nested `model_config`), staleness drift detection, fork reproduction with captured ModelConfig
- [x] `--dry-run` smoke-tested against an essay with existing rows (dedup-skip path) and one with no rows (plan path)
- [x] End-to-end smoke on prod: 58 haiku completions × active set + 58 haiku judgments (haiku-vs-human pairs, blind variant); 58 sonnet completions + judgments; one sonnet orch judgment for `forethought__ai-impacts-on-epistemics`
- [x] 275 versus + fork + thinking tests pass after the model-registry refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)