### PR TITLE
refactor(scouts): define scouts via metadata, not name prefix

### DIFF
--- a/scripts/run_call.py
+++ b/scripts/run_call.py
@@ -65,23 +65,32 @@ from rumil.calls.scout_web_questions import ScoutWebQuestionsCall
 from rumil.calls.stages import CallRunner
 from rumil.calls.web_research import WebResearchCall
 from rumil.database import DB
-from rumil.models import CallStage, CallType
+from rumil.models import SCOUT_CALL_TYPES, CallStage, CallType, ScoutScope
 from rumil.orchestrators import create_root_question
 from rumil.orchestrators.robustify import RobustifyOrchestrator
 from rumil.settings import get_settings
 from rumil.tracing import get_langfuse
 from rumil.views import get_active_view
 
-_SCOUT_CALL_TYPES: dict[str, tuple[CallType, type[CallRunner]]] = {
-    "scout-subquestions": (CallType.SCOUT_SUBQUESTIONS, ScoutSubquestionsCall),
-    "scout-estimates": (CallType.SCOUT_ESTIMATES, ScoutEstimatesCall),
-    "scout-hypotheses": (CallType.SCOUT_HYPOTHESES, ScoutHypothesesCall),
-    "scout-analogies": (CallType.SCOUT_ANALOGIES, ScoutAnalogiesCall),
-    "scout-paradigm-cases": (CallType.SCOUT_PARADIGM_CASES, ScoutParadigmCasesCall),
-    "scout-factchecks": (CallType.SCOUT_FACTCHECKS, ScoutFactchecksCall),
-    "scout-web-questions": (CallType.SCOUT_WEB_QUESTIONS, ScoutWebQuestionsCall),
-    "scout-deep-questions": (CallType.SCOUT_DEEP_QUESTIONS, ScoutDeepQuestionsCall),
+# CallRunner class for each question-scoped scout that this script can fire.
+# Claim-scoped scouts (see SCOUT_CALL_TYPES in models.py) are excluded because
+# this script only takes question scopes. CLI subcommand for each is derived
+# as ct.value.replace("_", "-") at usage sites.
+_SCOUT_RUNNERS: dict[CallType, type[CallRunner]] = {
+    CallType.SCOUT_SUBQUESTIONS: ScoutSubquestionsCall,
+    CallType.SCOUT_ESTIMATES: ScoutEstimatesCall,
+    CallType.SCOUT_HYPOTHESES: ScoutHypothesesCall,
+    CallType.SCOUT_ANALOGIES: ScoutAnalogiesCall,
+    CallType.SCOUT_PARADIGM_CASES: ScoutParadigmCasesCall,
+    CallType.SCOUT_FACTCHECKS: ScoutFactchecksCall,
+    CallType.SCOUT_WEB_QUESTIONS: ScoutWebQuestionsCall,
+    CallType.SCOUT_DEEP_QUESTIONS: ScoutDeepQuestionsCall,
 }
+assert set(_SCOUT_RUNNERS) == {
+    ct for ct, scope in SCOUT_CALL_TYPES.items() if scope == ScoutScope.QUESTION
+}, "run_call.py _SCOUT_RUNNERS is out of sync with models.SCOUT_CALL_TYPES"
+
+_SCOUT_CLI_LOOKUP: dict[str, CallType] = {ct.value.replace("_", "-"): ct for ct in _SCOUT_RUNNERS}
 
 
 async def run_call(args: argparse.Namespace, db: DB, question_id: str) -> None:
@@ -132,8 +141,9 @@ async def run_call(args: argparse.Namespace, db: DB, question_id: str) -> None:
         )
         await web_research.run()
 
-    elif call_type in _SCOUT_CALL_TYPES:
-        scout_ct, cls = _SCOUT_CALL_TYPES[call_type]
+    elif call_type in _SCOUT_CLI_LOOKUP:
+        scout_ct = _SCOUT_CLI_LOOKUP[call_type]
+        cls = _SCOUT_RUNNERS[scout_ct]
         call = await db.create_call(scout_ct, scope_page_id=question_id)
         instance = cls(
             question_id,
@@ -367,7 +377,7 @@ def main() -> None:
             "web-research",
             "link-subquestions",
             "refresh-view",
-            *_SCOUT_CALL_TYPES,
+            *_SCOUT_CLI_LOOKUP,
         ],
         help="Type of call to run",
     )

--- a/src/rumil/calls/context_builders.py
+++ b/src/rumil/calls/context_builders.py
@@ -35,6 +35,8 @@ from rumil.models import (
     PageDetail,
     PageLink,
     PageType,
+    ScoutScope,
+    scout_scope,
 )
 from rumil.settings import get_settings
 from rumil.views import get_active_view
@@ -234,18 +236,21 @@ class RedTeamContext(ContextBuilder):
 
 
 class EmbeddingContext(ContextBuilder):
-    """Embedding-based context. Used by embedding variants."""
+    """Embedding-based context. Used by embedding variants.
+
+    Question-scoped scouts (per ``SCOUT_CALL_TYPES``) automatically get a
+    scout-tailored view block prepended to the context. Other call types
+    do not.
+    """
 
     def __init__(
         self,
         call_type: CallType,
         *,
         require_take_for_questions: bool = False,
-        view_for_scout: bool = False,
     ) -> None:
         self._call_type = call_type
         self._require_take_for_questions = require_take_for_questions
-        self._view_for_scout = view_for_scout
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
         question = await infra.db.get_page(infra.question_id)
@@ -253,7 +258,7 @@ class EmbeddingContext(ContextBuilder):
 
         scout_view_block = ""
         exclude_page_ids: set[str] = set()
-        if self._view_for_scout:
+        if scout_scope(self._call_type) == ScoutScope.QUESTION:
             view = get_active_view()
             rendered = await view.render_for_scout(infra.question_id, infra.db)
             if rendered:
@@ -364,21 +369,9 @@ class ScoutSiblingAwareContext(EmbeddingContext):
     questions of the scope question, so the scout can avoid creating children
     whose impact on the parent is mediated through an existing sibling.
 
-    Scout-only by construction, so ``view_for_scout`` defaults to True.
+    Used only by question-scoped scouts; the parent class auto-derives the
+    scout-view treatment from the call type's scout scope.
     """
-
-    def __init__(
-        self,
-        call_type: CallType,
-        *,
-        require_take_for_questions: bool = False,
-        view_for_scout: bool = True,
-    ) -> None:
-        super().__init__(
-            call_type,
-            require_take_for_questions=require_take_for_questions,
-            view_for_scout=view_for_scout,
-        )
 
     async def build_context(self, infra: CallInfra) -> ContextResult:
         result = await super().build_context(infra)

--- a/src/rumil/calls/find_considerations.py
+++ b/src/rumil/calls/find_considerations.py
@@ -60,11 +60,7 @@ class FindConsiderationsCall(CallRunner):
         return 0
 
     def _make_context_builder(self) -> ContextBuilder:
-        return EmbeddingContext(
-            self.call_type,
-            require_take_for_questions=True,
-            view_for_scout=True,
-        )
+        return EmbeddingContext(self.call_type, require_take_for_questions=True)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:
         return MultiRoundLoop(

--- a/src/rumil/calls/scout_c_cruxes.py
+++ b/src/rumil/calls/scout_c_cruxes.py
@@ -21,8 +21,6 @@ class ScoutCCruxesCall(CallRunner):
     call_type = CallType.SCOUT_C_CRUXES
 
     def _make_context_builder(self) -> ContextBuilder:
-        # No view_for_scout: this scout's scope is a claim, not a question,
-        # so View.render_for_scout would just round-trip to no result.
         return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:

--- a/src/rumil/calls/scout_c_how_false.py
+++ b/src/rumil/calls/scout_c_how_false.py
@@ -21,8 +21,6 @@ class ScoutCHowFalseCall(CallRunner):
     call_type = CallType.SCOUT_C_HOW_FALSE
 
     def _make_context_builder(self) -> ContextBuilder:
-        # No view_for_scout: this scout's scope is a claim, not a question,
-        # so View.render_for_scout would just round-trip to no result.
         return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:

--- a/src/rumil/calls/scout_c_how_true.py
+++ b/src/rumil/calls/scout_c_how_true.py
@@ -21,8 +21,6 @@ class ScoutCHowTrueCall(CallRunner):
     call_type = CallType.SCOUT_C_HOW_TRUE
 
     def _make_context_builder(self) -> ContextBuilder:
-        # No view_for_scout: this scout's scope is a claim, not a question,
-        # so View.render_for_scout would just round-trip to no result.
         return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:

--- a/src/rumil/calls/scout_c_relevant_evidence.py
+++ b/src/rumil/calls/scout_c_relevant_evidence.py
@@ -21,8 +21,6 @@ class ScoutCRelevantEvidenceCall(CallRunner):
     call_type = CallType.SCOUT_C_RELEVANT_EVIDENCE
 
     def _make_context_builder(self) -> ContextBuilder:
-        # No view_for_scout: this scout's scope is a claim, not a question,
-        # so View.render_for_scout would just round-trip to no result.
         return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:

--- a/src/rumil/calls/scout_c_robustify.py
+++ b/src/rumil/calls/scout_c_robustify.py
@@ -21,8 +21,6 @@ class ScoutCRobustifyCall(CallRunner):
     call_type = CallType.SCOUT_C_ROBUSTIFY
 
     def _make_context_builder(self) -> ContextBuilder:
-        # No view_for_scout: this scout's scope is a claim, not a question,
-        # so View.render_for_scout would just round-trip to no result.
         return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:

--- a/src/rumil/calls/scout_c_strengthen.py
+++ b/src/rumil/calls/scout_c_strengthen.py
@@ -21,8 +21,6 @@ class ScoutCStrengthenCall(CallRunner):
     call_type = CallType.SCOUT_C_STRENGTHEN
 
     def _make_context_builder(self) -> ContextBuilder:
-        # No view_for_scout: this scout's scope is a claim, not a question,
-        # so View.render_for_scout would just round-trip to no result.
         return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:

--- a/src/rumil/calls/scout_c_stress_test_cases.py
+++ b/src/rumil/calls/scout_c_stress_test_cases.py
@@ -21,8 +21,6 @@ class ScoutCStressTestCasesCall(CallRunner):
     call_type = CallType.SCOUT_C_STRESS_TEST_CASES
 
     def _make_context_builder(self) -> ContextBuilder:
-        # No view_for_scout: this scout's scope is a claim, not a question,
-        # so View.render_for_scout would just round-trip to no result.
         return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:

--- a/src/rumil/calls/scout_hypotheses.py
+++ b/src/rumil/calls/scout_hypotheses.py
@@ -21,7 +21,7 @@ class ScoutHypothesesCall(CallRunner):
     call_type = CallType.SCOUT_HYPOTHESES
 
     def _make_context_builder(self) -> ContextBuilder:
-        return EmbeddingContext(self.call_type, view_for_scout=True)
+        return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:
         return MultiRoundLoop(

--- a/src/rumil/calls/scout_subquestions.py
+++ b/src/rumil/calls/scout_subquestions.py
@@ -21,7 +21,7 @@ class ScoutSubquestionsCall(CallRunner):
     call_type = CallType.SCOUT_SUBQUESTIONS
 
     def _make_context_builder(self) -> ContextBuilder:
-        return EmbeddingContext(self.call_type, view_for_scout=True)
+        return EmbeddingContext(self.call_type)
 
     def _make_workspace_updater(self) -> WorkspaceUpdater:
         return MultiRoundLoop(

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -22,6 +22,7 @@ from tenacity import (
 )
 
 from rumil.models import (
+    SCOUT_CALL_TYPES,
     Call,
     CallSequence,
     CallStatus,
@@ -2376,7 +2377,7 @@ class DB:
                 .select("call_type, completed_at, review_json")
                 .eq("scope_page_id", question_id)
                 .eq("status", "complete")
-                .like("call_type", "scout_%")
+                .in_("call_type", [ct.value for ct in SCOUT_CALL_TYPES])
                 .order("completed_at", desc=True)
             )
         )

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -46,6 +46,7 @@ from tenacity import (
 )
 
 from rumil.model_config import ModelConfig
+from rumil.models import CallType, ScoutScope, scout_scope
 from rumil.pricing import compute_cost
 from rumil.prompts import PROMPTS_DIR
 from rumil.settings import get_settings
@@ -206,20 +207,6 @@ def reset_experimental_scout_budget(token: contextvars.Token) -> None:
     _experimental_scout_budget.reset(token)
 
 
-_SCOUT_BUDGET_CALL_TYPES: frozenset[str] = frozenset(
-    {
-        "scout_subquestions",
-        "scout_estimates",
-        "scout_hypotheses",
-        "scout_analogies",
-        "scout_paradigm_cases",
-        "scout_factchecks",
-        "scout_web_questions",
-        "scout_deep_questions",
-    }
-)
-
-
 def build_system_prompt(
     call_type: str,
     *,
@@ -263,11 +250,16 @@ def build_system_prompt(
         parts.append(_load_file("citations.md"))
     parts.append(grounding)
     budget = _experimental_scout_budget.get()
-    if budget is not None and call_type in _SCOUT_BUDGET_CALL_TYPES:
-        budget_awareness = _load_file("scout_budget_awareness_experimental.md").format(
-            budget=budget
-        )
-        parts.append(budget_awareness)
+    if budget is not None:
+        try:
+            ct_enum = CallType(call_type)
+        except ValueError:
+            ct_enum = None
+        if ct_enum is not None and scout_scope(ct_enum) == ScoutScope.QUESTION:
+            budget_awareness = _load_file("scout_budget_awareness_experimental.md").format(
+                budget=budget
+            )
+            parts.append(budget_awareness)
     return "\n\n---\n\n".join(parts)
 
 

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -134,6 +134,41 @@ DISPATCHABLE_CALL_TYPES: set[CallType] = {
 }
 
 
+class ScoutScope(str, Enum):
+    QUESTION = "question"
+    CLAIM = "claim"
+
+
+# Single source of truth: which CallTypes are scouts and what their scope is.
+# Treat this as the authoritative answer to "is this a scout?" — never test
+# call_type names by string prefix.
+SCOUT_CALL_TYPES: dict[CallType, ScoutScope] = {
+    CallType.SCOUT_SUBQUESTIONS: ScoutScope.QUESTION,
+    CallType.SCOUT_ESTIMATES: ScoutScope.QUESTION,
+    CallType.SCOUT_HYPOTHESES: ScoutScope.QUESTION,
+    CallType.SCOUT_ANALOGIES: ScoutScope.QUESTION,
+    CallType.SCOUT_PARADIGM_CASES: ScoutScope.QUESTION,
+    CallType.SCOUT_FACTCHECKS: ScoutScope.QUESTION,
+    CallType.SCOUT_WEB_QUESTIONS: ScoutScope.QUESTION,
+    CallType.SCOUT_DEEP_QUESTIONS: ScoutScope.QUESTION,
+    CallType.SCOUT_C_HOW_TRUE: ScoutScope.CLAIM,
+    CallType.SCOUT_C_HOW_FALSE: ScoutScope.CLAIM,
+    CallType.SCOUT_C_CRUXES: ScoutScope.CLAIM,
+    CallType.SCOUT_C_RELEVANT_EVIDENCE: ScoutScope.CLAIM,
+    CallType.SCOUT_C_STRESS_TEST_CASES: ScoutScope.CLAIM,
+    CallType.SCOUT_C_ROBUSTIFY: ScoutScope.CLAIM,
+    CallType.SCOUT_C_STRENGTHEN: ScoutScope.CLAIM,
+}
+
+
+def is_scout(call_type: CallType) -> bool:
+    return call_type in SCOUT_CALL_TYPES
+
+
+def scout_scope(call_type: CallType) -> ScoutScope | None:
+    return SCOUT_CALL_TYPES.get(call_type)
+
+
 class CallStatus(str, Enum):
     PENDING = "pending"
     RUNNING = "running"

--- a/src/rumil/orchestrators/base.py
+++ b/src/rumil/orchestrators/base.py
@@ -19,6 +19,7 @@ from rumil.models import (
     CallType,
     CreateViewDispatchPayload,
     Dispatch,
+    is_scout,
 )
 from rumil.orchestrators.common import (
     PrioritizationResult,
@@ -400,15 +401,16 @@ class BaseOrchestrator(ABC):
         list (typically: stop when it is empty or all entries are exceptions).
 
         When ``self.run_initial_scouts_only`` is True, ``result`` is filtered
-        to scout-only sequences (every dispatch's ``call_type`` starts with
-        ``scout_``) and recursive children are skipped — useful for
-        inspecting scout outputs without firing off downstream work.
+        to scout-only sequences (every dispatch's ``call_type`` is a scout per
+        the ``SCOUT_CALL_TYPES`` registry) and recursive children are skipped
+        — useful for inspecting scout outputs without firing off downstream
+        work.
         """
         if self.run_initial_scouts_only:
             scout_sequences = [
                 seq
                 for seq in result.dispatch_sequences
-                if seq and all(d.call_type.value.startswith("scout_") for d in seq)
+                if seq and all(is_scout(d.call_type) for d in seq)
             ]
             skipped = len(result.dispatch_sequences) - len(scout_sequences)
             if skipped or result.children:


### PR DESCRIPTION
## Summary

- Replaces three brittle string-prefix sites that asked "is this a scout?" by name (`.startswith(\"scout_\")` in `orchestrators/base.py`, `_SCOUT_BUDGET_CALL_TYPES` frozenset in `llm.py`, `LIKE \"scout_%\"` in `database.py`) with a central `SCOUT_CALL_TYPES: dict[CallType, ScoutScope]` registry in `models.py`. The dict also captures the question-vs-claim scope distinction the codebase was making implicitly via the `_c_` infix.
- Drops the `view_for_scout` parameter from `EmbeddingContext`. The scout-view treatment now derives from `scout_scope(call_type) == ScoutScope.QUESTION`, so each scout subclass no longer has to remember to pass it; seven duplicated explanatory comments on claim-scoped scouts go away.
- Fixes a latent bug in `find_considerations.py`: it was passing `view_for_scout=True` even though `FIND_CONSIDERATIONS` is not a scout. After the refactor it correctly gets no scout-view block.

## Test plan

- [x] `uv run pyright` clean
- [x] `uv run pytest` — 1190 passed, 52 skipped, 2 xfailed
- [x] grep `startswith(.scout` / `scout_%` / `view_for_scout` / `_SCOUT_BUDGET` across `src/` and `scripts/` — zero hits
- [ ] End-to-end smoke run: `uv run python main.py \"Is the sky blue?\" --workspace metadata-scouts-scratch --smoke-test --budget 5` — confirm scouts dispatch and complete; spot-check a question-scoped scout's trace shows the scout-view callout and a claim-scoped scout's does not
- [ ] Confirm `find_considerations` calls no longer carry the scout-view callout (bug fix verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)