### PR TITLE
Prevent autoscaler from evicting orchestrator pods mid-run

### DIFF
--- a/src/rumil/k8s/orchestrator_job.yaml
+++ b/src/rumil/k8s/orchestrator_job.yaml
@@ -12,6 +12,9 @@ spec:
   backoffLimit: 0
   activeDeadlineSeconds: 14400
   template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       restartPolicy: Never
       serviceAccountName: rumil-orchestrator-job


### PR DESCRIPTION
## Summary

- Annotates the orchestrator Job's pod template with `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` so GKE Autopilot's autoscaler won't pick our pod up during voluntary node consolidation.

## Why

Hit this on a remote run today: the orchestrator was killed ~20 minutes into an 80-budget job because the autoscaler decided to scale the underlying node down. Pod-scoped events showed `deleting pod for node scale down (ScaleDown)` followed by `Stopping container orchestrator (Killing)`. Since the Job has `backoffLimit: 0`, the eviction was terminal and the run was lost. Application logs just stopped — nothing in the container's stdout/stderr explained it, since the kill came from outside.

`safe-to-evict: false` is the documented mechanism for opting a pod out of voluntary disruption. The cost is that the cluster can't consolidate the node holding an orchestrator pod for the lifetime of the run (still bounded by `activeDeadlineSeconds: 14400` = 4h), which is the right tradeoff for these batch jobs.

This does not protect against involuntary disruption (node upgrades, hardware failure, OOM). Combined with `backoffLimit: 0` those are still terminal — a follow-up could raise `backoffLimit` if the orchestrator can be made safe to re-enter mid-run.

## Test plan

- [ ] Submit a remote orchestrator run after the next `rumil-api` deploy and confirm the pod carries the annotation (`kubectl get pod <name> -n rumil -o jsonpath='{.metadata.annotations}'`).
- [ ] Let a long-budget run sit on a lightly-loaded node and confirm it isn't evicted by scale-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)