### PR TITLE
Capture available tools on LLM exchanges and Langfuse generations

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7554,6 +7554,21 @@
             "type": "array",
             "title": "Tool Calls"
           },
+          "available_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Available Tools"
+          },
           "input_tokens": {
             "anyOf": [
               {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7569,6 +7569,18 @@
             ],
             "title": "Available Tools"
           },
+          "response_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Schema"
+          },
           "input_tokens": {
             "anyOf": [
               {

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2569,6 +2569,12 @@ export type LlmExchangeOut = {
         [key: string]: unknown;
     }> | null;
     /**
+     * Response Schema
+     */
+    response_schema?: {
+        [key: string]: unknown;
+    } | null;
+    /**
      * Input Tokens
      */
     input_tokens: number | null;

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2563,6 +2563,12 @@ export type LlmExchangeOut = {
         [key: string]: unknown;
     }>;
     /**
+     * Available Tools
+     */
+    available_tools?: Array<{
+        [key: string]: unknown;
+    }> | null;
+    /**
      * Input Tokens
      */
     input_tokens: number | null;

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -590,6 +590,37 @@ function WebSearchResultEntry({ tc }: { tc: Record<string, unknown> }) {
   );
 }
 
+function AvailableToolsList({
+  tools,
+}: {
+  tools: Array<Record<string, unknown>>;
+}) {
+  return (
+    <div className="trace-tool-calls">
+      <div className="trace-tool-calls-label">
+        Available tools ({tools.length})
+      </div>
+      {tools.map((tool, i) => (
+        <details key={i} className="trace-tool-call">
+          <summary className="trace-tool-call-name">
+            {(tool.name as string | undefined) ?? `tool ${i}`}
+          </summary>
+          {tool.description ? (
+            <pre className="trace-tool-call-output">
+              {String(tool.description)}
+            </pre>
+          ) : null}
+          {tool.input_schema ? (
+            <pre className="trace-tool-call-input">
+              {JSON.stringify(tool.input_schema, null, 2)}
+            </pre>
+          ) : null}
+        </details>
+      ))}
+    </div>
+  );
+}
+
 function ToolCallsList({ toolCalls }: { toolCalls: Array<Record<string, unknown>> }) {
   const serverToolUses = toolCalls.filter((tc) => !tc.type);
   const webResults = toolCalls.filter((tc) => tc.type === "web_search_tool_result");
@@ -718,6 +749,11 @@ function ExchangeDetail({ detail }: { detail: LlmExchangeOut }) {
         <MessageThread messages={detail.user_messages as Array<Record<string, unknown>>} />
       ) : (
         <CollapsiblePre label="User message" content={detail.user_message} />
+      )}
+      {detail.available_tools && detail.available_tools.length > 0 && (
+        <AvailableToolsList
+          tools={detail.available_tools as Array<Record<string, unknown>>}
+        />
       )}
       {detail.thinking_blocks && (
         <ThinkingSection blocks={detail.thinking_blocks} />

--- a/frontend/src/app/traces/[runId]/call-node.tsx
+++ b/frontend/src/app/traces/[runId]/call-node.tsx
@@ -590,6 +590,26 @@ function WebSearchResultEntry({ tc }: { tc: Record<string, unknown> }) {
   );
 }
 
+function ResponseSchemaSection({
+  schema,
+}: {
+  schema: Record<string, unknown>;
+}) {
+  const name = (schema.name as string | undefined) ?? "response_schema";
+  const body = schema.schema ?? schema;
+  return (
+    <div className="trace-tool-calls">
+      <div className="trace-tool-calls-label">Response schema</div>
+      <details className="trace-tool-call">
+        <summary className="trace-tool-call-name">{name}</summary>
+        <pre className="trace-tool-call-input">
+          {JSON.stringify(body, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
 function AvailableToolsList({
   tools,
 }: {
@@ -753,6 +773,11 @@ function ExchangeDetail({ detail }: { detail: LlmExchangeOut }) {
       {detail.available_tools && detail.available_tools.length > 0 && (
         <AvailableToolsList
           tools={detail.available_tools as Array<Record<string, unknown>>}
+        />
+      )}
+      {detail.response_schema && (
+        <ResponseSchemaSection
+          schema={detail.response_schema as Record<string, unknown>}
         />
       )}
       {detail.thinking_blocks && (

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -882,6 +882,7 @@ async def get_llm_exchange(
         user_messages=row.get("user_messages"),
         response_text=row.get("response_text"),
         tool_calls=row.get("tool_calls", []),
+        available_tools=row.get("available_tools"),
         input_tokens=row.get("input_tokens"),
         output_tokens=row.get("output_tokens"),
         duration_ms=row.get("duration_ms"),

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -883,6 +883,7 @@ async def get_llm_exchange(
         response_text=row.get("response_text"),
         tool_calls=row.get("tool_calls", []),
         available_tools=row.get("available_tools"),
+        response_schema=row.get("response_schema"),
         input_tokens=row.get("input_tokens"),
         output_tokens=row.get("output_tokens"),
         duration_ms=row.get("duration_ms"),

--- a/src/rumil/api/schemas.py
+++ b/src/rumil/api/schemas.py
@@ -411,6 +411,7 @@ class LLMExchangeOut(BaseModel):
     user_messages: list[dict] | None = None
     response_text: str | None
     tool_calls: list[dict]
+    available_tools: list[dict] | None = None
     input_tokens: int | None
     output_tokens: int | None
     duration_ms: int | None

--- a/src/rumil/api/schemas.py
+++ b/src/rumil/api/schemas.py
@@ -412,6 +412,7 @@ class LLMExchangeOut(BaseModel):
     response_text: str | None
     tool_calls: list[dict]
     available_tools: list[dict] | None = None
+    response_schema: dict | None = None
     input_tokens: int | None
     output_tokens: int | None
     duration_ms: int | None

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -2884,6 +2884,7 @@ class DB:
         model: str | None = None,
         request_kwargs: dict[str, Any] | None = None,
         thinking_blocks: dict[str, Any] | None = None,
+        available_tools: Sequence[dict[str, Any]] | None = None,
     ) -> str:
         exchange_id = str(uuid.uuid4())
         row: dict[str, Any] = {
@@ -2910,6 +2911,8 @@ class DB:
             row["request_kwargs"] = request_kwargs
         if thinking_blocks is not None:
             row["thinking_blocks"] = thinking_blocks
+        if available_tools is not None:
+            row["available_tools"] = list(available_tools)
         await self._execute(self.client.table("call_llm_exchanges").insert(row))
         return exchange_id
 

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -2961,6 +2961,7 @@ class DB:
         request_kwargs: dict[str, Any] | None = None,
         thinking_blocks: dict[str, Any] | None = None,
         available_tools: Sequence[dict[str, Any]] | None = None,
+        response_schema: dict[str, Any] | None = None,
     ) -> str:
         exchange_id = str(uuid.uuid4())
         row: dict[str, Any] = {
@@ -2989,6 +2990,8 @@ class DB:
             row["thinking_blocks"] = thinking_blocks
         if available_tools is not None:
             row["available_tools"] = list(available_tools)
+        if response_schema is not None:
+            row["response_schema"] = response_schema
         await self._execute(self.client.table("call_llm_exchanges").insert(row))
         return exchange_id
 

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -738,16 +738,42 @@ def _extract_model_parameters(api_kwargs: dict) -> dict:
     return params
 
 
+def _anthropic_tool_calls_to_openai(tool_calls: Sequence[dict]) -> list[dict]:
+    """Translate the model's tool-use blocks into Langfuse's expected shape.
+
+    Langfuse's IOPreview pairs each tool call with the matching tool
+    definition (rendering counts on the def, vs. "not called") by reading
+    a ``tool_calls`` array on the assistant message in the OpenAI shape:
+    ``[{"name": ..., "arguments": "<json string>"}]``. We translate from
+    Anthropic's ``{"name", "input"}`` shape — and drop server-side blocks
+    (e.g. ``web_search_tool_result``) which carry a ``type`` field and
+    aren't model-issued calls.
+    """
+    out: list[dict] = []
+    for tc in tool_calls:
+        if tc.get("type"):
+            continue
+        out.append(
+            {
+                "name": tc.get("name"),
+                "arguments": json.dumps(tc.get("input", {})),
+            }
+        )
+    return out
+
+
 def _langfuse_output_for(parsed: ParsedAnthropicResponse) -> str | dict | None:
     """Render the assistant turn for Langfuse's IOPreview.
 
-    When the response contains thinking or redacted-thinking blocks, we
-    return a ChatML-shaped assistant message so Langfuse's
-    ``ThinkingBlock`` / ``RedactedThinkingBlock`` UI components light up.
-    Otherwise we return the joined text (or ``None``) to preserve the
-    existing string output for non-thinking models.
+    When the response contains thinking, redacted-thinking, or tool-use
+    blocks, we return a ChatML-shaped assistant message so Langfuse's
+    ``ThinkingBlock`` / ``RedactedThinkingBlock`` UI components light up
+    and the tool-definition cards count actual invocations. Otherwise we
+    return the joined text (or ``None``) to preserve the existing string
+    output for plain text responses.
     """
-    if not parsed.has_thinking:
+    invoked = _anthropic_tool_calls_to_openai(parsed.tool_calls)
+    if not parsed.has_thinking and not invoked:
         return parsed.text or None
     output: dict = {"role": "assistant", "content": parsed.text}
     if parsed.thinking:
@@ -756,6 +782,8 @@ def _langfuse_output_for(parsed: ParsedAnthropicResponse) -> str | dict | None:
         output["thinking"] = [{"content": t["content"]} for t in parsed.thinking]
     if parsed.redacted_thinking:
         output["redacted_thinking"] = [{"data": r["data"]} for r in parsed.redacted_thinking]
+    if invoked:
+        output["tool_calls"] = invoked
     return output
 
 
@@ -863,7 +891,7 @@ def _enrich_langfuse_generation(
         log.debug("Langfuse enrichment failed: %s", exc)
 
 
-@observe(as_type="generation", name="anthropic.messages.create")
+@observe(as_type="generation", name="anthropic.messages.create", capture_output=False)
 async def call_anthropic_api(
     client: anthropic.AsyncAnthropic,
     model: str,
@@ -1161,7 +1189,7 @@ def _enrich_langfuse_generation_google(
         log.debug("Langfuse enrichment (google) failed: %s", exc)
 
 
-@observe(as_type="generation", name="google.generate_content")
+@observe(as_type="generation", name="google.generate_content", capture_output=False)
 async def call_google_api(
     model: str,
     system_prompt: str,
@@ -1808,7 +1836,7 @@ async def _continuation_recovery_for_parse(
     return None
 
 
-@observe(as_type="generation", name="anthropic.messages.parse")
+@observe(as_type="generation", name="anthropic.messages.parse", capture_output=False)
 async def _structured_call_parse(
     system_prompt: str,
     response_model: type[T] | None,

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -450,6 +450,18 @@ def _capture_request_kwargs(cfg: ModelConfig) -> dict:
     return cfg.to_record_dict()
 
 
+def _capture_response_schema(response_model: type[BaseModel] | None) -> dict | None:
+    """Extract the JSON Schema the model is constrained to produce.
+
+    Returned in our internal ``{"name", "schema"}`` shape. ``None`` for
+    unstructured calls so the column stays NULL — both ``_save_exchange``
+    and the Langfuse enrichment skip persistence on None.
+    """
+    if response_model is None:
+        return None
+    return {"name": response_model.__name__, "schema": response_model.model_json_schema()}
+
+
 @dataclass
 class ParsedAnthropicResponse:
     """Decomposition of an Anthropic Message's content blocks.
@@ -558,6 +570,7 @@ async def _save_exchange(
     request_kwargs: dict | None = None,
     thinking_blocks: dict | None = None,
     available_tools: Sequence[dict] | None = None,
+    response_schema: dict | None = None,
     error: str | None = None,
 ) -> None:
     """Persist an LLM exchange and record a trace event.
@@ -585,6 +598,7 @@ async def _save_exchange(
         request_kwargs=request_kwargs,
         thinking_blocks=thinking_blocks,
         available_tools=available_tools,
+        response_schema=response_schema,
         error=error,
     )
     cost_usd = compute_cost(
@@ -653,6 +667,7 @@ async def _record_partial_failure(
     request_kwargs: dict | None = None,
     thinking_blocks: dict | None = None,
     available_tools: Sequence[dict] | None = None,
+    response_schema: dict | None = None,
 ) -> None:
     """Persist whatever forensics we have for a failed LLM call.
 
@@ -689,6 +704,7 @@ async def _record_partial_failure(
                 request_kwargs=request_kwargs,
                 thinking_blocks=thinking_blocks,
                 available_tools=available_tools,
+                response_schema=response_schema,
                 error=error_str,
             )
         except Exception as save_exc:
@@ -703,7 +719,12 @@ async def _record_partial_failure(
         try:
             client.update_current_generation(
                 model=model,
-                input=_langfuse_input_for(system_prompt, messages, tools=available_tools),
+                input=_langfuse_input_for(
+                    system_prompt,
+                    messages,
+                    tools=available_tools,
+                    response_schema=response_schema,
+                ),
                 output=(
                     partial_text[:_PARTIAL_FAILURE_LANGFUSE_OUTPUT_MAX] if partial_text else None
                 ),
@@ -808,11 +829,30 @@ def _anthropic_tool_to_openai(tool: dict) -> dict:
     }
 
 
+def _response_schema_to_openai(schema: dict) -> dict:
+    """Translate our internal {name, schema} shape to OpenAI's response_format.
+
+    OpenAI's chat completion API accepts ``response_format = {"type":
+    "json_schema", "json_schema": {"name", "schema", "strict"}}``.
+    Mirroring that shape on the Langfuse generation lets the trace UI
+    surface the schema in the same way it does for OpenAI calls.
+    """
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": schema.get("name"),
+            "schema": schema.get("schema"),
+            "strict": True,
+        },
+    }
+
+
 def _langfuse_input_for(
     system_prompt: str,
     messages: Sequence[dict],
     *,
     tools: Sequence[dict] | None = None,
+    response_schema: dict | None = None,
 ) -> list[dict] | dict:
     """Shape the ``input`` payload for Langfuse generations.
 
@@ -824,20 +864,26 @@ def _langfuse_input_for(
     system message at the top, and "Open in Playground" pre-fills it
     correctly.
 
-    When ``tools`` are present we wrap the same flat ChatML list in a
-    ``{"messages": [...], "tools": [...]}`` dict — the shape the
-    langfuse OpenAI integration emits — and translate each Anthropic
-    tool def into OpenAI's ``{"type": "function", "function": {...}}``
-    shape so Langfuse's IOPreview tool-definition UI renders rather
+    When ``tools`` or ``response_schema`` are present we wrap the same
+    flat ChatML list in a ``{"messages": [...], "tools": [...],
+    "response_format": {...}}`` dict — the shape the langfuse OpenAI
+    integration emits — translating each Anthropic tool def to OpenAI
+    ``{"type": "function", "function": {...}}`` and the schema to
+    OpenAI ``response_format`` so the trace UI surfaces both rather
     than dumping raw JSON.
     """
     serialized = list(_serialize_messages(messages))
     flat: list[dict] = (
         [{"role": "system", "content": system_prompt}, *serialized] if system_prompt else serialized
     )
+    if not tools and not response_schema:
+        return flat
+    payload: dict = {"messages": flat}
     if tools:
-        return {"messages": flat, "tools": [_anthropic_tool_to_openai(t) for t in tools]}
-    return flat
+        payload["tools"] = [_anthropic_tool_to_openai(t) for t in tools]
+    if response_schema:
+        payload["response_format"] = _response_schema_to_openai(response_schema)
+    return payload
 
 
 def _enrich_langfuse_generation(
@@ -849,6 +895,7 @@ def _enrich_langfuse_generation(
     elapsed_ms: int,
     parsed: ParsedAnthropicResponse,
     api_kwargs: dict | None = None,
+    response_schema: dict | None = None,
 ) -> None:
     """Populate the active Langfuse generation span with model, IO, and usage.
 
@@ -871,7 +918,10 @@ def _enrich_langfuse_generation(
         client.update_current_generation(
             model=model,
             input=_langfuse_input_for(
-                system_prompt, messages, tools=(api_kwargs or {}).get("tools")
+                system_prompt,
+                messages,
+                tools=(api_kwargs or {}).get("tools"),
+                response_schema=response_schema,
             ),
             output=_langfuse_output_for(parsed),
             model_parameters=_extract_model_parameters(api_kwargs or {}),
@@ -904,6 +954,7 @@ async def call_anthropic_api(
     cache: bool = False,
     effort: str | None = None,
     model_config: ModelConfig | None = None,
+    response_schema: dict | None = None,
 ) -> APIResponse:
     """Make a single Anthropic API call with retry logic.
 
@@ -1004,6 +1055,7 @@ async def call_anthropic_api(
             elapsed_ms=partial_state.get("elapsed_ms", 0),
             request_kwargs=_capture_request_kwargs(cfg),
             available_tools=tools,
+            response_schema=response_schema,
         )
         trace = get_trace()
         if trace:
@@ -1048,6 +1100,7 @@ async def call_anthropic_api(
                 request_kwargs=_capture_request_kwargs(cfg),
                 thinking_blocks=parsed.thinking_blocks_for_storage(),
                 available_tools=tools,
+                response_schema=response_schema,
             )
         except Exception as exc:
             log.error(
@@ -1072,6 +1125,7 @@ async def call_anthropic_api(
         elapsed_ms=elapsed_ms,
         parsed=parsed,
         api_kwargs=kwargs,
+        response_schema=response_schema,
     )
     return APIResponse(message=response, duration_ms=elapsed_ms)
 
@@ -1499,6 +1553,7 @@ async def _structured_call_cached(
     schema_text = _schema_instruction(response_model)
     inject_msgs = _inject_into_last_user_message(msg_list, schema_text)
     effective_model = model or settings.model
+    response_schema = _capture_response_schema(response_model)
 
     max_parse_attempts = 2
     for parse_attempt in range(max_parse_attempts):
@@ -1511,6 +1566,7 @@ async def _structured_call_cached(
             metadata=metadata,
             db=db,
             cache=cache,
+            response_schema=response_schema,
         )
         response_text = ""
         for block in api_resp.message.content:
@@ -1879,6 +1935,7 @@ async def _structured_call_parse(
         parse_kwargs["tools"] = tools
     if tool_choice is not None:
         parse_kwargs["tool_choice"] = tool_choice
+    response_schema = _capture_response_schema(response_model)
 
     @_api_retry
     async def _do_parse() -> Any:
@@ -1915,6 +1972,7 @@ async def _structured_call_parse(
             elapsed_ms=elapsed_ms,
             request_kwargs=_capture_request_kwargs(cfg),
             available_tools=tools,
+            response_schema=response_schema,
         )
         if (
             continuation_recovery
@@ -1957,6 +2015,7 @@ async def _structured_call_parse(
         elapsed_ms=elapsed_ms,
         parsed=parsed,
         api_kwargs=parse_kwargs,
+        response_schema=response_schema,
     )
     if metadata and db:
         serialized: Sequence[dict] | None = None
@@ -1983,6 +2042,7 @@ async def _structured_call_parse(
             request_kwargs=_capture_request_kwargs(cfg),
             thinking_blocks=parsed.thinking_blocks_for_storage(),
             available_tools=tools,
+            response_schema=response_schema,
         )
     if response.parsed_output is not None:
         log.debug(

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -557,6 +557,7 @@ async def _save_exchange(
     user_messages: Sequence[dict] | None = None,
     request_kwargs: dict | None = None,
     thinking_blocks: dict | None = None,
+    available_tools: Sequence[dict] | None = None,
     error: str | None = None,
 ) -> None:
     """Persist an LLM exchange and record a trace event.
@@ -583,6 +584,7 @@ async def _save_exchange(
         model=model,
         request_kwargs=request_kwargs,
         thinking_blocks=thinking_blocks,
+        available_tools=available_tools,
         error=error,
     )
     cost_usd = compute_cost(
@@ -650,6 +652,7 @@ async def _record_partial_failure(
     cache_read_input_tokens: int = 0,
     request_kwargs: dict | None = None,
     thinking_blocks: dict | None = None,
+    available_tools: Sequence[dict] | None = None,
 ) -> None:
     """Persist whatever forensics we have for a failed LLM call.
 
@@ -685,6 +688,7 @@ async def _record_partial_failure(
                 user_messages=serialized,
                 request_kwargs=request_kwargs,
                 thinking_blocks=thinking_blocks,
+                available_tools=available_tools,
                 error=error_str,
             )
         except Exception as save_exc:
@@ -699,7 +703,7 @@ async def _record_partial_failure(
         try:
             client.update_current_generation(
                 model=model,
-                input=_langfuse_input_for(system_prompt, messages),
+                input=_langfuse_input_for(system_prompt, messages, tools=available_tools),
                 output=(
                     partial_text[:_PARTIAL_FAILURE_LANGFUSE_OUTPUT_MAX] if partial_text else None
                 ),
@@ -755,7 +759,33 @@ def _langfuse_output_for(parsed: ParsedAnthropicResponse) -> str | dict | None:
     return output
 
 
-def _langfuse_input_for(system_prompt: str, messages: Sequence[dict]) -> list[dict]:
+def _anthropic_tool_to_openai(tool: dict) -> dict:
+    """Translate one Anthropic tool def into the OpenAI/ChatML shape.
+
+    Langfuse's IOPreview parses tool definitions from the OpenAI shape
+    (``{"type": "function", "function": {"name", "description",
+    "parameters"}}``); fed Anthropic's native shape it falls back to a
+    raw JSON dump. The translation is mechanical — ``input_schema`` and
+    ``parameters`` are both JSON Schema — so we render here in the shape
+    Langfuse understands while keeping the DB row in Anthropic's literal
+    shape (that's what was on the wire).
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.get("name"),
+            "description": tool.get("description"),
+            "parameters": tool.get("input_schema"),
+        },
+    }
+
+
+def _langfuse_input_for(
+    system_prompt: str,
+    messages: Sequence[dict],
+    *,
+    tools: Sequence[dict] | None = None,
+) -> list[dict] | dict:
     """Shape the ``input`` payload for Langfuse generations.
 
     Langfuse has no dedicated ``system`` field. Folding system into a
@@ -765,11 +795,21 @@ def _langfuse_input_for(system_prompt: str, messages: Sequence[dict]) -> list[di
     a flat ChatML list keeps both viewers happy: the trace UI shows the
     system message at the top, and "Open in Playground" pre-fills it
     correctly.
+
+    When ``tools`` are present we wrap the same flat ChatML list in a
+    ``{"messages": [...], "tools": [...]}`` dict — the shape the
+    langfuse OpenAI integration emits — and translate each Anthropic
+    tool def into OpenAI's ``{"type": "function", "function": {...}}``
+    shape so Langfuse's IOPreview tool-definition UI renders rather
+    than dumping raw JSON.
     """
     serialized = list(_serialize_messages(messages))
-    if not system_prompt:
-        return serialized
-    return [{"role": "system", "content": system_prompt}, *serialized]
+    flat: list[dict] = (
+        [{"role": "system", "content": system_prompt}, *serialized] if system_prompt else serialized
+    )
+    if tools:
+        return {"messages": flat, "tools": [_anthropic_tool_to_openai(t) for t in tools]}
+    return flat
 
 
 def _enrich_langfuse_generation(
@@ -802,7 +842,9 @@ def _enrich_langfuse_generation(
         )
         client.update_current_generation(
             model=model,
-            input=_langfuse_input_for(system_prompt, messages),
+            input=_langfuse_input_for(
+                system_prompt, messages, tools=(api_kwargs or {}).get("tools")
+            ),
             output=_langfuse_output_for(parsed),
             model_parameters=_extract_model_parameters(api_kwargs or {}),
             usage_details={
@@ -933,6 +975,7 @@ async def call_anthropic_api(
             messages=messages,
             elapsed_ms=partial_state.get("elapsed_ms", 0),
             request_kwargs=_capture_request_kwargs(cfg),
+            available_tools=tools,
         )
         trace = get_trace()
         if trace:
@@ -976,6 +1019,7 @@ async def call_anthropic_api(
                 user_messages=serialized,
                 request_kwargs=_capture_request_kwargs(cfg),
                 thinking_blocks=parsed.thinking_blocks_for_storage(),
+                available_tools=tools,
             )
         except Exception as exc:
             log.error(
@@ -1842,6 +1886,7 @@ async def _structured_call_parse(
             messages=msg_list,
             elapsed_ms=elapsed_ms,
             request_kwargs=_capture_request_kwargs(cfg),
+            available_tools=tools,
         )
         if (
             continuation_recovery
@@ -1909,6 +1954,7 @@ async def _structured_call_parse(
             user_messages=serialized,
             request_kwargs=_capture_request_kwargs(cfg),
             thinking_blocks=parsed.thinking_blocks_for_storage(),
+            available_tools=tools,
         )
     if response.parsed_output is not None:
         log.debug(

--- a/supabase/migrations/20260506092057_add_available_tools_to_llm_exchanges.sql
+++ b/supabase/migrations/20260506092057_add_available_tools_to_llm_exchanges.sql
@@ -1,0 +1,5 @@
+-- Captures the list of tool definitions made available to the model on a
+-- given exchange. Stored as JSONB (one element per tool, in Anthropic
+-- request shape: {name, description, input_schema}). NULL when the call
+-- ran without any tools.
+ALTER TABLE public.call_llm_exchanges ADD COLUMN available_tools JSONB;

--- a/supabase/migrations/20260506103034_add_response_schema_to_llm_exchanges.sql
+++ b/supabase/migrations/20260506103034_add_response_schema_to_llm_exchanges.sql
@@ -1,0 +1,5 @@
+-- Captures the JSON Schema the model was constrained to produce on a
+-- structured call. Stored as JSONB in our internal shape:
+-- {"name": <pydantic class name>, "schema": <JSON Schema dict>}.
+-- NULL for unstructured calls.
+ALTER TABLE public.call_llm_exchanges ADD COLUMN response_schema JSONB;

--- a/tests/test_langfuse_input_payload.py
+++ b/tests/test_langfuse_input_payload.py
@@ -80,6 +80,49 @@ def test_langfuse_input_for_returns_flat_list_when_tools_empty():
     ]
 
 
+def test_langfuse_input_for_includes_response_format_when_schema_present():
+    schema = {
+        "name": "MyModel",
+        "schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+    }
+
+    payload = _langfuse_input_for(
+        "sys", [{"role": "user", "content": "hi"}], response_schema=schema
+    )
+
+    # Schema-only (no tools) still wraps as a dict so the response_format field surfaces.
+    assert payload == {
+        "messages": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "MyModel",
+                "schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+                "strict": True,
+            },
+        },
+    }
+
+
+def test_langfuse_input_for_combines_tools_and_schema():
+    tools = [{"name": "noop", "description": "", "input_schema": {"type": "object"}}]
+    schema = {"name": "M", "schema": {"type": "object"}}
+
+    payload = _langfuse_input_for(
+        "sys",
+        [{"role": "user", "content": "hi"}],
+        tools=tools,
+        response_schema=schema,
+    )
+
+    assert isinstance(payload, dict)
+    assert "tools" in payload and "response_format" in payload
+    assert payload["response_format"]["json_schema"]["name"] == "M"
+
+
 @pytest.fixture
 def langfuse_client(mocker):
     client = mocker.MagicMock()

--- a/tests/test_langfuse_input_payload.py
+++ b/tests/test_langfuse_input_payload.py
@@ -44,6 +44,42 @@ def test_langfuse_input_for_handles_content_blocks():
     assert payload[2]["content"] == [{"type": "text", "text": "hello"}]
 
 
+def test_langfuse_input_for_wraps_messages_when_tools_present():
+    tools = [{"name": "search", "description": "search", "input_schema": {"type": "object"}}]
+
+    payload = _langfuse_input_for(
+        "you are helpful", [{"role": "user", "content": "hi"}], tools=tools
+    )
+
+    # Anthropic-shape tools translate to OpenAI shape so Langfuse's IOPreview
+    # renders with its tool-definition UI rather than dumping raw JSON.
+    assert payload == {
+        "messages": [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "hi"},
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "search",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    }
+
+
+def test_langfuse_input_for_returns_flat_list_when_tools_empty():
+    payload = _langfuse_input_for("you are helpful", [{"role": "user", "content": "hi"}], tools=[])
+
+    assert payload == [
+        {"role": "system", "content": "you are helpful"},
+        {"role": "user", "content": "hi"},
+    ]
+
+
 @pytest.fixture
 def langfuse_client(mocker):
     client = mocker.MagicMock()
@@ -84,6 +120,41 @@ def test_enrich_langfuse_generation_includes_system_in_input(langfuse_client):
         {"role": "system", "content": "you are helpful"},
         {"role": "user", "content": "hi"},
     ]
+
+
+def test_enrich_langfuse_generation_includes_tools_in_input(langfuse_client):
+    parsed = ParsedAnthropicResponse(
+        text_parts=["ok"], tool_calls=[], thinking=[], redacted_thinking=[]
+    )
+    tools = [{"name": "search", "description": "search", "input_schema": {"type": "object"}}]
+
+    _enrich_langfuse_generation(
+        model="claude-opus-4-7",
+        system_prompt="you are helpful",
+        messages=[{"role": "user", "content": "hi"}],
+        response=_fake_anthropic_response(),  # pyright: ignore[reportArgumentType]
+        elapsed_ms=10,
+        parsed=parsed,
+        api_kwargs={"model": "claude-opus-4-7", "max_tokens": 100, "tools": tools},
+    )
+
+    kwargs = langfuse_client.update_current_generation.call_args.kwargs
+    assert kwargs["input"] == {
+        "messages": [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "hi"},
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "search",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    }
 
 
 def test_enrich_langfuse_generation_google_includes_system_in_input(langfuse_client, mocker):

--- a/tests/test_langfuse_thinking_payload.py
+++ b/tests/test_langfuse_thinking_payload.py
@@ -15,10 +15,11 @@ def _parsed(
     text_parts: list[str] | None = None,
     thinking: list[dict] | None = None,
     redacted_thinking: list[dict] | None = None,
+    tool_calls: list[dict] | None = None,
 ) -> ParsedAnthropicResponse:
     return ParsedAnthropicResponse(
         text_parts=text_parts or [],
-        tool_calls=[],
+        tool_calls=tool_calls or [],
         thinking=thinking or [],
         redacted_thinking=redacted_thinking or [],
     )
@@ -107,4 +108,57 @@ def test_thinking_with_empty_text_still_emits_dict():
         "role": "assistant",
         "content": "",
         "thinking": [{"content": "internal-only"}],
+    }
+
+
+def test_tool_calls_emitted_in_openai_shape():
+    parsed = _parsed(
+        text_parts=["calling now"],
+        tool_calls=[
+            {"name": "search", "input": {"query": "ravens"}},
+            {"name": "load_page", "input": {"page_id": "abc12345"}},
+        ],
+    )
+
+    out = _langfuse_output_for(parsed)
+
+    assert out == {
+        "role": "assistant",
+        "content": "calling now",
+        "tool_calls": [
+            {"name": "search", "arguments": '{"query": "ravens"}'},
+            {"name": "load_page", "arguments": '{"page_id": "abc12345"}'},
+        ],
+    }
+
+
+def test_server_tool_results_excluded_from_tool_calls():
+    # Server-side blocks (e.g. web_search_tool_result) carry a `type` field
+    # and are not model-issued calls — they must not pair with definitions.
+    parsed = _parsed(
+        text_parts=["done"],
+        tool_calls=[
+            {"name": "web_search", "input": {"q": "x"}},
+            {"type": "web_search_tool_result", "tool_use_id": "abc", "content": []},
+        ],
+    )
+
+    out = _langfuse_output_for(parsed)
+
+    assert isinstance(out, dict)
+    assert out["tool_calls"] == [{"name": "web_search", "arguments": '{"q": "x"}'}]
+
+
+def test_tool_calls_without_thinking_still_emit_assistant_dict():
+    parsed = _parsed(
+        text_parts=["plain"],
+        tool_calls=[{"name": "noop", "input": {}}],
+    )
+
+    out = _langfuse_output_for(parsed)
+
+    assert out == {
+        "role": "assistant",
+        "content": "plain",
+        "tool_calls": [{"name": "noop", "arguments": "{}"}],
     }

--- a/tests/test_save_exchange_thinking.py
+++ b/tests/test_save_exchange_thinking.py
@@ -155,3 +155,50 @@ async def test_error_forwarded_to_db_and_event(metadata, db_mock, trace_mock, la
     kwargs = db_mock.save_llm_exchange.await_args.kwargs
     assert kwargs["error"] == "boom"
     assert _recorded_event(trace_mock).error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_available_tools_forwarded_to_db(metadata, db_mock, trace_mock, langfuse_url):
+    tools = [
+        {
+            "name": "search",
+            "description": "search the workspace",
+            "input_schema": {"type": "object"},
+        },
+        {"name": "load_page", "description": "load a page", "input_schema": {"type": "object"}},
+    ]
+
+    await _save_exchange(
+        metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        response_text="answer",
+        tool_calls=[],
+        input_tokens=1,
+        output_tokens=1,
+        duration_ms=1,
+        available_tools=tools,
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["available_tools"] == tools
+
+
+@pytest.mark.asyncio
+async def test_no_available_tools_passes_none_to_db(metadata, db_mock, trace_mock, langfuse_url):
+    await _save_exchange(
+        metadata,
+        db=db_mock,
+        model="claude-haiku-4-5",
+        system_prompt="sys",
+        response_text="answer",
+        tool_calls=[],
+        input_tokens=1,
+        output_tokens=1,
+        duration_ms=1,
+        # available_tools defaults to None
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["available_tools"] is None

--- a/tests/test_save_exchange_thinking.py
+++ b/tests/test_save_exchange_thinking.py
@@ -202,3 +202,42 @@ async def test_no_available_tools_passes_none_to_db(metadata, db_mock, trace_moc
 
     kwargs = db_mock.save_llm_exchange.await_args.kwargs
     assert kwargs["available_tools"] is None
+
+
+@pytest.mark.asyncio
+async def test_response_schema_forwarded_to_db(metadata, db_mock, trace_mock, langfuse_url):
+    schema = {"name": "MyModel", "schema": {"type": "object", "properties": {}}}
+
+    await _save_exchange(
+        metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        response_text="{}",
+        tool_calls=[],
+        input_tokens=1,
+        output_tokens=1,
+        duration_ms=1,
+        response_schema=schema,
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["response_schema"] == schema
+
+
+@pytest.mark.asyncio
+async def test_no_response_schema_passes_none_to_db(metadata, db_mock, trace_mock, langfuse_url):
+    await _save_exchange(
+        metadata,
+        db=db_mock,
+        model="claude-haiku-4-5",
+        system_prompt="sys",
+        response_text="answer",
+        tool_calls=[],
+        input_tokens=1,
+        output_tokens=1,
+        duration_ms=1,
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["response_schema"] is None


### PR DESCRIPTION
## Summary

Surface the list of tool definitions made available to the model on each LLM exchange — both in our custom trace and in Langfuse — so we're no longer blind to which tools were on the table at the time of a call.

- **Custom trace (DB):** new `available_tools JSONB` column on `call_llm_exchanges`, plumbed through `_save_exchange` / `_record_partial_failure` from both `call_anthropic_api` and `_structured_call_parse`. Stored verbatim in Anthropic's wire shape (`{name, description, input_schema}`). Surfaced via `LLMExchangeOut.available_tools` and rendered in the trace UI alongside the existing tool-calls list.
- **Langfuse:** `_langfuse_input_for` now wraps the input as `{"messages": [...], "tools": [...]}` when tools are present (the shape Langfuse's OpenAI integration emits) and translates each tool to the OpenAI `{type: "function", function: {name, description, parameters}}` shape so Langfuse's IOPreview tool-definition UI renders rather than dumping raw JSON. Empty-tools and no-tools paths keep the existing flat ChatML list, preserving the system-prompt + playground guarantee.
- New migration `20260506092057_add_available_tools_to_llm_exchanges.sql` (no backfill — existing rows stay NULL).

## Test plan

- [x] `uv run pytest` — 1435 passed (existing suite unchanged)
- [x] New unit tests for `_save_exchange` (tools forwarded; None default) and `_langfuse_input_for` / `_enrich_langfuse_generation` (OpenAI-shape translation; flat-list fallback).
- [x] Eyeball a real trace in Langfuse to confirm the tool-definition UI renders the translated shape.
- [ ] Eyeball the trace UI to confirm `Available tools (N)` appears for tool-using calls and is absent for tool-less ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)