### PR TITLE
fix(budget): let recurse children draw from full per-question pool

### DIFF
--- a/src/rumil/clean/feedback.py
+++ b/src/rumil/clean/feedback.py
@@ -110,7 +110,7 @@ def _make_investigation_tools(
         budget: int,
     ) -> str:
         """Run orchestrator and return a summary string."""
-        orchestrator = ExperimentalOrchestrator(db, broadcaster, budget_cap=budget)
+        orchestrator = ExperimentalOrchestrator(db, broadcaster, assigned_budget=budget)
         orchestrator._parent_call_id = call.id
         child_call_id = await orchestrator.create_initial_call(question_id, parent_call_id=call.id)
         try:

--- a/src/rumil/orchestrators/base.py
+++ b/src/rumil/orchestrators/base.py
@@ -110,7 +110,8 @@ class BaseOrchestrator(ABC):
     async def _pacing_params(self) -> tuple[int, int]:
         """Return (total, used) for budget pacing.
 
-        Subclasses with budget_cap should override to use their local scope.
+        Subclasses that participate in a question pool override this to pace
+        against the pool's totals once registered.
         """
         return await self.db.get_budget()
 
@@ -479,7 +480,7 @@ class BaseOrchestrator(ABC):
         round and the child call sits in a non-terminal state.
         """
         child_call_id = getattr(child, "_call_id", None)
-        allocated = getattr(child, "_budget_cap", None) or 0
+        allocated = getattr(child, "_assigned_budget", None) or 0
 
         refund = 0
         if self.pool_question_id:

--- a/src/rumil/orchestrators/claim_investigation.py
+++ b/src/rumil/orchestrators/claim_investigation.py
@@ -4,7 +4,6 @@ ClaimInvestigationOrchestrator: two-phase orchestrator for investigating claims.
 
 import asyncio
 import logging
-from collections.abc import Sequence
 
 from rumil.available_calls import get_available_calls_preset
 from rumil.calls.common import embed_task_for_page, mark_call_completed
@@ -66,7 +65,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         self,
         db: DB,
         broadcaster: Broadcaster | None = None,
-        budget_cap: int | None = None,
+        assigned_budget: int | None = None,
         pool_pre_registered: bool = False,
     ):
         super().__init__(db, broadcaster)
@@ -74,25 +73,22 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         self._call_id: str | None = None
 
         self._executed_since_last_plan: bool = False
-        self._budget_cap: int | None = budget_cap
-        self._consumed: int = 0
+        # See TwoPhaseOrchestrator for the semantics of these two fields.
+        self._assigned_budget: int | None = assigned_budget
         self._initial_call: Call | None = None
         self._parent_call_id: str | None = None
         self._sequence_id: str | None = None
         self._seq_position: int = 0
-        # See TwoPhaseOrchestrator for why this exists. When True, the
-        # parent already registered our contribution via qbp_recurse, so
-        # run() must not double-register.
         self._pool_pre_registered: bool = pool_pre_registered
 
     def _effective_budget(self, global_remaining: int) -> int:
-        if self._budget_cap is not None:
-            return min(global_remaining, self._budget_cap - self._consumed)
         return global_remaining
 
     async def _pacing_params(self) -> tuple[int, int]:
-        if self._budget_cap is not None:
-            return self._budget_cap, self._consumed
+        if self.pool_question_id:
+            pool = await self.db.qbp_get(self.pool_question_id)
+            if pool.registered:
+                return pool.contributed, pool.consumed
         return await self.db.get_budget()
 
     async def create_initial_call(
@@ -101,7 +97,11 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
         parent_call_id: str | None = None,
     ) -> str:
         """Eagerly create the phase-1 prioritization call record."""
-        budget = self._effective_budget(await self.db.budget_remaining())
+        budget = (
+            self._assigned_budget
+            if self._assigned_budget is not None
+            else await self.db.budget_remaining()
+        )
         budget = await self._paced_budget(budget)
         phase1_budget = budget
         p_call = await self.db.create_call(
@@ -141,7 +141,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             self._seq_position = 0
         self.pool_question_id = claim_id
         if not self._pool_pre_registered:
-            contribution = self._budget_cap if self._budget_cap is not None else effective
+            contribution = self._assigned_budget if self._assigned_budget is not None else effective
             await self.db.qbp_register(claim_id, contribution)
         try:
             while True:
@@ -196,25 +196,6 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
             finally:
                 await self._teardown()
                 await own_db.close()
-
-    async def _run_dispatch_sequence(
-        self,
-        sequence: Sequence[Dispatch],
-        scope_question_id: str,
-        parent_call_id: str | None,
-        base_index: int,
-        position_in_batch: int = 0,
-    ) -> bool:
-        result = await super()._run_dispatch_sequence(
-            sequence,
-            scope_question_id,
-            parent_call_id,
-            base_index,
-            position_in_batch=position_in_batch,
-        )
-        if result:
-            self._consumed += len(sequence)
-        return result
 
     async def _is_new_claim(self, claim_id: str) -> bool:
         """A claim is 'new' if no other page depends on it yet."""
@@ -625,7 +606,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                 child = ClaimInvestigationOrchestrator(
                     self.db,
                     self.broadcaster,
-                    budget_cap=d.payload.budget,
+                    assigned_budget=d.payload.budget,
                     pool_pre_registered=True,
                 )
                 child._parent_call_id = p_call.id
@@ -648,7 +629,7 @@ class ClaimInvestigationOrchestrator(BaseOrchestrator):
                 child = TwoPhaseOrchestrator(
                     self.db,
                     self.broadcaster,
-                    budget_cap=d.payload.budget,
+                    assigned_budget=d.payload.budget,
                     pool_pre_registered=True,
                 )
                 child._parent_call_id = p_call.id

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -108,7 +108,11 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         before ``run()`` begins. ``_initial_prioritization`` reuses the
         pre-created call.
         """
-        budget = self._effective_budget(await self.db.budget_remaining())
+        budget = (
+            self._assigned_budget
+            if self._assigned_budget is not None
+            else await self.db.budget_remaining()
+        )
         budget = await self._paced_budget(budget)
         initial_prioritization_budget = budget
         p_call = await self.db.create_call(

--- a/src/rumil/orchestrators/experimental.py
+++ b/src/rumil/orchestrators/experimental.py
@@ -6,7 +6,6 @@ Currently an exact copy of TwoPhaseOrchestrator.
 
 import asyncio
 import logging
-from collections.abc import Sequence
 from datetime import UTC, datetime
 
 from rumil.available_calls import get_available_calls_preset
@@ -71,7 +70,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         self,
         db: DB,
         broadcaster: Broadcaster | None = None,
-        budget_cap: int | None = None,
+        assigned_budget: int | None = None,
         pool_pre_registered: bool = False,
     ):
         super().__init__(db, broadcaster)
@@ -79,24 +78,23 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         self._call_id: str | None = None
 
         self._executed_since_last_plan: bool = False
-        self._budget_cap: int | None = budget_cap
-        self._consumed: int = 0
+        # See TwoPhaseOrchestrator for the semantics of these two fields.
+        self._assigned_budget: int | None = assigned_budget
         self._initial_call: Call | None = None
         self._parent_call_id: str | None = None
         self._sequence_id: str | None = None
         self._seq_position: int = 0
         self._last_linker_eval_at: datetime | None = None
-        # See TwoPhaseOrchestrator for why this exists.
         self._pool_pre_registered: bool = pool_pre_registered
 
     def _effective_budget(self, global_remaining: int) -> int:
-        if self._budget_cap is not None:
-            return min(global_remaining, self._budget_cap - self._consumed)
         return global_remaining
 
     async def _pacing_params(self) -> tuple[int, int]:
-        if self._budget_cap is not None:
-            return self._budget_cap, self._consumed
+        if self.pool_question_id:
+            pool = await self.db.qbp_get(self.pool_question_id)
+            if pool.registered:
+                return pool.contributed, pool.consumed
         return await self.db.get_budget()
 
     async def create_initial_call(
@@ -147,7 +145,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
         budget_token = set_experimental_scout_budget(effective)
         self.pool_question_id = root_question_id
         if not self._pool_pre_registered:
-            contribution = self._budget_cap if self._budget_cap is not None else effective
+            contribution = self._assigned_budget if self._assigned_budget is not None else effective
             await self.db.qbp_register(root_question_id, contribution)
         try:
             while True:
@@ -196,25 +194,6 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                 reset_experimental_scout_budget(budget_token)
                 await self._teardown()
                 await own_db.close()
-
-    async def _run_dispatch_sequence(
-        self,
-        sequence: Sequence[Dispatch],
-        scope_question_id: str,
-        parent_call_id: str | None,
-        base_index: int,
-        position_in_batch: int = 0,
-    ) -> bool:
-        result = await super()._run_dispatch_sequence(
-            sequence,
-            scope_question_id,
-            parent_call_id,
-            base_index,
-            position_in_batch=position_in_batch,
-        )
-        if result:
-            self._consumed += len(sequence)
-        return result
 
     async def _needs_initial_prioritization(self, question_id: str) -> bool:
         """Run initial_prioritization iff no view answers the question yet."""
@@ -699,7 +678,7 @@ class ExperimentalOrchestrator(BaseOrchestrator):
                 child = ExperimentalOrchestrator(
                     self.db,
                     self.broadcaster,
-                    budget_cap=d.payload.budget,
+                    assigned_budget=d.payload.budget,
                     pool_pre_registered=True,
                 )
                 child._parent_call_id = p_call.id

--- a/src/rumil/orchestrators/global_prio.py
+++ b/src/rumil/orchestrators/global_prio.py
@@ -453,7 +453,7 @@ class GlobalPrioOrchestrator(BaseOrchestrator):
 
     def _create_local_orchestrator(
         self,
-        budget_cap: int,
+        assigned_budget: int,
         parent_call_id: str | None = None,
     ) -> BaseOrchestrator | None:
         """Create the local orchestrator based on settings."""
@@ -464,7 +464,7 @@ class GlobalPrioOrchestrator(BaseOrchestrator):
             orch = ExperimentalOrchestrator(
                 self.db,
                 self.broadcaster,
-                budget_cap=budget_cap,
+                assigned_budget=assigned_budget,
             )
             orch._parent_call_id = parent_call_id
             return orch
@@ -472,7 +472,7 @@ class GlobalPrioOrchestrator(BaseOrchestrator):
             orch = TwoPhaseOrchestrator(
                 self.db,
                 self.broadcaster,
-                budget_cap=budget_cap,
+                assigned_budget=assigned_budget,
             )
             orch._parent_call_id = parent_call_id
             return orch

--- a/src/rumil/orchestrators/two_phase.py
+++ b/src/rumil/orchestrators/two_phase.py
@@ -4,7 +4,6 @@ TwoPhaseOrchestrator: two-phase orchestrator for new questions.
 
 import asyncio
 import logging
-from collections.abc import Sequence
 
 from rumil.available_calls import get_available_calls_preset
 from rumil.calls.common import embed_task_for_page, mark_call_completed
@@ -69,7 +68,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         self,
         db: DB,
         broadcaster: Broadcaster | None = None,
-        budget_cap: int | None = None,
+        assigned_budget: int | None = None,
         pool_pre_registered: bool = False,
     ):
         super().__init__(db, broadcaster)
@@ -77,8 +76,14 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         self._call_id: str | None = None
 
         self._executed_since_last_plan: bool = False
-        self._budget_cap: int | None = budget_cap
-        self._consumed: int = 0
+        # The budget assigned to this orchestrator at construction. NOT a
+        # runtime cap — it's the amount this orchestrator contributes to its
+        # question pool on run() start (when not pool_pre_registered) and the
+        # ``allocated`` figure surfaced in RecurseFailedEvent. The pool's
+        # ``remaining`` is the authoritative per-question gate during the run
+        # loop, so this orchestrator can spend more than ``_assigned_budget``
+        # if peer cycles or prior contributions have left surplus in the pool.
+        self._assigned_budget: int | None = assigned_budget
         self._initial_call: Call | None = None
         self._parent_call_id: str | None = None
         self._sequence_id: str | None = None
@@ -91,13 +96,13 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         self._pool_pre_registered: bool = pool_pre_registered
 
     def _effective_budget(self, global_remaining: int) -> int:
-        if self._budget_cap is not None:
-            return min(global_remaining, self._budget_cap - self._consumed)
         return global_remaining
 
     async def _pacing_params(self) -> tuple[int, int]:
-        if self._budget_cap is not None:
-            return self._budget_cap, self._consumed
+        if self.pool_question_id:
+            pool = await self.db.qbp_get(self.pool_question_id)
+            if pool.registered:
+                return pool.contributed, pool.consumed
         return await self.db.get_budget()
 
     async def create_initial_call(
@@ -111,7 +116,11 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
         before ``run()`` begins. ``_initial_prioritization`` reuses the
         pre-created call.
         """
-        budget = self._effective_budget(await self.db.budget_remaining())
+        budget = (
+            self._assigned_budget
+            if self._assigned_budget is not None
+            else await self.db.budget_remaining()
+        )
         budget = await self._paced_budget(budget)
         initial_prioritization_budget = budget
         p_call = await self.db.create_call(
@@ -151,7 +160,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             self._seq_position = 0
         self.pool_question_id = root_question_id
         if not self._pool_pre_registered:
-            contribution = self._budget_cap if self._budget_cap is not None else effective
+            contribution = self._assigned_budget if self._assigned_budget is not None else effective
             await self.db.qbp_register(root_question_id, contribution)
         try:
             while True:
@@ -219,25 +228,6 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
             finally:
                 await self._teardown()
                 await own_db.close()
-
-    async def _run_dispatch_sequence(
-        self,
-        sequence: Sequence[Dispatch],
-        scope_question_id: str,
-        parent_call_id: str | None,
-        base_index: int,
-        position_in_batch: int = 0,
-    ) -> bool:
-        result = await super()._run_dispatch_sequence(
-            sequence,
-            scope_question_id,
-            parent_call_id,
-            base_index,
-            position_in_batch=position_in_batch,
-        )
-        if result:
-            self._consumed += len(sequence)
-        return result
 
     async def _needs_initial_prioritization(self, question_id: str) -> bool:
         """Run initial_prioritization iff no view answers the question yet."""
@@ -719,7 +709,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 child_claim = ClaimInvestigationOrchestrator(
                     self.db,
                     self.broadcaster,
-                    budget_cap=d.payload.budget,
+                    assigned_budget=d.payload.budget,
                     pool_pre_registered=True,
                 )
                 child_claim._parent_call_id = p_call.id
@@ -742,7 +732,7 @@ class TwoPhaseOrchestrator(BaseOrchestrator):
                 child = TwoPhaseOrchestrator(
                     self.db,
                     self.broadcaster,
-                    budget_cap=d.payload.budget,
+                    assigned_budget=d.payload.budget,
                     pool_pre_registered=True,
                 )
                 child._parent_call_id = p_call.id

--- a/src/rumil/versus_bridge.py
+++ b/src/rumil/versus_bridge.py
@@ -639,7 +639,7 @@ async def judge_pair_orch(
         question_id = await ensure_versus_question(db, pair)
         await db.init_budget(budget)
 
-        orch = TwoPhaseOrchestrator(db=db, broadcaster=broadcaster, budget_cap=budget)
+        orch = TwoPhaseOrchestrator(db=db, broadcaster=broadcaster, assigned_budget=budget)
         try:
             await orch.run(question_id)
         except Exception:

--- a/tests/test_budget_pacing.py
+++ b/tests/test_budget_pacing.py
@@ -51,24 +51,28 @@ def test_base_allocation_scaling() -> None:
 
 
 @pytest.mark.asyncio
-async def test_paced_budget_uses_budget_cap_in_nested_orchestrator(tmp_db):
-    """When budget_cap is set, _pacing_params returns the local cap/consumed, not global.
-
-    Nested orchestrators pace against their own allocation; a child with cap=20
-    paces like a 20-budget run regardless of the global pool size.
+async def test_paced_budget_uses_pool_when_registered(tmp_db, question_page):
+    """When the orchestrator's pool is registered, ``_pacing_params`` returns
+    pool-level totals, so pacing scales with the actual shared pool — including
+    any sibling contributions — rather than just this orchestrator's slice.
     """
     await tmp_db.init_budget(100)
     await tmp_db.consume_budget(40)
 
-    capped = TwoPhaseOrchestrator(tmp_db, budget_cap=20)
-    capped._consumed = 5
-    total, used = await capped._pacing_params()
-    assert (total, used) == (20, 5), (
-        f"capped orch should pace from (budget_cap, _consumed); got ({total}, {used})"
+    # Pool registered with a sibling contribution of 30 already consumed by 10.
+    # When this orchestrator joins, contributions sum and pacing sees the total.
+    await tmp_db.qbp_register(question_page.id, 30)
+    await tmp_db.qbp_consume(question_page.id, 10)
+
+    pooled = TwoPhaseOrchestrator(tmp_db)
+    pooled.pool_question_id = question_page.id
+    total, used = await pooled._pacing_params()
+    assert (total, used) == (30, 10), (
+        f"pooled orch should pace from (pool.contributed, pool.consumed); got ({total}, {used})"
     )
 
     uncapped = TwoPhaseOrchestrator(tmp_db)
     g_total, g_used = await uncapped._pacing_params()
     assert (g_total, g_used) == (100, 40), (
-        f"uncapped orch should pace from global budget; got ({g_total}, {g_used})"
+        f"orch without a registered pool should pace from global budget; got ({g_total}, {g_used})"
     )

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -346,15 +346,15 @@ async def test_failed_recurse_child_refunds_and_records_event(
     )
 
     class FailingChild(BaseOrchestrator):
-        def __init__(self, db, call_id, budget_cap):
+        def __init__(self, db, call_id, assigned_budget):
             super().__init__(db)
             self._call_id = call_id
-            self._budget_cap = budget_cap
+            self._assigned_budget = assigned_budget
 
         async def run(self, root_question_id):
             raise ValueError("child cycle blew up before consuming any budget")
 
-    child = FailingChild(tmp_db, child_p_call.id, budget_cap=4)
+    child = FailingChild(tmp_db, child_p_call.id, assigned_budget=4)
 
     parent = TwoPhaseOrchestrator(tmp_db)
     parent.pool_question_id = question_page.id
@@ -422,15 +422,15 @@ async def test_partial_consumption_refund_only_unspent(
     )
 
     class FailingChild(BaseOrchestrator):
-        def __init__(self, db, call_id, budget_cap):
+        def __init__(self, db, call_id, assigned_budget):
             super().__init__(db)
             self._call_id = call_id
-            self._budget_cap = budget_cap
+            self._assigned_budget = assigned_budget
 
         async def run(self, root_question_id):
             raise RuntimeError("partial spend then crash")
 
-    child = FailingChild(tmp_db, child_p_call.id, budget_cap=5)
+    child = FailingChild(tmp_db, child_p_call.id, assigned_budget=5)
 
     parent = TwoPhaseOrchestrator(tmp_db)
     parent.pool_question_id = question_page.id

--- a/tests/test_parallel_investigations.py
+++ b/tests/test_parallel_investigations.py
@@ -247,12 +247,12 @@ async def _make_question(db, headline: str) -> Page:
 
 
 async def test_concurrent_recursive_children_dont_overspend_global_budget(tmp_db, mocker):
-    """Two concurrent recurse children with caps summing above remaining must not overspend.
+    """Two concurrent recurse children with assignments summing above remaining must
+    not overspend.
 
-    Pins the invariant that ``_consumed`` tracked locally per orchestrator
-    does not allow siblings to collectively overdraw the shared global pool.
-    If a future rearch holds stale per-orchestrator consumption counters, this
-    test should fail.
+    Pins the invariant that the per-question pool plus the run-level budget
+    bound concurrent siblings — neither is allowed to draw past the shared
+    global remaining, even when their assigned_budgets sum to more than that.
     """
     parent_q = await _make_question(tmp_db, "Parent Q")
     child_a = await _make_question(tmp_db, "Child A")

--- a/tests/test_question_budget_pool.py
+++ b/tests/test_question_budget_pool.py
@@ -289,7 +289,7 @@ async def test_orchestrator_registers_on_run_start_and_unregisters_after(
         RunCallResult(dispatches=[]),
     ]
 
-    parent = TwoPhaseOrchestrator(tmp_db, budget_cap=15)
+    parent = TwoPhaseOrchestrator(tmp_db, assigned_budget=15)
     await parent.run(question_page.id)
 
     pool = await tmp_db.qbp_get(question_page.id)
@@ -391,7 +391,7 @@ async def test_recurse_dispatch_charges_parent_pool_and_registers_child(
         RunCallResult(dispatches=[]),
     ]
 
-    parent = TwoPhaseOrchestrator(tmp_db, budget_cap=20)
+    parent = TwoPhaseOrchestrator(tmp_db, assigned_budget=20)
     await parent.run(question_page.id)
 
     parent_pool = await tmp_db.qbp_get(question_page.id)
@@ -402,6 +402,76 @@ async def test_recurse_dispatch_charges_parent_pool_and_registers_child(
     # Child orchestrator registered itself with budget=MIN_TWOPHASE_BUDGET when
     # its run() began.
     assert child_pool.contributed >= MIN_TWOPHASE_BUDGET
+
+
+@pytest.mark.asyncio
+async def test_recurse_child_consumes_full_pool_not_just_assigned_slice(
+    tmp_db, question_page, child_question_page, prio_harness
+):
+    """Recurse children draw from the full per-question pool, not just their slice.
+
+    Pins the fix for the budget-sharing bug: when a child question's pool
+    already has surplus contributions (e.g. from a prior peer cycle), the
+    recurse child orchestrator must be able to consume past its dispatched
+    budget. The previous ``budget_cap - _consumed`` clamp inside
+    ``_effective_budget`` prevented this and collapsed the shared pool back
+    into per-orchestrator slices.
+    """
+    await tmp_db.init_budget(80)
+
+    # A peer / prior cycle left ``surplus`` unconsumed in the child pool.
+    # This is what the recurse child should be allowed to spend on top of
+    # its own dispatched slice. Keep it large enough that the child runs
+    # several rounds — at small pool sizes the loop trips into last_call
+    # mode after one round and consumed never demonstrates "more than
+    # the slice".
+    surplus = MIN_TWOPHASE_BUDGET * 4
+    await tmp_db.qbp_register(child_question_page.id, surplus)
+
+    recurse = Dispatch(
+        call_type=CallType.PRIORITIZATION,
+        payload=RecurseDispatchPayload(
+            question_id=child_question_page.id,
+            budget=MIN_TWOPHASE_BUDGET,
+            reason="drill into subquestion",
+        ),
+    )
+    # The mocked prio queue feeds both parent and child orchestrators in turn.
+    # Parent: 1 seed scout, then 1 recurse. Child: deep queue of single-scout
+    # rounds so the only thing that can stop it is the pool draining.
+    prio_harness.prio_queue = [
+        RunCallResult(dispatches=[_scout_dispatch(question_page.id, "seed")]),
+        RunCallResult(dispatches=[recurse]),
+    ]
+    for i in range(30):
+        prio_harness.prio_queue.append(
+            RunCallResult(dispatches=[_scout_dispatch(child_question_page.id, f"c-{i}")])
+        )
+
+    parent = TwoPhaseOrchestrator(tmp_db, assigned_budget=20)
+    await parent.run(question_page.id)
+
+    child_pool = await tmp_db.qbp_get(child_question_page.id)
+    # Pool ends with: surplus (peer) + MIN_TWOPHASE_BUDGET (recurse contribution).
+    assert child_pool.contributed == surplus + MIN_TWOPHASE_BUDGET
+
+    # Count the scout dispatches the child executed against its own question.
+    # The old ``_budget_cap - _consumed`` clamp inside ``_effective_budget``
+    # would stop the child after exactly MIN_TWOPHASE_BUDGET dispatch sequences
+    # (one per increment of ``_consumed``), regardless of how much surplus the
+    # pool had. The fix lets the child keep running as long as the pool — the
+    # authoritative per-question gate — has remaining budget.
+    scout_count = sum(
+        1
+        for d in prio_harness.dispatched
+        if d["call_type"] == CallType.FIND_CONSIDERATIONS.value
+        and d["question_id"] == child_question_page.id
+    )
+    assert scout_count > MIN_TWOPHASE_BUDGET, (
+        f"Child dispatched only {scout_count} scouts on its question — capped at "
+        f"its assigned slice ({MIN_TWOPHASE_BUDGET}) instead of drawing from "
+        f"the pool's surplus contribution of {surplus}."
+    )
 
 
 @pytest.mark.asyncio
@@ -417,20 +487,23 @@ async def test_loop_stops_when_pool_exhausted_even_if_local_budget_remains(
     await tmp_db.qbp_consume(question_page.id, 10)
 
     # Endless dispatch script — we expect to exit before consuming much of
-    # our own budget_cap.
+    # our own assigned_budget.
     prio_harness.prio_queue = [
         RunCallResult(dispatches=[_scout_dispatch(question_page.id, f"r{i}")]) for i in range(20)
     ]
 
-    parent = TwoPhaseOrchestrator(tmp_db, budget_cap=20)
+    parent = TwoPhaseOrchestrator(tmp_db, assigned_budget=20)
     await parent.run(question_page.id)
 
     # The orchestrator should have exited because pool.remaining hit 0,
-    # not because budget_cap (20) was exhausted. Allow for a small bounded
-    # number of consumes from rounds that fired before the loop check tripped.
-    assert parent._consumed < 20
+    # not because its own assigned_budget (20) was drained. Allow for a small
+    # bounded number of consumes from rounds that fired before the loop check
+    # tripped — strictly less than what this orchestrator contributed (20).
+    pool = await tmp_db.qbp_get(question_page.id)
+    # Pool consumed = 10 (peer's pre-spent) + this orchestrator's spending.
+    # The latter must be small (< 20) for the early-exit to be meaningful.
+    assert pool.consumed - 10 < 20
 
     # Pool active_calls returned to 0 after our orchestrator unregistered
     # itself (we never unregistered the simulated peer).
-    pool = await tmp_db.qbp_get(question_page.id)
     assert pool.active_calls == 1

--- a/tests/test_two_phase_budget.py
+++ b/tests/test_two_phase_budget.py
@@ -54,37 +54,44 @@ async def test_twophase_raises_when_below_min_budget(tmp_db, question_page, prio
         await orch.run(question_page.id)
 
 
-def test_twophase_effective_budget_respects_cap(tmp_db):
-    """Pins the _effective_budget formula: min(global_remaining, cap - consumed)."""
-    orch = TwoPhaseOrchestrator(tmp_db, budget_cap=5)
-    assert orch._effective_budget(100) == 5
-    orch._consumed = 3
-    assert orch._effective_budget(100) == 2
-    orch._consumed = 5
-    assert orch._effective_budget(100) == 0
-    orch._consumed = 10
-    assert orch._effective_budget(100) < 0
+def test_twophase_effective_budget_is_passthrough(tmp_db):
+    """``_effective_budget`` is a passthrough — the run-loop's pool gate enforces
+    the per-question cap, not this method.
+    """
+    orch = TwoPhaseOrchestrator(tmp_db, assigned_budget=5)
+    assert orch._effective_budget(100) == 100
+    assert orch._effective_budget(0) == 0
+    uncapped = TwoPhaseOrchestrator(tmp_db)
+    assert uncapped._effective_budget(42) == 42
 
 
 @pytest.mark.asyncio
-async def test_twophase_budget_cap_limits_rounds(tmp_db, question_page, prio_harness):
-    """budget_cap bounds total dispatch rounds even when global budget is plentiful.
+async def test_twophase_assigned_budget_bounds_rounds_via_pool(tmp_db, question_page, prio_harness):
+    """assigned_budget bounds total dispatch rounds via the per-question pool, even
+    when global budget is plentiful.
 
-    With global budget = 200 but cap = 20, the loop must terminate long before
-    exhausting the scripted prio queue. Consumption also stays bounded by the cap.
+    With global budget = 200 but assigned = 20, the loop must terminate long before
+    exhausting the scripted prio queue. Consumption stays bounded by the pool's
+    contributed amount (= assigned_budget for a top-level orchestrator with no peers).
     """
     await tmp_db.init_budget(200)
     prio_harness.prio_queue = [
         RunCallResult(dispatches=[_scout_dispatch(question_page.id)]) for _ in range(50)
     ]
 
-    budget_cap = 20
-    orch = TwoPhaseOrchestrator(tmp_db, budget_cap=budget_cap)
+    assigned = 20
+    orch = TwoPhaseOrchestrator(tmp_db, assigned_budget=assigned)
     await orch.run(question_page.id)
 
-    assert orch._consumed <= budget_cap, f"_consumed={orch._consumed} exceeded cap={budget_cap}"
+    pool = await tmp_db.qbp_get(question_page.id)
+    assert pool.consumed <= pool.contributed, (
+        f"pool consumption {pool.consumed} exceeded contribution {pool.contributed}"
+    )
+    assert pool.contributed == assigned, (
+        f"top-level orchestrator should have contributed {assigned}, got {pool.contributed}"
+    )
     assert len(prio_harness.prio_queue) > 0, (
-        "prio queue was fully drained — budget_cap did not bound the number of rounds"
+        "prio queue was fully drained — assigned_budget did not bound the number of rounds"
     )
 
 

--- a/tests/test_two_phase_recurse.py
+++ b/tests/test_two_phase_recurse.py
@@ -2,7 +2,7 @@
 
 The recurse path is the closest analog of what the prioritizer rearch
 replaces: today, a recurse dispatch spawns a new ``TwoPhaseOrchestrator``
-(or ``ClaimInvestigationOrchestrator``) with its own ``budget_cap``.
+(or ``ClaimInvestigationOrchestrator``) with its own ``assigned_budget``.
 These tests pin the current contract so the rearch author can tell when
 they've accidentally dropped it.
 """
@@ -49,7 +49,7 @@ def _patch_init(mocker, cls):
         instances.append(
             {
                 "instance": self,
-                "budget_cap": kwargs.get("budget_cap"),
+                "assigned_budget": kwargs.get("assigned_budget"),
             }
         )
 
@@ -58,10 +58,10 @@ def _patch_init(mocker, cls):
 
 
 @pytest.mark.asyncio
-async def test_recurse_dispatch_spawns_child_twophase_with_budget_cap(
+async def test_recurse_dispatch_spawns_child_twophase_with_assigned_budget(
     tmp_db, question_page, child_question_page, prio_harness, mocker
 ):
-    """A RecurseDispatchPayload → a new TwoPhaseOrchestrator with the right budget_cap."""
+    """A RecurseDispatchPayload → a new TwoPhaseOrchestrator with the right assigned_budget."""
     instances = _patch_init(mocker, TwoPhaseOrchestrator)
     await tmp_db.init_budget(30)
     recurse = Dispatch(
@@ -84,14 +84,14 @@ async def test_recurse_dispatch_spawns_child_twophase_with_budget_cap(
 
     child_entries = [i for i in instances if i["instance"] is not parent]
     assert len(child_entries) >= 1
-    assert child_entries[0]["budget_cap"] == MIN_TWOPHASE_BUDGET
+    assert child_entries[0]["assigned_budget"] == MIN_TWOPHASE_BUDGET
 
 
 @pytest.mark.asyncio
 async def test_recurse_claim_dispatch_spawns_claim_investigation_orchestrator(
     tmp_db, question_page, prio_harness, mocker
 ):
-    """A RecurseClaimDispatchPayload → a new ClaimInvestigationOrchestrator with budget_cap."""
+    """A RecurseClaimDispatchPayload → a new ClaimInvestigationOrchestrator with assigned_budget."""
     claim = Page(
         page_type=PageType.CLAIM,
         layer=PageLayer.SQUIDGY,
@@ -131,7 +131,7 @@ async def test_recurse_claim_dispatch_spawns_claim_investigation_orchestrator(
     await parent.run(question_page.id)
 
     assert len(claim_instances) >= 1
-    assert claim_instances[0]["budget_cap"] == MIN_TWOPHASE_BUDGET
+    assert claim_instances[0]["assigned_budget"] == MIN_TWOPHASE_BUDGET
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Recurse children were silently capped at their dispatched budget by the ``_budget_cap - _consumed`` clamp inside ``_effective_budget``, even when the per-question pool had peer surplus available — defeating the whole point of the shared pool. Drop the clamp; the pool's ``remaining`` (already ``min``-ed in the run loop) is the authoritative per-question gate, and the run-level ``budget`` table is the global ceiling.
- Round-based orchestrators now pace against ``(pool.contributed, pool.consumed)`` once the pool is registered, so pacing scales with the actual shared total instead of just this orchestrator's slice.
- Rename ``budget_cap`` → ``assigned_budget`` so the field's role (initial pool contribution + ``RecurseFailedEvent`` metadata) matches its name. Drop the now-dead ``_consumed`` counter and ``_run_dispatch_sequence`` overrides in all three round-based orchestrators.

## Test plan

- [x] ``uv run pyright`` — clean (0 errors).
- [x] ``uv run pytest`` — 1190 passed, 52 skipped, 2 xfailed.
- [x] New regression test ``test_recurse_child_consumes_full_pool_not_just_assigned_slice`` in ``tests/test_question_budget_pool.py``: pre-seeds peer surplus on the child question's pool, dispatches a recurse with ``MIN_TWOPHASE_BUDGET``, and asserts the child dispatched more scouts than its assigned slice. Verified the test fails when the old ``_budget_cap`` clamp is reintroduced.
- [x] Updated ``test_twophase_budget_cap_limits_rounds`` → ``test_twophase_assigned_budget_bounds_rounds_via_pool`` (asserts pool consumption, not the deleted ``_consumed``); ``test_paced_budget_uses_budget_cap_in_nested_orchestrator`` → ``test_paced_budget_uses_pool_when_registered``; ``test_twophase_effective_budget_respects_cap`` → ``test_twophase_effective_budget_is_passthrough``.
- [ ] Smoke run on a real question — confirm a recurse child can spend past its dispatched slice when peer surplus exists in the pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)