### PR TITLE
Introduce optional page scopes restricting visibility to a question's calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ uv run python main.py --list-workspaces
 uv run python main.py "Your question here" --workspace test-scratch --smoke-test
 ```
 
-`--smoke-test` caps agent loop rounds at 2 per call, making runs fast and cheap. Use it for development and manual testing. When running smoke tests, don't override `--budget` unless there's a good reason to.
+`--smoke-test` caps agent loop rounds at a sensible number, making runs fast and cheap while leaving enough for the full flow to be exercised. When running smoke tests, don't override `--budget`.
 
 Tests: `uv run pytest`.
 
@@ -61,6 +61,7 @@ Tests: `uv run pytest`.
 Always use the supabase cli to create new migrations: `supabase migration new`.
 
 **Row-Level Security:** RLS is enabled on all tables with **no policies**. This means:
+
 - `service_role` (used by all backend code) bypasses RLS entirely — no performance impact, full access.
 - `anon` and `authenticated` roles are denied all table access by PostgreSQL's implicit-deny default.
 - The frontend anon key is only used for Realtime broadcast subscriptions, which do not touch the database.
@@ -81,6 +82,7 @@ Do NOT add "allow all" policies. If you need non-service-role access, add target
 **Call types** (`src/rumil/calls/`): Composition-based architecture using three pluggable stage ABCs. `CallRunner` (in `stages.py`) orchestrates the three phases by delegating to `ContextBuilder`, `WorkspaceUpdater`, and `ClosingReviewer` instances. Each call type lives in its own module (`find_considerations.py`, `assess.py`, `ingest.py`, etc.) as a thin `CallRunner` subclass. `common.py` has shared utilities (`run_agent_loop()`, `run_single_call()`, closing reviews). Public API re-exported from `__init__.py`.
 
 Architecture:
+
 - `CallRunner` (`stages.py`) — base class for all call types. Owns `run()` orchestration via `CallInfra` (bundles `CallTrace`, `MoveState`, DB, call). Subclasses set class-level `context_builder_cls`, `workspace_updater_cls`, `closing_reviewer_cls`, and `call_type` attributes, plus override `_make_*()` factory methods for parameterized stages and `task_description()`.
 - `ContextBuilder` ABC — `build_context(infra) -> ContextResult`. Implementations in `context_builders.py`: `EmbeddingContext`, `IngestEmbeddingContext`, `ScoutEmbeddingContext`, `WebResearchEmbeddingContext`, `BigAssessContext`.
 - `WorkspaceUpdater` ABC — `update_workspace(infra, context) -> UpdateResult`. Reusable implementations in `page_creators.py`: `SimpleAgentLoop` (single-pass), `MultiRoundLoop` (multi-round with fruit checks), `WebResearchLoop` (server tools + scraping). Call-specific implementations may live in the call's own module (e.g. `LinkerWorkspaceUpdater` in `link_subquestions.py`).
@@ -88,6 +90,7 @@ Architecture:
 - Data types (`stages.py`): `CallInfra` (shared infra), `ContextResult` (context output), `UpdateResult` (workspace update output).
 
 The three phases:
+
 1. **build_context** — `ContextBuilder.build_context()` returns `ContextResult`
 2. **update_workspace** — `WorkspaceUpdater.update_workspace()` returns `UpdateResult`
 3. **closing_review** — `ClosingReviewer.closing_review()` persists results and calls `mark_call_completed()`
@@ -107,16 +110,17 @@ To add a new call type: subclass `CallRunner`. Set `call_type`, override `_make_
 **Data layer** (`src/rumil/database.py`): Supabase (Postgres) via the `supabase` Python SDK. Tables: pages, page_links, calls, budget, page_ratings, page_flags, mutation_events, runs, projects. `DB.create(run_id, prod=True, staged=False)` classmethod handles connection setup (delegated to `settings.py`); defaults to local Supabase. When `staged=True`, writes tag rows with `staged`/`run_id` and mutations go to `mutation_events` (see "Staged Runs and the Mutation Log" above). Several operations use Postgres RPC functions defined in the migrations.
 
 **Projects vs Workspace enum** — two separate concepts with confusingly similar names:
+
 - **Project** (`projects` table, `project_id` FK): The user-facing isolation mechanism. The CLI `--workspace <name>` flag resolves to a `Project` row via `db.get_or_create_project(name)`, then `db.project_id` is set. Every query on pages/calls/runs/links filters by `project_id`, so projects are fully isolated from each other.
 - **Workspace enum** (`models.Workspace`): An internal layer within a project — `RESEARCH` (default, normal pages), `PRIORITIZATION` (prioritization call outputs). This is orthogonal to project_id; every page has both.
 
-**Data models** (`src/rumil/models.py`): Pydantic BaseModels for Page, PageLink, Call, Project. Used directly as both internal models and FastAPI response types (no separate `*Out` duplicates). Fields with defaults use `_all_fields_required` schema helper so they appear required in the OpenAPI spec. Key enums: PageType, CallType, CallStage, LinkType, ConsiderationDirection, MoveType. MoveType is the source of truth for valid moves — the moves registry maps each to its `MoveDef`. `DISPATCHABLE_CALL_TYPES` defines which `CallType`s prioritization can dispatch (find_considerations, assess, the scout_* family, and web_research) — the dispatch tool validates against it and the orchestrator dispatches on `CallType` enum values. Recursion dispatches (prioritization/claim-investigation sub-cycles) are not in this set; they are added separately via `RECURSE_DISPATCH_DEF` / `RECURSE_CLAIM_DISPATCH_DEF` passed as `extra_dispatch_defs`.
+**Data models** (`src/rumil/models.py`): Pydantic BaseModels for Page, PageLink, Call, Project. Used directly as both internal models and FastAPI response types (no separate `*Out` duplicates). Fields with defaults use `_all_fields_required` schema helper so they appear required in the OpenAPI spec. Key enums: PageType, CallType, CallStage, LinkType, ConsiderationDirection, MoveType. MoveType is the source of truth for valid moves — the moves registry maps each to its `MoveDef`. `DISPATCHABLE_CALL_TYPES` defines which `CallType`s prioritization can dispatch (find*considerations, assess, the scout*\* family, and web_research) — the dispatch tool validates against it and the orchestrator dispatches on `CallType` enum values. Recursion dispatches (prioritization/claim-investigation sub-cycles) are not in this set; they are added separately via `RECURSE_DISPATCH_DEF` / `RECURSE_CLAIM_DISPATCH_DEF` passed as `extra_dispatch_defs`.
 
 **Context building** (`src/rumil/context.py`): Assembles LLM context from DB state. `build_prioritization_context()` includes a question index with dispatchable IDs. `build_embedding_based_context()` uses vector similarity search (`embed_query` + `search_pages_by_vector`) to surface the most relevant pages from the entire workspace regardless of graph distance, filling a full-page tier then a summary tier within configurable char budgets (settings: `context_char_budget`, `full_page_char_fraction`, `summary_page_char_fraction`, `distillation_page_char_fraction`). Helper functions include `format_page()` for rendering individual pages and `render_page_and_immediate_children()` for depth-bounded page rendering.
 
 **Tracing** (`src/rumil/tracing/`): Package containing `tracer.py`, `trace_events.py`, and `broadcast.py`. `CallTrace` (in `tracing/tracer.py`) accumulates typed events during a call's lifecycle and persists them as JSONB in the `trace_json` column on `calls`. Events are defined as Pydantic models in `tracing/trace_events.py` with a `Literal` discriminator field (e.g. `event: Literal["context_built"] = "context_built"`). The `TraceEvent` discriminated union is the accepted type for `CallTrace.record()`. API envelope types in `schemas.py` inherit from these events and add `ts`/`call_id` fields. Frontend types are auto-generated. To add a new trace event: (1) define a new Pydantic model in `tracing/trace_events.py` with an `event: Literal["..."] = "..."` field, (2) add it to the `TraceEvent` union, (3) create a corresponding `*EventOut` subclass in `schemas.py` that inherits from both the event and `_TraceEnvelopeMixin`, (4) add it to the `TraceEventOut` union, (5) regenerate frontend types with `./scripts/generate-api-types.sh`, (6) handle the new event in the frontend's `EventSection` component in `call-node.tsx`.
 
-**Events** (`src/rumil/events.py`): In-process publish/subscribe bus for workspace lifecycle events (distinct from tracing — this is about extensibility hooks, not call-lifetime diagnostics). Events are Pydantic models subclassing `Event` with a `Literal` discriminator on `event_type` (e.g. `PageCreatedEvent.event_type: Literal["page_created"]`). Async handlers are registered per concrete event class and invoked sequentially by `fire(event)`. Dispatch is by *exact type*, not `isinstance` — register on the concrete class you care about. A raising handler is logged and swallowed; other handlers still run. Fire events **after** the underlying state has been persisted so handlers observe committed state. Use the bus for *optional* side effects that extend lifecycle points (e.g. auto-create a View on question creation); use direct calls for mandatory workflow — if A must do X after Y, call X directly rather than hiding it behind an event. Tests should scope registrations with `isolated_bus()` to avoid cross-test leakage. To add a new event type: (1) subclass `Event` in `events.py` with an `event_type: Literal["..."] = "..."` discriminator, (2) add fields describing the event, (3) fire instances from the appropriate lifecycle point after persistence.
+**Events** (`src/rumil/events.py`): In-process publish/subscribe bus for workspace lifecycle events (distinct from tracing — this is about extensibility hooks, not call-lifetime diagnostics). Events are Pydantic models subclassing `Event` with a `Literal` discriminator on `event_type` (e.g. `PageCreatedEvent.event_type: Literal["page_created"]`). Async handlers are registered per concrete event class and invoked sequentially by `fire(event)`. Dispatch is by _exact type_, not `isinstance` — register on the concrete class you care about. A raising handler is logged and swallowed; other handlers still run. Fire events **after** the underlying state has been persisted so handlers observe committed state. Use the bus for _optional_ side effects that extend lifecycle points (e.g. auto-create a View on question creation); use direct calls for mandatory workflow — if A must do X after Y, call X directly rather than hiding it behind an event. Tests should scope registrations with `isolated_bus()` to avoid cross-test leakage. To add a new event type: (1) subclass `Event` in `events.py` with an `event_type: Literal["..."] = "..."` discriminator, (2) add fields describing the event, (3) fire instances from the appropriate lifecycle point after persistence.
 
 **API** (`src/rumil/api/`): FastAPI read-only API for the frontend. Core models from `models.py` are used directly as response types. `schemas.py` defines composite response types (e.g. `CallTraceOut`) and trace event envelope types. `app.py` defines endpoints. Run with `./scripts/dev-api.sh` — this reads the API port from `frontend/.env.overrides` (then `frontend/.env`) so it matches what the frontend expects. To stop the server, read the port from those files (`NEXT_PUBLIC_API_URL`) and kill the process on that port.
 
@@ -143,7 +147,7 @@ Load-bearing invariants you shouldn't break in a passing edit:
 
 - **NEVER pass `--prod` when running `main.py` unless the user explicitly asks you to.** The production database contains real research data. Default to the local database for all testing, development, and exploratory runs.
 - **Never run `supabase db reset`** — this wipes the database and is destructive. To apply pending migrations, use `supabase migration up` instead. If you find yourself wanting to reset the database, stop and ask the user first.
-- Always scope your test runs to a temp/scratch workspace, e.g. `uv run main.py "Is the sky blue?" --workspace skyblue-scratch`
+- Always scope your test runs to a temp/scratch workspace, e.g. `uv run main.py "When will TAI emerge?" --workspace scratch`
 
 - **Settings precedence: dotenv beats shell env.** `Settings` overrides pydantic-settings' default source order so `.env` / `.env.overrides` win over exported shell variables (see `settings.py:settings_customise_sources`). This is intentional — per-worktree `.env.overrides` is the canonical override mechanism. If a value seems wrong, check the dotenv files before assuming `export FOO=...` took effect.
 
@@ -184,6 +188,7 @@ Whenever you run a script that prints a trace url, please report that trace url 
 ## Skills
 
 You must always invoke the relevant skill when doing certain types of work
+
 - **Writing unit tests** Always invoke the write-tests skill
 - **Writing frontend code** Always invoke the frontend-design skill
-When you write a plan that involes either of these things, always include a reminder to invoke the appropriate skill.
+  When you write a plan that involes either of these things, always include a reminder to invoke the appropriate skill.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8296,6 +8296,17 @@
             "type": "boolean",
             "title": "Hidden",
             "default": false
+          },
+          "scope_question_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scope Question Id"
           }
         },
         "type": "object",
@@ -8325,7 +8336,8 @@
           "sections",
           "meta_type",
           "run_id",
-          "hidden"
+          "hidden",
+          "scope_question_id"
         ],
         "title": "Page"
       },
@@ -8477,6 +8489,17 @@
             "type": "string",
             "title": "Run Id",
             "default": ""
+          },
+          "scope_question_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scope Question Id"
           }
         },
         "type": "object",
@@ -8494,7 +8517,8 @@
           "position",
           "impact_on_parent_question",
           "created_at",
-          "run_id"
+          "run_id",
+          "scope_question_id"
         ],
         "title": "PageLink"
       },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2971,6 +2971,10 @@ export type Page = {
      * Hidden
      */
     hidden: boolean;
+    /**
+     * Scope Question Id
+     */
+    scope_question_id: string | null;
 };
 
 /**
@@ -3058,6 +3062,10 @@ export type PageLink = {
      * Run Id
      */
     run_id: string;
+    /**
+     * Scope Question Id
+     */
+    scope_question_id: string | null;
 };
 
 /**

--- a/src/rumil/calls/prioritization.py
+++ b/src/rumil/calls/prioritization.py
@@ -49,6 +49,8 @@ async def run_prioritization_call(
         call.id[:8],
         call.scope_page_id[:8] if call.scope_page_id else None,
     )
+    if call.scope_page_id and db.scope_question_id != call.scope_page_id:
+        db = db.with_scope(call.scope_page_id)
     await db.update_call_status(call.id, CallStatus.RUNNING)
 
     if available_moves is None:

--- a/src/rumil/calls/stages.py
+++ b/src/rumil/calls/stages.py
@@ -220,7 +220,7 @@ class CallRunner(ABC):
 
     @observe(name="call.run")
     async def run(self) -> None:
-        call_db = await self.infra.db.fork()
+        call_db = await self.infra.db.fork(scope_question_id=self.infra.question_id or None)
         self.infra.db = call_db
         self.infra.state.db = call_db
         self.infra.trace.db = call_db

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -208,14 +208,14 @@ _db_retry = retry(
 _LINK_COLUMNS = (
     "id,from_page_id,to_page_id,link_type,direction,"
     "strength,reasoning,role,importance,section,position,"
-    "impact_on_parent_question,created_at,run_id"
+    "impact_on_parent_question,created_at,run_id,scope_question_id"
 )
 
 _SLIM_PAGE_COLUMNS = (
     "id,page_type,layer,workspace,headline,abstract,"
     "epistemic_status,epistemic_type,credence,credence_reasoning,"
     "robustness,robustness_reasoning,extra,is_superseded,"
-    "project_id,created_at,superseded_by,run_id,hidden"
+    "project_id,created_at,superseded_by,run_id,hidden,scope_question_id"
 )
 
 
@@ -247,6 +247,7 @@ def _row_to_page(row: dict[str, Any]) -> Page:
         meta_type=row.get("meta_type"),
         run_id=row.get("run_id") or "",
         hidden=bool(row.get("hidden", False)),
+        scope_question_id=row.get("scope_question_id"),
     )
 
 
@@ -266,6 +267,7 @@ def _row_to_link(row: dict[str, Any]) -> PageLink:
         impact_on_parent_question=row.get("impact_on_parent_question"),
         created_at=datetime.fromisoformat(row["created_at"]),
         run_id=row.get("run_id") or "",
+        scope_question_id=row.get("scope_question_id"),
     )
 
 
@@ -356,6 +358,15 @@ def clear_mutation_caches() -> None:
     _MUTATION_CACHES.clear()
 
 
+class _Unset:
+    """Sentinel type so callers can pass ``None`` explicitly without it being
+    confused with 'argument omitted'. Used by ``DB.fork`` to distinguish
+    'inherit the parent's scope' from 'clear the scope'."""
+
+
+_UNSET = _Unset()
+
+
 class DB:
     def __init__(
         self,
@@ -363,11 +374,13 @@ class DB:
         client: AsyncClient,
         project_id: str = "",
         staged: bool = False,
+        scope_question_id: str | None = None,
     ):
         self.run_id = run_id
         self.client = client
         self.project_id = project_id
         self.staged = staged
+        self.scope_question_id = scope_question_id
         self._semaphore = asyncio.Semaphore(get_settings().db_max_concurrent_queries)
         self._prod: bool = False
 
@@ -379,6 +392,7 @@ class DB:
         project_id: str = "",
         client: AsyncClient | None = None,
         staged: bool = False,
+        scope_question_id: str | None = None,
     ) -> "DB":
         if client is None:
             url, key = get_settings().get_supabase_credentials(prod)
@@ -388,24 +402,34 @@ class DB:
             client=client,
             project_id=project_id,
             staged=staged,
+            scope_question_id=scope_question_id,
         )
         db._prod = prod
         return db
 
-    async def fork(self) -> "DB":
+    async def fork(self, scope_question_id: str | None | _Unset = _UNSET) -> "DB":
         """Create a new DB instance with a fresh Supabase client.
 
         Shares run_id, project_id, and staged flag with the parent but gets
         its own HTTP connection. Use this to scope connections to a single
         call, avoiding HTTP/2 stream exhaustion on long-running jobs.
+
+        Pass ``scope_question_id`` to enter a scoped view: reads will be
+        filtered to rows where ``scope_question_id IS NULL`` or matches the
+        passed value. Pass ``None`` explicitly to clear an inherited scope.
+        Omit the argument to inherit the parent's scope unchanged.
         """
         url, key = get_settings().get_supabase_credentials(self._prod)
         client = await acreate_client(url, key, options=AsyncClientOptions(schema="public"))
+        resolved_scope = (
+            self.scope_question_id if isinstance(scope_question_id, _Unset) else scope_question_id
+        )
         db = DB(
             run_id=self.run_id,
             client=client,
             project_id=self.project_id,
             staged=self.staged,
+            scope_question_id=resolved_scope,
         )
         db._prod = self._prod
         return db
@@ -423,6 +447,26 @@ class DB:
             client=self.client,
             project_id=self.project_id,
             staged=True,
+            scope_question_id=self.scope_question_id,
+        )
+        db._prod = self._prod
+        return db
+
+    def with_scope(self, scope_question_id: str | None) -> "DB":
+        """Return a sibling DB with a different page-scope visibility.
+
+        Reuses the same Supabase client (no new HTTP connection, no close
+        needed) and only swaps the scope filter. Use this when a call entry
+        point already runs on a parent's HTTP client and just needs to
+        narrow its read visibility — e.g. ``run_prioritization_call``
+        scoping reads to its target question.
+        """
+        db = DB(
+            run_id=self.run_id,
+            client=self.client,
+            project_id=self.project_id,
+            staged=self.staged,
+            scope_question_id=scope_question_id,
         )
         db._prod = self._prod
         return db
@@ -449,6 +493,19 @@ class DB:
         if self.staged:
             return query.or_(f"staged.eq.false,run_id.eq.{self.run_id}")
         return query.eq("staged", False)
+
+    def _scope_filter(self, query: Any) -> Any:
+        """Apply page-scope visibility filter to a query.
+
+        Unscoped DBs (``scope_question_id is None``) see every row — no
+        filter is applied. Scoped DBs see rows where ``scope_question_id``
+        is NULL (unscoped row) or matches the DB's scope. Mirrors the SQL
+        predicate used by the discovery RPCs (match_pages,
+        get_root_questions).
+        """
+        if self.scope_question_id is None:
+            return query
+        return query.or_(f"scope_question_id.is.null,scope_question_id.eq.{self.scope_question_id}")
 
     async def _load_mutation_state(self) -> MutationState:
         """Fetch and cache mutation events for this staged run."""
@@ -726,6 +783,7 @@ class DB:
                     "staged": self.staged,
                     "abstract": page.abstract,
                     "hidden": page.hidden,
+                    "scope_question_id": page.scope_question_id,
                 }
             )
         )
@@ -804,7 +862,7 @@ class DB:
 
     async def get_page(self, page_id: str) -> Page | None:
         query = self.client.table("pages").select("*").eq("id", page_id)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         rows = _rows(await self._execute(query))
         if not rows:
             return None
@@ -845,7 +903,9 @@ class DB:
             batch = id_list[start : start + batch_size]
             rows = _rows(
                 await self._execute(
-                    self._staged_filter(self.client.table("pages").select("*").in_("id", batch))
+                    self._scope_filter(
+                        self._staged_filter(self.client.table("pages").select("*").in_("id", batch))
+                    )
                 )
             )
             for r in rows:
@@ -1047,7 +1107,7 @@ class DB:
             query = query.eq("is_superseded", False)
         if not include_hidden:
             query = query.eq("hidden", False)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         pages = [
             _row_to_page(r)
             for r in _rows(await self._execute(query.order("created_at", desc=True).limit(10000)))
@@ -1075,7 +1135,7 @@ class DB:
             query = query.eq("is_superseded", False)
         if not include_hidden:
             query = query.eq("hidden", False)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         pages = [
             _row_to_page(r)
             for r in _rows(await self._execute(query.order("created_at", desc=True).limit(10000)))
@@ -1153,7 +1213,7 @@ class DB:
             query = query.eq("hidden", False)
         if search:
             query = query.or_(f"headline.ilike.%{search}%,content.ilike.%{search}%")
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         query = query.order(
             "is_human_created",
             desc=True,
@@ -1281,6 +1341,7 @@ class DB:
                     "created_at": link.created_at.isoformat(),
                     "run_id": self.run_id,
                     "staged": self.staged,
+                    "scope_question_id": link.scope_question_id,
                 }
             )
         )
@@ -1312,7 +1373,7 @@ class DB:
 
     async def get_link(self, link_id: str) -> PageLink | None:
         query = self.client.table("page_links").select("*").eq("id", link_id)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         rows = _rows(await self._execute(query))
         if not rows:
             return None
@@ -1321,7 +1382,7 @@ class DB:
 
     async def get_links_to(self, page_id: str) -> list[PageLink]:
         query = self.client.table("page_links").select("*").eq("to_page_id", page_id)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         rows = _rows(await self._execute(query))
         return await self._apply_link_events([_row_to_link(r) for r in rows])
 
@@ -1333,7 +1394,7 @@ class DB:
             .eq("to_page_id", question_id)
             .eq("link_type", LinkType.VIEW_OF.value)
         )
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         rows = _rows(await self._execute(query))
         links = await self._apply_link_events([_row_to_link(r) for r in rows])
         if not links:
@@ -1423,7 +1484,7 @@ class DB:
 
     async def get_links_from(self, page_id: str) -> list[PageLink]:
         query = self.client.table("page_links").select("*").eq("from_page_id", page_id)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         rows = _rows(await self._execute(query))
         return await self._apply_link_events([_row_to_link(r) for r in rows])
 
@@ -1446,7 +1507,7 @@ class DB:
                 query = (
                     self.client.table("page_links").select(_LINK_COLUMNS).in_("from_page_id", batch)
                 )
-                query = self._staged_filter(query)
+                query = self._scope_filter(self._staged_filter(query))
                 rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
                 all_links.extend(_row_to_link(r) for r in rows)
                 if len(rows) < page_size:
@@ -1476,7 +1537,7 @@ class DB:
                 query = (
                     self.client.table("page_links").select(_LINK_COLUMNS).in_("to_page_id", batch)
                 )
-                query = self._staged_filter(query)
+                query = self._scope_filter(self._staged_filter(query))
                 rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
                 all_links.extend(_row_to_link(r) for r in rows)
                 if len(rows) < page_size:
@@ -1683,7 +1744,7 @@ class DB:
                     .in_("to_page_id", batch)
                     .eq("link_type", LinkType.ANSWERS.value)
                 )
-                query = self._staged_filter(query)
+                query = self._scope_filter(self._staged_filter(query))
                 rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
                 all_links.extend(_row_to_link(r) for r in rows)
                 if len(rows) < page_size:
@@ -1751,7 +1812,7 @@ class DB:
         page_size = 1000
         while True:
             query = self.client.table("pages").select("id").eq("project_id", self.project_id)
-            query = self._staged_filter(query)
+            query = self._scope_filter(self._staged_filter(query))
             rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
             page_ids.update(r["id"] for r in rows)
             if len(rows) < page_size:
@@ -1784,7 +1845,7 @@ class DB:
                         .eq("link_type", "depends_on")
                         .in_("from_page_id", batch)
                     )
-                    query = self._staged_filter(query)
+                    query = self._scope_filter(self._staged_filter(query))
                     rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
                     all_links.extend(_row_to_link(r) for r in rows)
                     if len(rows) < page_size:
@@ -1795,7 +1856,7 @@ class DB:
             page_size = 1000
             while True:
                 query = self.client.table("page_links").select("*").eq("link_type", "depends_on")
-                query = self._staged_filter(query)
+                query = self._scope_filter(self._staged_filter(query))
                 rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
                 all_links.extend(_row_to_link(r) for r in rows)
                 if len(rows) < page_size:
@@ -2232,7 +2293,7 @@ class DB:
             .eq("from_page_id", from_page_id)
             .eq("to_page_id", to_page_id)
         )
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         rows = _rows(await self._execute(query))
         return await self._apply_link_events([_row_to_link(r) for r in rows])
 
@@ -2250,8 +2311,10 @@ class DB:
             return await self._get_links_for_pages(page_ids)
         page_size = 2000
         if self.project_id:
-            page_ids_query = self._staged_filter(
-                self.client.table("pages").select("id").eq("project_id", self.project_id)
+            page_ids_query = self._scope_filter(
+                self._staged_filter(
+                    self.client.table("pages").select("id").eq("project_id", self.project_id)
+                )
             )
             page_ids_rows = _rows(await self._execute(page_ids_query.limit(50000)))
             proj_page_ids = {r["id"] for r in page_ids_rows}
@@ -2259,7 +2322,7 @@ class DB:
             offset = 0
             while True:
                 query = self.client.table("page_links").select(_LINK_COLUMNS)
-                query = self._staged_filter(query)
+                query = self._scope_filter(self._staged_filter(query))
                 rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
                 all_rows.extend(rows)
                 if len(rows) < page_size:
@@ -2275,7 +2338,7 @@ class DB:
             offset = 0
             while True:
                 query = self.client.table("page_links").select(_LINK_COLUMNS)
-                query = self._staged_filter(query)
+                query = self._scope_filter(self._staged_filter(query))
                 rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
                 all_rows.extend(rows)
                 if len(rows) < page_size:
@@ -2303,7 +2366,7 @@ class DB:
                 offset = 0
                 while True:
                     query = self.client.table("page_links").select(_LINK_COLUMNS).in_(col, batch)
-                    query = self._staged_filter(query)
+                    query = self._scope_filter(self._staged_filter(query))
                     rows = _rows(await self._execute(query.range(offset, offset + page_size - 1)))
                     for r in rows:
                         link = _row_to_link(r)
@@ -2317,7 +2380,11 @@ class DB:
         """Delete a page link by ID."""
         rows = _rows(
             await self._execute(
-                self._staged_filter(self.client.table("page_links").select("*").eq("id", link_id))
+                self._scope_filter(
+                    self._staged_filter(
+                        self.client.table("page_links").select("*").eq("id", link_id)
+                    )
+                )
             )
         )
         link_snapshot = rows[0] if rows else {}
@@ -2715,6 +2782,8 @@ class DB:
             params["p_staged_run_id"] = self.run_id
         if include_hidden:
             params["p_include_hidden"] = True
+        if self.scope_question_id is not None:
+            params["p_scope_question_id"] = self.scope_question_id
         rows = _rows(await self._execute(self.client.rpc("get_root_questions", params)))
         pages = [_row_to_page(r) for r in rows]
         pages = await self._apply_page_events(pages)
@@ -2744,7 +2813,7 @@ class DB:
             query = query.eq("project_id", self.project_id)
         if not include_hidden:
             query = query.eq("hidden", False)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         rows = _rows(await self._execute(query))
         pages = [_row_to_page(r) for r in rows]
         pages = await self._apply_page_events(pages)
@@ -2830,7 +2899,7 @@ class DB:
             .select(_LINK_COLUMNS)
             .in_("to_page_id", list(question_ids))
         )
-        links_query = self._staged_filter(links_query)
+        links_query = self._scope_filter(self._staged_filter(links_query))
         links_result = await self._execute(links_query)
         links = [_row_to_link(r) for r in _rows(links_result)]
         links = await self._apply_link_events(links)
@@ -2861,7 +2930,7 @@ class DB:
         )
         if self.project_id:
             query = query.eq("project_id", self.project_id)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         result = await self._execute(query)
         return result.count or 0
 
@@ -3149,7 +3218,7 @@ class DB:
         )
         if self.project_id:
             query = query.eq("project_id", self.project_id)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         result = await self._execute(query)
         return result.count or 0
 
@@ -3168,7 +3237,7 @@ class DB:
         )
         if self.project_id:
             query = query.eq("project_id", self.project_id)
-        query = self._staged_filter(query)
+        query = self._scope_filter(self._staged_filter(query))
         result = await self._execute(query)
         pages = [_row_to_page(r) for r in _rows(result)]
         return await self._apply_page_events(pages)

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -2387,7 +2387,14 @@ class DB:
                 )
             )
         )
-        link_snapshot = rows[0] if rows else {}
+        if not rows:
+            # Link is invisible to this DB's staged/scope view. Recording an
+            # empty mutation event would corrupt the log (retroactive staging
+            # cannot restore from an empty payload), and the DELETE below is
+            # unfiltered — proceeding would silently bypass the visibility
+            # filter the snapshot fetch just enforced.
+            return
+        link_snapshot = rows[0]
         await self.record_mutation_event("delete_link", link_id, link_snapshot)
         if not self.staged:
             await self._execute(self.client.table("page_links").delete().eq("id", link_id))
@@ -3299,6 +3306,7 @@ class DB:
                     "created_at": payload.get("created_at"),
                     "run_id": payload.get("run_id", run_id),
                     "staged": was_own_link,
+                    "scope_question_id": payload.get("scope_question_id"),
                 }
                 await self._execute(self.client.table("page_links").upsert(restore_row))
 

--- a/src/rumil/embeddings.py
+++ b/src/rumil/embeddings.py
@@ -186,6 +186,8 @@ async def search_pages_by_vector(
         params["filter_staged_run_id"] = db.run_id
     if include_hidden:
         params["filter_include_hidden"] = True
+    if db.scope_question_id is not None:
+        params["filter_scope_question_id"] = db.scope_question_id
     rows: _Rows = _rows(await db.client.rpc("match_pages", params).execute())
     results: list[tuple[Page, float]] = []
     for row in rows:

--- a/src/rumil/models.py
+++ b/src/rumil/models.py
@@ -433,6 +433,7 @@ class Page(BaseModel):
     meta_type: str | None = None  # VIEW_META pages: priority/annotation/proposal
     run_id: str = ""
     hidden: bool = False
+    scope_question_id: str | None = None
 
     def is_active(self) -> bool:
         return not self.is_superseded
@@ -454,6 +455,7 @@ class PageLink(BaseModel):
     impact_on_parent_question: int | None = None  # CHILD_QUESTION links: 0-10
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     run_id: str = ""
+    scope_question_id: str | None = None
 
 
 class CallSequence(BaseModel):

--- a/supabase/migrations/20260506084410_page_scopes.sql
+++ b/supabase/migrations/20260506084410_page_scopes.sql
@@ -1,0 +1,126 @@
+-- Page scopes: optional per-page (and per-link) restriction to a single
+-- question. A row tagged with `scope_question_id = Q` is only visible to
+-- callers whose DB instance is forked into matching scope; an untagged
+-- row (NULL) is visible to all callers.
+--
+-- This is the same shape as the staged-runs visibility mechanism, with
+-- one difference: the filter is opt-in. A DB with `scope_question_id IS
+-- NULL` (the default) sees everything; a DB scoped to Q sees rows where
+-- `scope_question_id IS NULL OR scope_question_id = Q`.
+--
+-- Discovery RPCs (match_pages, get_root_questions) gain a
+-- filter_scope_question_id parameter; existing visibility predicates
+-- (staged, hidden) are preserved verbatim.
+
+ALTER TABLE pages ADD COLUMN scope_question_id TEXT REFERENCES pages(id);
+ALTER TABLE page_links ADD COLUMN scope_question_id TEXT REFERENCES pages(id);
+CREATE INDEX idx_pages_scope ON pages(scope_question_id) WHERE scope_question_id IS NOT NULL;
+CREATE INDEX idx_page_links_scope ON page_links(scope_question_id) WHERE scope_question_id IS NOT NULL;
+
+DROP FUNCTION IF EXISTS match_pages(
+    extensions.vector, DOUBLE PRECISION, INTEGER, TEXT, UUID, TEXT, TEXT, BOOLEAN
+);
+
+CREATE OR REPLACE FUNCTION match_pages(
+    query_embedding extensions.vector(1024),
+    match_threshold DOUBLE PRECISION DEFAULT 0.5,
+    match_count INTEGER DEFAULT 10,
+    filter_workspace TEXT DEFAULT NULL,
+    filter_project_id UUID DEFAULT NULL,
+    filter_field_name TEXT DEFAULT NULL,
+    filter_staged_run_id TEXT DEFAULT NULL,
+    filter_include_hidden BOOLEAN DEFAULT false,
+    filter_scope_question_id TEXT DEFAULT NULL
+)
+RETURNS TABLE(
+    id TEXT,
+    page_type TEXT,
+    layer TEXT,
+    workspace TEXT,
+    content TEXT,
+    headline TEXT,
+    abstract TEXT,
+    project_id UUID,
+    epistemic_status DOUBLE PRECISION,
+    epistemic_type TEXT,
+    credence INTEGER,
+    robustness INTEGER,
+    provenance_model TEXT,
+    provenance_call_type TEXT,
+    provenance_call_id TEXT,
+    created_at TIMESTAMPTZ,
+    superseded_by TEXT,
+    is_superseded BOOLEAN,
+    extra JSONB,
+    run_id TEXT,
+    field_name TEXT,
+    similarity DOUBLE PRECISION
+)
+LANGUAGE sql STABLE
+SET search_path = public, extensions
+AS $$
+    SELECT
+        p.id,
+        p.page_type,
+        p.layer,
+        p.workspace,
+        p.content,
+        p.headline,
+        p.abstract,
+        p.project_id,
+        p.epistemic_status,
+        p.epistemic_type,
+        p.credence,
+        p.robustness,
+        p.provenance_model,
+        p.provenance_call_type,
+        p.provenance_call_id,
+        p.created_at,
+        p.superseded_by,
+        p.is_superseded,
+        p.extra,
+        p.run_id,
+        pe.field_name,
+        1 - (pe.embedding <=> query_embedding) AS similarity
+    FROM page_embeddings pe
+    JOIN pages p ON p.id = pe.page_id
+    WHERE p.is_superseded = FALSE
+      AND 1 - (pe.embedding <=> query_embedding) > match_threshold
+      AND (filter_workspace IS NULL OR p.workspace = filter_workspace)
+      AND (filter_project_id IS NULL OR p.project_id = filter_project_id)
+      AND (filter_field_name IS NULL OR pe.field_name = filter_field_name)
+      AND (p.staged = FALSE OR p.run_id = filter_staged_run_id)
+      AND (filter_include_hidden OR NOT p.hidden)
+      AND (filter_scope_question_id IS NULL
+           OR p.scope_question_id IS NULL
+           OR p.scope_question_id = filter_scope_question_id)
+    ORDER BY pe.embedding <=> query_embedding
+    LIMIT match_count;
+$$;
+
+DROP FUNCTION IF EXISTS get_root_questions(TEXT, UUID, TEXT, BOOLEAN);
+
+CREATE OR REPLACE FUNCTION get_root_questions(
+    ws TEXT,
+    pid UUID DEFAULT NULL,
+    p_staged_run_id TEXT DEFAULT NULL,
+    p_include_hidden BOOLEAN DEFAULT false,
+    p_scope_question_id TEXT DEFAULT NULL
+)
+RETURNS SETOF pages
+LANGUAGE sql STABLE AS $$
+    SELECT p.* FROM pages p
+    WHERE p.page_type = 'question'
+      AND p.workspace = ws
+      AND p.is_superseded = FALSE
+      AND (pid IS NULL OR p.project_id = pid)
+      AND (p.staged = FALSE OR p.run_id = p_staged_run_id)
+      AND (p_include_hidden OR NOT p.hidden)
+      AND (p_scope_question_id IS NULL
+           OR p.scope_question_id IS NULL
+           OR p.scope_question_id = p_scope_question_id)
+      AND p.id NOT IN (
+          SELECT to_page_id FROM page_links WHERE link_type = 'child_question'
+      )
+    ORDER BY p.created_at DESC;
+$$;

--- a/tests/test_page_scopes.py
+++ b/tests/test_page_scopes.py
@@ -22,7 +22,7 @@ from rumil.calls.stages import (
     UpdateResult,
     WorkspaceUpdater,
 )
-from rumil.database import DB
+from rumil.database import DB, _rows
 from rumil.models import (
     Call,
     CallStatus,
@@ -366,3 +366,61 @@ async def test_run_prioritization_call_enters_scoped_mode(writer_db, mocker):
 
     assert seen["scope"] == question.id
     assert writer_db.scope_question_id is None
+
+
+async def test_delete_link_refuses_when_invisible_to_caller(writer_db, project_id):
+    """A scoped DB cannot delete an out-of-scope link.
+
+    Without this guard, the snapshot fetch (scope-filtered) returns nothing
+    while the unfiltered DELETE still removes the row, producing a
+    delete_link mutation event with an empty payload — retroactive staging
+    cannot then restore the link.
+    """
+    q1 = await _make_question(writer_db, "q1")
+    q2 = await _make_question(writer_db, "q2")
+    a = await _make_page(writer_db, "claim a")
+    b = await _make_page(writer_db, "claim b")
+    link = await _link(writer_db, a, b, scope_question_id=q1.id)
+
+    reader_q2 = await _make_db(project_id, scope_question_id=q2.id)
+    try:
+        await reader_q2.delete_link(link.id)
+    finally:
+        await reader_q2.close()
+
+    assert await writer_db.get_link(link.id) is not None
+
+    events = _rows(
+        await writer_db._execute(
+            writer_db.client.table("mutation_events")
+            .select("event_type, target_id")
+            .eq("target_id", link.id)
+        )
+    )
+    assert events == []
+
+
+async def test_stage_run_restores_scope_question_id_on_deleted_link(writer_db, project_id):
+    """``stage_run``'s delete_link restore must repopulate ``scope_question_id``.
+
+    Without this, retroactively staging a run that deleted a scoped link
+    silently strips the scope on resurrection — a quiet visibility leak.
+    """
+    q1 = await _make_question(writer_db, "q1")
+    a = await _make_page(writer_db, "claim a")
+    b = await _make_page(writer_db, "claim b")
+    link = await _link(writer_db, a, b, scope_question_id=q1.id)
+
+    delete_run = await DB.create(run_id=str(uuid.uuid4()), scope_question_id=q1.id)
+    delete_run.project_id = project_id
+    try:
+        await delete_run.delete_link(link.id)
+    finally:
+        await delete_run.close()
+    assert await writer_db.get_link(link.id) is None
+
+    await writer_db.stage_run(delete_run.run_id)
+
+    restored = await writer_db.get_link(link.id)
+    assert restored is not None
+    assert restored.scope_question_id == q1.id

--- a/tests/test_page_scopes.py
+++ b/tests/test_page_scopes.py
@@ -1,0 +1,368 @@
+"""Test page-scope visibility: optional per-row restriction to a question.
+
+A page (or link) tagged with ``scope_question_id = Q`` is only visible to
+DB instances that have been scoped to Q. Untagged rows are visible to
+every DB.
+
+Mirrors the staged-runs test layout — see ``test_staged_runs.py`` for the
+pattern.
+"""
+
+import uuid
+
+import pytest_asyncio
+
+from rumil.calls.prioritization import run_prioritization_call
+from rumil.calls.stages import (
+    CallInfra,
+    CallRunner,
+    ClosingReviewer,
+    ContextBuilder,
+    ContextResult,
+    UpdateResult,
+    WorkspaceUpdater,
+)
+from rumil.database import DB
+from rumil.models import (
+    Call,
+    CallStatus,
+    CallType,
+    LinkType,
+    Page,
+    PageLayer,
+    PageLink,
+    PageType,
+    Workspace,
+)
+
+
+async def _make_db(project_id: str, scope_question_id: str | None = None) -> DB:
+    db = await DB.create(run_id=str(uuid.uuid4()), scope_question_id=scope_question_id)
+    db.project_id = project_id
+    return db
+
+
+async def _make_page(
+    db: DB,
+    headline: str,
+    page_type: PageType = PageType.CLAIM,
+    scope_question_id: str | None = None,
+) -> Page:
+    page = Page(
+        page_type=page_type,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content=f"Content for: {headline}",
+        headline=headline,
+        scope_question_id=scope_question_id,
+    )
+    await db.save_page(page)
+    return page
+
+
+async def _make_question(db: DB, headline: str) -> Page:
+    return await _make_page(db, headline, page_type=PageType.QUESTION)
+
+
+async def _link(
+    db: DB,
+    from_page: Page,
+    to_page: Page,
+    scope_question_id: str | None = None,
+) -> PageLink:
+    link = PageLink(
+        from_page_id=from_page.id,
+        to_page_id=to_page.id,
+        link_type=LinkType.CONSIDERATION,
+        strength=5.0,
+        reasoning="test link",
+        scope_question_id=scope_question_id,
+    )
+    await db.save_link(link)
+    return link
+
+
+@pytest_asyncio.fixture
+async def project_id():
+    db = await DB.create(run_id=str(uuid.uuid4()))
+    project = await db.get_or_create_project(f"test-scopes-{uuid.uuid4().hex[:8]}")
+    try:
+        yield project.id
+    finally:
+        await db._execute(db.client.table("projects").delete().eq("id", project.id))
+        await db.close()
+
+
+@pytest_asyncio.fixture
+async def writer_db(project_id):
+    """An unscoped DB used to write rows with explicit scope_question_id values."""
+    db = await _make_db(project_id)
+    await db.init_budget(100)
+    try:
+        yield db
+    finally:
+        await db.delete_run_data()
+        await db.close()
+
+
+async def test_unscoped_page_visible_to_every_db(writer_db, project_id):
+    """A page with NULL scope is visible to every reader regardless of their scope."""
+    q1 = await _make_question(writer_db, "scope question 1")
+    p = await _make_page(writer_db, "unscoped claim", scope_question_id=None)
+
+    unscoped_reader = await _make_db(project_id, scope_question_id=None)
+    scoped_reader = await _make_db(project_id, scope_question_id=q1.id)
+    try:
+        assert await unscoped_reader.get_page(p.id) is not None
+        assert await scoped_reader.get_page(p.id) is not None
+    finally:
+        await unscoped_reader.close()
+        await scoped_reader.close()
+
+
+async def test_scoped_page_invisible_to_mismatched_scope(writer_db, project_id):
+    """A page scoped to Q1 is invisible to a reader scoped to Q2."""
+    q1 = await _make_question(writer_db, "scope question 1")
+    q2 = await _make_question(writer_db, "scope question 2")
+    p = await _make_page(writer_db, "Q1-only claim", scope_question_id=q1.id)
+
+    reader_q2 = await _make_db(project_id, scope_question_id=q2.id)
+    try:
+        assert await reader_q2.get_page(p.id) is None
+    finally:
+        await reader_q2.close()
+
+
+async def test_scoped_page_visible_to_matching_scope(writer_db, project_id):
+    """A page scoped to Q1 is visible to a reader scoped to Q1."""
+    q1 = await _make_question(writer_db, "scope question 1")
+    p = await _make_page(writer_db, "Q1-only claim", scope_question_id=q1.id)
+
+    reader_q1 = await _make_db(project_id, scope_question_id=q1.id)
+    try:
+        assert await reader_q1.get_page(p.id) is not None
+    finally:
+        await reader_q1.close()
+
+
+async def test_scoped_page_visible_to_unscoped_reader(writer_db, project_id):
+    """A page scoped to Q1 is visible to an unscoped DB (the default).
+
+    Unscoped DBs see everything — only scoped DBs apply the filter. This
+    is the load-bearing semantic that keeps the API/CLI/orchestrator
+    paths unaffected.
+    """
+    q1 = await _make_question(writer_db, "scope question 1")
+    p = await _make_page(writer_db, "Q1-only claim", scope_question_id=q1.id)
+
+    unscoped_reader = await _make_db(project_id, scope_question_id=None)
+    try:
+        assert await unscoped_reader.get_page(p.id) is not None
+    finally:
+        await unscoped_reader.close()
+
+
+async def test_get_pages_by_ids_respects_scope(writer_db, project_id):
+    q1 = await _make_question(writer_db, "scope question 1")
+    q2 = await _make_question(writer_db, "scope question 2")
+    p_q1 = await _make_page(writer_db, "Q1 claim", scope_question_id=q1.id)
+    p_q2 = await _make_page(writer_db, "Q2 claim", scope_question_id=q2.id)
+    p_open = await _make_page(writer_db, "unscoped claim", scope_question_id=None)
+
+    reader_q1 = await _make_db(project_id, scope_question_id=q1.id)
+    try:
+        pages = await reader_q1.get_pages_by_ids([p_q1.id, p_q2.id, p_open.id])
+        assert p_q1.id in pages
+        assert p_open.id in pages
+        assert p_q2.id not in pages
+    finally:
+        await reader_q1.close()
+
+
+async def test_scoped_link_invisible_to_mismatched_scope(writer_db, project_id):
+    """Links carry scope_question_id too; same visibility semantics."""
+    q1 = await _make_question(writer_db, "scope question 1")
+    q2 = await _make_question(writer_db, "scope question 2")
+    a = await _make_page(writer_db, "claim a")
+    b = await _make_page(writer_db, "claim b")
+    link = await _link(writer_db, a, b, scope_question_id=q1.id)
+
+    reader_q1 = await _make_db(project_id, scope_question_id=q1.id)
+    reader_q2 = await _make_db(project_id, scope_question_id=q2.id)
+    unscoped = await _make_db(project_id, scope_question_id=None)
+    try:
+        assert await reader_q1.get_link(link.id) is not None
+        assert await reader_q2.get_link(link.id) is None
+        assert await unscoped.get_link(link.id) is not None
+
+        ids_q1 = {ln.id for ln in await reader_q1.get_links_from(a.id)}
+        ids_q2 = {ln.id for ln in await reader_q2.get_links_from(a.id)}
+        ids_unscoped = {ln.id for ln in await unscoped.get_links_from(a.id)}
+        assert link.id in ids_q1
+        assert link.id not in ids_q2
+        assert link.id in ids_unscoped
+
+        ids_q1_to = {ln.id for ln in await reader_q1.get_links_to(b.id)}
+        ids_q2_to = {ln.id for ln in await reader_q2.get_links_to(b.id)}
+        assert link.id in ids_q1_to
+        assert link.id not in ids_q2_to
+    finally:
+        await reader_q1.close()
+        await reader_q2.close()
+        await unscoped.close()
+
+
+async def test_get_root_questions_rpc_respects_scope(writer_db, project_id):
+    """The get_root_questions RPC applies the scope predicate in SQL."""
+    open_root = await _make_question(writer_db, "open root")
+    scope_anchor = await _make_question(writer_db, "scope anchor")
+    scoped_root = Page(
+        page_type=PageType.QUESTION,
+        layer=PageLayer.SQUIDGY,
+        workspace=Workspace.RESEARCH,
+        content="scoped root content",
+        headline="scoped root",
+        scope_question_id=scope_anchor.id,
+    )
+    await writer_db.save_page(scoped_root)
+
+    reader_anchor = await _make_db(project_id, scope_question_id=scope_anchor.id)
+    other_anchor = await _make_question(writer_db, "other anchor")
+    reader_other = await _make_db(project_id, scope_question_id=other_anchor.id)
+    try:
+        roots_anchor = {q.id for q in await reader_anchor.get_root_questions()}
+        roots_other = {q.id for q in await reader_other.get_root_questions()}
+
+        assert open_root.id in roots_anchor
+        assert scoped_root.id in roots_anchor
+
+        assert open_root.id in roots_other
+        assert scoped_root.id not in roots_other
+    finally:
+        await reader_anchor.close()
+        await reader_other.close()
+
+
+async def test_with_scope_returns_sibling_with_shared_client(writer_db, project_id):
+    """``with_scope`` flips the scope on a sibling DB without forking the HTTP client."""
+    q1 = await _make_question(writer_db, "q1")
+    p_q1 = await _make_page(writer_db, "Q1 claim", scope_question_id=q1.id)
+
+    sibling = writer_db.with_scope(q1.id)
+    assert sibling.client is writer_db.client
+    assert sibling.scope_question_id == q1.id
+    assert await sibling.get_page(p_q1.id) is not None
+
+    cleared = sibling.with_scope(None)
+    assert cleared.scope_question_id is None
+    assert await cleared.get_page(p_q1.id) is not None
+
+
+async def test_fork_preserves_scope_by_default(writer_db, project_id):
+    """``fork()`` without args inherits the parent's scope; pass None to clear it."""
+    q1 = await _make_question(writer_db, "q1")
+    scoped = writer_db.with_scope(q1.id)
+
+    inherited = await scoped.fork()
+    try:
+        assert inherited.scope_question_id == q1.id
+    finally:
+        await inherited.close()
+
+    cleared = await scoped.fork(scope_question_id=None)
+    try:
+        assert cleared.scope_question_id is None
+    finally:
+        await cleared.close()
+
+
+class _CapturingContextBuilder(ContextBuilder):
+    async def build_context(self, infra: CallInfra) -> ContextResult:
+        captured["context_db_scope"] = infra.db.scope_question_id
+        return ContextResult(context_text="", working_page_ids=[])
+
+
+class _NoopWorkspaceUpdater(WorkspaceUpdater):
+    async def update_workspace(self, infra: CallInfra, context: ContextResult) -> UpdateResult:
+        captured["update_db_scope"] = infra.db.scope_question_id
+        return UpdateResult(created_page_ids=[], moves=[], all_loaded_ids=[])
+
+
+class _NoopClosingReviewer(ClosingReviewer):
+    async def closing_review(
+        self,
+        infra: CallInfra,
+        context: ContextResult,
+        creation: UpdateResult,
+    ) -> None:
+        captured["closing_db_scope"] = infra.db.scope_question_id
+
+
+captured: dict[str, str | None] = {}
+
+
+class _ScopeProbeRunner(CallRunner):
+    context_builder_cls = _CapturingContextBuilder
+    workspace_updater_cls = _NoopWorkspaceUpdater
+    closing_reviewer_cls = _NoopClosingReviewer
+    call_type = CallType.FIND_CONSIDERATIONS
+
+    def task_description(self) -> str:
+        return "probe"
+
+
+async def test_call_runner_forks_db_into_scoped_mode(writer_db):
+    """CallRunner.run() forks the DB so each stage sees ``scope_question_id == question_id``."""
+    captured.clear()
+    question = await _make_question(writer_db, "scope target question")
+    call = Call(
+        call_type=CallType.FIND_CONSIDERATIONS,
+        workspace=Workspace.RESEARCH,
+        scope_page_id=question.id,
+        status=CallStatus.PENDING,
+    )
+    await writer_db.save_call(call)
+
+    runner = _ScopeProbeRunner(question.id, call, writer_db)
+    await runner.run()
+
+    assert captured["context_db_scope"] == question.id
+    assert captured["update_db_scope"] == question.id
+    assert captured["closing_db_scope"] == question.id
+
+
+async def test_run_prioritization_call_enters_scoped_mode(writer_db, mocker):
+    """run_prioritization_call narrows the DB scope to ``call.scope_page_id``."""
+    question = await _make_question(writer_db, "prio target question")
+    call = Call(
+        call_type=CallType.PRIORITIZATION,
+        workspace=Workspace.PRIORITIZATION,
+        scope_page_id=question.id,
+        status=CallStatus.PENDING,
+        budget_allocated=5,
+    )
+    await writer_db.save_call(call)
+
+    seen: dict[str, str | None] = {}
+
+    async def _stub_run_single_call(*args, **kwargs):
+        seen["scope"] = kwargs["db"].scope_question_id
+        from rumil.calls.common import RunCallResult
+
+        return RunCallResult()
+
+    mocker.patch(
+        "rumil.calls.prioritization.run_single_call",
+        side_effect=_stub_run_single_call,
+    )
+
+    await run_prioritization_call(
+        task_description="probe",
+        context_text="",
+        call=call,
+        db=writer_db,
+        system_prompt="probe system",
+    )
+
+    assert seen["scope"] == question.id
+    assert writer_db.scope_question_id is None


### PR DESCRIPTION
## Summary

- Adds an optional ``scope_question_id`` to pages and links. A row tagged ``scope_question_id = Q`` is only visible to a ``DB`` instance that has been forked into matching scope; untagged rows (the default for everything that exists today) stay visible to every reader.
- ``CallRunner.run()`` and ``run_prioritization_call`` now narrow their DB to the call's question — so every move and prioritiser call automatically reads through its call's scope. Orchestrator/API/CLI code keep an unscoped DB and see everything.
- Plumbing only: no current code path actually creates a scoped page. The writer (LLM-facing flag, orchestrator policy, etc.) is a future follow-up.

## Design

Mirrors the staged-runs visibility pattern with one inversion: the scope filter is opt-in. ``DB.scope_question_id is None`` (the default) applies **no** filter; ``DB.scope_question_id == Q`` filters to rows where ``scope_question_id IS NULL`` or ``= Q``. Same predicate is replicated in the ``match_pages`` and ``get_root_questions`` RPCs via a new ``filter_scope_question_id`` parameter.

A new ``DB.with_scope(...)`` returns a sibling DB that shares the HTTP client (no fork/close required) and just swaps the scope, used by ``run_prioritization_call`` to avoid leaking connections.

## Test plan

- [x] ``uv run pyright`` — clean.
- [x] ``uv run pytest`` — 1441 passed, 0 failed. New ``tests/test_page_scopes.py`` adds 11 tests covering visibility on pages, links, the ``get_root_questions`` RPC, ``with_scope`` / ``fork`` semantics, ``CallRunner`` forking into scope, and ``run_prioritization_call`` entering scope.
- [x] Smoke run: ``uv run python main.py "Is the sky blue?" --workspace test-page-scopes-smoke --smoke-test --budget 4`` completed end-to-end; all 7 produced pages have ``scope_question_id = NULL``, confirming the plumbing-only boundary holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)