### PR TITLE
trace UI: run-level token + cache rollup next to total cost

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -10267,6 +10267,50 @@
             ],
             "title": "Cost Usd"
           },
+          "input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Tokens"
+          },
+          "output_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Tokens"
+          },
+          "cache_read_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Read Tokens"
+          },
+          "cache_create_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Create Tokens"
+          },
           "staged": {
             "type": "boolean",
             "title": "Staged",

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -4211,6 +4211,22 @@ export type RunTraceTreeOut = {
      */
     cost_usd?: number | null;
     /**
+     * Input Tokens
+     */
+    input_tokens?: number | null;
+    /**
+     * Output Tokens
+     */
+    output_tokens?: number | null;
+    /**
+     * Cache Read Tokens
+     */
+    cache_read_tokens?: number | null;
+    /**
+     * Cache Create Tokens
+     */
+    cache_create_tokens?: number | null;
+    /**
      * Staged
      */
     staged?: boolean;

--- a/frontend/src/app/traces/[runId]/trace-viewer.tsx
+++ b/frontend/src/app/traces/[runId]/trace-viewer.tsx
@@ -12,6 +12,44 @@ export type SequenceNode = {
   calls: TreeNode[];
 };
 
+function fmtTokens(n: number | null | undefined): string {
+  const v = n ?? 0;
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}
+
+function RunRollup({ trace }: { trace: RunTraceTreeOut }) {
+  const hasCost = trace.cost_usd != null;
+  const hasTokens =
+    (trace.input_tokens ?? 0) > 0 ||
+    (trace.output_tokens ?? 0) > 0 ||
+    (trace.cache_read_tokens ?? 0) > 0 ||
+    (trace.cache_create_tokens ?? 0) > 0;
+  if (!hasCost && !hasTokens) return null;
+
+  const cr = trace.cache_read_tokens ?? 0;
+  const cc = trace.cache_create_tokens ?? 0;
+  const fresh = trace.input_tokens ?? 0;
+  const totalIn = cr + cc + fresh;
+  const hitPct = totalIn > 0 ? Math.round((cr / totalIn) * 100) : null;
+
+  return (
+    <div className="trace-run-cost">
+      {hasCost && <>Total cost: ${trace.cost_usd!.toFixed(4)}</>}
+      {hasCost && hasTokens && <> · </>}
+      {hasTokens && (
+        <>
+          in {fmtTokens(totalIn)} (cache {fmtTokens(cr)} read / {fmtTokens(cc)}{" "}
+          write / {fmtTokens(fresh)} fresh
+          {hitPct !== null && <>, {hitPct}% hit</>}) · out{" "}
+          {fmtTokens(trace.output_tokens)}
+        </>
+      )}
+    </div>
+  );
+}
+
 function buildTree(calls: CallNodeOut[]): TreeNode[] {
   const byId = new Map<string, CallNodeOut>();
   for (const n of calls) byId.set(n.call.id, n);
@@ -102,11 +140,7 @@ export function TraceViewer({
   return (
     <HashTargetProvider>
       <div className="trace-root">
-        {trace.cost_usd != null && (
-          <div className="trace-run-cost">
-            Total cost: ${trace.cost_usd.toFixed(4)}
-          </div>
-        )}
+        <RunRollup trace={trace} />
         {tree.map((t) => (
           <CallNode key={t.node.call.id} tree={t} depth={0} />
         ))}

--- a/src/rumil/api/app.py
+++ b/src/rumil/api/app.py
@@ -519,11 +519,17 @@ async def get_run_trace_tree(
             )
         )
     total_cost = sum(c.cost_usd or 0 for c in calls)
+    totals = await read_db.get_llm_exchange_totals_for_run(run_id)
+    has_exchanges = any(totals.values())
     return RunTraceTreeOut(
         run_id=run_id,
         question=question_page,
         calls=nodes,
         cost_usd=total_cost if total_cost > 0 else None,
+        input_tokens=totals["input_tokens"] if has_exchanges else None,
+        output_tokens=totals["output_tokens"] if has_exchanges else None,
+        cache_read_tokens=totals["cache_read_tokens"] if has_exchanges else None,
+        cache_create_tokens=totals["cache_create_tokens"] if has_exchanges else None,
         staged=is_staged,
         config=run_config,
     )

--- a/src/rumil/api/schemas.py
+++ b/src/rumil/api/schemas.py
@@ -452,6 +452,13 @@ class RunTraceTreeOut(BaseModel):
     question: Page | None
     calls: list[CallNodeOut]
     cost_usd: float | None = None
+    # Run-level token + cache rollup summed across every llm exchange on
+    # the run. Surfaced next to cost in the trace UI so cache reuse is
+    # visible at a glance. ``None`` when the run has no exchanges yet.
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cache_create_tokens: int | None = None
     staged: bool = False
     config: dict = {}
 

--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -3008,6 +3008,33 @@ class DB:
         )
         return rows
 
+    async def get_llm_exchange_totals_for_run(self, run_id: str) -> dict[str, int]:
+        """Sum token counts across every llm exchange in the run.
+
+        Returns a dict with ``input_tokens``, ``output_tokens``,
+        ``cache_read_tokens``, ``cache_create_tokens`` — zero when the run has
+        no exchanges or no rows match. Used by ``/api/runs/{id}/trace-tree``
+        to render a run-level token/cache rollup alongside total cost.
+        """
+        rows = _rows(
+            await self._execute(
+                self.client.table("call_llm_exchanges")
+                .select(
+                    "input_tokens, output_tokens, "
+                    "cache_creation_input_tokens, cache_read_input_tokens"
+                )
+                .eq("run_id", run_id)
+            )
+        )
+        return {
+            "input_tokens": sum(int(r.get("input_tokens") or 0) for r in rows),
+            "output_tokens": sum(int(r.get("output_tokens") or 0) for r in rows),
+            "cache_read_tokens": sum(int(r.get("cache_read_input_tokens") or 0) for r in rows),
+            "cache_create_tokens": sum(
+                int(r.get("cache_creation_input_tokens") or 0) for r in rows
+            ),
+        }
+
     async def get_llm_exchange(self, exchange_id: str) -> dict[str, Any] | None:
         rows = _rows(
             await self._execute(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -261,6 +261,125 @@ async def test_create_run_default_entrypoint_is_null(tmp_db):
     assert row.get("entrypoint") is None
 
 
+async def test_exchange_totals_for_run_empty(tmp_db):
+    """Runs with no exchanges return zeros, not nulls or errors."""
+    totals = await tmp_db.get_llm_exchange_totals_for_run(tmp_db.run_id)
+    assert totals == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_create_tokens": 0,
+    }
+
+
+async def test_exchange_totals_for_run_sums_rows(tmp_db, scout_call):
+    """Tokens and cache counts sum across every exchange in the run, treating
+    null fields as zero."""
+    await tmp_db.save_llm_exchange(
+        call_id=scout_call.id,
+        phase="agent",
+        system_prompt="s",
+        user_message="u",
+        response_text="r",
+        tool_calls=[],
+        input_tokens=10,
+        output_tokens=5,
+        cache_creation_input_tokens=100,
+        cache_read_input_tokens=200,
+    )
+    await tmp_db.save_llm_exchange(
+        call_id=scout_call.id,
+        phase="agent",
+        system_prompt="s",
+        user_message="u",
+        response_text="r",
+        tool_calls=[],
+        input_tokens=2,
+        output_tokens=3,
+        cache_creation_input_tokens=None,
+        cache_read_input_tokens=50,
+    )
+    totals = await tmp_db.get_llm_exchange_totals_for_run(tmp_db.run_id)
+    assert totals == {
+        "input_tokens": 12,
+        "output_tokens": 8,
+        "cache_read_tokens": 250,
+        "cache_create_tokens": 100,
+    }
+
+
+async def test_exchange_totals_for_run_filters_by_run(tmp_db, scout_call):
+    """Exchanges from other runs must not leak into the totals."""
+    await tmp_db.save_llm_exchange(
+        call_id=scout_call.id,
+        phase="agent",
+        system_prompt="s",
+        user_message="u",
+        response_text="r",
+        tool_calls=[],
+        input_tokens=7,
+    )
+
+    other_run_id = str(uuid.uuid4())
+    other = await DB.create(run_id=other_run_id, project_id=str(tmp_db.project_id))
+    other.project_id = tmp_db.project_id
+    try:
+        await other.save_llm_exchange(
+            call_id=scout_call.id,
+            phase="agent",
+            system_prompt="s",
+            user_message="u",
+            response_text="r",
+            tool_calls=[],
+            input_tokens=999,
+        )
+        totals = await tmp_db.get_llm_exchange_totals_for_run(tmp_db.run_id)
+        assert totals["input_tokens"] == 7
+    finally:
+        await other._execute(
+            other.client.table("call_llm_exchanges").delete().eq("run_id", other_run_id)
+        )
+        await other.close()
+
+
+async def test_trace_tree_surfaces_run_token_totals(api_client, tmp_db, scout_call):
+    """Trace-tree should report run-level token + cache totals when exchanges exist."""
+    await tmp_db.save_llm_exchange(
+        call_id=scout_call.id,
+        phase="agent",
+        system_prompt="s",
+        user_message="u",
+        response_text="r",
+        tool_calls=[],
+        input_tokens=11,
+        output_tokens=22,
+        cache_creation_input_tokens=33,
+        cache_read_input_tokens=44,
+    )
+    await tmp_db.create_run(name="trace-token-totals", question_id=None, config={})
+
+    resp = await api_client.get(f"/api/runs/{tmp_db.run_id}/trace-tree")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["input_tokens"] == 11
+    assert body["output_tokens"] == 22
+    assert body["cache_create_tokens"] == 33
+    assert body["cache_read_tokens"] == 44
+
+
+async def test_trace_tree_no_exchanges_returns_null_token_totals(api_client, tmp_db):
+    """Runs with no exchanges get null token fields so the UI knows to omit the rollup."""
+    await tmp_db.create_run(name="no-exchanges", question_id=None, config={})
+
+    resp = await api_client.get(f"/api/runs/{tmp_db.run_id}/trace-tree")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["input_tokens"] is None
+    assert body["output_tokens"] is None
+    assert body["cache_read_tokens"] is None
+    assert body["cache_create_tokens"] is None
+
+
 async def test_list_run_call_experiments_filters_by_entrypoint(tmp_db):
     """Only rows with entrypoint='run_call' in this project should come back."""
     project_id = tmp_db.project_id


### PR DESCRIPTION
## Summary
- New `RunRollup` next to the existing `Total cost` line on each run's trace page: shows total input / output tokens with cache read / write / fresh split + hit %.
- DB helper `get_llm_exchange_totals_for_run` sums the four token columns (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`) across the run's `call_llm_exchanges` rows. One query, no migration — the columns already existed (since `20260313003428_add_cache_tokens_to_llm_exchanges`).
- `RunTraceTreeOut` gains four `int | None` fields; the existing `/api/runs/{id}/trace-tree` endpoint populates them.
- Per-exchange cache visualization via `TokenMeter` was already in place; this is the run-level rollup on top of it.

Example rendering: `Total cost: $0.0161 · in 23.2k (cache 17.9k read / 5.3k write / 2 fresh, 77% hit) · out 1.5k`

Motivation: workflows that lean on cache reuse (e.g. cache-aware mainline loops) had no easy way to verify the cache is actually being hit. A 0% hit rate is a red flag; high hit rate without expected reuse (cross-run TTL bleed-through) is also worth knowing.

## Test plan
- [ ] `curl /api/runs/<run_id>/trace-tree` returns the four new fields, populated for runs with exchanges and null otherwise.
- [ ] Trace page in the browser shows the rollup inline with `Total cost` for runs with exchanges; cost line renders unchanged for runs without.
- [ ] Hit rate matches `cache_read_tokens / (cache_read_tokens + cache_create_tokens + input_tokens)` on a sample run.
- [ ] Existing trace UI features (call tree, per-exchange `TokenMeter`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)