### PR TITLE
Capture full request/response bodies and provider_request_id on exchanges

### DIFF
--- a/src/rumil/database.py
+++ b/src/rumil/database.py
@@ -2962,6 +2962,9 @@ class DB:
         thinking_blocks: dict[str, Any] | None = None,
         available_tools: Sequence[dict[str, Any]] | None = None,
         response_schema: dict[str, Any] | None = None,
+        request: dict[str, Any] | None = None,
+        response: dict[str, Any] | None = None,
+        provider_request_id: str | None = None,
     ) -> str:
         exchange_id = str(uuid.uuid4())
         row: dict[str, Any] = {
@@ -2992,6 +2995,12 @@ class DB:
             row["available_tools"] = list(available_tools)
         if response_schema is not None:
             row["response_schema"] = response_schema
+        if request is not None:
+            row["request"] = request
+        if response is not None:
+            row["response"] = response
+        if provider_request_id is not None:
+            row["provider_request_id"] = provider_request_id
         await self._execute(self.client.table("call_llm_exchanges").insert(row))
         return exchange_id
 

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -488,17 +488,46 @@ def _capture_request_kwargs(cfg: ModelConfig) -> dict:
     return cfg.to_record_dict()
 
 
+def _jsonable(obj: Any) -> Any:
+    """Recursively replace Pydantic instances with their JSON-mode dump.
+
+    Goal is byte-faithful storage for the ``request`` JSONB column: plain
+    dicts/lists/scalars travel through untouched, and any SDK Pydantic
+    object (e.g. ``ThinkingBlock`` echoed back on an assistant turn under
+    Opus extended thinking) gets ``model_dump(mode="json")`` — the same
+    wire-format dict the Anthropic API would accept on replay.
+
+    ``type`` objects (e.g. the structured-call ``output_format`` class)
+    are left for the caller to rewrite; this helper only flattens
+    instances.
+    """
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(mode="json")
+    if isinstance(obj, dict):
+        return {k: _jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_jsonable(v) for v in obj]
+    if isinstance(obj, tuple):
+        return [_jsonable(v) for v in obj]
+    return obj
+
+
 def _serialize_request_for_storage(kwargs: dict) -> dict:
     """Make the full request kwargs JSONB-safe for the ``request`` column.
 
-    Most kwargs are already plain dicts/strings. The structured-call path
-    puts a ``type[BaseModel]`` under ``output_format``; replace it with
-    ``{"name", "schema"}`` so the column is a faithful, replay-able
-    snapshot of what went on the wire (with the schema substituted for
-    the class).
+    Two rewrites:
+
+    - Pydantic instances anywhere in the tree (``messages`` often carries
+      SDK ``ContentBlock`` objects on echoed assistant turns) are replaced
+      with their ``model_dump(mode="json")`` dict — same wire format the
+      API would accept on replay.
+    - ``output_format`` on the structured-call path is a
+      ``type[BaseModel]`` (class, not instance); replace it with
+      ``{"name", "schema"}`` so the schema travels with the snapshot
+      rather than the class reference.
     """
-    out = dict(kwargs)
-    output_format = out.get("output_format")
+    out: dict = _jsonable(dict(kwargs))
+    output_format = kwargs.get("output_format")
     if output_format is not None and hasattr(output_format, "model_json_schema"):
         out["output_format"] = {
             "name": output_format.__name__,

--- a/src/rumil/llm.py
+++ b/src/rumil/llm.py
@@ -488,6 +488,25 @@ def _capture_request_kwargs(cfg: ModelConfig) -> dict:
     return cfg.to_record_dict()
 
 
+def _serialize_request_for_storage(kwargs: dict) -> dict:
+    """Make the full request kwargs JSONB-safe for the ``request`` column.
+
+    Most kwargs are already plain dicts/strings. The structured-call path
+    puts a ``type[BaseModel]`` under ``output_format``; replace it with
+    ``{"name", "schema"}`` so the column is a faithful, replay-able
+    snapshot of what went on the wire (with the schema substituted for
+    the class).
+    """
+    out = dict(kwargs)
+    output_format = out.get("output_format")
+    if output_format is not None and hasattr(output_format, "model_json_schema"):
+        out["output_format"] = {
+            "name": output_format.__name__,
+            "schema": output_format.model_json_schema(),
+        }
+    return out
+
+
 def _capture_response_schema(response_model: type[BaseModel] | None) -> dict | None:
     """Extract the JSON Schema the model is constrained to produce.
 
@@ -610,6 +629,9 @@ async def _save_exchange(
     available_tools: Sequence[dict] | None = None,
     response_schema: dict | None = None,
     error: str | None = None,
+    request: dict | None = None,
+    response: dict | None = None,
+    provider_request_id: str | None = None,
 ) -> None:
     """Persist an LLM exchange and record a trace event.
 
@@ -638,6 +660,9 @@ async def _save_exchange(
         available_tools=available_tools,
         response_schema=response_schema,
         error=error,
+        request=request,
+        response=response,
+        provider_request_id=provider_request_id,
     )
     cost_usd = compute_cost(
         model=model,
@@ -706,6 +731,8 @@ async def _record_partial_failure(
     thinking_blocks: dict | None = None,
     available_tools: Sequence[dict] | None = None,
     response_schema: dict | None = None,
+    request: dict | None = None,
+    provider_request_id: str | None = None,
 ) -> None:
     """Persist whatever forensics we have for a failed LLM call.
 
@@ -744,6 +771,8 @@ async def _record_partial_failure(
                 available_tools=available_tools,
                 response_schema=response_schema,
                 error=error_str,
+                request=request,
+                provider_request_id=provider_request_id,
             )
         except Exception as save_exc:
             log.warning(
@@ -1054,10 +1083,10 @@ async def call_anthropic_api(
                 response = await stream.get_final_message()
             except Exception:
                 # Capture whatever was decoded before the stream raised —
-                # ``current_message_snapshot`` is only valid while the
-                # context manager is open, so do this here, not in the
-                # outer except. Asserting access on an empty stream
-                # raises AssertionError; treat as no partial.
+                # ``current_message_snapshot`` / ``request_id`` are only
+                # valid while the context manager is open, so do this
+                # here, not in the outer except. Asserting access on an
+                # empty stream raises AssertionError; treat as no partial.
                 snapshot_content: list | None = None
                 try:
                     snapshot_content = stream.current_message_snapshot.content
@@ -1065,9 +1094,15 @@ async def call_anthropic_api(
                     snapshot_content = None
                 partial_state["snapshot_content"] = snapshot_content
                 partial_state["elapsed_ms"] = int((time.monotonic() - start) * 1000)
+                try:
+                    partial_state["request_id"] = stream.request_id
+                except Exception:
+                    partial_state["request_id"] = None
                 raise
+            stream_request_id = stream.request_id
         elapsed = int((time.monotonic() - start) * 1000)
         response._elapsed_ms = elapsed  # type: ignore[attr-defined]
+        response._request_id = stream_request_id  # type: ignore[attr-defined]
         return response
 
     try:
@@ -1094,6 +1129,8 @@ async def call_anthropic_api(
             request_kwargs=_capture_request_kwargs(cfg),
             available_tools=tools,
             response_schema=response_schema,
+            request=_serialize_request_for_storage(kwargs),
+            provider_request_id=partial_state.get("request_id"),
         )
         trace = get_trace()
         if trace:
@@ -1139,6 +1176,9 @@ async def call_anthropic_api(
                 thinking_blocks=parsed.thinking_blocks_for_storage(),
                 available_tools=tools,
                 response_schema=response_schema,
+                request=_serialize_request_for_storage(kwargs),
+                response=response.model_dump(mode="json"),
+                provider_request_id=getattr(response, "_request_id", None),
             )
         except Exception as exc:
             log.error(
@@ -2011,6 +2051,8 @@ async def _structured_call_parse(
             request_kwargs=_capture_request_kwargs(cfg),
             available_tools=tools,
             response_schema=response_schema,
+            request=_serialize_request_for_storage(parse_kwargs),
+            provider_request_id=getattr(exc, "request_id", None),
         )
         if (
             continuation_recovery
@@ -2081,6 +2123,9 @@ async def _structured_call_parse(
             thinking_blocks=parsed.thinking_blocks_for_storage(),
             available_tools=tools,
             response_schema=response_schema,
+            request=_serialize_request_for_storage(parse_kwargs),
+            response=response.model_dump(mode="json"),
+            provider_request_id=getattr(response, "_request_id", None),
         )
     if response.parsed_output is not None:
         log.debug(

--- a/supabase/migrations/20260510023935_add_request_response_to_llm_exchanges.sql
+++ b/supabase/migrations/20260510023935_add_request_response_to_llm_exchanges.sql
@@ -8,8 +8,7 @@
 -- provider_request_id is the request id assigned by the LLM provider
 -- (Anthropic returns this in response headers as ``request-id`` and
 -- exposes it via ``stream.request_id`` / ``response._request_id``).
--- Stored top-level so it's indexable for support-ticket lookups
--- without parsing JSONB.
+-- Stored top-level so support-ticket lookups don't have to parse JSONB.
 
 ALTER TABLE public.call_llm_exchanges
     ADD COLUMN request JSONB,

--- a/supabase/migrations/20260510023935_add_request_response_to_llm_exchanges.sql
+++ b/supabase/migrations/20260510023935_add_request_response_to_llm_exchanges.sql
@@ -1,0 +1,17 @@
+-- Store the full request body and full response body as sent/received,
+-- so exchanges are byte-faithful enough to replay or re-render without
+-- depending on the existing decomposed columns (system_prompt,
+-- user_messages, response_text, tool_calls, thinking_blocks). The
+-- decomposed columns become derived/cached views of these two; new
+-- content-block types can be surfaced without a migration.
+--
+-- provider_request_id is the request id assigned by the LLM provider
+-- (Anthropic returns this in response headers as ``request-id`` and
+-- exposes it via ``stream.request_id`` / ``response._request_id``).
+-- Stored top-level so it's indexable for support-ticket lookups
+-- without parsing JSONB.
+
+ALTER TABLE public.call_llm_exchanges
+    ADD COLUMN request JSONB,
+    ADD COLUMN response JSONB,
+    ADD COLUMN provider_request_id TEXT;

--- a/tests/test_exchange_request_response.py
+++ b/tests/test_exchange_request_response.py
@@ -5,9 +5,11 @@ Pydantic classes to a JSONB-safe shape, and the API/persistence path forwards
 ``request``/``response``/``provider_request_id`` to ``db.save_llm_exchange``.
 """
 
+import json
 from typing import Any
 
 import pytest
+from anthropic.types import ThinkingBlock
 from pydantic import BaseModel
 
 from rumil.llm import (
@@ -81,6 +83,28 @@ def test_serialize_does_not_mutate_input():
     _serialize_request_for_storage(original)
 
     assert original["output_format"] is _Schema
+
+
+def test_serialize_flattens_sdk_thinking_blocks_in_messages():
+    """Assistant turns echoed back to the API carry ``ThinkingBlock`` SDK objects
+    on extended-thinking models. The serialized form must be JSON-encodable so
+    Supabase can write the ``request`` JSONB column."""
+    thinking = ThinkingBlock(type="thinking", thinking="reasoning…", signature="sig")
+    kwargs = {
+        "model": "claude-opus-4-7",
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [thinking, {"type": "text", "text": "ok"}]},
+        ],
+    }
+
+    out = _serialize_request_for_storage(kwargs)
+
+    json.dumps(out)
+    assistant_blocks = out["messages"][1]["content"]
+    assert assistant_blocks[0]["type"] == "thinking"
+    assert assistant_blocks[0]["thinking"] == "reasoning…"
+    assert assistant_blocks[1] == {"type": "text", "text": "ok"}
 
 
 def test_serialize_preserves_other_kwargs_alongside_rewrite():

--- a/tests/test_exchange_request_response.py
+++ b/tests/test_exchange_request_response.py
@@ -1,0 +1,281 @@
+"""Full request/response bodies and provider_request_id on call_llm_exchanges.
+
+Covers the changes from #463: ``_serialize_request_for_storage`` rewrites
+Pydantic classes to a JSONB-safe shape, and the API/persistence path forwards
+``request``/``response``/``provider_request_id`` to ``db.save_llm_exchange``.
+"""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from rumil.llm import (
+    LLMExchangeMetadata,
+    _record_partial_failure,
+    _save_exchange,
+    _serialize_request_for_storage,
+    call_anthropic_api,
+)
+
+
+class _Schema(BaseModel):
+    item_id: str
+    score: int
+
+
+@pytest.fixture
+def metadata() -> LLMExchangeMetadata:
+    return LLMExchangeMetadata(call_id="call_123", phase="test_phase", round_num=0)
+
+
+@pytest.fixture
+def db_mock(mocker):
+    db = mocker.MagicMock()
+    db.save_llm_exchange = mocker.AsyncMock(return_value="exchange_abc")
+    return db
+
+
+@pytest.fixture
+def trace_mock(mocker):
+    trace = mocker.MagicMock()
+    trace.record = mocker.AsyncMock()
+    mocker.patch("rumil.llm.get_trace", return_value=trace)
+    return trace
+
+
+@pytest.fixture
+def langfuse_url(mocker):
+    mocker.patch("rumil.llm.langfuse_trace_url_for_current_observation", return_value=None)
+
+
+@pytest.fixture
+def no_langfuse(mocker):
+    mocker.patch("rumil.llm.get_langfuse", return_value=None)
+
+
+def test_serialize_rewrites_pydantic_output_format():
+    out = _serialize_request_for_storage({"model": "claude", "output_format": _Schema})
+
+    assert out["output_format"]["name"] == "_Schema"
+    assert out["output_format"]["schema"] == _Schema.model_json_schema()
+
+
+def test_serialize_passes_through_without_output_format():
+    kwargs = {"model": "claude", "max_tokens": 100, "messages": [{"role": "user", "content": "hi"}]}
+
+    out = _serialize_request_for_storage(kwargs)
+
+    assert out == kwargs
+
+
+def test_serialize_passes_through_when_output_format_is_none():
+    out = _serialize_request_for_storage({"model": "claude", "output_format": None})
+
+    assert out["output_format"] is None
+
+
+def test_serialize_does_not_mutate_input():
+    original = {"model": "claude", "output_format": _Schema}
+
+    _serialize_request_for_storage(original)
+
+    assert original["output_format"] is _Schema
+
+
+def test_serialize_preserves_other_kwargs_alongside_rewrite():
+    out = _serialize_request_for_storage(
+        {
+            "model": "claude-opus-4-7",
+            "max_tokens": 200,
+            "messages": [{"role": "user", "content": "hi"}],
+            "output_format": _Schema,
+        }
+    )
+
+    assert out["model"] == "claude-opus-4-7"
+    assert out["max_tokens"] == 200
+    assert out["messages"] == [{"role": "user", "content": "hi"}]
+    assert isinstance(out["output_format"], dict)
+
+
+@pytest.mark.asyncio
+async def test_save_exchange_forwards_request_response_and_provider_id(
+    metadata, db_mock, trace_mock, langfuse_url
+):
+    request = {"model": "claude-opus-4-7", "max_tokens": 100}
+    response = {"id": "msg_01abc", "content": [{"type": "text", "text": "hi"}]}
+
+    await _save_exchange(
+        metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        response_text="hi",
+        tool_calls=[],
+        input_tokens=1,
+        output_tokens=1,
+        duration_ms=1,
+        request=request,
+        response=response,
+        provider_request_id="req_01XYZ",
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["request"] == request
+    assert kwargs["response"] == response
+    assert kwargs["provider_request_id"] == "req_01XYZ"
+
+
+@pytest.mark.asyncio
+async def test_save_exchange_defaults_new_fields_to_none(
+    metadata, db_mock, trace_mock, langfuse_url
+):
+    await _save_exchange(
+        metadata,
+        db=db_mock,
+        model="claude-haiku-4-5",
+        system_prompt="sys",
+        response_text="hi",
+        tool_calls=[],
+        input_tokens=1,
+        output_tokens=1,
+        duration_ms=1,
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["request"] is None
+    assert kwargs["response"] is None
+    assert kwargs["provider_request_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_record_partial_failure_forwards_request_and_provider_id(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse
+):
+    await _record_partial_failure(
+        exc=RuntimeError("boom"),
+        partial_text="partial",
+        partial_tool_calls=None,
+        metadata=metadata,
+        db=db_mock,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        elapsed_ms=10,
+        request={"model": "claude-opus-4-7", "max_tokens": 50},
+        provider_request_id="req_partialXYZ",
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["request"] == {"model": "claude-opus-4-7", "max_tokens": 50}
+    assert kwargs["provider_request_id"] == "req_partialXYZ"
+    assert kwargs["error"].startswith("RuntimeError")
+
+
+def _make_stream_cm(
+    *,
+    response: Any | None,
+    request_id: str | None,
+    partial_blocks: Any | None = None,
+    snapshot_raises: bool = False,
+    mocker,
+):
+    """Async-context-manager mock for ``client.messages.stream``.
+
+    Pass ``response=None`` to make the stream raise on get_final_message;
+    pass a response object to make it succeed.
+    """
+    stream = mocker.MagicMock()
+    stream.request_id = request_id
+    if response is None:
+        stream.get_final_message = mocker.AsyncMock(side_effect=RuntimeError("stream broke"))
+        if snapshot_raises:
+            type(stream).current_message_snapshot = mocker.PropertyMock(
+                side_effect=AssertionError("no message_start yet")
+            )
+        else:
+            snapshot = mocker.MagicMock()
+            snapshot.content = partial_blocks or []
+            stream.current_message_snapshot = snapshot
+    else:
+        stream.get_final_message = mocker.AsyncMock(return_value=response)
+
+    cm = mocker.MagicMock()
+    cm.__aenter__ = mocker.AsyncMock(return_value=stream)
+    cm.__aexit__ = mocker.AsyncMock(return_value=False)
+    return cm
+
+
+def _make_response_mock(mocker, *, response_dict: dict) -> Any:
+    """Build a Message-like mock that parse_anthropic_response can consume."""
+    from anthropic.types import TextBlock
+
+    response = mocker.MagicMock()
+    response.content = [TextBlock(type="text", text="hi")]
+    response.usage.input_tokens = 5
+    response.usage.output_tokens = 7
+    response.usage.cache_creation_input_tokens = 0
+    response.usage.cache_read_input_tokens = 0
+    response.model_dump = mocker.MagicMock(return_value=response_dict)
+    return response
+
+
+@pytest.mark.asyncio
+async def test_call_anthropic_api_success_persists_request_response_and_provider_id(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, mocker
+):
+    response_dict = {"id": "msg_01success", "content": [{"type": "text", "text": "hi"}]}
+    response = _make_response_mock(mocker, response_dict=response_dict)
+    cm = _make_stream_cm(response=response, request_id="req_01SUCCESS", mocker=mocker)
+    client = mocker.MagicMock()
+    client.messages.stream = mocker.MagicMock(return_value=cm)
+
+    await call_anthropic_api(
+        client,
+        model="claude-opus-4-7",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        metadata=metadata,
+        db=db_mock,
+    )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["provider_request_id"] == "req_01SUCCESS"
+    assert kwargs["response"] == response_dict
+    # Request snapshot includes the user message and model that went on the wire.
+    assert kwargs["request"]["model"] == "claude-opus-4-7"
+    assert kwargs["request"]["messages"] == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.asyncio
+async def test_call_anthropic_api_partial_failure_captures_stream_request_id(
+    metadata, db_mock, trace_mock, langfuse_url, no_langfuse, mocker
+):
+    from anthropic.types import TextBlock
+
+    text_block = TextBlock(type="text", text="partial assistant text")
+    cm = _make_stream_cm(
+        response=None,
+        request_id="req_01PARTIAL",
+        partial_blocks=[text_block],
+        mocker=mocker,
+    )
+    client = mocker.MagicMock()
+    client.messages.stream = mocker.MagicMock(return_value=cm)
+
+    with pytest.raises(RuntimeError, match="stream broke"):
+        await call_anthropic_api(
+            client,
+            model="claude-opus-4-7",
+            system_prompt="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata=metadata,
+            db=db_mock,
+        )
+
+    kwargs = db_mock.save_llm_exchange.await_args.kwargs
+    assert kwargs["provider_request_id"] == "req_01PARTIAL"
+    assert kwargs["request"]["model"] == "claude-opus-4-7"
+    # Response column stays NULL on failure — we never got a final Message.
+    assert kwargs["response"] is None


### PR DESCRIPTION
## Summary

- Add `request` (JSONB), `response` (JSONB), and `provider_request_id` (TEXT) columns to `call_llm_exchanges`, populated from the Anthropic API path (streaming + `messages.parse`).
- `request` stores the full kwargs that went on the wire; `response` stores the assembled `Message.model_dump(mode="json")`. Together they make exchanges byte-faithful enough to replay or re-render without needing to extend the decomposed columns (`system_prompt`, `user_messages`, `response_text`, `tool_calls`, `thinking_blocks`, `available_tools`, `response_schema`) every time Anthropic ships a new block type.
- `provider_request_id` captures Anthropic's `req_*` from response headers (via `stream.request_id` / `ParsedMessage._request_id`), as a top-level column so support-ticket lookups don't have to grep JSONB.
- `_serialize_request_for_storage` recursively replaces Pydantic instances (e.g. `ThinkingBlock` SDK objects on echoed assistant turns) with `model_dump(mode="json")` dicts, and rewrites the structured-call `output_format` class to `{"name", "schema"}`.
- Partial-failure path also captures the request snapshot and `stream.request_id` inside the stream's context manager (both go invalid once it closes).
- SDK-agent and Google provider paths intentionally untouched; the former reconstructs turn-by-turn and has no single wire-faithful request body, the latter is a separate provider with a different response shape.
- Storage-only for now: the new columns are not surfaced via `LLMExchangeOut` / `GET /api/llm-exchanges/{id}`. Follow-up if/when we want them in the UI.

## Test plan

- [x] `uv run pytest tests/test_exchange_request_response.py` — 11 tests covering the serializer (incl. the `ThinkingBlock`-in-messages regression), `_save_exchange` / `_record_partial_failure` field forwarding, and `call_anthropic_api` success + partial-failure capture.
- [x] `uv run pytest tests/test_save_exchange_thinking.py tests/test_llm_partial_failure.py` — 32 adjacent tests still pass.
- [x] Live dispatch against local Supabase (`find_considerations`): 6 exchange rows persisted with non-null `request`/`response` JSONB and real `req_*` `provider_request_id` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)