### PR TITLE
Langfuse: system prompt in input + enrich failed parse generations

### DIFF
--- a/src/rumil/forks.py
+++ b/src/rumil/forks.py
@@ -34,6 +34,7 @@ from rumil.llm import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_TEMPERATURE,
     _is_retryable,
+    _langfuse_input_for,
     _log_before_retry,
     _stop_after_status_retries,
     _supports_sampling_params,
@@ -370,10 +371,9 @@ async def _do_call(
                     }
                     lf.update_current_generation(
                         model=model,
-                        input={
-                            "system": kwargs.get("system"),
-                            "messages": kwargs.get("messages"),
-                        },
+                        input=_langfuse_input_for(
+                            kwargs.get("system") or "", kwargs.get("messages") or []
+                        ),
                         output=partial_text,
                         model_parameters=params or None,
                     )
@@ -415,7 +415,7 @@ def _enrich_fork_generation(
         }
         lf.update_current_generation(
             model=model,
-            input={"system": kwargs.get("system"), "messages": kwargs.get("messages")},
+            input=_langfuse_input_for(kwargs.get("system") or "", kwargs.get("messages") or []),
             output=output_text or None,
             model_parameters=params or None,
             usage_details={

--- a/src/rumil/forks.py
+++ b/src/rumil/forks.py
@@ -360,13 +360,25 @@ async def _do_call(
                 partial_text = "".join(b.text for b in content if isinstance(b, TextBlock)) or None
             except Exception:
                 pass
-            if partial_text:
-                lf = get_langfuse()
-                if lf is not None:
-                    try:
-                        lf.update_current_generation(output=partial_text)
-                    except Exception as lf_exc:
-                        log.debug("Langfuse partial-failure enrichment (fork) failed: %s", lf_exc)
+            lf = get_langfuse()
+            if lf is not None:
+                try:
+                    params = {
+                        k: kwargs.get(k)
+                        for k in ("temperature", "top_p", "max_tokens", "thinking")
+                        if kwargs.get(k) is not None
+                    }
+                    lf.update_current_generation(
+                        model=model,
+                        input={
+                            "system": kwargs.get("system"),
+                            "messages": kwargs.get("messages"),
+                        },
+                        output=partial_text,
+                        model_parameters=params or None,
+                    )
+                except Exception as lf_exc:
+                    log.debug("Langfuse partial-failure enrichment (fork) failed: %s", lf_exc)
             raise
     elapsed_ms = int((time.monotonic() - start) * 1000)
     _enrich_fork_generation(model=model, kwargs=kwargs, response=response, elapsed_ms=elapsed_ms)

--- a/src/rumil/forks.py
+++ b/src/rumil/forks.py
@@ -403,7 +403,7 @@ def _enrich_fork_generation(
         }
         lf.update_current_generation(
             model=model,
-            input=kwargs.get("messages"),
+            input={"system": kwargs.get("system"), "messages": kwargs.get("messages")},
             output=output_text or None,
             model_parameters=params or None,
             usage_details={

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -749,9 +749,20 @@ def _langfuse_output_for(parsed: ParsedAnthropicResponse) -> str | dict | None:
     return output
 
 
+def _langfuse_input_for(system_prompt: str, messages: Sequence[dict]) -> dict:
+    """Shape the ``input`` payload for Langfuse generations.
+
+    Langfuse has no dedicated `system` field; folding it into `input`
+    keeps the trace self-contained and lets the playground / replay tools
+    see exactly what the model saw.
+    """
+    return {"system": system_prompt, "messages": _serialize_messages(messages)}
+
+
 def _enrich_langfuse_generation(
     *,
     model: str,
+    system_prompt: str,
     messages: Sequence[dict],
     response: anthropic.types.Message,
     elapsed_ms: int,
@@ -778,7 +789,7 @@ def _enrich_langfuse_generation(
         )
         client.update_current_generation(
             model=model,
-            input=_serialize_messages(messages),
+            input=_langfuse_input_for(system_prompt, messages),
             output=_langfuse_output_for(parsed),
             model_parameters=_extract_model_parameters(api_kwargs or {}),
             usage_details={
@@ -970,6 +981,7 @@ async def call_anthropic_api(
                 )
     _enrich_langfuse_generation(
         model=model,
+        system_prompt=system_prompt,
         messages=messages,
         response=response,
         elapsed_ms=elapsed_ms,
@@ -1052,6 +1064,7 @@ def _to_google_contents(messages: Sequence[dict]) -> list[Any]:
 def _enrich_langfuse_generation_google(
     *,
     model: str,
+    system_prompt: str,
     messages: Sequence[dict],
     response: Any,
     elapsed_ms: int,
@@ -1076,7 +1089,7 @@ def _enrich_langfuse_generation_google(
         output_text = getattr(response, "text", None) or ""
         client.update_current_generation(
             model=model,
-            input=_serialize_messages(messages),
+            input=_langfuse_input_for(system_prompt, messages),
             output=output_text or None,
             model_parameters=config or {},
             usage_details={
@@ -1232,6 +1245,7 @@ async def call_google_api(
 
     _enrich_langfuse_generation_google(
         model=model,
+        system_prompt=system_prompt,
         messages=messages,
         response=response,
         elapsed_ms=elapsed_ms,
@@ -1851,6 +1865,7 @@ async def _structured_call_parse(
     response_text = parsed.text
     _enrich_langfuse_generation(
         model=model,
+        system_prompt=system_prompt,
         messages=msg_list,
         response=response,
         elapsed_ms=elapsed_ms,

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -766,7 +766,10 @@ def _langfuse_input_for(system_prompt: str, messages: Sequence[dict]) -> list[di
     system message at the top, and "Open in Playground" pre-fills it
     correctly.
     """
-    return [{"role": "system", "content": system_prompt}, *_serialize_messages(messages)]
+    serialized = list(_serialize_messages(messages))
+    if not system_prompt:
+        return serialized
+    return [{"role": "system", "content": system_prompt}, *serialized]
 
 
 def _enrich_langfuse_generation(

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -755,14 +755,18 @@ def _langfuse_output_for(parsed: ParsedAnthropicResponse) -> str | dict | None:
     return output
 
 
-def _langfuse_input_for(system_prompt: str, messages: Sequence[dict]) -> dict:
+def _langfuse_input_for(system_prompt: str, messages: Sequence[dict]) -> list[dict]:
     """Shape the ``input`` payload for Langfuse generations.
 
-    Langfuse has no dedicated `system` field; folding it into `input`
-    keeps the trace self-contained and lets the playground / replay tools
-    see exactly what the model saw.
+    Langfuse has no dedicated ``system`` field. Folding system into a
+    nested ``{"system": ..., "messages": [...]}`` dict renders nicely in
+    the trace UI but the playground reads only ``messages`` and drops
+    the system prompt. Prepending a ``{"role": "system", ...}`` entry to
+    a flat ChatML list keeps both viewers happy: the trace UI shows the
+    system message at the top, and "Open in Playground" pre-fills it
+    correctly.
     """
-    return {"system": system_prompt, "messages": _serialize_messages(messages)}
+    return [{"role": "system", "content": system_prompt}, *_serialize_messages(messages)]
 
 
 def _enrich_langfuse_generation(

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -695,10 +695,16 @@ async def _record_partial_failure(
             )
 
     client = get_langfuse()
-    if client is not None and partial_text:
+    if client is not None:
         try:
             client.update_current_generation(
-                output=partial_text[:_PARTIAL_FAILURE_LANGFUSE_OUTPUT_MAX],
+                model=model,
+                input=_langfuse_input_for(system_prompt, messages),
+                output=(
+                    partial_text[:_PARTIAL_FAILURE_LANGFUSE_OUTPUT_MAX] if partial_text else None
+                ),
+                model_parameters=_extract_model_parameters(request_kwargs or {}),
+                metadata={"duration_ms": elapsed_ms},
             )
         except Exception as lf_exc:
             log.debug("Langfuse partial-failure enrichment failed: %s", lf_exc)

--- a/tests/test_langfuse_input_payload.py
+++ b/tests/test_langfuse_input_payload.py
@@ -17,13 +17,13 @@ from rumil.llm import (
 )
 
 
-def test_langfuse_input_for_folds_system_and_serializes_messages():
+def test_langfuse_input_for_prepends_system_as_chatml_message():
     payload = _langfuse_input_for("you are helpful", [{"role": "user", "content": "hi"}])
 
-    assert payload == {
-        "system": "you are helpful",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
+    assert payload == [
+        {"role": "system", "content": "you are helpful"},
+        {"role": "user", "content": "hi"},
+    ]
 
 
 def test_langfuse_input_for_handles_content_blocks():
@@ -34,8 +34,8 @@ def test_langfuse_input_for_handles_content_blocks():
 
     payload = _langfuse_input_for("sys", messages)
 
-    assert payload["system"] == "sys"
-    assert payload["messages"][1]["content"] == [{"type": "text", "text": "hello"}]
+    assert payload[0] == {"role": "system", "content": "sys"}
+    assert payload[2]["content"] == [{"type": "text", "text": "hello"}]
 
 
 @pytest.fixture
@@ -74,10 +74,10 @@ def test_enrich_langfuse_generation_includes_system_in_input(langfuse_client):
     )
 
     kwargs = langfuse_client.update_current_generation.call_args.kwargs
-    assert kwargs["input"] == {
-        "system": "you are helpful",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
+    assert kwargs["input"] == [
+        {"role": "system", "content": "you are helpful"},
+        {"role": "user", "content": "hi"},
+    ]
 
 
 def test_enrich_langfuse_generation_google_includes_system_in_input(langfuse_client, mocker):
@@ -98,7 +98,7 @@ def test_enrich_langfuse_generation_google_includes_system_in_input(langfuse_cli
     )
 
     kwargs = langfuse_client.update_current_generation.call_args.kwargs
-    assert kwargs["input"] == {
-        "system": "be concise",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
+    assert kwargs["input"] == [
+        {"role": "system", "content": "be concise"},
+        {"role": "user", "content": "hi"},
+    ]

--- a/tests/test_langfuse_input_payload.py
+++ b/tests/test_langfuse_input_payload.py
@@ -1,8 +1,8 @@
 """`_langfuse_input_for` and per-site enrichment fold system_prompt into input.
 
-Langfuse has no dedicated `system` field. We fold it into `input` as
-`{"system": ..., "messages": [...]}` so the trace is self-contained and the
-playground can replay the call faithfully.
+Langfuse has no dedicated `system` field. We prepend a `{"role": "system", ...}`
+entry to a flat ChatML list so the trace UI shows the system message at the
+top and "Open in Playground" pre-fills it correctly.
 """
 
 from types import SimpleNamespace
@@ -24,6 +24,12 @@ def test_langfuse_input_for_prepends_system_as_chatml_message():
         {"role": "system", "content": "you are helpful"},
         {"role": "user", "content": "hi"},
     ]
+
+
+def test_langfuse_input_for_omits_system_when_empty():
+    payload = _langfuse_input_for("", [{"role": "user", "content": "hi"}])
+
+    assert payload == [{"role": "user", "content": "hi"}]
 
 
 def test_langfuse_input_for_handles_content_blocks():

--- a/tests/test_langfuse_input_payload.py
+++ b/tests/test_langfuse_input_payload.py
@@ -1,0 +1,104 @@
+"""`_langfuse_input_for` and per-site enrichment fold system_prompt into input.
+
+Langfuse has no dedicated `system` field. We fold it into `input` as
+`{"system": ..., "messages": [...]}` so the trace is self-contained and the
+playground can replay the call faithfully.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from rumil.llm import (
+    ParsedAnthropicResponse,
+    _enrich_langfuse_generation,
+    _enrich_langfuse_generation_google,
+    _langfuse_input_for,
+)
+
+
+def test_langfuse_input_for_folds_system_and_serializes_messages():
+    payload = _langfuse_input_for("you are helpful", [{"role": "user", "content": "hi"}])
+
+    assert payload == {
+        "system": "you are helpful",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def test_langfuse_input_for_handles_content_blocks():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+    ]
+
+    payload = _langfuse_input_for("sys", messages)
+
+    assert payload["system"] == "sys"
+    assert payload["messages"][1]["content"] == [{"type": "text", "text": "hello"}]
+
+
+@pytest.fixture
+def langfuse_client(mocker):
+    client = mocker.MagicMock()
+    client.update_current_generation = mocker.MagicMock()
+    mocker.patch("rumil.llm.get_langfuse", return_value=client)
+    return client
+
+
+def _fake_anthropic_response():
+    return SimpleNamespace(
+        stop_reason="end_turn",
+        usage=SimpleNamespace(
+            input_tokens=5,
+            output_tokens=2,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        ),
+    )
+
+
+def test_enrich_langfuse_generation_includes_system_in_input(langfuse_client):
+    parsed = ParsedAnthropicResponse(
+        text_parts=["ok"], tool_calls=[], thinking=[], redacted_thinking=[]
+    )
+
+    _enrich_langfuse_generation(
+        model="claude-opus-4-7",
+        system_prompt="you are helpful",
+        messages=[{"role": "user", "content": "hi"}],
+        response=_fake_anthropic_response(),  # pyright: ignore[reportArgumentType]
+        elapsed_ms=10,
+        parsed=parsed,
+        api_kwargs={"model": "claude-opus-4-7", "max_tokens": 100},
+    )
+
+    kwargs = langfuse_client.update_current_generation.call_args.kwargs
+    assert kwargs["input"] == {
+        "system": "you are helpful",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def test_enrich_langfuse_generation_google_includes_system_in_input(langfuse_client, mocker):
+    mocker.patch("rumil.llm.get_langfuse", return_value=langfuse_client)
+    response = mocker.MagicMock()
+    response.usage_metadata.prompt_token_count = 5
+    response.usage_metadata.candidates_token_count = 2
+    response.usage_metadata.cached_content_token_count = 0
+    response.text = "ok"
+
+    _enrich_langfuse_generation_google(
+        model="gemini-2.5-pro",
+        system_prompt="be concise",
+        messages=[{"role": "user", "content": "hi"}],
+        response=response,
+        elapsed_ms=10,
+        config={"temperature": 0.0},
+    )
+
+    kwargs = langfuse_client.update_current_generation.call_args.kwargs
+    assert kwargs["input"] == {
+        "system": "be concise",
+        "messages": [{"role": "user", "content": "hi"}],
+    }

--- a/tests/test_llm_partial_failure.py
+++ b/tests/test_llm_partial_failure.py
@@ -127,7 +127,7 @@ async def test_record_partial_failure_writes_exchange_with_error_and_partial(
 
 
 @pytest.mark.asyncio
-async def test_record_partial_failure_enriches_langfuse_with_partial_output(
+async def test_record_partial_failure_enriches_langfuse_with_full_shape(
     metadata, db_mock, trace_mock, langfuse_url, langfuse_mock
 ):
     await _record_partial_failure(
@@ -140,13 +140,22 @@ async def test_record_partial_failure_enriches_langfuse_with_partial_output(
         system_prompt="sys",
         messages=[{"role": "user", "content": "hi"}],
         elapsed_ms=10,
+        request_kwargs={"model": "claude-opus-4-7", "max_tokens": 100},
     )
 
-    langfuse_mock.update_current_generation.assert_called_once_with(output="partial output")
+    langfuse_mock.update_current_generation.assert_called_once()
+    kwargs = langfuse_mock.update_current_generation.call_args.kwargs
+    assert kwargs["model"] == "claude-opus-4-7"
+    assert kwargs["input"] == {
+        "system": "sys",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    assert kwargs["output"] == "partial output"
+    assert kwargs["model_parameters"] == {"model": "claude-opus-4-7", "max_tokens": 100}
 
 
 @pytest.mark.asyncio
-async def test_record_partial_failure_skips_langfuse_when_no_partial_text(
+async def test_record_partial_failure_enriches_langfuse_even_without_partial_text(
     metadata, db_mock, trace_mock, langfuse_url, langfuse_mock
 ):
     await _record_partial_failure(
@@ -161,7 +170,13 @@ async def test_record_partial_failure_skips_langfuse_when_no_partial_text(
         elapsed_ms=10,
     )
 
-    langfuse_mock.update_current_generation.assert_not_called()
+    langfuse_mock.update_current_generation.assert_called_once()
+    kwargs = langfuse_mock.update_current_generation.call_args.kwargs
+    assert kwargs["input"] == {
+        "system": "sys",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    assert kwargs["output"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_partial_failure.py
+++ b/tests/test_llm_partial_failure.py
@@ -146,10 +146,10 @@ async def test_record_partial_failure_enriches_langfuse_with_full_shape(
     langfuse_mock.update_current_generation.assert_called_once()
     kwargs = langfuse_mock.update_current_generation.call_args.kwargs
     assert kwargs["model"] == "claude-opus-4-7"
-    assert kwargs["input"] == {
-        "system": "sys",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
+    assert kwargs["input"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
     assert kwargs["output"] == "partial output"
     assert kwargs["model_parameters"] == {"model": "claude-opus-4-7", "max_tokens": 100}
 
@@ -172,10 +172,10 @@ async def test_record_partial_failure_enriches_langfuse_even_without_partial_tex
 
     langfuse_mock.update_current_generation.assert_called_once()
     kwargs = langfuse_mock.update_current_generation.call_args.kwargs
-    assert kwargs["input"] == {
-        "system": "sys",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
+    assert kwargs["input"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
     assert kwargs["output"] is None
 
 

--- a/versus/src/versus/anthropic_client.py
+++ b/versus/src/versus/anthropic_client.py
@@ -136,7 +136,7 @@ def _enrich_anthropic_generation(
         }
         update_generation(
             model=model,
-            input=messages,
+            input={"system": payload.get("system"), "messages": messages},
             output=_maybe_extract_text(resp) or None,
             model_parameters=params or None,
             usage_details={

--- a/versus/src/versus/anthropic_client.py
+++ b/versus/src/versus/anthropic_client.py
@@ -134,9 +134,15 @@ def _enrich_anthropic_generation(
             for k in ("temperature", "top_p", "max_tokens", "thinking", "output_config")
             if payload.get(k) is not None
         }
+        system = payload.get("system")
+        if isinstance(system, list):
+            system = " ".join(b.get("text", "") for b in system if isinstance(b, dict))
+        chatml_input: list[dict] = (
+            [{"role": "system", "content": system}, *messages] if system else list(messages)
+        )
         update_generation(
             model=model,
-            input={"system": payload.get("system"), "messages": messages},
+            input=chatml_input,
             output=_maybe_extract_text(resp) or None,
             model_parameters=params or None,
             usage_details={


### PR DESCRIPTION
## Summary

Make Langfuse traces self-contained and replayable from the "Open in Playground" button across all our LLM call sites (Anthropic create / parse, Google, fork samples, versus's Anthropic client).

Closes #450, closes #452.

## What changed

**System prompt now in `input` (#450)** — previously dropped silently. Now prepended as a `{"role": "system", ...}` ChatML message at the top of the input list. Applied across all six generation-instrumentation sites surfaced by the survey.

**Failed `messages.parse` calls now enrich the generation properly (#452)** — `_record_partial_failure` was only setting `output=partial_text`, leaving `input` as `@observe`'s auto-captured kwargs dict. Playground gate rejected it as "not valid ChatML". Now mirrors the success-path shape (input + model + model_parameters), and works even when there's no partial text (non-ValidationError failures).

**Shape iteration:** first attempt used a nested `{"system": ..., "messages": [...]}` dict, which renders cleanly in the trace UI but the playground extracted only `messages` and dropped system. Switched to a flat ChatML list — pure ChatML, both viewers happy.

## Test plan
- [x] `tests/test_langfuse_input_payload.py` — input shape on success path (Anthropic + Google enrichers, helper unit test)
- [x] `tests/test_llm_partial_failure.py` — input + model + model_parameters on failure path, even without partial_text
- [x] Full suite: 1414 passed
- [x] Smoke-test on redwood ws: confirmed "Open in Playground" populates system + user messages correctly

## Out of scope
- Versus openrouter path doesn't have a system prompt — left unchanged.
- LF playground re-runs against its own configured providers, not our Anthropic client. So this enables prompt/model/param tweaking, not bit-exact reproduction.