### PR TITLE
Show full subquestion headlines on stats page

### DIFF
--- a/frontend/src/components/question-focus.tsx
+++ b/frontend/src/components/question-focus.tsx
@@ -398,7 +398,6 @@ export function SubquestionFocusGrid({
           display: flex;
           flex-direction: column;
           gap: 0.2rem;
-          min-height: 2.4rem;
         }
         .subq-index {
           font-family: var(--font-geist-mono), monospace;
@@ -422,13 +421,10 @@ export function SubquestionFocusGrid({
         }
         .subq-headline {
           font-size: 0.82rem;
-          line-height: 1.3;
+          line-height: 1.35;
           color: var(--color-foreground);
           font-weight: 500;
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
+          word-break: break-word;
         }
         .subq-headline a {
           color: inherit;
@@ -481,7 +477,7 @@ export function SubquestionFocusGrid({
                     </span>
                   ) : null}
                 </div>
-                <div className="subq-headline" title={headline}>
+                <div className="subq-headline">
                   <Link href={withStagedRun(`/pages/${qid}/stats`, activeStagedRunId)}>{headline}</Link>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Drop the 2-line clamp on subquestion cells in the per-question stats grid so headlines render in full
- Remove the now-redundant `title={headline}` hover tooltip
- Drop the `min-height` reservation on the header so single-line headlines don't carry extra padding

## Test plan
- [x] Open a per-question stats page with both short and long subquestion headlines and confirm both render fully without ellipsis or hover
- [x] Confirm rows with mixed-length headlines still align cleanly and barcharts sit beneath the headline

🤖 Generated with [Claude Code](https://claude.com/claude-code)