### PR TITLE
feat(trace): show staged/committed status badge in run header

### DIFF
--- a/frontend/src/app/traces/[runId]/page.tsx
+++ b/frontend/src/app/traces/[runId]/page.tsx
@@ -98,6 +98,11 @@ export default async function TracePage({
         <div className="trace-title-row">
           <h1 className="trace-title">Execution Trace</h1>
           <span className="trace-run-id">{runId.slice(0, 8)}</span>
+          <span
+            className={`trace-status-badge trace-status-${trace.staged ? "staged" : "committed"}`}
+          >
+            {trace.staged ? "STAGED" : "COMMITTED"}
+          </span>
         </div>
       </header>
       {configEntries.length > 0 && (

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -43,6 +43,23 @@
   letter-spacing: 0.02em;
 }
 
+.trace-status-badge {
+  font-size: 11px;
+  font-weight: 700;
+  font-family: var(--font-geist-mono), monospace;
+  letter-spacing: 0.06em;
+  padding: 2px 6px;
+  border-radius: 2px;
+}
+.trace-status-staged {
+  color: #5a8a7a;
+  background: rgba(90, 138, 122, 0.12);
+}
+.trace-status-committed {
+  color: #6a6a6a;
+  background: rgba(120, 120, 120, 0.1);
+}
+
 .trace-error {
   color: #c44;
   font-size: 15px;


### PR DESCRIPTION
## Summary
- Adds a STAGED/COMMITTED badge to the `/traces/<runId>` header, next to the short run id
- Driven by the existing `staged` field on `RunTraceTreeOut` — no API changes needed

## Test plan
- [x] Open a trace for a non-staged run and confirm the COMMITTED badge appears
- [x] Open a trace for a staged run and confirm the STAGED badge appears
- [x] Verify the badge styling matches the existing run-staged-badge in the projects page

🤖 Generated with [Claude Code](https://claude.com/claude-code)