### PR TITLE
feat(citations): classify DEPENDS_ON direction (derivation vs engagement)

### DIFF
--- a/src/rumil/moves/base.py
+++ b/src/rumil/moves/base.py
@@ -4,7 +4,7 @@ import logging
 import re
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -378,32 +378,61 @@ async def create_page(
 _CITATION_RE = re.compile(r"\[([a-f0-9]{8})\]")
 
 _STRENGTH_SYSTEM_PROMPT = (
-    "You are assigning dependency strengths for a newly-created page that "
-    "cites other claims or judgements as direct dependencies. The page's "
-    "content is its argument or observation, citing each dependency inline "
-    "with a short ID in square brackets. The citing page may be a claim, a "
-    "judgement, or a view item — its type is shown in the user message.\n\n"
-    "For each cited page listed in the user message, return an entry with "
-    "its 8-character page_id, a strength 1-5, and a one-sentence reasoning "
-    "naming the role the cited page plays.\n"
-    "- 1 = weak; if the cited page were false, the citing page would mostly stand.\n"
-    "- 3 = material; the citing page would need reworking.\n"
-    "- 5 = fully load-bearing; the citing page would collapse.\n\n"
-    "Return one entry per cited page; do not invent IDs."
+    "You are classifying inline citations from a newly-created page (a claim, "
+    "judgement, or view item) that cites other claims or judgements. Each "
+    "citation falls into one of two directions:\n\n"
+    "- 'derivation': the cited page is a foundational input to the new page's "
+    "argument. The new page builds on top of it; if the cited page were false, "
+    "the new page's conclusions would be undermined.\n"
+    "- 'engagement': the new page is critiquing, extending, refining, or "
+    "bolstering the cited page. The new page provides new insight ABOUT the "
+    "cited page rather than resting on it. The cited page's current standing "
+    "in the workspace is what changes; the new page would still stand even if "
+    "the cited page were retracted.\n\n"
+    "Use the citation excerpts in the user message to judge which direction "
+    "fits each cited page. When in doubt — e.g. the new page neither clearly "
+    "rests on nor clearly modifies the cited page — prefer 'derivation'.\n\n"
+    "Also assign a strength 1-5 measuring how load-bearing the link is in the "
+    "chosen direction:\n"
+    "- For 'derivation', strength is how much the new page rests on the cited "
+    "page: 1 = the new page would mostly stand without it, 3 = the new page "
+    "would need reworking, 5 = the new page would collapse.\n"
+    "- For 'engagement', strength is how much the engagement changes the "
+    "cited page's standing: 1 = a passing remark, 3 = a substantive "
+    "qualification or supporting note, 5 = a demolishing critique or "
+    "decisive corroboration that materially shifts the cited page's "
+    "credence or scope.\n\n"
+    "Return one entry per cited page with its 8-character page_id, the "
+    "direction, the strength, and a one-sentence reasoning naming the role "
+    "the cited page plays. Do not invent IDs."
 )
 
 
 class _CitedPageStrength(BaseModel):
     page_id: str = Field(description="8-character short ID of the cited page")
+    direction: Literal["derivation", "engagement"] = Field(
+        description=(
+            "'derivation' if the new page rests on the cited page (cited is a "
+            "foundational input); 'engagement' if the new page critiques, "
+            "extends, refines, or bolsters the cited page (new page provides "
+            "insight about cited rather than building on it)."
+        ),
+    )
     strength: float = Field(
         description=(
-            "1-5: how load-bearing this dependency is for the citing page "
-            "(1 = mildly depends on, 5 = would collapse without it)"
+            "1-5 load-bearing scale for the chosen direction. For 'derivation', "
+            "how much the new page rests on the cited page (5 = would collapse "
+            "without it). For 'engagement', how much the engagement changes "
+            "the cited page's standing (5 = demolishing critique or decisive "
+            "corroboration)."
         ),
     )
     reasoning: str = Field(
         "",
-        description="One sentence: what role the cited page plays in the derivation",
+        description=(
+            "One sentence: the role the cited page plays — either how the new "
+            "page derives from it, or how the new page modifies it."
+        ),
     )
 
 
@@ -422,22 +451,30 @@ def _citation_excerpts(content: str, short_id: str, max_lines: int = 3) -> Seque
     return pattern.findall(content)[:max_lines]
 
 
+CitationDirection = Literal["derivation", "engagement"]
+
+
 async def _assign_dependency_strengths(
     citing_page: Page,
     cited_pages: Sequence[Page],
     call: Call | None,
     db: DB,
-) -> dict[str, tuple[float, str]]:
-    """Ask Sonnet to assign dependency strengths for each cited page.
+) -> dict[str, tuple[CitationDirection, float, str]]:
+    """Ask Sonnet to classify direction and assign strength for each cited page.
 
-    Returns a mapping ``{cited_page_id: (strength, reasoning)}``. On LLM
-    failure or if a cited page is missing from the response, that page's
-    entry defaults to ``(2.5, "")``.
+    Returns a mapping ``{cited_page_id: (direction, strength, reasoning)}``.
+    Direction is ``'derivation'`` (citing rests on cited) or ``'engagement'``
+    (citing critiques/extends/bolsters cited). On LLM failure or if a cited
+    page is missing from the response, that page's entry defaults to
+    ``('derivation', 2.5, "")`` — preserves the prior behavior of treating
+    every citation as a forward dependency.
     """
     if not cited_pages:
         return {}
 
-    defaults: dict[str, tuple[float, str]] = {p.id: (2.5, "") for p in cited_pages}
+    defaults: dict[str, tuple[CitationDirection, float, str]] = {
+        p.id: ("derivation", 2.5, "") for p in cited_pages
+    }
 
     entries: list[str] = []
     for p in cited_pages:
@@ -496,7 +533,7 @@ async def _assign_dependency_strengths(
 
     short_to_full = {p.id[:8]: p.id for p in cited_pages}
     full_set = {p.id for p in cited_pages}
-    assigned: dict[str, tuple[float, str]] = dict(defaults)
+    assigned: dict[str, tuple[CitationDirection, float, str]] = dict(defaults)
     for entry in result.parsed.strengths:
         pid = entry.page_id
         full = short_to_full.get(pid) if len(pid) == 8 else (pid if pid in full_set else None)
@@ -504,7 +541,7 @@ async def _assign_dependency_strengths(
             log.debug("Strength entry for unknown page_id %s ignored", pid)
             continue
         strength = max(1.0, min(5.0, float(entry.strength)))
-        assigned[full] = (strength, entry.reasoning)
+        assigned[full] = (entry.direction, strength, entry.reasoning)
     return assigned
 
 
@@ -523,9 +560,12 @@ async def extract_and_link_citations(
     cited pages' types:
 
     - Cited SOURCE → CITES (from=citing, to=cited)
-    - Citing CLAIM/JUDGEMENT/VIEW_ITEM cites a CLAIM/JUDGEMENT → DEPENDS_ON
-      (from=citing, to=cited): the citing page's conclusions rest on the
-      cited page being true. The set of citing types that produce
+    - Citing CLAIM/JUDGEMENT/VIEW_ITEM cites a CLAIM/JUDGEMENT → DEPENDS_ON.
+      Sonnet classifies each citation in the same call where it scores
+      strength: 'derivation' (citing rests on cited; from=citing, to=cited)
+      or 'engagement' (citing critiques/extends/bolsters cited, so the
+      cited page's standing now depends on citing; direction is flipped to
+      from=cited, to=citing). The set of citing types that produce
       DEPENDS_ON is ``_DEPENDS_ON_CITING_TYPES``.
     - Citing QUESTION cites a CLAIM/JUDGEMENT → RELATED
       (from=cited, to=citing): inline citations from a question's body are
@@ -588,7 +628,7 @@ async def extract_and_link_citations(
 
         pending.append((from_id, to_id, link_type, cited_page))
 
-    strengths: dict[str, tuple[float, str]] = {}
+    strengths: dict[str, tuple[CitationDirection, float, str]] = {}
     if citing_page is not None:
         depends_on_targets = [cited for (_, _, lt, cited) in pending if lt == LinkType.DEPENDS_ON]
         if depends_on_targets:
@@ -602,7 +642,9 @@ async def extract_and_link_citations(
     linked: set[str] = set()
     for from_id, to_id, link_type, cited_page in pending:
         if link_type == LinkType.DEPENDS_ON and cited_page.id in strengths:
-            strength, reasoning = strengths[cited_page.id]
+            direction, strength, reasoning = strengths[cited_page.id]
+            if direction == "engagement":
+                from_id, to_id = to_id, from_id
             link = PageLink(
                 from_page_id=from_id,
                 to_page_id=to_id,

--- a/tests/test_inline_citations.py
+++ b/tests/test_inline_citations.py
@@ -23,16 +23,17 @@ from rumil.moves.base import _CITATION_RE, extract_and_link_citations
 
 @pytest.fixture(autouse=True)
 def _stub_strength_helper(mocker):
-    """Stub the Sonnet-backed dependency-strength helper with a deterministic result.
+    """Stub the Sonnet-backed dependency-classification helper with a deterministic result.
 
-    The helper is invoked by extract_and_link_citations when a CLAIM or
-    JUDGEMENT cites another claim/judgement. Unit tests should not hit the
-    network; return a fixed strength + reasoning for every cited page so
-    tests can assert on it.
+    The helper is invoked by extract_and_link_citations when a CLAIM,
+    JUDGEMENT, or VIEW_ITEM cites another claim/judgement. Unit tests
+    should not hit the network; default every citation to a 'derivation'
+    direction with a fixed strength + reasoning. Individual tests can
+    override `side_effect` to exercise the 'engagement' branch.
     """
 
     async def _stub(citing_page, cited_pages, call, db):
-        return {p.id: (3.5, "stub-reason") for p in cited_pages}
+        return {p.id: ("derivation", 3.5, "stub-reason") for p in cited_pages}
 
     return mocker.patch(
         "rumil.moves.base._assign_dependency_strengths",
@@ -203,6 +204,50 @@ async def test_judgement_citing_claim_creates_depends_on_link(
     assert deps[0].strength == 3.5
     assert deps[0].reasoning == "stub-reason"
     _stub_strength_helper.assert_called_once()
+
+
+async def test_engagement_direction_flips_depends_on_link(
+    tmp_db,
+    claim_page,
+    _stub_strength_helper,
+):
+    """When Sonnet classifies a citation as 'engagement', the DEPENDS_ON link
+    is flipped: from=cited, to=citing. Semantically, the cited page's
+    standing now depends on the new (citing) page that critiques or extends it.
+    """
+
+    async def _engagement_stub(citing_page, cited_pages, call, db):
+        return {p.id: ("engagement", 4.0, "critiques the cited claim") for p in cited_pages}
+
+    _stub_strength_helper.side_effect = _engagement_stub
+
+    citing_page = Page(
+        page_type=PageType.CLAIM,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=(
+            f"Contra [{claim_page.id[:8]}], the wavelength dependence is steeper than "
+            "the standard scattering treatment suggests."
+        ),
+        headline="Wavelength dependence steeper than standard treatment",
+    )
+    await tmp_db.save_page(citing_page)
+
+    linked = await extract_and_link_citations(citing_page.id, citing_page.content, tmp_db)
+
+    assert linked == {claim_page.id}
+    # Engagement direction means the link points cited -> citing, so
+    # outbound links from the citing page should NOT include this DEPENDS_ON.
+    links_from_citing = await tmp_db.get_links_from(citing_page.id)
+    assert not [l for l in links_from_citing if l.link_type == LinkType.DEPENDS_ON]
+    # Instead, the cited page should have an outbound DEPENDS_ON to the citing page.
+    links_from_cited = await tmp_db.get_links_from(claim_page.id)
+    deps = [l for l in links_from_cited if l.link_type == LinkType.DEPENDS_ON]
+    assert len(deps) == 1
+    assert deps[0].from_page_id == claim_page.id
+    assert deps[0].to_page_id == citing_page.id
+    assert deps[0].strength == 4.0
+    assert deps[0].reasoning == "critiques the cited claim"
 
 
 async def test_question_citing_claim_creates_related_link(


### PR DESCRIPTION
## Summary

- Models often cite pages they're critiquing or extending rather than deriving from. Rather than fight that, the strength-scoring Sonnet call now also classifies each citation as either `derivation` (citing rests on cited — current behaviour, from=citing→to=cited) or `engagement` (citing critiques/refines/bolsters cited — flip to from=cited→to=citing so the cited page's standing now depends on the new page).
- Strength is redefined per direction: derivation = how much the new page would collapse without the cited; engagement = how much the engagement shifts the cited page's standing. The 1-5 scale and the load-bearing framing are preserved on both sides.
- LLM failure / missing entries default to `('derivation', 2.5, "")`, preserving the prior forward-only behaviour rather than silently flipping links.

## Test plan

- [x] `uv run pytest tests/test_inline_citations.py` — 11 passed (1 LLM-marked skip)
- [x] `uv run pyright` — clean
- [x] New regression test: `test_engagement_direction_flips_depends_on_link` asserts that an 'engagement' classification produces a DEPENDS_ON link with `from_page_id=cited` and `to_page_id=citing`
- [ ] Manual: run a real call (e.g. an assess) on a question whose claim cites a critique target, and check via the trace / page detail UI that some DEPENDS_ON links have flipped direction with sensible reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)