### PR TITLE
Retry httpx connection drops + show real duration for failed jobs

### DIFF
--- a/src/rumil/api/jobs.py
+++ b/src/rumil/api/jobs.py
@@ -148,7 +148,7 @@ def _job_to_item(job: client.V1Job) -> JobListItem:
         status=_classify_status(job),
         created_at=metadata.creation_timestamp,
         started_at=status.start_time if status else None,
-        completed_at=status.completion_time if status else None,
+        completed_at=_terminal_at(status),
         run_id=run_id,
         owner_user_id=labels.get(JOB_LABEL_OWNER, ""),
         workspace=annotations[JOB_ANNOTATION_WORKSPACE_NAME],
@@ -156,6 +156,34 @@ def _job_to_item(job: client.V1Job) -> JobListItem:
         logs_url=build_logs_url(name),
         trace_url=_build_trace_url(run_id),
     )
+
+
+def _terminal_at(status: client.V1JobStatus | None):
+    """Best-available timestamp for "this job stopped running".
+
+    Kubernetes only populates ``completion_time`` on **success**. For a
+    failed job ``completion_time`` stays None, so the frontend's duration
+    calculation falls back to ``Date.now()`` and the row appears to run
+    forever. Fall back to the latest ``Failed`` / ``Complete`` condition
+    transition time so failed runs report a sensible duration.
+    """
+    if status is None:
+        return None
+    if status.completion_time is not None:
+        return status.completion_time
+    conditions = status.conditions or []
+    terminal = [
+        c
+        for c in conditions
+        if (c.type or "") in ("Complete", "Failed") and (c.status or "") == "True"
+    ]
+    if not terminal:
+        return None
+    terminal.sort(
+        key=lambda c: c.last_transition_time or c.last_probe_time,
+        reverse=True,
+    )
+    return terminal[0].last_transition_time
 
 
 def _classify_status(job: client.V1Job) -> JobStatus:

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -130,6 +130,32 @@ def _exc_status(exc: BaseException | None) -> int | None:
     return status if isinstance(status, int) else None
 
 
+_CONNECTION_ERROR_NAME_MARKERS = (
+    "readerror",
+    "writeerror",
+    "connecterror",
+    "readtimeout",
+    "writetimeout",
+    "connecttimeout",
+    "pooltimeout",
+)
+
+
+def _is_connection_error(exc: BaseException | None) -> bool:
+    """True for httpx/httpcore connection-class transients.
+
+    These are real transients (mid-stream connection drops), but they
+    can also fire on destined-to-fail generations — e.g. very long
+    streams the edge can't sustain. They get a separate, smaller retry
+    budget (``max_api_retries_connection_error``) so we don't retry 60
+    times and burn money on every attempt.
+    """
+    if exc is None:
+        return False
+    name = type(exc).__name__.lower()
+    return any(marker in name for marker in _CONNECTION_ERROR_NAME_MARKERS)
+
+
 def _is_retryable(exc: BaseException) -> bool:
     """Return True if the exception represents a transient API error."""
     status = _exc_status(exc)
@@ -150,15 +176,27 @@ def _is_retryable(exc: BaseException) -> bool:
         or "remoteprotocol" in name
         or "incomplete chunked read" in msg
         or "peer closed connection" in msg
+        or _is_connection_error(exc)
     )
+
+
+def _max_retries_for_exc(exc: BaseException | None) -> int:
+    """Pick the retry-budget for *exc*.
+
+    Connection-class errors get the smaller ``max_api_retries_connection_error``
+    cap. Everything else routes through the per-status defaults.
+    """
+    settings = get_settings()
+    if _is_connection_error(exc):
+        cap = settings.max_api_retries_connection_error
+        return min(cap, 3) if settings.is_test_mode else cap
+    return settings.get_max_retries(_exc_status(exc))
 
 
 def _stop_after_status_retries(retry_state: RetryCallState) -> bool:
     """Stop callback that respects per-status retry limits from settings."""
     exc = retry_state.outcome.exception() if retry_state.outcome else None
-    status = _exc_status(exc)
-    max_retries = get_settings().get_max_retries(status)
-    return retry_state.attempt_number >= max_retries
+    return retry_state.attempt_number >= _max_retries_for_exc(exc)
 
 
 def _log_before_retry(retry_state: RetryCallState) -> None:
@@ -168,7 +206,7 @@ def _log_before_retry(retry_state: RetryCallState) -> None:
     name = type(exc).__name__.lower() if exc else "unknown"
     label = f"HTTP {status}" if status else name
     wait = retry_state.next_action.sleep if retry_state.next_action else 0
-    max_retries = get_settings().get_max_retries(status)
+    max_retries = _max_retries_for_exc(exc)
     log.warning(
         "API temporarily unavailable (%s), retrying in %gs (attempt %d/%d)",
         label,

--- a/src/rumil/settings.py
+++ b/src/rumil/settings.py
@@ -201,6 +201,11 @@ class Settings(BaseSettings):
     max_api_retries_429: int | None = _capture_field(default=None)
     max_api_retries_500: int | None = _capture_field(default=None)
     max_api_retries_529: int | None = _capture_field(default=None)
+    # Separate, smaller cap for connection-class transients (httpx/httpcore
+    # ReadError, ConnectError, *Timeout). These can fire on destined-to-fail
+    # generations (e.g. very long max_tokens streams the edge can't sustain),
+    # so we don't want to retry 60 times and burn money on every attempt.
+    max_api_retries_connection_error: int = _capture_field(default=5)
 
     view_importance_5_cap: int = _capture_field(default=5)
     view_importance_4_cap: int = _capture_field(default=10)


### PR DESCRIPTION
## Summary

Two related fixes that surfaced together on a failed cloud run.

**1. Retry httpx connection-class drops.** A recent ai-character orch run died with `httpx.ReadError` — the Anthropic edge dropping a streaming connection mid-response. `_is_retryable` only matched specific substrings (`remoteprotocol`, `incomplete chunked read`, `peer closed connection`) and missed the `ReadError` family entirely, so tenacity reraised on attempt #1 with **zero retries** despite our 60-attempt budget. The classifier now also catches `ReadError`, `WriteError`, `ConnectError`, and the four httpx Timeout classes by name.

To avoid burning money retrying destined-to-fail long generations 60 times, connection-class transients get a **separate, smaller budget** — `max_api_retries_connection_error` (default 5) — routed via a new `_max_retries_for_exc(exc)` helper. The existing per-status budgets (429/500/529 etc.) are unchanged.

**2. Real duration for failed jobs on /jobs.** Kubernetes only populates `Job.status.completion_time` on successful completion. Failed jobs leave it `None`, so the frontend's duration calc falls back to `Date.now()` and the row ticks up forever — the same failed run that triggered fix (1) showed >6h on /jobs despite actually running for 22 minutes. `_job_to_item` now falls back to the latest `Failed`/`Complete` condition's `last_transition_time`.

## Test plan

- [x] `uv run pyright` clean
- [x] `uv run pytest tests/test_versus_retry.py tests/test_db_retry.py -q` — 26 passed
- [x] Smoke-checked `_is_retryable` / `_is_connection_error` / `_max_retries_for_exc` against `httpx.ReadError`, `httpx.ConnectTimeout`, fake-429, and `ValueError` — budgets resolve to 5 / 5 / 60 / (won't retry) respectively
- [x] Verified `_terminal_at` against the actual failing job: resolves to `2026-05-08 11:08:03` (Failed condition), giving the correct ~22 min duration instead of 6h+

🤖 Generated with [Claude Code](https://claude.com/claude-code)