### PR TITLE
fix: recover and observe truncated JSON failures in deep_review

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7439,6 +7439,17 @@
               }
             ],
             "title": "Langfuse Trace Url"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
           }
         },
         "type": "object",
@@ -7457,7 +7468,8 @@
           "cost_usd",
           "has_thinking",
           "tool_uses",
-          "langfuse_trace_url"
+          "langfuse_trace_url",
+          "error"
         ],
         "title": "LLMExchangeEventOut"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2512,6 +2512,10 @@ export type LlmExchangeEventOut = {
      * Langfuse Trace Url
      */
     langfuse_trace_url: string | null;
+    /**
+     * Error
+     */
+    error: string | null;
 };
 
 /**

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -750,8 +750,9 @@ function StatusDot({ status }: { status: string }) {
 
 const EventSection = memo(function EventSection({ event }: { event: TraceEvent }) {
   const isWarning = event.event === "warning";
-  const isError = event.event === "error";
   const isExchange = event.event === "llm_exchange";
+  const exchangeFailed = isExchange && !!event.error;
+  const isError = event.event === "error" || exchangeFailed;
 
   const [exchangeDetail, setExchangeDetail] = useState<LlmExchangeOut | null>(null);
   const [exchangeOpen, setExchangeOpen] = useState(false);
@@ -794,6 +795,11 @@ const EventSection = memo(function EventSection({ event }: { event: TraceEvent }
         {isExchange && (
           <span className="trace-exchange-info">
             {event.phase.replace(/_/g, " ")}{event.round != null ? ` round ${event.round}` : ""}
+            {exchangeFailed && (
+              <span className="trace-exchange-failed-badge" title={event.error ?? undefined}>
+                failed
+              </span>
+            )}
             {event.input_tokens != null && (
               <TokenMeter
                 inputTokens={event.input_tokens}

--- a/frontend/src/app/traces/[runId]/trace.css
+++ b/frontend/src/app/traces/[runId]/trace.css
@@ -1524,6 +1524,18 @@
   margin-top: 4px;
 }
 
+.trace-exchange-failed-badge {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #b33;
+  background: #fdf2f2;
+  border: 1px solid #f0caca;
+  border-radius: 3px;
+  padding: 1px 6px;
+}
+
 /* Expand button */
 
 .trace-expand-btn {

--- a/src/rumil/calls/update_view.py
+++ b/src/rumil/calls/update_view.py
@@ -739,6 +739,7 @@ class UpdateViewWorkspaceUpdater(WorkspaceUpdater):
                     phase=f"deep_review_batch_{batch_idx}",
                 ),
                 db=infra.db,
+                continuation_recovery=True,
             )
 
             messages.append({"role": "assistant", "content": result.response_text or ""})

--- a/src/rumil/forks.py
+++ b/src/rumil/forks.py
@@ -346,7 +346,28 @@ async def _do_call(
 ) -> tuple[anthropic.types.Message, int]:
     start = time.monotonic()
     async with client.messages.stream(**kwargs) as stream:
-        response = await stream.get_final_message()
+        try:
+            response = await stream.get_final_message()
+        except Exception:
+            # Pull whatever was decoded before the stream raised and
+            # attach it to the active langfuse generation as ``output``.
+            # ``@observe`` will layer ``level=ERROR`` + ``status_message``
+            # on re-raise; we just need to surface the partial here so
+            # admins can see what the model produced before collapse.
+            partial_text: str | None = None
+            try:
+                content = stream.current_message_snapshot.content
+                partial_text = "".join(b.text for b in content if isinstance(b, TextBlock)) or None
+            except Exception:
+                pass
+            if partial_text:
+                lf = get_langfuse()
+                if lf is not None:
+                    try:
+                        lf.update_current_generation(output=partial_text)
+                    except Exception as lf_exc:
+                        log.debug("Langfuse partial-failure enrichment (fork) failed: %s", lf_exc)
+            raise
     elapsed_ms = int((time.monotonic() - start) * 1000)
     _enrich_fork_generation(model=model, kwargs=kwargs, response=response, elapsed_ms=elapsed_ms)
     return response, elapsed_ms

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -1596,6 +1596,91 @@ def _inject_into_last_user_message(
     return msgs
 
 
+_CONTINUATION_NUDGE = (
+    "Your previous response was cut off mid-string before the JSON could "
+    "close. Continue from exactly where you stopped — do not restate, "
+    "repeat, or summarize anything you already wrote. Close the open "
+    'string with a quote (`"`), complete any remaining items, and end '
+    "with `]}`. Output ONLY the continuation text starting from the "
+    "next character after where you stopped."
+)
+
+
+async def _continuation_recovery_for_parse(
+    *,
+    response_model: type[T],
+    system_prompt: str,
+    msg_list: Sequence[dict],
+    partial_text: str,
+    model: str,
+    cfg: ModelConfig,
+    cache: bool,
+    metadata: LLMExchangeMetadata | None,
+    db: DB | None,
+    max_attempts: int = 2,
+) -> T | None:
+    """Try to recover a clean parse by asking the model to complete the JSON.
+
+    Mirrors the multi-turn pattern from
+    ``draft_and_edit._continue_editor_until_complete``: send the partial
+    response back as an assistant turn, append a user nudge asking the
+    model to finish from where it stopped, concatenate the new fragment
+    onto the partial, and re-validate. Bounded by ``max_attempts``.
+
+    Returns the parsed model on success, or ``None`` if all attempts
+    fail (the caller is expected to re-raise the original error). Each
+    continuation attempt routes through ``call_anthropic_api`` so it
+    gets its own ``call_llm_exchanges`` row tagged
+    ``phase="<original>:continueN"`` for trace visibility.
+    """
+    settings = get_settings()
+    client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
+    full = partial_text
+    for attempt in range(max_attempts):
+        cont_messages: list[dict] = [
+            *msg_list,
+            {"role": "assistant", "content": full},
+            {"role": "user", "content": _CONTINUATION_NUDGE},
+        ]
+        cont_metadata = (
+            replace(metadata, phase=f"{metadata.phase}:continue{attempt + 1}")
+            if metadata is not None
+            else None
+        )
+        try:
+            api_resp = await call_anthropic_api(
+                client,
+                model,
+                system_prompt,
+                cont_messages,
+                metadata=cont_metadata,
+                db=db,
+                cache=cache,
+                model_config=cfg,
+            )
+        except Exception as exc:
+            log.warning(
+                "Continuation attempt %d/%d raised %s; aborting recovery",
+                attempt + 1,
+                max_attempts,
+                type(exc).__name__,
+            )
+            return None
+        more = "".join(b.text for b in api_resp.message.content if isinstance(b, TextBlock))
+        if not more:
+            log.debug("Continuation attempt %d produced no text; aborting", attempt + 1)
+            return None
+        full = full + more
+        try:
+            return response_model.model_validate_json(full)
+        except ValidationError:
+            log.debug(
+                "Continuation attempt %d still didn't parse cleanly; trying again",
+                attempt + 1,
+            )
+    return None
+
+
 @observe(as_type="generation", name="anthropic.messages.parse")
 async def _structured_call_parse(
     system_prompt: str,
@@ -1610,6 +1695,7 @@ async def _structured_call_parse(
     max_tokens: int | None = None,
     disable_thinking: bool = False,
     cache: bool = False,
+    continuation_recovery: bool = False,
 ) -> StructuredCallResult[T]:
     """Structured output via messages.parse.
 
@@ -1674,6 +1760,34 @@ async def _structured_call_parse(
             elapsed_ms=elapsed_ms,
             request_kwargs=parse_kwargs,
         )
+        if (
+            continuation_recovery
+            and response_model is not None
+            and isinstance(exc, ValidationError)
+            and partial_text
+        ):
+            recovered = await _continuation_recovery_for_parse(
+                response_model=response_model,
+                system_prompt=system_prompt,
+                msg_list=msg_list,
+                partial_text=partial_text,
+                model=model,
+                cfg=cfg,
+                cache=cache,
+                metadata=metadata,
+                db=db,
+            )
+            if recovered is not None:
+                log.info(
+                    "structured_call_parse: recovered via continuation after "
+                    "ValidationError (phase=%s)",
+                    metadata.phase if metadata else "structured_call",
+                )
+                return StructuredCallResult(
+                    parsed=recovered,
+                    response_text=partial_text,
+                    duration_ms=elapsed_ms,
+                )
         raise
     elapsed_ms = getattr(response, "_elapsed_ms", 0)
     parsed = parse_anthropic_response(response.content)
@@ -1754,6 +1868,7 @@ async def structured_call(
     model: str | None = None,
     max_tokens: int | None = None,
     disable_thinking: bool = False,
+    continuation_recovery: bool = False,
 ) -> StructuredCallResult[T]: ...
 
 
@@ -1773,6 +1888,7 @@ async def structured_call(
     model: str | None = None,
     max_tokens: int | None = None,
     disable_thinking: bool = False,
+    continuation_recovery: bool = False,
 ) -> StructuredCallResult[T]: ...
 
 
@@ -1810,6 +1926,7 @@ async def structured_call(
     model: str | None = None,
     max_tokens: int | None = None,
     disable_thinking: bool = False,
+    continuation_recovery: bool = False,
 ) -> StructuredCallResult[T] | StructuredCallResult[BaseModel]:
     """Run an LLM call that returns structured output matching response_model.
 
@@ -1903,4 +2020,5 @@ async def structured_call(
         max_tokens=max_tokens,
         disable_thinking=disable_thinking,
         cache=cache,
+        continuation_recovery=continuation_recovery,
     )

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -1758,7 +1758,7 @@ async def _structured_call_parse(
             system_prompt=system_prompt,
             messages=msg_list,
             elapsed_ms=elapsed_ms,
-            request_kwargs=parse_kwargs,
+            request_kwargs=_capture_request_kwargs(cfg),
         )
         if (
             continuation_recovery

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -1597,13 +1597,55 @@ def _inject_into_last_user_message(
 
 
 _CONTINUATION_NUDGE = (
-    "Your previous response was cut off mid-string before the JSON could "
-    "close. Continue from exactly where you stopped — do not restate, "
-    "repeat, or summarize anything you already wrote. Close the open "
-    'string with a quote (`"`), complete any remaining items, and end '
-    "with `]}`. Output ONLY the continuation text starting from the "
-    "next character after where you stopped."
+    "Your previous response was truncated. The text shown above is the "
+    "portion that completed cleanly — everything after the last "
+    "successfully-closed element was lost. Continue the JSON from "
+    "exactly where it ends: emit any remaining elements (with leading "
+    "comma if appropriate) and the closing brackets needed to make the "
+    "concatenation a valid JSON object matching the schema. Output ONLY "
+    "the continuation text — do not restate or repeat the portion shown."
 )
+
+
+def _safe_truncate_partial_json(partial: str) -> str | None:
+    """Trim partial JSON to the last clean structural boundary.
+
+    Walks ``partial`` tracking quote/escape state and brace depth,
+    recording every position where a ``}`` or ``]`` closes a
+    non-outermost element (depth-after-close > 0). Returns the prefix
+    up to and including the last such close — a "between elements"
+    state where a continuation can splice cleanly without landing inside
+    a string or mid-escape.
+
+    Returns ``None`` if no such boundary exists (e.g. truncation
+    happened inside the first sub-element, or the partial is a flat
+    object with no sub-element closes).
+    """
+    in_string = False
+    escape = False
+    depth = 0
+    last_boundary = -1
+    for i, c in enumerate(partial):
+        if escape:
+            escape = False
+            continue
+        if in_string:
+            if c == "\\":
+                escape = True
+            elif c == '"':
+                in_string = False
+            continue
+        if c == '"':
+            in_string = True
+        elif c in "{[":
+            depth += 1
+        elif c in "}]":
+            depth -= 1
+            if depth > 0:
+                last_boundary = i + 1
+    if last_boundary == -1:
+        return None
+    return partial[:last_boundary]
 
 
 async def _continuation_recovery_for_parse(
@@ -1637,13 +1679,23 @@ async def _continuation_recovery_for_parse(
     ``call_llm_exchanges`` row tagged ``phase="<original>:continueN"``
     for trace visibility.
     """
+    trimmed = _safe_truncate_partial_json(partial_text)
+    if trimmed is None:
+        log.debug(
+            "Continuation recovery: no clean splice boundary in partial "
+            "(truncation likely inside first sub-element); aborting"
+        )
+        return None
     settings = get_settings()
     client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
-    full = partial_text
     for attempt in range(max_attempts):
+        # Reset each attempt to the clean trimmed prefix — compounding
+        # a failed continuation across retries just sends the model
+        # invalid mid-stream context. Re-sample from the same splice
+        # point instead.
         cont_messages: list[dict] = [
             *msg_list,
-            {"role": "assistant", "content": full},
+            {"role": "assistant", "content": trimmed},
             {"role": "user", "content": _CONTINUATION_NUDGE},
         ]
         cont_metadata = (
@@ -1674,12 +1726,12 @@ async def _continuation_recovery_for_parse(
         if not more:
             log.debug("Continuation attempt %d produced no text; aborting", attempt + 1)
             return None
-        full = full + more
+        full = trimmed + more
         try:
             return response_model.model_validate_json(full), full
         except ValidationError:
             log.debug(
-                "Continuation attempt %d still didn't parse cleanly; trying again",
+                "Continuation attempt %d still didn't parse cleanly; retrying",
                 attempt + 1,
             )
     return None

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -1618,7 +1618,7 @@ async def _continuation_recovery_for_parse(
     metadata: LLMExchangeMetadata | None,
     db: DB | None,
     max_attempts: int = 2,
-) -> T | None:
+) -> tuple[T, str] | None:
     """Try to recover a clean parse by asking the model to complete the JSON.
 
     Mirrors the multi-turn pattern from
@@ -1627,11 +1627,15 @@ async def _continuation_recovery_for_parse(
     model to finish from where it stopped, concatenate the new fragment
     onto the partial, and re-validate. Bounded by ``max_attempts``.
 
-    Returns the parsed model on success, or ``None`` if all attempts
-    fail (the caller is expected to re-raise the original error). Each
-    continuation attempt routes through ``call_anthropic_api`` so it
-    gets its own ``call_llm_exchanges`` row tagged
-    ``phase="<original>:continueN"`` for trace visibility.
+    Returns ``(parsed, full_text)`` on success — the reconstructed
+    `partial + continuation` JSON, valid against ``response_model`` —
+    so callers can persist it as the assistant turn in conversation
+    history without poisoning later turns with the original truncated
+    string. Returns ``None`` if all attempts fail (the caller is
+    expected to re-raise the original error). Each continuation
+    attempt routes through ``call_anthropic_api`` so it gets its own
+    ``call_llm_exchanges`` row tagged ``phase="<original>:continueN"``
+    for trace visibility.
     """
     settings = get_settings()
     client = anthropic.AsyncAnthropic(api_key=settings.require_anthropic_key())
@@ -1672,7 +1676,7 @@ async def _continuation_recovery_for_parse(
             return None
         full = full + more
         try:
-            return response_model.model_validate_json(full)
+            return response_model.model_validate_json(full), full
         except ValidationError:
             log.debug(
                 "Continuation attempt %d still didn't parse cleanly; trying again",
@@ -1778,14 +1782,15 @@ async def _structured_call_parse(
                 db=db,
             )
             if recovered is not None:
+                parsed_model, full_text = recovered
                 log.info(
                     "structured_call_parse: recovered via continuation after "
                     "ValidationError (phase=%s)",
                     metadata.phase if metadata else "structured_call",
                 )
                 return StructuredCallResult(
-                    parsed=recovered,
-                    response_text=partial_text,
+                    parsed=parsed_model,
+                    response_text=full_text,
                     duration_ms=elapsed_ms,
                 )
         raise

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -557,8 +557,15 @@ async def _save_exchange(
     user_messages: Sequence[dict] | None = None,
     request_kwargs: dict | None = None,
     thinking_blocks: dict | None = None,
+    error: str | None = None,
 ) -> None:
-    """Persist an LLM exchange and record a trace event."""
+    """Persist an LLM exchange and record a trace event.
+
+    Pass ``error`` to mark this exchange as a recovered failure — the row
+    still carries any partial ``response_text`` we managed to capture, but
+    consumers (trace UI, find_confusion, forks) can distinguish it from a
+    successful exchange via the non-null error column.
+    """
     exchange_id = await db.save_llm_exchange(
         call_id=metadata.call_id,
         phase=metadata.phase,
@@ -576,6 +583,7 @@ async def _save_exchange(
         model=model,
         request_kwargs=request_kwargs,
         thinking_blocks=thinking_blocks,
+        error=error,
     )
     cost_usd = compute_cost(
         model=model,
@@ -599,8 +607,101 @@ async def _save_exchange(
                 cost_usd=cost_usd or None,
                 has_thinking=thinking_blocks is not None,
                 langfuse_trace_url=langfuse_trace_url_for_current_observation(),
+                error=error,
             )
         )
+
+
+_PARTIAL_FAILURE_ERROR_MAX = 5000
+_PARTIAL_FAILURE_LANGFUSE_OUTPUT_MAX = 200_000
+
+
+def _partial_from_validation_error(exc: ValidationError) -> str | None:
+    """Pull the full malformed input string out of a pydantic ValidationError.
+
+    Pydantic v2's ``str(exc)`` truncates the ``input_value`` repr to ~80
+    chars, but ``exc.errors()[0]["input"]`` carries the full original
+    string. The Anthropic SDK's ``messages.parse`` raises this exception
+    inside its post-parser when ``model_validate_json`` rejects the
+    response — that's the only place we can recover the malformed text.
+    """
+    try:
+        first = exc.errors()[0]
+        inp = first.get("input")
+    except (IndexError, KeyError):
+        return None
+    return inp if isinstance(inp, str) else None
+
+
+async def _record_partial_failure(
+    *,
+    exc: BaseException,
+    partial_text: str | None,
+    partial_tool_calls: list[dict] | None,
+    metadata: LLMExchangeMetadata | None,
+    db: DB | None,
+    model: str,
+    system_prompt: str,
+    messages: Sequence[dict],
+    elapsed_ms: int,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+    request_kwargs: dict | None = None,
+    thinking_blocks: dict | None = None,
+) -> None:
+    """Persist whatever forensics we have for a failed LLM call.
+
+    Two writes, both clearly marked as error state:
+
+    - ``call_llm_exchanges`` row with non-null ``error`` and any partial
+      response_text we managed to recover. Skipped if metadata/db missing.
+    - ``update_current_generation(output=partial)`` on the active langfuse
+      span. ``@observe`` already sets ``level=ERROR`` and
+      ``status_message`` when the wrapped call re-raises, so we only need
+      to attach the partial output here — don't double-set level.
+
+    Both writes are best-effort; an exception in either is logged and
+    swallowed so the original failure still propagates cleanly.
+    """
+    error_str = f"{type(exc).__name__}: {exc}"[:_PARTIAL_FAILURE_ERROR_MAX]
+
+    if metadata and db:
+        try:
+            serialized = _serialize_messages(messages) if len(messages) > 1 else None
+            await _save_exchange(
+                metadata,
+                db=db,
+                model=model,
+                system_prompt=system_prompt,
+                response_text=partial_text,
+                tool_calls=partial_tool_calls or [],
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                duration_ms=elapsed_ms,
+                cache_creation_input_tokens=cache_creation_input_tokens,
+                cache_read_input_tokens=cache_read_input_tokens,
+                user_messages=serialized,
+                request_kwargs=request_kwargs,
+                thinking_blocks=thinking_blocks,
+                error=error_str,
+            )
+        except Exception as save_exc:
+            log.warning(
+                "Failed to persist partial-failure exchange for call %s: %s",
+                metadata.call_id[:8],
+                save_exc,
+            )
+
+    client = get_langfuse()
+    if client is not None and partial_text:
+        try:
+            client.update_current_generation(
+                output=partial_text[:_PARTIAL_FAILURE_LANGFUSE_OUTPUT_MAX],
+            )
+        except Exception as lf_exc:
+            log.debug("Langfuse partial-failure enrichment failed: %s", lf_exc)
 
 
 def _extract_model_parameters(api_kwargs: dict) -> dict:
@@ -753,6 +854,10 @@ async def call_anthropic_api(
         len(messages),
     )
 
+    # Partial-state container populated by ``_do_api_call`` on failure.
+    # Re-populated each retry; reflects only the final failed attempt.
+    partial_state: dict[str, Any] = {}
+
     @_api_retry
     async def _do_api_call() -> anthropic.types.Message:
         start = time.monotonic()
@@ -762,7 +867,22 @@ async def call_anthropic_api(
         # call with large context + high max_tokens — e.g. d&e's editor
         # stage on a long essay.
         async with client.messages.stream(**kwargs) as stream:
-            response = await stream.get_final_message()
+            try:
+                response = await stream.get_final_message()
+            except Exception:
+                # Capture whatever was decoded before the stream raised —
+                # ``current_message_snapshot`` is only valid while the
+                # context manager is open, so do this here, not in the
+                # outer except. Asserting access on an empty stream
+                # raises AssertionError; treat as no partial.
+                snapshot_content: list | None = None
+                try:
+                    snapshot_content = stream.current_message_snapshot.content
+                except Exception:
+                    snapshot_content = None
+                partial_state["snapshot_content"] = snapshot_content
+                partial_state["elapsed_ms"] = int((time.monotonic() - start) * 1000)
+                raise
         elapsed = int((time.monotonic() - start) * 1000)
         response._elapsed_ms = elapsed  # type: ignore[attr-defined]
         return response
@@ -771,6 +891,25 @@ async def call_anthropic_api(
         response = await _do_api_call()
     except Exception as e:
         log.error("API call failed: %s", e, exc_info=True)
+        snapshot_content = partial_state.get("snapshot_content")
+        partial_text: str | None = None
+        partial_tool_calls: list[dict] | None = None
+        if snapshot_content is not None:
+            partial_parsed = parse_anthropic_response(snapshot_content)
+            partial_text = partial_parsed.text or None
+            partial_tool_calls = partial_parsed.tool_calls or None
+        await _record_partial_failure(
+            exc=e,
+            partial_text=partial_text,
+            partial_tool_calls=partial_tool_calls,
+            metadata=metadata,
+            db=db,
+            model=model,
+            system_prompt=system_prompt,
+            messages=messages,
+            elapsed_ms=partial_state.get("elapsed_ms", 0),
+            request_kwargs=_capture_request_kwargs(cfg),
+        )
         trace = get_trace()
         if trace:
             phase = metadata.phase if metadata else "api_call"
@@ -998,14 +1137,20 @@ async def call_google_api(
         len(messages),
     )
 
+    partial_state: dict[str, Any] = {}
+
     @_api_retry
     async def _do_api_call() -> Any:
         start = time.monotonic()
-        response = await client.aio.models.generate_content(
-            model=model,
-            contents=contents,
-            config=config,
-        )
+        try:
+            response = await client.aio.models.generate_content(
+                model=model,
+                contents=contents,
+                config=config,
+            )
+        except Exception:
+            partial_state["elapsed_ms"] = int((time.monotonic() - start) * 1000)
+            raise
         elapsed = int((time.monotonic() - start) * 1000)
         response._elapsed_ms = elapsed  # type: ignore[attr-defined]
         return response
@@ -1014,6 +1159,20 @@ async def call_google_api(
         response = await _do_api_call()
     except Exception as e:
         log.error("Google API call failed: %s", e, exc_info=True)
+        # Non-streaming path — no partial response to recover from the
+        # google-genai SDK. Still record a forensic row so the trace UI
+        # / find_confusion see the failed exchange.
+        await _record_partial_failure(
+            exc=e,
+            partial_text=None,
+            partial_tool_calls=None,
+            metadata=metadata,
+            db=db,
+            model=model,
+            system_prompt=system_prompt,
+            messages=messages,
+            elapsed_ms=partial_state.get("elapsed_ms", 0),
+        )
         trace = get_trace()
         if trace:
             phase = metadata.phase if metadata else "api_call"
@@ -1487,8 +1646,36 @@ async def _structured_call_parse(
         resp._elapsed_ms = int((time.monotonic() - t0) * 1000)  # type: ignore[attr-defined]
         return resp
 
-    response: Any = await _do_parse()
-    elapsed_ms: int = getattr(response, "_elapsed_ms", 0)
+    parse_start = time.monotonic()
+    try:
+        response: Any = await _do_parse()
+    except Exception as exc:
+        # Cover both shapes of failure: (a) ``messages.parse`` runs
+        # ``model_validate_json`` on the response text inside the SDK's
+        # post-parser — on failure the response object is discarded but
+        # the malformed text is preserved on the ``ValidationError`` via
+        # ``errors()[0]["input"]`` (#444 / #446); (b) any other exception
+        # (API error after retries, network failure, etc.) — no partial
+        # text to recover, but we still want a forensic row so the trace
+        # UI / find_confusion can see the failed exchange.
+        partial_text = (
+            _partial_from_validation_error(exc) if isinstance(exc, ValidationError) else None
+        )
+        elapsed_ms = int((time.monotonic() - parse_start) * 1000)
+        await _record_partial_failure(
+            exc=exc,
+            partial_text=partial_text,
+            partial_tool_calls=None,
+            metadata=metadata,
+            db=db,
+            model=model,
+            system_prompt=system_prompt,
+            messages=msg_list,
+            elapsed_ms=elapsed_ms,
+            request_kwargs=parse_kwargs,
+        )
+        raise
+    elapsed_ms = getattr(response, "_elapsed_ms", 0)
     parsed = parse_anthropic_response(response.content)
     response_text = parsed.text
     _enrich_langfuse_generation(

--- a/src/rumil/tracing/trace_events.py
+++ b/src/rumil/tracing/trace_events.py
@@ -96,6 +96,7 @@ class LLMExchangeEvent(BaseModel):
     has_thinking: bool | None = None
     tool_uses: list[dict[str, Any]] | None = None
     langfuse_trace_url: str | None = None
+    error: str | None = None
 
 
 class WarningEvent(BaseModel):

--- a/tests/test_continuation_recovery.py
+++ b/tests/test_continuation_recovery.py
@@ -12,6 +12,7 @@ from rumil.llm import (
     APIResponse,
     LLMExchangeMetadata,
     _continuation_recovery_for_parse,
+    _safe_truncate_partial_json,
     _structured_call_parse,
     derive_model_config,
 )
@@ -76,12 +77,58 @@ def anthropic_test_key(mocker):
     mocker.patch("rumil.llm.anthropic.AsyncAnthropic", return_value=mocker.MagicMock())
 
 
+def test_safe_truncate_skips_garbage_after_completed_items():
+    partial = '{"item_reviews":[{"item_id":"a","r":"x"},{"item_id":"b","r":"GARBAGE\\n.\\n.\\n'
+
+    trimmed = _safe_truncate_partial_json(partial)
+
+    assert trimmed == '{"item_reviews":[{"item_id":"a","r":"x"}'
+
+
+def test_safe_truncate_takes_latest_completed_boundary():
+    partial = '{"item_reviews":[{"a":1},{"b":2},{"c":3},{"d":"GARB'
+
+    trimmed = _safe_truncate_partial_json(partial)
+
+    assert trimmed == '{"item_reviews":[{"a":1},{"b":2},{"c":3}'
+
+
+def test_safe_truncate_returns_none_when_no_subelement_closed():
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+
+    assert _safe_truncate_partial_json(partial) is None
+
+
+def test_safe_truncate_ignores_braces_inside_strings():
+    partial = '{"item_reviews":[{"r":"text with } and { inside"},{"r":"GARB'
+
+    trimmed = _safe_truncate_partial_json(partial)
+
+    assert trimmed == '{"item_reviews":[{"r":"text with } and { inside"}'
+
+
+def test_safe_truncate_ignores_escaped_quotes_inside_strings():
+    partial = '{"item_reviews":[{"r":"he said \\"hi\\""},{"r":"GARB'
+
+    trimmed = _safe_truncate_partial_json(partial)
+
+    assert trimmed == '{"item_reviews":[{"r":"he said \\"hi\\""}'
+
+
+def test_safe_truncate_handles_nested_arrays():
+    partial = '[{"a":[1,2,3]},{"b":[4,5,'
+
+    trimmed = _safe_truncate_partial_json(partial)
+
+    assert trimmed == '[{"a":[1,2,3]}'
+
+
 @pytest.mark.asyncio
 async def test_continuation_recovery_completes_truncated_json(
     metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
 ):
-    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
-    continuation = '"}]}'
+    partial = '{"item_reviews":[{"item_id":"a","r":"x"},{"item_id":"b","r":"GARB'
+    continuation = ',{"item_id":"b","r":"y"}]}'
     call_api = mocker.patch(
         "rumil.llm.call_anthropic_api",
         new=mocker.AsyncMock(return_value=_api_response(continuation)),
@@ -102,7 +149,7 @@ async def test_continuation_recovery_completes_truncated_json(
     assert result is not None
     parsed, full = result
     assert isinstance(parsed, _Schema)
-    assert full == partial + continuation
+    assert full == '{"item_reviews":[{"item_id":"a","r":"x"}' + continuation
     assert call_api.await_count == 1
 
 
@@ -110,13 +157,13 @@ async def test_continuation_recovery_completes_truncated_json(
 async def test_continuation_recovery_retries_until_success(
     metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
 ):
-    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    partial = '{"item_reviews":[{"item_id":"a","r":"x"},{"item_id":"b","r":"GARB'
     call_api = mocker.patch(
         "rumil.llm.call_anthropic_api",
         new=mocker.AsyncMock(
             side_effect=[
-                _api_response(" more text"),
-                _api_response('"}]}'),
+                _api_response(" still bad"),
+                _api_response(',{"item_id":"b","r":"y"}]}'),
             ]
         ),
     )
@@ -135,9 +182,8 @@ async def test_continuation_recovery_retries_until_success(
     )
 
     assert result is not None
-    parsed, full = result
+    parsed, _full = result
     assert isinstance(parsed, _Schema)
-    assert full == partial + ' more text"}]}'
     assert call_api.await_count == 2
 
 
@@ -145,7 +191,7 @@ async def test_continuation_recovery_retries_until_success(
 async def test_continuation_recovery_returns_none_on_exhaustion(
     metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
 ):
-    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    partial = '{"item_reviews":[{"item_id":"a","r":"x"},{"item_id":"b","r":"GARB'
     call_api = mocker.patch(
         "rumil.llm.call_anthropic_api",
         new=mocker.AsyncMock(
@@ -171,10 +217,36 @@ async def test_continuation_recovery_returns_none_on_exhaustion(
 
 
 @pytest.mark.asyncio
+async def test_continuation_recovery_skips_when_no_completed_items(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
+):
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"GARB'
+    call_api = mocker.patch(
+        "rumil.llm.call_anthropic_api",
+        new=mocker.AsyncMock(),
+    )
+
+    result = await _continuation_recovery_for_parse(
+        response_model=_Schema,
+        system_prompt="sys",
+        msg_list=[{"role": "user", "content": "hi"}],
+        partial_text=partial,
+        model="claude-opus-4-7",
+        cfg=derive_model_config("claude-opus-4-7"),
+        cache=False,
+        metadata=metadata,
+        db=db_mock,
+    )
+
+    assert result is None
+    assert call_api.await_count == 0
+
+
+@pytest.mark.asyncio
 async def test_continuation_recovery_aborts_on_continuation_exception(
     metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
 ):
-    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    partial = '{"item_reviews":[{"item_id":"a","r":"x"},{"item_id":"b","r":"GARB'
     call_api = mocker.patch(
         "rumil.llm.call_anthropic_api",
         new=mocker.AsyncMock(side_effect=RuntimeError("net down")),
@@ -234,12 +306,12 @@ async def test_structured_call_parse_propagates_when_recovery_disabled(
 async def test_structured_call_parse_recovers_when_recovery_enabled(
     metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
 ):
-    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    partial = '{"item_reviews":[{"item_id":"a","r":"x"},{"item_id":"b","r":"GARB'
     parse_exc = _make_validation_error(partial)
     patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=parse_exc)
     call_api = mocker.patch(
         "rumil.llm.call_anthropic_api",
-        new=mocker.AsyncMock(return_value=_api_response('"}]}')),
+        new=mocker.AsyncMock(return_value=_api_response("]}")),
     )
 
     result = await _structured_call_parse(
@@ -253,7 +325,7 @@ async def test_structured_call_parse_recovers_when_recovery_enabled(
     )
 
     assert isinstance(result.parsed, _Schema)
-    assert result.response_text == partial + '"}]}'
+    assert result.response_text == '{"item_reviews":[{"item_id":"a","r":"x"}]}'
     assert call_api.await_count == 1
 
 
@@ -261,7 +333,7 @@ async def test_structured_call_parse_recovers_when_recovery_enabled(
 async def test_structured_call_parse_reraises_when_recovery_exhausts(
     metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
 ):
-    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    partial = '{"item_reviews":[{"item_id":"a","r":"x"},{"item_id":"b","r":"GARB'
     parse_exc = _make_validation_error(partial)
     patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=parse_exc)
     mocker.patch(

--- a/tests/test_continuation_recovery.py
+++ b/tests/test_continuation_recovery.py
@@ -1,0 +1,275 @@
+"""Continuation-style recovery for cut-off structured-output JSON (#444).
+
+Covers ``_continuation_recovery_for_parse`` and the
+``continuation_recovery=True`` opt-in on ``_structured_call_parse``.
+"""
+
+import pytest
+from anthropic.types import TextBlock
+from pydantic import BaseModel, ValidationError
+
+from rumil.llm import (
+    APIResponse,
+    LLMExchangeMetadata,
+    _continuation_recovery_for_parse,
+    _structured_call_parse,
+    derive_model_config,
+)
+
+
+class _Schema(BaseModel):
+    item_reviews: list
+
+
+def _make_validation_error(text: str) -> ValidationError:
+    try:
+        _Schema.model_validate_json(text)
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("expected ValidationError")
+
+
+def _api_response(text: str) -> APIResponse:
+    msg = type(
+        "FakeMessage",
+        (),
+        {"content": [TextBlock(type="text", text=text)]},
+    )()
+    return APIResponse(message=msg, duration_ms=10)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def metadata() -> LLMExchangeMetadata:
+    return LLMExchangeMetadata(call_id="call_123", phase="deep_review_batch_0", round_num=0)
+
+
+@pytest.fixture
+def db_mock(mocker):
+    db = mocker.MagicMock()
+    db.save_llm_exchange = mocker.AsyncMock(return_value="exchange_abc")
+    return db
+
+
+@pytest.fixture
+def trace_mock(mocker):
+    trace = mocker.MagicMock()
+    trace.record = mocker.AsyncMock()
+    mocker.patch("rumil.llm.get_trace", return_value=trace)
+    return trace
+
+
+@pytest.fixture
+def langfuse_url(mocker):
+    mocker.patch("rumil.llm.langfuse_trace_url_for_current_observation", return_value=None)
+
+
+@pytest.fixture
+def no_langfuse(mocker):
+    mocker.patch("rumil.llm.get_langfuse", return_value=None)
+
+
+@pytest.fixture
+def anthropic_test_key(mocker):
+    from rumil.settings import Settings
+
+    mocker.patch.object(Settings, "require_anthropic_key", lambda self: "test-key")
+    mocker.patch("rumil.llm.anthropic.AsyncAnthropic", return_value=mocker.MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_continuation_recovery_completes_truncated_json(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
+):
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    continuation = '"}]}'
+    call_api = mocker.patch(
+        "rumil.llm.call_anthropic_api",
+        new=mocker.AsyncMock(return_value=_api_response(continuation)),
+    )
+
+    result = await _continuation_recovery_for_parse(
+        response_model=_Schema,
+        system_prompt="sys",
+        msg_list=[{"role": "user", "content": "hi"}],
+        partial_text=partial,
+        model="claude-opus-4-7",
+        cfg=derive_model_config("claude-opus-4-7"),
+        cache=False,
+        metadata=metadata,
+        db=db_mock,
+    )
+
+    assert isinstance(result, _Schema)
+    assert call_api.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_continuation_recovery_retries_until_success(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
+):
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    call_api = mocker.patch(
+        "rumil.llm.call_anthropic_api",
+        new=mocker.AsyncMock(
+            side_effect=[
+                _api_response(" more text"),
+                _api_response('"}]}'),
+            ]
+        ),
+    )
+
+    result = await _continuation_recovery_for_parse(
+        response_model=_Schema,
+        system_prompt="sys",
+        msg_list=[{"role": "user", "content": "hi"}],
+        partial_text=partial,
+        model="claude-opus-4-7",
+        cfg=derive_model_config("claude-opus-4-7"),
+        cache=False,
+        metadata=metadata,
+        db=db_mock,
+        max_attempts=2,
+    )
+
+    assert isinstance(result, _Schema)
+    assert call_api.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_continuation_recovery_returns_none_on_exhaustion(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
+):
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    call_api = mocker.patch(
+        "rumil.llm.call_anthropic_api",
+        new=mocker.AsyncMock(
+            return_value=_api_response(" still no closing brackets"),
+        ),
+    )
+
+    result = await _continuation_recovery_for_parse(
+        response_model=_Schema,
+        system_prompt="sys",
+        msg_list=[{"role": "user", "content": "hi"}],
+        partial_text=partial,
+        model="claude-opus-4-7",
+        cfg=derive_model_config("claude-opus-4-7"),
+        cache=False,
+        metadata=metadata,
+        db=db_mock,
+        max_attempts=2,
+    )
+
+    assert result is None
+    assert call_api.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_continuation_recovery_aborts_on_continuation_exception(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, anthropic_test_key, mocker
+):
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    call_api = mocker.patch(
+        "rumil.llm.call_anthropic_api",
+        new=mocker.AsyncMock(side_effect=RuntimeError("net down")),
+    )
+
+    result = await _continuation_recovery_for_parse(
+        response_model=_Schema,
+        system_prompt="sys",
+        msg_list=[{"role": "user", "content": "hi"}],
+        partial_text=partial,
+        model="claude-opus-4-7",
+        cfg=derive_model_config("claude-opus-4-7"),
+        cache=False,
+        metadata=metadata,
+        db=db_mock,
+        max_attempts=2,
+    )
+
+    assert result is None
+    assert call_api.await_count == 1
+
+
+@pytest.fixture
+def patch_anthropic_client(mocker):
+    client = mocker.MagicMock()
+    mocker.patch("rumil.llm.anthropic.AsyncAnthropic", return_value=client)
+    from rumil.settings import Settings
+
+    mocker.patch.object(Settings, "require_anthropic_key", lambda self: "test-key")
+    return client
+
+
+@pytest.mark.asyncio
+async def test_structured_call_parse_propagates_when_recovery_disabled(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
+):
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    parse_exc = _make_validation_error(partial)
+    patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=parse_exc)
+    call_api = mocker.patch("rumil.llm.call_anthropic_api", new=mocker.AsyncMock())
+
+    with pytest.raises(ValidationError):
+        await _structured_call_parse(
+            "system",
+            _Schema,
+            [{"role": "user", "content": "hi"}],
+            metadata=metadata,
+            db=db_mock,
+            model="claude-opus-4-7",
+            continuation_recovery=False,
+        )
+
+    assert call_api.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_structured_call_parse_recovers_when_recovery_enabled(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
+):
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    parse_exc = _make_validation_error(partial)
+    patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=parse_exc)
+    call_api = mocker.patch(
+        "rumil.llm.call_anthropic_api",
+        new=mocker.AsyncMock(return_value=_api_response('"}]}')),
+    )
+
+    result = await _structured_call_parse(
+        "system",
+        _Schema,
+        [{"role": "user", "content": "hi"}],
+        metadata=metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        continuation_recovery=True,
+    )
+
+    assert isinstance(result.parsed, _Schema)
+    assert result.response_text == partial
+    assert call_api.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_structured_call_parse_reraises_when_recovery_exhausts(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
+):
+    partial = '{"item_reviews":[{"item_id":"a","reasoning":"hello'
+    parse_exc = _make_validation_error(partial)
+    patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=parse_exc)
+    mocker.patch(
+        "rumil.llm.call_anthropic_api",
+        new=mocker.AsyncMock(return_value=_api_response(" still bad")),
+    )
+
+    with pytest.raises(ValidationError):
+        await _structured_call_parse(
+            "system",
+            _Schema,
+            [{"role": "user", "content": "hi"}],
+            metadata=metadata,
+            db=db_mock,
+            model="claude-opus-4-7",
+            continuation_recovery=True,
+        )

--- a/tests/test_continuation_recovery.py
+++ b/tests/test_continuation_recovery.py
@@ -99,7 +99,10 @@ async def test_continuation_recovery_completes_truncated_json(
         db=db_mock,
     )
 
-    assert isinstance(result, _Schema)
+    assert result is not None
+    parsed, full = result
+    assert isinstance(parsed, _Schema)
+    assert full == partial + continuation
     assert call_api.await_count == 1
 
 
@@ -131,7 +134,10 @@ async def test_continuation_recovery_retries_until_success(
         max_attempts=2,
     )
 
-    assert isinstance(result, _Schema)
+    assert result is not None
+    parsed, full = result
+    assert isinstance(parsed, _Schema)
+    assert full == partial + ' more text"}]}'
     assert call_api.await_count == 2
 
 
@@ -247,7 +253,7 @@ async def test_structured_call_parse_recovers_when_recovery_enabled(
     )
 
     assert isinstance(result.parsed, _Schema)
-    assert result.response_text == partial
+    assert result.response_text == partial + '"}]}'
     assert call_api.await_count == 1
 
 

--- a/tests/test_llm_partial_failure.py
+++ b/tests/test_llm_partial_failure.py
@@ -1,0 +1,346 @@
+"""Forensics for failed LLM calls (#446).
+
+Covers the partial-response recovery helpers in ``rumil.llm`` and the
+failure paths of ``_structured_call_parse`` / ``call_anthropic_api``.
+"""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from rumil.llm import (
+    LLMExchangeMetadata,
+    _partial_from_validation_error,
+    _record_partial_failure,
+    _structured_call_parse,
+    call_anthropic_api,
+)
+
+
+class _Schema(BaseModel):
+    item_reviews: list
+
+
+def _make_validation_error(text: str) -> ValidationError:
+    try:
+        _Schema.model_validate_json(text)
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("expected ValidationError")
+
+
+@pytest.fixture
+def metadata() -> LLMExchangeMetadata:
+    return LLMExchangeMetadata(call_id="call_123", phase="test_phase", round_num=0)
+
+
+@pytest.fixture
+def db_mock(mocker):
+    db = mocker.MagicMock()
+    db.save_llm_exchange = mocker.AsyncMock(return_value="exchange_abc")
+    return db
+
+
+@pytest.fixture
+def trace_mock(mocker):
+    trace = mocker.MagicMock()
+    trace.record = mocker.AsyncMock()
+    mocker.patch("rumil.llm.get_trace", return_value=trace)
+    return trace
+
+
+@pytest.fixture
+def langfuse_url(mocker):
+    mocker.patch("rumil.llm.langfuse_trace_url_for_current_observation", return_value=None)
+
+
+@pytest.fixture
+def langfuse_mock(mocker):
+    client = mocker.MagicMock()
+    client.update_current_generation = mocker.MagicMock()
+    mocker.patch("rumil.llm.get_langfuse", return_value=client)
+    return client
+
+
+@pytest.fixture
+def no_langfuse(mocker):
+    mocker.patch("rumil.llm.get_langfuse", return_value=None)
+
+
+def test_partial_from_validation_error_returns_full_input():
+    big = '{"item_reviews":[{"item_id":"a","reasoning":"' + ("blah " * 6000) + "...END"
+    exc = _make_validation_error(big)
+
+    result = _partial_from_validation_error(exc)
+
+    assert isinstance(result, str)
+    assert result == big
+    assert len(result) > 30_000
+
+
+def test_partial_from_validation_error_returns_none_for_non_string_input(mocker):
+    exc = mocker.MagicMock(spec=ValidationError)
+    exc.errors = mocker.MagicMock(return_value=[{"type": "missing", "input": 42}])
+
+    assert _partial_from_validation_error(exc) is None
+
+
+def test_partial_from_validation_error_returns_none_when_errors_empty(mocker):
+    exc = mocker.MagicMock(spec=ValidationError)
+    exc.errors = mocker.MagicMock(return_value=[])
+
+    assert _partial_from_validation_error(exc) is None
+
+
+def test_partial_from_validation_error_returns_none_when_input_missing(mocker):
+    exc = mocker.MagicMock(spec=ValidationError)
+    exc.errors = mocker.MagicMock(return_value=[{"type": "missing"}])
+
+    assert _partial_from_validation_error(exc) is None
+
+
+@pytest.mark.asyncio
+async def test_record_partial_failure_writes_exchange_with_error_and_partial(
+    metadata, db_mock, trace_mock, langfuse_url, langfuse_mock
+):
+    exc = RuntimeError("collapse")
+
+    await _record_partial_failure(
+        exc=exc,
+        partial_text="partial output",
+        partial_tool_calls=None,
+        metadata=metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        elapsed_ms=42,
+    )
+
+    db_mock.save_llm_exchange.assert_awaited_once()
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["response_text"] == "partial output"
+    assert kwargs["error"].startswith("RuntimeError: collapse")
+    assert kwargs["duration_ms"] == 42
+
+
+@pytest.mark.asyncio
+async def test_record_partial_failure_enriches_langfuse_with_partial_output(
+    metadata, db_mock, trace_mock, langfuse_url, langfuse_mock
+):
+    await _record_partial_failure(
+        exc=RuntimeError("boom"),
+        partial_text="partial output",
+        partial_tool_calls=None,
+        metadata=metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        elapsed_ms=10,
+    )
+
+    langfuse_mock.update_current_generation.assert_called_once_with(output="partial output")
+
+
+@pytest.mark.asyncio
+async def test_record_partial_failure_skips_langfuse_when_no_partial_text(
+    metadata, db_mock, trace_mock, langfuse_url, langfuse_mock
+):
+    await _record_partial_failure(
+        exc=RuntimeError("boom"),
+        partial_text=None,
+        partial_tool_calls=None,
+        metadata=metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        elapsed_ms=10,
+    )
+
+    langfuse_mock.update_current_generation.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_record_partial_failure_no_op_without_metadata_or_db(no_langfuse):
+    await _record_partial_failure(
+        exc=RuntimeError("boom"),
+        partial_text="partial",
+        partial_tool_calls=None,
+        metadata=None,
+        db=None,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        elapsed_ms=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_partial_failure_swallows_save_exchange_errors(
+    metadata, trace_mock, langfuse_url, no_langfuse, mocker
+):
+    db = mocker.MagicMock()
+    db.save_llm_exchange = mocker.AsyncMock(side_effect=Exception("db down"))
+
+    await _record_partial_failure(
+        exc=RuntimeError("boom"),
+        partial_text=None,
+        partial_tool_calls=None,
+        metadata=metadata,
+        db=db,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        elapsed_ms=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_partial_failure_swallows_langfuse_errors(
+    metadata, db_mock, trace_mock, langfuse_url, mocker
+):
+    client = mocker.MagicMock()
+    client.update_current_generation = mocker.MagicMock(side_effect=Exception("lf down"))
+    mocker.patch("rumil.llm.get_langfuse", return_value=client)
+
+    await _record_partial_failure(
+        exc=RuntimeError("boom"),
+        partial_text="partial",
+        partial_tool_calls=None,
+        metadata=metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        elapsed_ms=10,
+    )
+
+
+@pytest.fixture
+def patch_anthropic_client(mocker):
+    """Replace ``anthropic.AsyncAnthropic(...)`` in rumil.llm with a configurable mock client."""
+    client = mocker.MagicMock()
+    mocker.patch("rumil.llm.anthropic.AsyncAnthropic", return_value=client)
+    from rumil.settings import Settings
+
+    mocker.patch.object(Settings, "require_anthropic_key", lambda self: "test-key")
+    return client
+
+
+@pytest.mark.asyncio
+async def test_structured_call_parse_records_partial_on_validation_error(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
+):
+    big = '{"item_reviews":[{"item_id":"a","reasoning":"' + ("X" * 30_000) + "...END"
+    parse_exc = _make_validation_error(big)
+    patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=parse_exc)
+
+    with pytest.raises(ValidationError):
+        await _structured_call_parse(
+            "system",
+            _Schema,
+            [{"role": "user", "content": "hi"}],
+            metadata=metadata,
+            db=db_mock,
+            model="claude-opus-4-7",
+        )
+
+    db_mock.save_llm_exchange.assert_awaited_once()
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["response_text"] == big
+    assert "ValidationError" in kwargs["error"]
+
+
+@pytest.mark.asyncio
+async def test_structured_call_parse_records_failure_on_non_validation_exception(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
+):
+    patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=RuntimeError("net"))
+
+    with pytest.raises(RuntimeError, match="net"):
+        await _structured_call_parse(
+            "system",
+            _Schema,
+            [{"role": "user", "content": "hi"}],
+            metadata=metadata,
+            db=db_mock,
+            model="claude-opus-4-7",
+        )
+
+    db_mock.save_llm_exchange.assert_awaited_once()
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["response_text"] is None
+    assert "RuntimeError" in kwargs["error"]
+
+
+def _make_stream_cm(*, partial_blocks: Any | None, snapshot_raises: bool, mocker):
+    """Build an async-context-manager mock matching ``client.messages.stream``."""
+    stream = mocker.MagicMock()
+    stream.get_final_message = mocker.AsyncMock(side_effect=RuntimeError("stream broke"))
+    if snapshot_raises:
+        type(stream).current_message_snapshot = mocker.PropertyMock(
+            side_effect=AssertionError("no message_start yet")
+        )
+    else:
+        snapshot = mocker.MagicMock()
+        snapshot.content = partial_blocks or []
+        stream.current_message_snapshot = snapshot
+
+    cm = mocker.MagicMock()
+    cm.__aenter__ = mocker.AsyncMock(return_value=stream)
+    cm.__aexit__ = mocker.AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_call_anthropic_api_records_partial_text_from_stream_snapshot(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, mocker
+):
+    from anthropic.types import TextBlock
+
+    text_block = TextBlock(type="text", text="partial assistant text")
+    cm = _make_stream_cm(partial_blocks=[text_block], snapshot_raises=False, mocker=mocker)
+    client = mocker.MagicMock()
+    client.messages.stream = mocker.MagicMock(return_value=cm)
+
+    with pytest.raises(RuntimeError, match="stream broke"):
+        await call_anthropic_api(
+            client,
+            model="claude-opus-4-7",
+            system_prompt="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata=metadata,
+            db=db_mock,
+        )
+
+    db_mock.save_llm_exchange.assert_awaited_once()
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["response_text"] == "partial assistant text"
+    assert "RuntimeError" in kwargs["error"]
+
+
+@pytest.mark.asyncio
+async def test_call_anthropic_api_records_failure_when_snapshot_unavailable(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, mocker
+):
+    cm = _make_stream_cm(partial_blocks=None, snapshot_raises=True, mocker=mocker)
+    client = mocker.MagicMock()
+    client.messages.stream = mocker.MagicMock(return_value=cm)
+
+    with pytest.raises(RuntimeError, match="stream broke"):
+        await call_anthropic_api(
+            client,
+            model="claude-opus-4-7",
+            system_prompt="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata=metadata,
+            db=db_mock,
+        )
+
+    db_mock.save_llm_exchange.assert_awaited_once()
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["response_text"] is None
+    assert "RuntimeError" in kwargs["error"]

--- a/tests/test_llm_partial_failure.py
+++ b/tests/test_llm_partial_failure.py
@@ -4,6 +4,7 @@ Covers the partial-response recovery helpers in ``rumil.llm`` and the
 failure paths of ``_structured_call_parse`` / ``call_anthropic_api``.
 """
 
+import json
 from typing import Any
 
 import pytest
@@ -326,8 +327,6 @@ async def test_call_anthropic_api_records_partial_text_from_stream_snapshot(
 async def test_structured_call_parse_request_kwargs_are_json_serializable(
     metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
 ):
-    import json
-
     big = '{"item_reviews":[{"item_id":"a","reasoning":"' + ("X" * 100) + "...END"
     parse_exc = _make_validation_error(big)
     patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=parse_exc)
@@ -344,7 +343,7 @@ async def test_structured_call_parse_request_kwargs_are_json_serializable(
 
     db_mock.save_llm_exchange.assert_awaited_once()
     kwargs = db_mock.save_llm_exchange.await_args.kwargs
-    json.dumps(kwargs.get("request_kwargs"))
+    json.dumps(kwargs["request_kwargs"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_partial_failure.py
+++ b/tests/test_llm_partial_failure.py
@@ -323,6 +323,31 @@ async def test_call_anthropic_api_records_partial_text_from_stream_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_structured_call_parse_request_kwargs_are_json_serializable(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, patch_anthropic_client, mocker
+):
+    import json
+
+    big = '{"item_reviews":[{"item_id":"a","reasoning":"' + ("X" * 100) + "...END"
+    parse_exc = _make_validation_error(big)
+    patch_anthropic_client.messages.parse = mocker.AsyncMock(side_effect=parse_exc)
+
+    with pytest.raises(ValidationError):
+        await _structured_call_parse(
+            "system",
+            _Schema,
+            [{"role": "user", "content": "hi"}],
+            metadata=metadata,
+            db=db_mock,
+            model="claude-opus-4-7",
+        )
+
+    db_mock.save_llm_exchange.assert_awaited_once()
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    json.dumps(kwargs.get("request_kwargs"))
+
+
+@pytest.mark.asyncio
 async def test_call_anthropic_api_records_failure_when_snapshot_unavailable(
     metadata, db_mock, trace_mock, langfuse_url, no_langfuse, mocker
 ):

--- a/tests/test_save_exchange_thinking.py
+++ b/tests/test_save_exchange_thinking.py
@@ -116,3 +116,42 @@ async def test_no_thinking_passes_none_to_db_and_false_on_event(
     kwargs = db_mock.save_llm_exchange.await_args.kwargs
     assert kwargs["thinking_blocks"] is None
     assert _recorded_event(trace_mock).has_thinking is False
+
+
+@pytest.mark.asyncio
+async def test_error_defaults_to_none(metadata, db_mock, trace_mock, langfuse_url):
+    await _save_exchange(
+        metadata,
+        db=db_mock,
+        model="claude-haiku-4-5",
+        system_prompt="sys",
+        response_text="answer",
+        tool_calls=[],
+        input_tokens=1,
+        output_tokens=1,
+        duration_ms=1,
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["error"] is None
+    assert _recorded_event(trace_mock).error is None
+
+
+@pytest.mark.asyncio
+async def test_error_forwarded_to_db_and_event(metadata, db_mock, trace_mock, langfuse_url):
+    await _save_exchange(
+        metadata,
+        db=db_mock,
+        model="claude-haiku-4-5",
+        system_prompt="sys",
+        response_text=None,
+        tool_calls=[],
+        input_tokens=0,
+        output_tokens=0,
+        duration_ms=1,
+        error="boom",
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["error"] == "boom"
+    assert _recorded_event(trace_mock).error == "boom"

--- a/tests/test_versus_bridge.py
+++ b/tests/test_versus_bridge.py
@@ -412,26 +412,27 @@ def test_build_abstract_does_not_leak_source_ids():
     from versus.tasks.judge_pair import _build_abstract
 
     pair = _make_pair(
-        continuation_a_id="human",
-        continuation_b_id="anthropic/claude-opus-4-7",
-        source_a_id="human",
-        source_b_id="anthropic/claude-opus-4-7",
+        continuation_a_id="anthropic/claude-opus-4-7",
+        continuation_a_text="Neutral continuation text alpha.",
+        continuation_b_id="openai/gpt-5.4",
+        continuation_b_text="Neutral continuation text beta.",
+        source_a_id="anthropic/claude-opus-4-7",
+        source_b_id="openai/gpt-5.4",
     )
     abstract = _build_abstract(pair)
 
     # Raw source ids must not surface in the abstract — it's read into
-    # the parent-context prioritization scoring step, which is agent-
-    # visible.
+    # the parent-context prioritization scoring step (agent-visible)
+    # and now also carries the pair body for view-creation paths.
     assert "anthropic/claude-opus-4-7" not in abstract
-    assert "human" not in abstract.lower()
+    assert "openai/gpt-5.4" not in abstract
 
 
-def test_build_abstract_does_not_leak_essay_id_or_prefix_text():
+def test_build_abstract_does_not_leak_essay_id():
     from versus.tasks.judge_pair import _build_abstract
 
     pair = _make_pair(
         essay_id="forethought__the-ai-frontier",
-        prefix_text="The opening of an essay about a sensitive topic.",
         prefix_hash="deadbeefcafef00d",
     )
     abstract = _build_abstract(pair)
@@ -439,9 +440,25 @@ def test_build_abstract_does_not_leak_essay_id_or_prefix_text():
     # essay_id leaks the source via the namespacing prefix.
     assert "forethought" not in abstract
     assert "the-ai-frontier" not in abstract
-    # The abstract intentionally omits prefix text (substring truncation
-    # is misleading; agents that need it read the question content).
-    assert "sensitive topic" not in abstract
+
+
+def test_build_abstract_includes_pair_body():
+    """The abstract carries the full pair body verbatim so research-phase
+    calls that render the scope question at ABSTRACT detail (the default
+    in build_embedding_based_context — see issue #448) still see the
+    essay continuations they're meant to assess."""
+    from versus.tasks.judge_pair import _build_abstract
+
+    pair = _make_pair(
+        prefix_text="PREFIX_SIGIL_OPENING",
+        continuation_a_text="CONT_A_SIGIL_BODY",
+        continuation_b_text="CONT_B_SIGIL_BODY",
+    )
+    abstract = _build_abstract(pair)
+
+    assert "PREFIX_SIGIL_OPENING" in abstract
+    assert "CONT_A_SIGIL_BODY" in abstract
+    assert "CONT_B_SIGIL_BODY" in abstract
 
 
 def test_build_abstract_includes_dimension_for_meta_evaluation_framing():
@@ -472,17 +489,17 @@ def test_ensure_versus_question_sets_page_abstract():
 
 def test_ensure_versus_question_abstract_does_not_leak_source_ids():
     pair = _make_pair(
-        continuation_a_id="human",
-        source_a_id="human",
-        continuation_b_id="anthropic/claude-opus-4-7",
-        source_b_id="anthropic/claude-opus-4-7",
+        continuation_a_id="anthropic/claude-opus-4-7",
+        continuation_a_text="Neutral continuation text alpha.",
+        continuation_b_id="openai/gpt-5.4",
+        continuation_b_text="Neutral continuation text beta.",
+        source_a_id="anthropic/claude-opus-4-7",
+        source_b_id="openai/gpt-5.4",
     )
     page = _make_question_page_synchronously(pair)
 
     assert "anthropic/claude-opus-4-7" not in page.abstract
-    # `human` as a substring is risky (English word), but as a literal
-    # source label it must not appear — guard against the obvious leak.
-    assert "human" not in page.abstract.lower()
+    assert "openai/gpt-5.4" not in page.abstract
 
 
 def test_build_headline_uses_prefix_hash_not_essay_id():

--- a/versus/src/versus/anthropic_client.py
+++ b/versus/src/versus/anthropic_client.py
@@ -100,18 +100,25 @@ def chat(
     client = client or httpx.Client(timeout=timeout)
     try:
         last_resp: dict = {}
-        for attempt in range(retries + 1):
-            r = client.post(API_URL, headers=_headers(), json=payload)
-            r.raise_for_status()
-            last_resp = r.json()
-            text = _maybe_extract_text(last_resp)
-            if text:
-                _enrich_anthropic_generation(model, messages, payload, last_resp)
-                return last_resp
-            if attempt < retries:
-                time.sleep(1.5 * (attempt + 1))
-        _enrich_anthropic_generation(model, messages, payload, last_resp)
-        return last_resp
+        try:
+            for attempt in range(retries + 1):
+                r = client.post(API_URL, headers=_headers(), json=payload)
+                r.raise_for_status()
+                last_resp = r.json()
+                text = _maybe_extract_text(last_resp)
+                if text:
+                    _enrich_anthropic_generation(model, messages, payload, last_resp)
+                    return last_resp
+                if attempt < retries:
+                    time.sleep(1.5 * (attempt + 1))
+            _enrich_anthropic_generation(model, messages, payload, last_resp)
+            return last_resp
+        except Exception:
+            # Enrich the active langfuse generation with whatever request
+            # context we have so the failed span isn't bare. ``@observe``
+            # will layer ``level=ERROR`` + ``status_message`` on re-raise.
+            _enrich_anthropic_generation(model, messages, payload, last_resp)
+            raise
     finally:
         if close:
             client.close()

--- a/versus/src/versus/openrouter.py
+++ b/versus/src/versus/openrouter.py
@@ -65,20 +65,27 @@ def chat(
     client = client or httpx.Client(timeout=timeout)
     try:
         last_resp: dict | None = None
-        for attempt in range(retries + 1):
-            r = client.post(API_URL, headers=_headers(), json=payload)
-            r.raise_for_status()
-            last_resp = r.json()
-            content = last_resp["choices"][0]["message"].get("content")
-            if content is not None and content != "":
+        try:
+            for attempt in range(retries + 1):
+                r = client.post(API_URL, headers=_headers(), json=payload)
+                r.raise_for_status()
+                last_resp = r.json()
+                content = last_resp["choices"][0]["message"].get("content")
+                if content is not None and content != "":
+                    _enrich_openrouter_generation(model, messages, payload, last_resp)
+                    return last_resp
+                # empty content: transient upstream failure — backoff + retry
+                if attempt < retries:
+                    _time.sleep(1.5 * (attempt + 1))
+            if last_resp is not None:
                 _enrich_openrouter_generation(model, messages, payload, last_resp)
-                return last_resp
-            # empty content: transient upstream failure — backoff + retry
-            if attempt < retries:
-                _time.sleep(1.5 * (attempt + 1))
-        if last_resp is not None:
-            _enrich_openrouter_generation(model, messages, payload, last_resp)
-        return last_resp  # caller's extract_text will raise a clean error
+            return last_resp  # caller's extract_text will raise a clean error
+        except Exception:
+            # Enrich the active langfuse generation with whatever request
+            # context we have so the failed span isn't bare. ``@observe``
+            # will layer ``level=ERROR`` + ``status_message`` on re-raise.
+            _enrich_openrouter_generation(model, messages, payload, last_resp or {})
+            raise
     finally:
         if close:
             client.close()

--- a/versus/src/versus/tasks/judge_pair.py
+++ b/versus/src/versus/tasks/judge_pair.py
@@ -119,25 +119,28 @@ def _build_abstract(pair: PairContext) -> str:
     """Compose the Versus Question's ``abstract``.
 
     Read by parent-context renderers (notably
-    :func:`rumil.orchestrators.common.score_items_sequentially`) when
-    the orch's prioritization scoring step needs to know what its
-    parent question is about. Intentionally fixed-shape and
-    dimension-aware: NO essay text. The synthetic Question
-    headline ("Versus judgment: ...") is misleading on its own —
-    "general_quality" reads like a topic when it's a dimension —
-    so this abstract clarifies the framing for meta-evaluation
-    agents without leaking essay content.
+    :func:`rumil.orchestrators.common.score_items_sequentially`) and
+    by any rumil call type whose context builder renders the scope
+    question at ``PageDetail.ABSTRACT`` (the current default for
+    ``build_embedding_based_context``; see issue #448). Without the
+    pair body here, view-creation and other research-phase calls
+    that scope to a versus question see only the dimension framing
+    and never the actual essay continuations they're meant to assess.
 
-    Essay content is intentionally NOT spliced in here: substring-
-    truncation of source text (``prefix_text[:N]``) is the kind of
-    silent-mid-clause cut that misleads agents. Research-phase
-    calls that genuinely need the essay get it via the Question's
-    ``content`` field; meta-evaluation calls only need the framing.
+    Mirrors :func:`_format_pair_content` rather than carrying a
+    scoring-specific instruction, so the same abstract reads
+    sensibly across the call types that consume it. Inlining the
+    full pair content (no truncation) avoids the silent mid-clause
+    ``prefix_text[:N]`` concern that motivated the earlier
+    framing-only version.
     """
     return (
-        f"Versus pairwise judging task on dimension '{pair.task_name}'. "
-        "Score considerations by their relevance to comparing two "
-        "essay continuations on this dimension."
+        "Two continuations of the same essay opening are compared on one dimension. "
+        "Workspace material may be consulted if it bears on the essay's subject.\n\n"
+        f"## Dimension\n\n{pair.task_name}\n\n"
+        f"## Essay opening\n\n{pair.prefix_text}\n\n"
+        f"## Continuation A\n\n{pair.continuation_a_text}\n\n"
+        f"## Continuation B\n\n{pair.continuation_b_text}\n"
     )
 
 


### PR DESCRIPTION
## Summary

Two related fixes for the `deep_review` truncation pattern from #444:

- **#446 — persist partial responses on failure.** When `messages.parse` raises `ValidationError` (the canonical #444 failure) or `messages.stream` errors mid-response, no `call_llm_exchanges` row was written and the partial text was lost — phantom holes in the trace UI, `rumil-forks` couldn't replay, `find_confusion` missed the break. Now every failure surface persists a forensic row with the partial text and a non-null `error` column. Pydantic v2's `exc.errors()[0]["input"]` keeps the full malformed input even though `str(exc)` truncates to ~80 chars; the streaming path captures `current_message_snapshot` inside the `async with` via closure. Adds `error: str | None` to `LLMExchangeEvent` and regenerates frontend types so the trace UI can distinguish failed exchanges.

- **#444 — recover truncated JSON via continuation.** When opus produces malformed JSON because output got cut off mid-string, ask the model to continue from where it stopped rather than failing the whole call. Mirrors `draft_and_edit._continue_editor_until_complete`: `[user..., assistant=partial, user=nudge]`, concatenate, re-validate, retry up to `max_attempts=2`. Each attempt routes through `call_anthropic_api` so it gets its own `call_llm_exchanges` row tagged `phase=":continueN"`. Opt-in via `continuation_recovery=True`; only `update_view._phase_deep_review` opts in for now. On exhaustion, original `ValidationError` re-raises — no behavior change for non-opting callers. Trim helper walks the partial with quote/escape state, splices at the last clean `}` / `]` close so the continuation lands on a known structural boundary, not mid-escape.

The two are sequenced deliberately: #446 lands first so we can see what's happening; #444 attempts recovery on top with full forensic visibility into how often it succeeds.

## Verified on a real b=16 collapse + caveats

Real-run on `lockin_nh × WR × b=16`: 2 of 3 update_view calls had a deep_review collapse. Trim recovered cleanly when ≥1 item completed before collapse (1/2 recovery rate on this run). First-item collapse (~25% of observed collapses, n=4) returns `None` from the trim and the call still dies — see #451 for the upstream investigation into *why* opus lands in degenerate sampling on long `reasoning` fields in the first place.

Continuation effectiveness past the trim is still uncertain — if the underlying issue is long-output regime degradation, asking for more output may not produce clean JSON either. Forensics from #446 will tell us the actual recovery rate over time.

## Also in this PR

- **fix(versus): inline pair body into question abstract.** Unrelated to the deep_review pair, surfaced while inspecting a `create_view` trace. Versus questions render the pair into `page.content` and used a generic dimension-framing string for `page.abstract`. But research-phase rumil calls render the scope question at `PageDetail.ABSTRACT` by default (filed as #448), so `find_considerations` / `view.refresh` / `score_items_sequentially` parent context never saw the pair — `create_view` in particular synthesized views without exposure to the continuations it was meant to assess. `_build_abstract` now mirrors `_format_pair_content` (full pair body, no source ids). Closer (`render_for_closer`) is unaffected — reads `content` at CONTENT detail. Auto-forks `compute_pair_surface_hash` for orch/tools paths; blind judging is unchanged.

## Test plan

- [x] `tests/test_llm_partial_failure.py` — covers all three partial-recovery paths
- [x] `tests/test_continuation_recovery.py` — covers concat, retry, exhaustion
- [x] `tests/test_save_exchange_thinking.py` — exchange row shape with `error` column
- [x] `tests/test_versus_bridge.py` — abstract contract (source ids excluded, pair body included)
- [ ] Watch trace UI for failed exchanges showing partial text on real failures
- [x] Watched `phase=":continueN"` rows on real `_phase_deep_review` failures — trim works on multi-item collapses; first-item collapse remains an open class (#451)
- [x] Watch a versus run's `create_view` trace to confirm pair lands in scope context

🤖 Generated with [Claude Code](https://claude.com/claude-code)